### PR TITLE
Fix PostGIS dependency in trail status test

### DIFF
--- a/backend/tests/trailStatus.integration.test.js
+++ b/backend/tests/trailStatus.integration.test.js
@@ -63,28 +63,16 @@ describe('Trail Status Integration Tests', () => {
     `, [JSON.stringify(TWITTER_COOKIES)]);
     console.log(`[Test Setup] Inserted Twitter cookies for authenticated access`);
 
-    // Check if East Rim Trail exists
-    const existingResult = await pool.query(`
-      SELECT id FROM pois WHERE name = $1
-    `, [EAST_RIM_NAME]);
+    // Remove any existing East Rim trails to ensure clean state (including similar names)
+    await pool.query(`DELETE FROM pois WHERE name LIKE '%East Rim%'`);
+    console.log(`[Test Setup] Removed any existing East Rim trail entries`);
 
-    if (existingResult.rows.length > 0) {
-      // Update existing trail with status_url
-      await pool.query(`
-        UPDATE pois
-        SET status_url = $1
-        WHERE name = $2
-      `, [EAST_RIM_STATUS_URL, EAST_RIM_NAME]);
-      console.log(`[Test Setup] Updated ${EAST_RIM_NAME} with status_url: ${EAST_RIM_STATUS_URL}`);
-    } else {
-      // Create East Rim Trail if it doesn't exist
-      await pool.query(`
-        INSERT INTO pois (name, poi_type, status_url, brief_description, geometry)
-        VALUES ($1, 'trail', $2, 'MTB trail system in Cuyahoga Valley National Park',
-                ST_SetSRID(ST_Point(-81.5558, 41.2275), 4326))
-      `, [EAST_RIM_NAME, EAST_RIM_STATUS_URL]);
-      console.log(`[Test Setup] Created ${EAST_RIM_NAME} with status_url: ${EAST_RIM_STATUS_URL}`);
-    }
+    // Create East Rim Trail (without geometry - PostGIS not required for status testing)
+    await pool.query(`
+      INSERT INTO pois (name, poi_type, status_url, brief_description, latitude, longitude)
+      VALUES ($1, 'trail', $2, 'MTB trail system in Cuyahoga Valley National Park', 41.2275, -81.5558)
+    `, [EAST_RIM_NAME, EAST_RIM_STATUS_URL]);
+    console.log(`[Test Setup] Created ${EAST_RIM_NAME} with status_url: ${EAST_RIM_STATUS_URL}`);
 
     // Clear any existing trail status for East Rim to ensure fresh collection
     const poiResult = await pool.query(`SELECT id FROM pois WHERE name = $1`, [EAST_RIM_NAME]);


### PR DESCRIPTION
## Summary

Fixes the failing trail status integration test that required PostGIS extension.

## Problem

The test was failing in CI/CD with:
```
error: function st_point(numeric, numeric) does not exist
```

This was because:
- The test used PostGIS spatial functions `ST_Point()` and `ST_SetSRID()`
- PostGIS isn't available on RHEL 10 / UBI 10 yet
- The trail status collection feature doesn't actually need PostGIS

## Solution

- Replace PostGIS geometry field with simple `latitude` and `longitude` fields
- Remove any existing East Rim trails before test to prevent duplicates
- Simplified test setup by removing conditional update/insert logic

## Testing

✅ Container builds successfully
✅ Trail status test no longer requires PostGIS
✅ Test setup creates clean state for each run

## Impact

- Fixes failing CI/CD tests
- No functional changes to the application
- Trail status collection still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)