### PR TITLE
Refactor: Remove era text field references from codebase

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -671,7 +671,7 @@ app.get('/api/pois', async (req, res) => {
     let query = `
       SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.image_mime_type, p.image_drive_file_id,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
@@ -703,7 +703,7 @@ app.get('/api/pois/:id', async (req, res) => {
     const result = await pool.query(`
       SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.image_mime_type, p.image_drive_file_id,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
@@ -1009,7 +1009,7 @@ app.get('/api/destinations', async (req, res) => {
     const result = await pool.query(`
       SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.image_mime_type, p.image_drive_file_id, p.news_url, p.events_url,
              p.locally_modified, p.deleted, p.synced, p.created_at, p.updated_at
@@ -1033,7 +1033,7 @@ app.get('/api/destinations/:id', async (req, res) => {
     const result = await pool.query(`
       SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.image_mime_type, p.image_drive_file_id, p.news_url, p.events_url,
              p.locally_modified, p.deleted, p.synced, p.created_at, p.updated_at
@@ -1083,7 +1083,7 @@ app.get('/api/linear-features', async (req, res) => {
     const result = await pool.query(`
       SELECT p.id, p.name, p.poi_type as feature_type, p.geometry,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.image_mime_type, p.image_drive_file_id,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
@@ -1107,7 +1107,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
     const result = await pool.query(`
       SELECT p.id, p.name, p.poi_type as feature_type, p.geometry,
              p.owner_id, o.name as owner_name, p.property_owner,
-             p.brief_description, p.era_id, e.name as era_name, p.era, p.historical_description,
+             p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.image_mime_type, p.image_drive_file_id,
              p.boundary_type, p.boundary_color,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -329,7 +329,7 @@ function AppContent() {
     }
 
     if (activeFilters.era) {
-      filtered = filtered.filter(d => d.era === activeFilters.era);
+      filtered = filtered.filter(d => d.era_name === activeFilters.era);
     }
 
     if (activeFilters.pets === 'yes') {
@@ -530,7 +530,6 @@ function AppContent() {
       longitude: coords.lng,
       property_owner: '',
       brief_description: '',
-      era: '',
       historical_description: '',
       primary_activities: '',
       surface: '',

--- a/frontend/src/components/NewPOIForm.jsx
+++ b/frontend/src/components/NewPOIForm.jsx
@@ -8,7 +8,6 @@ function NewPOIForm({ onClose, onCreate, initialCoords }) {
     owner_id: null,
     property_owner: '',
     brief_description: '',
-    era: '',
     era_id: null,
     historical_description: '',
     primary_activities: '',
@@ -161,9 +160,7 @@ function NewPOIForm({ onClose, onCreate, initialCoords }) {
                 value={formData.era_id || ''}
                 onChange={(e) => {
                   const eraId = e.target.value ? parseInt(e.target.value) : null;
-                  const selectedEra = availableEras.find(era => era.id === eraId);
                   handleChange('era_id', eraId);
-                  handleChange('era', selectedEra ? selectedEra.name : '');
                 }}
               >
                 <option value="">Select an era...</option>

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -65,8 +65,8 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual
           <span className={`poi-type-icon ${poiType}`}>
             {poiType === 'virtual' ? 'O' : poiType === 'destination' ? 'D' : poiType === 'trail' ? 'T' : poiType === 'river' ? 'R' : 'B'}
           </span>
-          {poi.era && (
-            <span className="results-tile-era">{poi.era}</span>
+          {poi.era_name && (
+            <span className="results-tile-era">{poi.era_name}</span>
           )}
           {isLinear && poi.difficulty && (
             <span className={`results-tile-difficulty ${poi.difficulty.toLowerCase()}`}>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -266,8 +266,8 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, showImage = true,
               {destination.difficulty}
             </span>
           )}
-          {destination.era && destination.poi_type !== 'virtual' && (
-            <span className="era-badge-large">{destination.era}</span>
+          {destination.era_name && destination.poi_type !== 'virtual' && (
+            <span className="era-badge-large">{destination.era_name}</span>
           )}
           {(destination.owner_name || destination.property_owner) && destination.poi_type !== 'virtual' && (
             <span className={`owner-badge ${getOwnerClass(destination.owner_name || destination.property_owner)}`}>
@@ -546,7 +546,6 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       // Update all fields that have data
       setEditedData(prev => ({
         ...prev,
-        era: data.era || prev.era,
         property_owner: data.property_owner || prev.property_owner,
         primary_activities: data.primary_activities || prev.primary_activities,
         surface: data.surface || prev.surface,
@@ -767,9 +766,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
                 value={editedData.era_id || ''}
                 onChange={(e) => {
                   const eraId = e.target.value ? parseInt(e.target.value) : null;
-                  const selectedEra = availableEras.find(era => era.id === eraId);
                   handleChange('era_id', eraId);
-                  handleChange('era', selectedEra ? selectedEra.name : '');
                 }}
                 className="era-select"
               >
@@ -1849,8 +1846,8 @@ function AssociationsModal({ isOpen, onClose, poi, associations, allDestinations
                           {associatedPoi._isOwned && (
                             <span className="owner-badge-small">Owned</span>
                           )}
-                          {associatedPoi.era && !associatedPoi._isVirtual && (
-                            <span className="association-item-era">{associatedPoi.era}</span>
+                          {associatedPoi.era_name && !associatedPoi._isVirtual && (
+                            <span className="association-item-era">{associatedPoi.era_name}</span>
                           )}
                         </div>
                         {associatedPoi.brief_description && (
@@ -2409,7 +2406,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         more_info_link: newOrganization.more_info_link || '',
         historical_description: '',
         primary_activities: '',
-        era: '',
         surface: '',
         pets: '',
         cell_signal: null


### PR DESCRIPTION
## Summary
This PR removes all references to the `era` text field from the application code, completing the migration to `era_id` foreign key.

**Backend changes:**
- Remove `era` column from all SELECT queries in server.js
- Remove `era` from all allowedFields arrays in admin.js
- Remove era name update logic when renaming eras (no longer needed)
- Update linear features CREATE to use `era_id` instead of `era`
- Keep era sync logic in sheetsSync.js for backward compatibility

**Frontend changes:**
- Update all components to use `era_name` from API instead of `era`
- Update era dropdown to only set `era_id` (not `era`)
- Remove `era` from initial state objects

**Database:**
The `era` text column still exists in the database for backward compatibility with Google Sheets sync, but is no longer used in the application code. All era display now uses `era_name` from JOIN with eras table.

After this PR is merged, we can drop the `era` column from the database in a follow-up migration.

## Test plan
- [x] Run tests locally (`./run.sh test`) - all 27 tests pass
- [x] Build container (`./run.sh build`) - successful
- [ ] Manual testing: Verify era badges display correctly
- [ ] Manual testing: Edit POI era and verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)