### PR TITLE
Add organizations (virtual POIs) with association management

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,11 @@
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""
     />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css"
+      crossorigin=""
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "rotv-frontend",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotv-frontend",
-      "version": "1.0.0",
+      "version": "1.5.0",
       "dependencies": {
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1"
@@ -1393,6 +1394,12 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
     "react-leaflet": "^4.2.1"
   },
   "devDependencies": {

--- a/frontend/public/icons/thumbnails/virtual.svg
+++ b/frontend/public/icons/thumbnails/virtual.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="virtualBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f3e5f5"/>
+      <stop offset="100%" style="stop-color:#e1bee7"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="120" height="120" fill="url(#virtualBg)" rx="8"/>
+  <!-- Abstract mountains/landscape -->
+  <path d="M0 90 L30 50 L45 65 L70 35 L95 70 L120 45 L120 120 L0 120 Z" fill="#ba68c8" opacity="0.3"/>
+  <path d="M0 100 L40 60 L60 80 L90 55 L120 85 L120 120 L0 120 Z" fill="#ab47bc" opacity="0.4"/>
+  <!-- Organization building icon -->
+  <g transform="translate(60, 60)">
+    <!-- Building structure -->
+    <rect x="-25" y="-25" width="50" height="50" fill="#7b1fa2" rx="2"/>
+    <!-- Windows -->
+    <rect x="-18" y="-18" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="-5" y="-18" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="8" y="-18" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="-18" y="-5" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="-5" y="-5" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="8" y="-5" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="-18" y="8" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="-5" y="8" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <rect x="8" y="8" width="8" height="8" fill="#f3e5f5" opacity="0.8"/>
+    <!-- Door -->
+    <rect x="-5" y="13" width="10" height="12" fill="#4a148c"/>
+  </g>
+  <!-- Network connection dots -->
+  <circle cx="25" cy="30" r="4" fill="#9c27b0" opacity="0.6"/>
+  <circle cx="95" cy="35" r="4" fill="#9c27b0" opacity="0.6"/>
+  <circle cx="15" cy="70" r="4" fill="#9c27b0" opacity="0.6"/>
+  <circle cx="105" cy="75" r="4" fill="#9c27b0" opacity="0.6"/>
+  <!-- Connection lines -->
+  <line x1="25" y1="30" x2="60" y2="60" stroke="#9c27b0" stroke-width="1" opacity="0.3"/>
+  <line x1="95" y1="35" x2="60" y2="60" stroke="#9c27b0" stroke-width="1" opacity="0.3"/>
+  <line x1="15" y1="70" x2="60" y2="60" stroke="#9c27b0" stroke-width="1" opacity="0.3"/>
+  <line x1="105" y1="75" x2="60" y2="60" stroke="#9c27b0" stroke-width="1" opacity="0.3"/>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -633,6 +633,30 @@ body {
   flex-shrink: 0;
 }
 
+/* Associations badge button in badges row */
+.associations-badge-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  background: #ff9800;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.associations-badge-btn:hover {
+  background: #f57c00;
+}
+
+.associations-badge-btn svg {
+  flex-shrink: 0;
+}
+
 /* Share Modal */
 .share-modal-overlay {
   position: fixed;
@@ -798,6 +822,117 @@ body {
 
 .share-copy-btn.copied {
   background: #198754;
+}
+
+/* Associations Modal */
+.associations-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.associations-modal {
+  background: white;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.associations-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: #ff9800;
+  color: white;
+}
+
+.associations-modal-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.associations-modal-close {
+  background: rgba(255,255,255,0.2);
+  border: none;
+  color: white;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+}
+
+.associations-modal-close:hover {
+  background: rgba(255,255,255,0.35);
+}
+
+.associations-modal-content {
+  padding: 1.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.associations-modal-description {
+  margin: 0 0 1rem 0;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.associations-modal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.associations-modal-empty {
+  padding: 2rem;
+  text-align: center;
+  color: #999;
+}
+
+/* Associations Tab View - shows button to open modal */
+.associations-tab-view {
+  padding: 1rem;
+  text-align: center;
+}
+
+.associations-tab-view p {
+  margin-bottom: 1rem;
+  color: #666;
+}
+
+.btn-view-associations {
+  padding: 0.75rem 1.5rem;
+  background: #ff9800;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-view-associations:hover {
+  background: #f57c00;
 }
 
 /* Sidebar Image */
@@ -1638,10 +1773,20 @@ body {
   background: #e8f5e9;
 }
 
-/* When sidebar is open on desktop, move Results chip to the left of sidebar */
+/* When sidebar is open on desktop, move buttons to the left of sidebar */
 @media (min-width: 768px) {
   .map-poi-count.sidebar-open {
-    right: calc(400px + 1rem);
+    right: calc(400px + 1rem) !important;
+    transition: right 0.3s ease;
+  }
+
+  .map-refresh-news.sidebar-open {
+    right: calc(400px + 1rem) !important;
+    transition: right 0.3s ease;
+  }
+
+  .map-create-organization.sidebar-open {
+    right: calc(400px + 1rem) !important;
     transition: right 0.3s ease;
   }
 }
@@ -1649,13 +1794,13 @@ body {
 /* Admin refresh news chip */
 .map-refresh-news {
   position: absolute;
-  top: 1rem;
-  right: 10rem;
+  top: 3.5rem; /* Evenly spaced below Results (2.5rem gap) */
+  right: 1rem;
   background: #4a7c23;
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-  z-index: 1000;
+  z-index: 2000;
   font-size: 0.85rem;
   font-weight: 500;
   color: white;
@@ -1682,6 +1827,29 @@ body {
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
+}
+
+/* Admin create organization chip */
+.map-create-organization {
+  position: absolute;
+  top: 6rem; /* Evenly spaced below Update News & Events (2.5rem gap) */
+  right: 1rem;
+  background: #ff9800;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  z-index: 2000;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.map-create-organization:hover {
+  background: #f57c00;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.2);
 }
 
 /* Refresh result message */
@@ -1727,12 +1895,17 @@ body {
 
 /* Stack chips vertically in edit mode to prevent overlap */
 .map-container.edit-mode-active .map-refresh-news {
-  top: 5rem;
+  top: 5.5rem; /* Evenly spaced below Results in edit mode (2.5rem gap) */
+  right: 1rem;
+}
+
+.map-container.edit-mode-active .map-create-organization {
+  top: 8rem; /* Evenly spaced below Update News & Events in edit mode (2.5rem gap) */
   right: 1rem;
 }
 
 .map-container.edit-mode-active .map-refresh-result {
-  top: 7.5rem;
+  top: 10.25rem; /* Below all buttons */
 }
 
 /* Boundary polygons - only respond to hover on the stroke, not the fill */
@@ -2543,6 +2716,8 @@ body {
 
 .legend-header-row h4 {
   margin: 0;
+  font-size: 0.85rem;
+  color: #333;
 }
 
 .legend-filter-btns {
@@ -7992,6 +8167,11 @@ body {
   color: #7b2d8e;
 }
 
+.poi-type-badge.virtual {
+  background: #fff3e0;
+  color: #ff9800;
+}
+
 .poi-type-badge .poi-type-icon {
   width: 18px;
   height: 18px;
@@ -8412,4 +8592,728 @@ body {
   .results-tab-empty-text {
     font-size: 1rem;
   }
+}
+
+/* Associations Tab Styling */
+.associations-tab-content {
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: 100%;
+}
+
+.associations-description {
+  margin-bottom: 1rem;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.associations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 400px;
+  overflow-y: auto;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+
+.associations-list::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+.association-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--card-bg, #f9f9f9);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border-color, #e0e0e0);
+}
+
+.association-item:hover {
+  background: var(--card-hover-bg, #f0f0f0);
+  transform: translateX(2px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.association-item-badge {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--primary-color, #4a90e2);
+  color: white;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.association-item-badge.destination {
+  background: #2e7d32;
+}
+
+.association-item-badge.trail {
+  background: #795548;
+}
+
+.association-item-badge.river {
+  background: #1565c0;
+}
+
+.association-item-badge.boundary {
+  background: #7b2d8e;
+}
+
+.association-item-badge.virtual {
+  background: #ff9800;
+}
+
+.association-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.association-item-name {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  color: var(--text-primary, #333);
+}
+
+.association-item-description {
+  font-size: 0.85rem;
+  color: var(--text-secondary, #666);
+  line-height: 1.4;
+}
+
+/* Virtual POI type styling for badge */
+.poi-type-icon.virtual {
+  background-color: #ff9800;
+}
+
+/* Virtual POI Creator Styling */
+.virtual-poi-creator-banner {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 400;
+  background: #ff9800;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+}
+
+.banner-content {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  pointer-events: auto;
+}
+
+.banner-close {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: none;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.banner-close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.virtual-poi-creator-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 1rem;
+}
+
+.virtual-poi-creator-modal {
+  background: white;
+  border-radius: 12px;
+  max-width: 800px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  z-index: 10001;
+  position: relative;
+}
+
+.virtual-poi-creator-modal .modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.virtual-poi-creator-modal .modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.virtual-poi-creator-modal .modal-close {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  color: #666;
+  line-height: 1;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.virtual-poi-creator-modal .modal-close:hover {
+  color: #333;
+}
+
+.virtual-poi-creator-modal .modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.virtual-poi-creator-modal .form-section h3,
+.virtual-poi-creator-modal .poi-selection-section h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1.1rem;
+}
+
+.virtual-poi-creator-modal .form-group {
+  margin-bottom: 1rem;
+}
+
+.virtual-poi-creator-modal .form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.virtual-poi-creator-modal .form-group input,
+.virtual-poi-creator-modal .form-group textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.virtual-poi-creator-modal .form-group input:focus,
+.virtual-poi-creator-modal .form-group textarea:focus {
+  outline: none;
+  border-color: #9c27b0;
+  box-shadow: 0 0 0 3px rgba(156, 39, 176, 0.1);
+}
+
+.virtual-poi-creator-modal .section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.virtual-poi-creator-modal .selection-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.virtual-poi-creator-modal .poi-list {
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5rem;
+}
+
+.virtual-poi-creator-modal .poi-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.virtual-poi-creator-modal .poi-checkbox-item:hover {
+  background: #f5f5f5;
+}
+
+.virtual-poi-creator-modal .poi-checkbox-item input[type="checkbox"] {
+  width: auto;
+  cursor: pointer;
+}
+
+.virtual-poi-creator-modal .poi-type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #4a90e2;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.virtual-poi-creator-modal .poi-type-badge.destination {
+  background: #2e7d32;
+}
+
+.virtual-poi-creator-modal .poi-type-badge.trail {
+  background: #795548;
+}
+
+.virtual-poi-creator-modal .poi-type-badge.river {
+  background: #1565c0;
+}
+
+.virtual-poi-creator-modal .poi-type-badge.boundary {
+  background: #7b2d8e;
+}
+
+.virtual-poi-creator-modal .poi-name {
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.virtual-poi-creator-modal .empty-message {
+  padding: 2rem;
+  text-align: center;
+  color: #666;
+}
+
+.virtual-poi-creator-modal .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.virtual-poi-creator-modal .btn-primary,
+.virtual-poi-creator-modal .btn-secondary {
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.virtual-poi-creator-modal .btn-primary {
+  background: #9c27b0;
+  color: white;
+}
+
+.virtual-poi-creator-modal .btn-primary:hover:not(:disabled) {
+  background: #7b1fa2;
+}
+
+.virtual-poi-creator-modal .btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.virtual-poi-creator-modal .btn-secondary {
+  background: #e0e0e0;
+  color: #333;
+}
+
+.virtual-poi-creator-modal .btn-secondary:hover:not(:disabled) {
+  background: #d0d0d0;
+}
+
+/* Association Editing Styles */
+.section-header-with-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.btn-add-association {
+  background: #9c27b0;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s ease;
+}
+
+.btn-add-association:hover {
+  background: #7b1fa2;
+}
+
+.association-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.association-item-clickable {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--card-bg, #f9f9f9);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border-color, #e0e0e0);
+}
+
+.association-item-clickable:hover {
+  background: var(--card-hover-bg, #f0f0f0);
+  transform: translateX(2px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.btn-delete-association {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #e0e0e0;
+  background: white;
+  color: #d32f2f;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-delete-association:hover:not(:disabled) {
+  background: #ffebee;
+  border-color: #d32f2f;
+}
+
+.btn-delete-association:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Add associations modal - pop-up */
+.add-associations-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2001;
+}
+
+.add-associations-modal {
+  background: white;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.add-associations-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: #ff9800;
+  color: white;
+}
+
+.add-associations-modal-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.add-associations-modal-close {
+  background: rgba(255,255,255,0.2);
+  border: none;
+  color: white;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+}
+
+.add-associations-modal-close:hover {
+  background: rgba(255,255,255,0.35);
+}
+
+.add-associations-modal-content {
+  padding: 1.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.filter-input-container {
+  margin-bottom: 1rem;
+}
+
+.filter-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s;
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: #ff9800;
+  box-shadow: 0 0 0 3px rgba(255, 152, 0, 0.1);
+}
+
+.add-associations-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.available-pois-list {
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.poi-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.poi-checkbox-item:hover {
+  background: #f5f5f5;
+}
+
+.poi-checkbox-item input[type="checkbox"] {
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+}
+
+.poi-checkbox-item .poi-type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #4a90e2;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.poi-checkbox-item .poi-type-badge.destination {
+  background: #2e7d32;
+}
+
+.poi-checkbox-item .poi-type-badge.trail {
+  background: #795548;
+}
+
+.poi-checkbox-item .poi-type-badge.river {
+  background: #1565c0;
+}
+
+.poi-checkbox-item .poi-type-badge.boundary {
+  background: #7b2d8e;
+}
+
+.poi-checkbox-item .poi-name {
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.add-associations-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.add-associations-actions .btn-cancel,
+.add-associations-actions .btn-save {
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.add-associations-actions .btn-cancel {
+  background: #e0e0e0;
+  color: #333;
+}
+
+.add-associations-actions .btn-cancel:hover {
+  background: #d0d0d0;
+}
+
+.add-associations-modal-footer .btn-cancel,
+.add-associations-modal-footer .btn-save {
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.add-associations-modal-footer .btn-cancel {
+  background: #e0e0e0;
+  color: #333;
+}
+
+.add-associations-modal-footer .btn-cancel:hover {
+  background: #d0d0d0;
+}
+
+.add-associations-modal-footer .btn-save {
+  background: #ff9800;
+  color: white;
+}
+
+.add-associations-modal-footer .btn-save:hover:not(:disabled) {
+  background: #f57c00;
+}
+
+.add-associations-modal-footer .btn-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Leaflet Draw Styles - Ensure drawing guides are visible */
+.leaflet-draw-tooltip {
+  background: #363636;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: #fff;
+  font: 12px/18px "Helvetica Neue", Arial, Helvetica, sans-serif;
+  margin-left: 20px;
+  margin-top: -21px;
+  padding: 4px 8px;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  z-index: 6000;
+}
+
+.leaflet-draw-guide-dash {
+  font-size: 1%;
+  opacity: 0.6;
+  position: absolute;
+  width: 5px;
+  height: 5px;
+}
+
+/* Drawing shape - make sure it's visible */
+.leaflet-overlay-pane svg path.leaflet-interactive {
+  pointer-events: auto;
+}
+
+/* Ensure drawing shapes are above map layers */
+.leaflet-draw-section {
+  position: relative;
+}
+
+/* Rectangle being drawn */
+path.leaflet-interactive {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Leaflet Draw - Drawing shapes visibility */
+.leaflet-draw-tooltip-single {
+  margin-top: -12px;
+}
+
+.leaflet-draw-tooltip-subtext {
+  color: #f8f8f8;
+}
+
+/* Make sure the drawing shape is visible above everything */
+.leaflet-overlay-pane svg {
+  z-index: 400 !important;
+  position: relative;
+}
+
+/* Ensure drawn items layer is visible */
+.leaflet-draw-actions {
+  z-index: 1000;
+}
+
+/* Drawing guide lines */
+.leaflet-mouse-marker {
+  background-color: #fff;
+  cursor: crosshair;
+}
+
+/* Ensure drawing shapes render properly */
+svg.leaflet-zoom-animated {
+  will-change: auto !important;
 }

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 
 // Individual POI tile for the Results tab
-const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isSelected }) {
+const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual, isSelected }) {
   // Use thumbnail endpoint for fast, cached small images
   const imageUrl = poi.image_mime_type
     ? `/api/pois/${poi.id}/thumbnail?size=small`
@@ -9,6 +9,7 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isSelecte
 
   // Get default thumbnail SVG path based on type
   const getDefaultThumbnail = () => {
+    if (isVirtual) return '/icons/thumbnails/virtual.svg';
     if (isLinear) {
       if (poi.feature_type === 'river') return '/icons/thumbnails/river.svg';
       if (poi.feature_type === 'boundary') return '/icons/thumbnails/boundary.svg';
@@ -19,6 +20,7 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isSelecte
 
   // Get POI type for styling and labels
   const getPoiType = () => {
+    if (isVirtual) return 'virtual';
     if (!isLinear) return 'destination';
     if (poi.feature_type === 'river') return 'river';
     if (poi.feature_type === 'boundary') return 'boundary';
@@ -28,6 +30,7 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isSelecte
   // Get type label
   const getTypeLabel = () => {
     const type = getPoiType();
+    if (type === 'virtual') return 'Organization';
     if (type === 'destination') return 'Destination';
     if (type === 'river') return 'River';
     if (type === 'boundary') return 'Boundary';
@@ -59,7 +62,7 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isSelecte
         {/* Badges row */}
         <div className="results-tile-badges">
           <span className={`poi-type-icon ${poiType}`}>
-            {poiType === 'destination' ? 'D' : poiType === 'trail' ? 'T' : poiType === 'river' ? 'R' : 'B'}
+            {poiType === 'virtual' ? 'O' : poiType === 'destination' ? 'D' : poiType === 'trail' ? 'T' : poiType === 'river' ? 'R' : 'B'}
           </span>
           {poi.era && (
             <span className="results-tile-era">{poi.era}</span>

--- a/frontend/src/components/VirtualPoiCreator.jsx
+++ b/frontend/src/components/VirtualPoiCreator.jsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet-draw/dist/leaflet.draw.css';
+import 'leaflet-draw';
+
+// Virtual POI Creator component - handles drawing rectangle and finding POIs for organization creation or adding associations
+function VirtualPoiCreator({ isActive, onCancel, destinations, linearFeatures, onPoisSelected, visibleTypes, showTrails, showRivers, visibleBoundaries, getDestinationIconType, mode = 'create' }) {
+  const map = useMap();
+
+  const drawnItemsRef = useRef(new L.FeatureGroup());
+  const rectangleHandlerRef = useRef(null);
+
+  useEffect(() => {
+    const drawnItems = drawnItemsRef.current;
+
+    if (!isActive) {
+      // Clean up when component becomes inactive
+      drawnItems.clearLayers();
+      if (rectangleHandlerRef.current) {
+        rectangleHandlerRef.current.disable();
+      }
+      return;
+    }
+
+    map.addLayer(drawnItems);
+
+    // Initialize rectangle handler
+    const rectangleHandler = new L.Draw.Rectangle(map, {
+      shapeOptions: {
+        stroke: true,
+        color: '#ff9800',
+        weight: 3,
+        opacity: 1,
+        fill: true,
+        fillColor: '#ff9800',
+        fillOpacity: 0.2,
+        clickable: true
+      },
+      showArea: false,
+      metric: false
+    });
+
+    rectangleHandlerRef.current = rectangleHandler;
+
+    // Auto-start drawing mode
+    console.log('Enabling rectangle drawing mode');
+    rectangleHandler.enable();
+    console.log('Rectangle handler enabled:', rectangleHandler.enabled());
+
+    // Handle rectangle creation
+    const onDrawCreated = (e) => {
+      const layer = e.layer;
+      drawnItems.clearLayers();
+      drawnItems.addLayer(layer);
+
+      const bounds = layer.getBounds();
+
+      // Extract raw bounds values to avoid circular reference issues
+      const south = bounds.getSouth();
+      const west = bounds.getWest();
+      const north = bounds.getNorth();
+      const east = bounds.getEast();
+
+      // Disable rectangle handler to prevent drawing additional rectangles
+      if (rectangleHandler) {
+        rectangleHandler.disable();
+      }
+
+      // Debug logging
+      console.log('Rectangle drawn with bounds:', { south, west, north, east });
+      console.log('Destinations:', destinations?.length || 0);
+      console.log('Linear features:', linearFeatures?.length || 0);
+
+      // Manual bounds checking function
+      const isPointInBounds = (lat, lng) => {
+        return lat >= south && lat <= north && lng >= west && lng <= east;
+      };
+
+      // Find POIs within bounds
+      const allPois = [
+        ...(destinations || []).map(d => ({ ...d, _type: 'point' })),
+        ...(linearFeatures || []).map(f => ({ ...f, _type: f.feature_type || 'trail' }))
+      ];
+
+      console.log('Total POIs to check:', allPois.length);
+      console.log('Active filters - visibleTypes:', visibleTypes ? Array.from(visibleTypes) : 'none',
+                  'showTrails:', showTrails, 'showRivers:', showRivers,
+                  'visibleBoundaries:', visibleBoundaries ? visibleBoundaries.size : 0);
+
+      const poisInBounds = allPois.filter(poi => {
+        if (poi._type === 'point' && poi.latitude && poi.longitude) {
+          // Check if POI type is visible in legend
+          const iconType = getDestinationIconType ? getDestinationIconType(poi) : 'default';
+          if (!visibleTypes || !visibleTypes.has(iconType)) {
+            return false;
+          }
+
+          const lat = parseFloat(poi.latitude);
+          const lng = parseFloat(poi.longitude);
+          const contains = isPointInBounds(lat, lng);
+          if (contains) console.log('Found point POI:', poi.name, 'type:', iconType);
+          return contains;
+        } else if ((poi._type === 'trail' || poi._type === 'river' || poi._type === 'boundary') && poi.geometry) {
+          // Check if the linear feature's layer is visible
+          if (poi._type === 'trail' && !showTrails) return false;
+          if (poi._type === 'river' && !showRivers) return false;
+          if (poi._type === 'boundary' && (!visibleBoundaries || !visibleBoundaries.has(poi.id))) return false;
+
+          // For linear features, check if any part intersects bounds
+          try {
+            const geojson = typeof poi.geometry === 'string' ? JSON.parse(poi.geometry) : poi.geometry;
+            if (geojson.type === 'LineString') {
+              const contains = geojson.coordinates.some(([lng, lat]) => isPointInBounds(lat, lng));
+              if (contains) console.log('Found linear POI:', poi.name, 'type:', poi._type);
+              return contains;
+            } else if (geojson.type === 'MultiLineString') {
+              const contains = geojson.coordinates.some(line =>
+                line.some(([lng, lat]) => isPointInBounds(lat, lng))
+              );
+              if (contains) console.log('Found multiline POI:', poi.name, 'type:', poi._type);
+              return contains;
+            }
+          } catch (err) {
+            console.error('Error parsing geometry:', err);
+          }
+        }
+        return false;
+      });
+
+      console.log('POIs found in bounds:', poisInBounds.length, poisInBounds.map(p => p.name));
+
+      // Call callback with found POIs
+      if (onPoisSelected && poisInBounds.length > 0) {
+        onPoisSelected(poisInBounds);
+      } else if (poisInBounds.length === 0) {
+        alert('No locations found in the selected area. Please draw a larger rectangle.');
+        // Re-enable drawing to try again
+        if (rectangleHandler) {
+          drawnItems.clearLayers();
+          rectangleHandler.enable();
+        }
+      }
+    };
+
+    map.on(L.Draw.Event.CREATED, onDrawCreated);
+
+    return () => {
+      map.off(L.Draw.Event.CREATED, onDrawCreated);
+      if (rectangleHandler) {
+        rectangleHandler.disable();
+      }
+      map.removeLayer(drawnItems);
+    };
+  }, [isActive, map, destinations, linearFeatures, onPoisSelected, visibleTypes, showTrails, showRivers, visibleBoundaries, getDestinationIconType]);
+
+  if (!isActive) return null;
+
+  const bannerText = mode === 'add'
+    ? 'Add Associations: Draw a rectangle around locations to add'
+    : 'Create Organization: Draw a rectangle around locations you want to associate';
+
+  return (
+    <div className="virtual-poi-creator-banner">
+      <div className="banner-content">
+        <strong>{bannerText}</strong>
+        <button onClick={onCancel} className="banner-close">Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+export default VirtualPoiCreator;


### PR DESCRIPTION
## Summary

Implements organizations - virtual entities that can be associated with multiple physical locations (POIs). Organizations appear in the Results panel when any of their associated locations are visible in the map viewport.

## Key Features

### Organization Creation
- ✅ Create organizations by drawing rectangles around locations on the map
- ✅ Automatic POI selection respects active legend filters (only includes visible types)
- ✅ Organizations are full-featured POIs with all standard fields
- ✅ Soft delete support allows name reuse after deletion

### Association Management
- ✅ **Add from Map**: Draw rectangle to select multiple locations at once
- ✅ **Add from List**: Individual selection with search/filter
- ✅ Remove associations with confirmation
- ✅ Many-to-many relationships (organizations can share locations)

### User Interface
- ✅ Organizations appear in Results when associated POIs are in viewport
- ✅ Full sidebar support: Info, History, News, Events, Associations tabs
- ✅ Visual indicator: "organization" badge/type in Results
- ✅ Auto-expanding textareas for descriptions
- ✅ Alphabetically sorted Points of Interest legend
- ✅ "All"/"None" buttons scoped to POI section only

### Google Sheets Sync
- ✅ Organizations in "Destinations" sheet with POI Type = "organization"
- ✅ New "Associations" sheet for organization-location links
- ✅ Bidirectional sync with name-based lookups (works across environments)
- ✅ Removed deprecated "Trails & Rivers" sheet (unified in Destinations)

## Technical Implementation

### Backend Changes

**Database Schema:**
- Add `poi_type='virtual'` support with all standard POI fields
- Create `poi_associations` junction table for many-to-many relationships
- Partial unique index on `pois(name, poi_type)` excluding deleted rows

**API Endpoints:**
- `POST /api/admin/pois` - Create virtual POI (organization)
- `POST /api/admin/poi-associations/batch` - Bulk create associations
- `GET /api/pois/:id/associations` - Get associations for a POI
- `DELETE /api/admin/poi-associations/:id` - Remove association
- `GET /api/pois/virtual-in-viewport?bounds=[s,w,n,e]` - Get virtual POIs with associated physical POIs in bounds

**Google Sheets Sync:**
- Map internal "virtual" type ↔ user-friendly "organization" for sheets
- `pushAssociationsToSheets()` - Push to "Associations" sheet
- `pullAssociationsFromSheets()` - Pull from "Associations" sheet
- Virtual POI pull/push support in `pullAllFromSheets()` and `pushAllToSheets()`

### Frontend Changes

**New Components:**
- `VirtualPoiCreator.jsx` - Rectangle drawing for POI selection (Leaflet.draw)
- Filters POIs by active legend selections during creation

**State Management:**
- `virtualPois` state for organizations
- `associations` state for organization-location links
- `isCreatingVirtualPoi` and `isDrawingAssociations` drawing modes
- Viewport filtering logic to show orgs when associated POIs visible

**UI Enhancements:**
- "Add from Map" and "Add from List" buttons in Associations tab
- Virtual POI icon (`thumbnails/virtual.svg`)
- Auto-expanding textareas (Brief Description, Historical Description)
- Alphabetically sorted Points of Interest with Trails/Rivers included
- Fixed "All"/"None" button scope (POI section only, not Boundaries)

## Database Migration

The schema changes are applied automatically via `server.js`:
```sql
-- Add poi_type='virtual' support
-- Create poi_associations table with foreign keys
-- Create partial unique index for name reuse after deletion
```

## Testing

Tested scenarios:
- ✅ Create organization by drawing rectangle
- ✅ Filter selection respects active legend filters
- ✅ Add associations via "Add from Map" (rectangle)
- ✅ Add associations via "Add from List" (individual selection)
- ✅ Organizations appear/disappear in Results based on viewport
- ✅ Delete organizations (soft delete, name reuse works)
- ✅ Push to Google Sheets (shows "organization" type)
- ✅ Associations sheet created with correct data
- ✅ Pull from Google Sheets (organizations and associations restored)

## Breaking Changes

None. This is a new feature that doesn't affect existing POI functionality.

## Future Enhancements

- Organization cluster icons on map (Phase 2)
- Bulk association editing
- Association metadata (e.g., relationship strength, notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)