### PR TITLE
Fix social sharing, News/Events scope, and sidebar width

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -950,6 +950,7 @@ app.get('/share/destination/:id', async (req, res) => {
     const description = poi.brief_description || `Explore ${poi.name} at Cuyahoga Valley National Park`;
 
     // Generate HTML with OpenGraph meta tags
+    // Note: No instant redirect - let crawlers read the tags, users click to continue
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -963,6 +964,8 @@ app.get('/share/destination/:id', async (req, res) => {
   <meta property="og:title" content="${poi.name} | Roots of The Valley">
   <meta property="og:description" content="${description.replace(/"/g, '&quot;')}">
   <meta property="og:image" content="${imageUrl}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:url" content="${appUrl}">
   <meta property="og:site_name" content="Roots of The Valley">
 
@@ -972,12 +975,16 @@ app.get('/share/destination/:id', async (req, res) => {
   <meta name="twitter:description" content="${description.replace(/"/g, '&quot;')}">
   <meta name="twitter:image" content="${imageUrl}">
 
-  <!-- Redirect to the actual app -->
-  <meta http-equiv="refresh" content="0;url=${appUrl}">
-  <script>window.location.href = "${appUrl}";</script>
+  <!-- Delayed redirect for human users (crawlers don't execute JS or follow meta refresh quickly) -->
+  <meta http-equiv="refresh" content="3;url=${appUrl}">
 </head>
-<body>
-  <p>Redirecting to <a href="${appUrl}">${poi.name}</a>...</p>
+<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5;">
+  <div style="text-align: center; padding: 2rem;">
+    <h1 style="color: #2d5016; margin-bottom: 1rem;">${poi.name}</h1>
+    <p style="color: #666; margin-bottom: 1.5rem;">${description.replace(/"/g, '&quot;')}</p>
+    <p>Redirecting to <a href="${appUrl}" style="color: #4a7c23;">Roots of The Valley</a>...</p>
+    <p style="font-size: 0.9rem; color: #999;">Click the link if you're not redirected automatically.</p>
+  </div>
 </body>
 </html>`;
 
@@ -1008,6 +1015,7 @@ app.get('/share/linear-feature/:id', async (req, res) => {
     const description = feature.brief_description || `Explore the ${feature.name} at Cuyahoga Valley National Park`;
 
     // Generate HTML with OpenGraph meta tags
+    // Note: No instant redirect - let crawlers read the tags, users click to continue
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1021,6 +1029,8 @@ app.get('/share/linear-feature/:id', async (req, res) => {
   <meta property="og:title" content="${feature.name} | Roots of The Valley">
   <meta property="og:description" content="${description.replace(/"/g, '&quot;')}">
   <meta property="og:image" content="${imageUrl}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:url" content="${appUrl}">
   <meta property="og:site_name" content="Roots of The Valley">
 
@@ -1030,12 +1040,16 @@ app.get('/share/linear-feature/:id', async (req, res) => {
   <meta name="twitter:description" content="${description.replace(/"/g, '&quot;')}">
   <meta name="twitter:image" content="${imageUrl}">
 
-  <!-- Redirect to the actual app -->
-  <meta http-equiv="refresh" content="0;url=${appUrl}">
-  <script>window.location.href = "${appUrl}";</script>
+  <!-- Delayed redirect for human users (crawlers don't execute JS or follow meta refresh quickly) -->
+  <meta http-equiv="refresh" content="3;url=${appUrl}">
 </head>
-<body>
-  <p>Redirecting to <a href="${appUrl}">${feature.name}</a>...</p>
+<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5;">
+  <div style="text-align: center; padding: 2rem;">
+    <h1 style="color: #2d5016; margin-bottom: 1rem;">${feature.name}</h1>
+    <p style="color: #666; margin-bottom: 1.5rem;">${description.replace(/"/g, '&quot;')}</p>
+    <p>Redirecting to <a href="${appUrl}" style="color: #4a7c23;">Roots of The Valley</a>...</p>
+    <p style="font-size: 0.9rem; color: #999;">Click the link if you're not redirected automatically.</p>
+  </div>
 </body>
 </html>`;
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotv-frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Roots of The Valley - Frontend",
   "type": "module",
   "scripts": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2981,12 +2981,7 @@ body {
   cursor: not-allowed;
 }
 
-/* Sidebar Edit Mode - desktop only, mobile stays 100% width */
-@media (min-width: 769px) {
-  .sidebar.editing {
-    width: 450px;
-  }
-}
+/* Sidebar Edit Mode - desktop stays same width as view mode */
 
 /* View container - fills remaining space */
 .view-container {


### PR DESCRIPTION
## Summary
- Fix Facebook OG tags not populating in production
- Fix News/Events scope changing when POI selected and map zooms
- Fix sidebar width changing between View and Edit mode

## Bug Fixes

### Social Sharing (Facebook OG tags)
- Removed instant redirect (`content="0"`) that prevented crawlers from reading tags
- Added 3-second delay for human users while crawlers can read OG tags
- Added `og:image:width` and `og:image:height` meta tags
- Added styled landing page with POI name and description

### News/Events Scope
- Added `_isProgrammaticMove` flag to map to distinguish user vs selection zooms
- MapBoundsTracker now skips updating visible POIs during programmatic movements
- News/Events filter now preserves user's viewport when selecting a POI

### Sidebar Width
- Removed 450px override for edit mode on desktop
- Sidebar now stays consistent at 400px in both View and Edit modes

## Test plan
- [ ] Share a POI to Facebook and verify preview shows title, description, image
- [ ] Select a POI and verify News/Events don't change scope
- [ ] Switch between View and Edit mode and verify sidebar width stays constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)