### PR TITLE
hotfix: create /tmp/pgsocket directory on PostgreSQL startup

### DIFF
--- a/Containerfile.base
+++ b/Containerfile.base
@@ -82,6 +82,9 @@ Environment=PGPORT=5432
 # Fix permissions on data directory (runs as root due to ! prefix)
 ExecStartPre=+/bin/bash -c 'mkdir -p /data/pgdata && chown -R postgres:postgres /data/pgdata && chmod 700 /data/pgdata'
 
+# Create socket directory (runs as root due to ! prefix)
+ExecStartPre=+/bin/bash -c 'mkdir -p /tmp/pgsocket && chmod 1777 /tmp/pgsocket'
+
 # Initialization script - creates DB if needed (runs as postgres user)
 ExecStartPre=/bin/bash -c 'if [ ! -f /data/pgdata/PG_VERSION ]; then /usr/pgsql-17/bin/initdb -D /data/pgdata; fi'
 


### PR DESCRIPTION
## Critical Production Hotfix

Fixes PostgreSQL startup failure in production.

### Problem
PostgreSQL systemd service fails with:
```
FATAL: could not create lock file "/tmp/pgsocket/.s.PGSQL.5432.lock": No such file or directory
```

### Root Cause
The production container doesn't use `--tmpfs /tmp/pgsocket` mount (unlike development), so the socket directory doesn't exist when PostgreSQL starts.

### Solution
Add `ExecStartPre` to postgresql.service systemd unit to create the socket directory with proper permissions (1777) before PostgreSQL starts.

### Testing
- ✅ Production manually fixed and running (site responding HTTP 200)
- ✅ Local development tested with hotfix
- ⏳ GitHub Actions will build and push fixed images

### Changes
- `Containerfile.base`: Add socket directory creation to postgresql.service ExecStartPre

### Deployment
Once merged, GitHub Actions will automatically:
1. Build base image with socket directory fix
2. Build app image using fixed base
3. Push both to quay.io
4. Production can pull latest image on next restart