### PR TITLE
Improve social sharing with thumbnails and OG tag injection

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi10/ubi:latest AS infrastructure
 
 LABEL maintainer="fatherlinux"
 LABEL description="Roots of The Valley - Cuyahoga Valley National Park destination explorer"
-LABEL version="1.6.0"
+LABEL version="1.7.0"
 
 # Install Node.js
 RUN dnf install -y nodejs npm && dnf clean all

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
         "passport-google-oauth20": "^2.0.0",
         "pg": "^8.11.3",
         "pg-boss": "^12.5.4",
-        "sharp": "^0.33.2"
+        "sharp": "^0.33.5"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,6 @@
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.11.3",
     "pg-boss": "^12.5.4",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.5"
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
     <meta property="og:title" content="Roots of The Valley" />
     <meta property="og:description" content="Explore the rich history and natural beauty of Cuyahoga Valley National Park. Discover trails, historic sites, and hidden gems." />
     <meta property="og:site_name" content="Roots of The Valley" />
-    <meta property="og:url" content="https://rotv.app" />
+    <meta property="og:url" content="https://rootsofthevalley.org" />
 
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,15 +4,11 @@ import NewsEvents from './NewsEvents';
 
 // Sidebar component with tabs: Info, News, Events, History
 // Share Modal Component
-// poiId and poiType are used to construct share URLs with proper OpenGraph meta tags
-function ShareModal({ isOpen, onClose, poiName, poiDescription, poiId, poiType = 'destination' }) {
+function ShareModal({ isOpen, onClose, poiName, poiDescription }) {
   const [copied, setCopied] = useState(false);
 
-  // Use the share endpoint URL which serves proper OpenGraph meta tags for social platforms
-  const baseUrl = window.location.origin;
-  const shareUrl = poiId
-    ? `${baseUrl}/share/${poiType}/${poiId}`
-    : window.location.href;
+  // Use the current URL directly - server injects OG tags for ?poi= URLs
+  const shareUrl = window.location.href;
 
   const shareText = poiDescription
     ? `${poiName} - ${poiDescription.substring(0, 100)}${poiDescription.length > 100 ? '...' : ''}`
@@ -39,7 +35,7 @@ function ShareModal({ isOpen, onClose, poiName, poiDescription, poiId, poiType =
   };
 
   const shareLinks = {
-    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}&quote=${encodeURIComponent(shareText)}`,
     threads: `https://www.threads.net/intent/post?text=${encodeURIComponent(shareText + ' ' + shareUrl)}`,
     linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`,
     twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,
@@ -1562,8 +1558,6 @@ function Sidebar({ destination, isNewPOI, onClose, isAdmin, editMode, onDestinat
           onClose={() => setShowShareModal(false)}
           poiName={linearFeature.name}
           poiDescription={linearFeature.brief_description}
-          poiId={linearFeature.id}
-          poiType="linear-feature"
         />
       </div>
     );
@@ -1709,8 +1703,6 @@ function Sidebar({ destination, isNewPOI, onClose, isAdmin, editMode, onDestinat
         onClose={() => setShowShareModal(false)}
         poiName={destination?.name || ''}
         poiDescription={destination?.brief_description}
-        poiId={destination?.id}
-        poiType="destination"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add server-side OG tag injection for `?poi=` URLs so social media crawlers see proper meta tags
- Create `/api/pois/:id/thumbnail` endpoint serving optimized 1200x630 JPEG images (~200KB vs ~4MB)
- Update share modal to use direct URLs instead of `/share/` redirect (removes 3-second delay)
- Add CORS headers and `og:image:type` for better cross-platform compatibility
- Bump version to 1.7.0

## Test plan
- [x] Verified thumbnails are ~200KB (down from ~4MB)
- [x] Tested sharing on Twitter/X - image, title, description all show
- [x] Tested sharing on Threads - image, title, description all show
- [x] Tested sharing on Facebook - image shows in link preview
- [x] Tested sharing on LinkedIn - image shows in link preview  
- [x] Tested sharing on Mastodon - image shows after posting
- [ ] Verify no regression on existing POI viewing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)