### PR TITLE
Fix carousel collapse animation to eliminate white gap

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1016,14 +1016,17 @@ body {
   top: 0;
   z-index: 10;
   opacity: 1;
-  transform: translateY(0);
-  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  max-height: 200px; /* Enough for carousel + padding */
+  overflow: hidden;
+  transition: opacity 0.5s ease-out, max-height 0.5s ease-out, padding 0.5s ease-out;
 }
 
 /* Auto-hide carousel after 5 seconds of inactivity */
 .thumbnail-carousel-wrapper.hidden {
   opacity: 0;
-  transform: translateY(-100%);
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
   pointer-events: none;
 }
 
@@ -1066,7 +1069,7 @@ body {
   gap: 0.5rem;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 1rem 0.5rem 1rem;
+  padding: 0 1rem 1rem 1rem; /* Increased bottom padding to prevent scrollbar collision */
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;


### PR DESCRIPTION
## Problem

Production shows a white gap when the carousel hides instead of the POI panel moving up to fill the space. This works correctly in development but not in production.

**Root Cause:** PR #56 was squash-merged before the final CSS refinements were pushed. Production has the old `translateY(-100%)` approach which moves the carousel up but doesn't collapse its height, leaving empty white space.

## Solution

Change carousel hide animation from `transform: translateY(-100%)` to `max-height: 0` collapse:

### CSS Changes (App.css)

**Before:**
```css
.thumbnail-carousel-wrapper {
  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
}

.thumbnail-carousel-wrapper.hidden {
  opacity: 0;
  transform: translateY(-100%);
  pointer-events: none;
}
```

**After:**
```css
.thumbnail-carousel-wrapper {
  max-height: 200px;
  overflow: hidden;
  transition: opacity 0.5s ease-out, max-height 0.5s ease-out, padding 0.5s ease-out;
}

.thumbnail-carousel-wrapper.hidden {
  opacity: 0;
  max-height: 0;
  padding-top: 0;
  padding-bottom: 0;
  pointer-events: none;
}
```

### Additional Fix

- Increase carousel bottom padding from `0.5rem` to `1rem` to prevent scrollbar collision with highlighted thumbnails

## Benefits

- ✅ Carousel fully collapses when hidden (no white gap)
- ✅ POI panel moves up to fill reclaimed space
- ✅ Smooth transition for height and padding
- ✅ More space for carousel scrollbar (no collision)

## Test Results

✅ All 39 tests passing locally (100%)

## Related Issues

Fixes white gap issue reported in production after PR #56 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)