### PR TITLE
Feature: Support Multiple Boundaries

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -554,6 +554,18 @@ async function initDatabase() {
       ALTER TABLE news_job_status ADD COLUMN IF NOT EXISTS total_pois INTEGER DEFAULT 0
     `);
 
+    // Add boundary_type and boundary_color columns for multiple boundary support
+    await client.query(`
+      ALTER TABLE pois ADD COLUMN IF NOT EXISTS boundary_type TEXT
+    `);
+    await client.query(`
+      ALTER TABLE pois ADD COLUMN IF NOT EXISTS boundary_color TEXT DEFAULT '#228B22'
+    `);
+    // Set default boundary_type for existing boundaries
+    await client.query(`
+      UPDATE pois SET boundary_type = 'cvnp' WHERE poi_type = 'boundary' AND boundary_type IS NULL
+    `);
+
     // Note: linear_features table is deprecated - data migrated to pois table above
 
     // Seed default icons if table is empty
@@ -602,6 +614,7 @@ app.get('/api/pois', async (req, res) => {
              property_owner, brief_description, era, historical_description,
              primary_activities, surface, pets, cell_signal, more_info_link,
              length_miles, difficulty, image_mime_type, image_drive_file_id,
+             boundary_type, boundary_color,
              locally_modified, deleted, synced, created_at, updated_at
       FROM pois
       WHERE (deleted IS NULL OR deleted = FALSE)
@@ -621,6 +634,7 @@ app.get('/api/pois/:id', async (req, res) => {
              property_owner, brief_description, era, historical_description,
              primary_activities, surface, pets, cell_signal, more_info_link,
              length_miles, difficulty, image_mime_type, image_drive_file_id,
+             boundary_type, boundary_color,
              locally_modified, deleted, synced, created_at, updated_at
       FROM pois WHERE id = $1`,
       [req.params.id]
@@ -749,6 +763,7 @@ app.get('/api/linear-features', async (req, res) => {
              property_owner, brief_description, era, historical_description,
              primary_activities, surface, pets, cell_signal, more_info_link,
              length_miles, difficulty, image_mime_type, image_drive_file_id,
+             boundary_type, boundary_color,
              locally_modified, deleted, synced, created_at, updated_at
       FROM pois
       WHERE poi_type IN ('trail', 'river', 'boundary')
@@ -769,6 +784,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
              property_owner, brief_description, era, historical_description,
              primary_activities, surface, pets, cell_signal, more_info_link,
              length_miles, difficulty, image_mime_type, image_drive_file_id,
+             boundary_type, boundary_color,
              locally_modified, deleted, synced, created_at, updated_at
       FROM pois WHERE id = $1`,
       [req.params.id]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1523,6 +1523,92 @@ body {
   margin: 0.5rem 0;
 }
 
+/* Boundary chips section */
+.boundary-chips-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.boundary-chips-header h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.boundary-chips-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.boundary-chips-actions button {
+  padding: 0.15rem 0.4rem;
+  font-size: 0.7rem;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #666;
+}
+
+.boundary-chips-actions button:hover {
+  background: #e8e8e8;
+}
+
+.boundary-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.boundary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  border: 1px solid #ddd;
+  background: white;
+  transition: all 0.15s ease;
+}
+
+.boundary-chip.active {
+  background: #f0f7e6;
+  border-color: #4a7c23;
+}
+
+.boundary-chip.inactive {
+  opacity: 0.5;
+  background: #f5f5f5;
+}
+
+.boundary-chip:hover {
+  border-color: #4a7c23;
+}
+
+.boundary-chip-color {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.boundary-chip-icon {
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.boundary-chip-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+}
+
 .legend-toggle {
   display: flex;
   align-items: center;
@@ -2197,6 +2283,53 @@ body {
 .legend-icon-item img {
   width: 18px;
   height: 18px;
+}
+
+/* Expandable section header (e.g., Boundaries) */
+.legend-icon-item.legend-section-header {
+  position: relative;
+}
+
+.legend-expand-icon {
+  margin-left: auto;
+  font-size: 0.6rem;
+  opacity: 0.6;
+}
+
+/* Expanded section content */
+.legend-section-content {
+  background: #f9f9f9;
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.legend-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.15rem;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.legend-checkbox-label:hover {
+  background: #e8f5e9;
+}
+
+.legend-checkbox-label input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.legend-color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  flex-shrink: 0;
 }
 
 /* Auth Components */
@@ -5756,6 +5889,97 @@ body {
   color: #c62828;
 }
 
+/* Boundaries Settings */
+.boundaries-settings {
+  margin-top: 1rem;
+}
+
+.no-boundaries {
+  color: #666;
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+  background: #f9f9f9;
+  border-radius: 4px;
+}
+
+.boundaries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.boundary-item {
+  background: #f9f9f9;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.boundary-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.boundary-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.boundary-preview {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+.boundary-controls {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.boundary-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.boundary-field span:first-child {
+  color: #666;
+  font-weight: 500;
+}
+
+.boundary-field input[type="color"] {
+  width: 40px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.boundary-field select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.color-value {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #666;
+}
+
 /* Eras Settings */
 .eras-settings {
   margin-top: 1rem;
@@ -7106,6 +7330,74 @@ body {
 .feature-type-badge.river {
   background: #1E90FF;
   color: white;
+}
+
+.feature-type-badge.boundary {
+  background: #6B8E23;
+  color: white;
+}
+
+/* Boundary color swatch - shown in view mode badges row */
+.boundary-color-swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+/* Boundary color palette - edit mode */
+.boundary-color-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 0.5rem;
+}
+
+.boundary-color-palette .color-swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 2px solid rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  padding: 0;
+}
+
+.boundary-color-palette .color-swatch:hover {
+  transform: scale(1.1);
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.boundary-color-palette .color-swatch.selected {
+  border-color: #333;
+  box-shadow: 0 0 0 2px white, 0 0 0 4px #333;
+  transform: scale(1.05);
+}
+
+.current-color-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.current-color-display .color-preview {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.current-color-display .color-hex {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #888;
 }
 
 /* Difficulty badges */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -79,7 +79,7 @@ function AppContent() {
   const [showNpsMap, setShowNpsMap] = useState(false);
   const [showTrails, setShowTrails] = useState(true);
   const [showRivers, setShowRivers] = useState(true);
-  const [showBoundaries, setShowBoundaries] = useState(true);
+  const [visibleBoundaries, setVisibleBoundaries] = useState(new Set()); // Set of boundary IDs
 
   // Map state for thumbnail display (center, zoom, bounds)
   const [mapState, setMapState] = useState({
@@ -198,6 +198,7 @@ function AppContent() {
   useEffect(() => {
     refreshAllData();
   }, [refreshAllData]);
+
 
   // Compute destinations filtered by map viewport visibility (for News/Events tabs)
   // This uses the actual POI IDs visible on the map (respects zoom, pan, and legend filters)
@@ -636,8 +637,21 @@ function AppContent() {
           onToggleTrails={setShowTrails}
           showRivers={showRivers}
           onToggleRivers={setShowRivers}
-          showBoundaries={showBoundaries}
-          onToggleBoundaries={setShowBoundaries}
+          visibleBoundaries={visibleBoundaries}
+          onToggleBoundary={(id) => setVisibleBoundaries(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+              next.delete(id);
+            } else {
+              next.add(id);
+            }
+            return next;
+          })}
+          onShowAllBoundaries={() => {
+            const boundaryIds = linearFeatures.filter(f => f.feature_type === 'boundary').map(f => f.id);
+            setVisibleBoundaries(new Set(boundaryIds));
+          }}
+          onHideAllBoundaries={() => setVisibleBoundaries(new Set())}
           searchQuery={activeFilters.search}
           onSearchChange={(value) => handleFilterChange('search', value)}
           onNewsRefresh={() => setNewsRefreshTrigger(prev => prev + 1)}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -85,8 +85,17 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, showImage = true 
           {/* Linear feature type badge */}
           {isLinearFeature && (
             <span className={`feature-type-badge ${destination.feature_type}`}>
-              {destination.feature_type === 'river' ? 'River/Waterway' : 'Trail'}
+              {destination.feature_type === 'river' ? 'River/Waterway' :
+               destination.feature_type === 'boundary' ? 'Boundary' : 'Trail'}
             </span>
+          )}
+          {/* Boundary color swatch */}
+          {isLinearFeature && destination.feature_type === 'boundary' && destination.boundary_color && (
+            <span
+              className="boundary-color-swatch"
+              style={{ backgroundColor: destination.boundary_color }}
+              title={`Color: ${destination.boundary_color}`}
+            />
           )}
           {/* Difficulty badge for trails */}
           {isLinearFeature && destination.difficulty && (
@@ -622,8 +631,8 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
         </div>
       </div>
 
-      {/* Linear feature specific fields */}
-      {isLinearFeature && (
+      {/* Linear feature specific fields - trails and rivers */}
+      {isLinearFeature && editedData.feature_type !== 'boundary' && (
         <>
           <div className="edit-row">
             <div className="edit-section half">
@@ -660,6 +669,45 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
             />
           </div>
         </>
+      )}
+
+      {/* Boundary color picker */}
+      {isLinearFeature && editedData.feature_type === 'boundary' && (
+        <div className="edit-section">
+          <label>Boundary Color</label>
+          <div className="boundary-color-palette">
+            {[
+              '#228B22', // Forest Green
+              '#2E8B57', // Sea Green
+              '#006400', // Dark Green
+              '#8B4513', // Saddle Brown
+              '#A0522D', // Sienna
+              '#CD853F', // Peru
+              '#4169E1', // Royal Blue
+              '#1E90FF', // Dodger Blue
+              '#4682B4', // Steel Blue
+              '#8B008B', // Dark Magenta
+              '#9932CC', // Dark Orchid
+              '#DC143C', // Crimson
+              '#FF6347', // Tomato
+              '#FF8C00', // Dark Orange
+              '#FFD700', // Gold
+            ].map(color => (
+              <button
+                key={color}
+                type="button"
+                className={`color-swatch ${editedData.boundary_color === color ? 'selected' : ''}`}
+                style={{ backgroundColor: color }}
+                onClick={() => handleChange('boundary_color', color)}
+                title={color}
+              />
+            ))}
+          </div>
+          <div className="current-color-display">
+            Current: <span style={{ backgroundColor: editedData.boundary_color || '#228B22' }} className="color-preview" />
+            <span className="color-hex">{editedData.boundary_color || '#228B22'}</span>
+          </div>
+        </div>
       )}
 
       {/* Lat/long fields - only for point destinations */}


### PR DESCRIPTION
## Summary
- Added individual boundary chips in legend to toggle each boundary on/off
- Implemented color picker with 15 preset colors for boundary customization
- Boundaries now hidden by default (user opts-in to which ones to show)
- Moved NPS Map overlay to new "Boundaries & Overlays" section
- Increased boundary fill opacity to 15% normal, 30% when selected

## Changes
- **Frontend**: New boundary chip UI, color picker in sidebar, visibility controls
- **Backend**: Added boundary_color/boundary_type fields to linear features API
- **CSS**: Styles for boundary chips, color palette, and swatches

## Test plan
- [x] Import a boundary GeoJSON file
- [x] Verify boundary chips appear in legend
- [x] Toggle individual boundaries on/off
- [x] Change boundary color via sidebar color picker
- [x] Verify NPS Map toggle works in new location

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)