### PR TITLE
Fix GPS button positioning on mobile

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -331,6 +331,26 @@ body {
   margin-right: 10px !important;
 }
 
+/* Ensure Leaflet controls stay within viewport on mobile */
+@media (max-width: 768px) {
+  .leaflet-bottom.leaflet-right {
+    /* Account for mobile safe areas (notch, home indicator) */
+    bottom: calc(20px + env(safe-area-inset-bottom, 0px)) !important;
+    right: calc(10px + env(safe-area-inset-right, 0px)) !important;
+  }
+
+  .locate-control {
+    margin-bottom: 5px !important;
+  }
+}
+
+/* Extra small screens - ensure button is well above bottom edge */
+@media (max-width: 480px) {
+  .leaflet-bottom.leaflet-right {
+    bottom: calc(30px + env(safe-area-inset-bottom, 0px)) !important;
+  }
+}
+
 .locate-button {
   display: flex !important;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fixed GPS button being cut off on mobile devices
- Added CSS safe-area-inset support for phones with notches/home indicators
- Moved controls up from bottom edge on mobile (20-30px depending on screen size)

## Test plan
- [x] Tested in browser mobile emulation mode
- [ ] Test on actual mobile device after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)