### PR TITLE
Make trails and rivers less obtrusive (Issue #27)

### DIFF
--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1292,8 +1292,10 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
     const viewSelectedColor = '#0066CC';
 
     if (feature.feature_type === 'river') {
+      // river - thinner solid line for less obtrusive appearance
       return {
-        ...baseStyle,
+        weight: isSelected ? 3 : 2,  // Thinner than base: 2 normal, 3 selected
+        opacity: isSelected ? 1 : 0.8,
         color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#1E90FF'
       };
     } else if (feature.feature_type === 'boundary') {
@@ -1312,9 +1314,11 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         opacity: 1
       };
     } else {
-      // trail
+      // trail - thinner and dashed for less obtrusive appearance
       return {
-        ...baseStyle,
+        weight: isSelected ? 3 : 2,  // Thinner than base: 2 normal, 3 selected
+        opacity: isSelected ? 1 : 0.8,
+        dashArray: '5, 5',  // Dashed line pattern
         color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#8B4513'
       };
     }


### PR DESCRIPTION
## Summary
- Reduce trail line weight from 6/8 to 2/3 (normal/selected) with dashed pattern
- Reduce river line weight from 6/8 to 2/3 (normal/selected) with solid lines
- Invisible hit area (weight 20) already exists for easy clicking

## Changes
- **Trails**: Thinner (weight 2/3) with 5px dashed pattern
- **Rivers**: Thinner (weight 2/3) with solid lines (no dashes)

## Testing
- ✅ Container builds successfully
- ✅ All 27 tests passing
- ✅ Manually verified visual appearance

Closes #27