### PR TITLE
Fix: Implement era_id foreign key for eras table

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -221,7 +221,7 @@ export function createAdminRouter(pool, clearThumbnailCache) {
     const { id } = req.params;
     const allowedFields = [
       'name', 'poi_type', 'latitude', 'longitude', 'geometry', 'geometry_drive_file_id',
-      'property_owner', 'owner_id', 'brief_description', 'era', 'historical_description',
+      'property_owner', 'owner_id', 'brief_description', 'era', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url',
       'length_miles', 'difficulty', 'boundary_type', 'boundary_color'
@@ -280,7 +280,7 @@ export function createAdminRouter(pool, clearThumbnailCache) {
     const { id } = req.params;
     const allowedFields = [
       'name', 'latitude', 'longitude', 'property_owner', 'owner_id', 'brief_description',
-      'era', 'historical_description', 'primary_activities', 'surface',
+      'era', 'era_id', 'historical_description', 'primary_activities', 'surface',
       'pets', 'cell_signal', 'more_info_link', 'events_url', 'news_url'
     ];
     const updates = {};
@@ -352,7 +352,7 @@ export function createAdminRouter(pool, clearThumbnailCache) {
     }
 
     const allowedFields = [
-      'property_owner', 'owner_id', 'brief_description', 'era', 'historical_description',
+      'property_owner', 'owner_id', 'brief_description', 'era', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url'
     ];
@@ -422,7 +422,7 @@ export function createAdminRouter(pool, clearThumbnailCache) {
     }
 
     const allowedFields = [
-      'poi_type', 'property_owner', 'owner_id', 'brief_description', 'era', 'historical_description',
+      'poi_type', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'image_drive_file_id'
     ];
@@ -2553,7 +2553,7 @@ export function createAdminRouter(pool, clearThumbnailCache) {
       const { id } = req.params;
       const allowedFields = [
         'name', 'poi_type', 'geometry', 'property_owner', 'owner_id', 'brief_description',
-        'era', 'historical_description', 'primary_activities', 'surface', 'pets',
+        'era', 'era_id', 'historical_description', 'primary_activities', 'surface', 'pets',
         'cell_signal', 'more_info_link', 'length_miles', 'difficulty',
         'boundary_type', 'boundary_color'
       ];

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -764,13 +764,18 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
             <div className="edit-section half">
               <label>Era</label>
               <select
-                value={editedData.era || ''}
-                onChange={(e) => handleChange('era', e.target.value)}
+                value={editedData.era_id || ''}
+                onChange={(e) => {
+                  const eraId = e.target.value ? parseInt(e.target.value) : null;
+                  const selectedEra = availableEras.find(era => era.id === eraId);
+                  handleChange('era_id', eraId);
+                  handleChange('era', selectedEra ? selectedEra.name : '');
+                }}
                 className="era-select"
               >
                 <option value="">Select an era...</option>
                 {availableEras.map(era => (
-                  <option key={era.id} value={era.name}>
+                  <option key={era.id} value={era.id}>
                     {era.name}
                     {era.year_start || era.year_end
                       ? ` (${era.year_start || ''}${era.year_start && era.year_end ? '-' : ''}${era.year_end || '+'})`


### PR DESCRIPTION
## Summary
- Add era_id column references to all backend API endpoints
- Update backend/server.js to return era_id and era_name via JOIN
- Update admin.js to accept era_id in allowedFields for all POI operations
- Update frontend Sidebar.jsx era dropdown to use era_id
- Update frontend NewPOIForm.jsx to use era dropdown with API fetch
- Fix run.sh test command to import seed data into test database

This replaces the free-form text era field with a proper foreign key relationship to the eras table, ensuring data consistency.

## Test plan
- [x] Run tests locally (`./run.sh test`) - all 27 tests pass
- [x] Build container (`./run.sh build`) - successful
- [ ] Manual testing: Edit a POI and verify era dropdown works
- [ ] Manual testing: Create a new POI and verify era dropdown works

🤖 Generated with [Claude Code](https://claude.com/claude-code)