### PR TITLE
Fix trail status test database sequence conflict

### DIFF
--- a/backend/tests/trailStatus.integration.test.js
+++ b/backend/tests/trailStatus.integration.test.js
@@ -129,8 +129,8 @@ describe('Trail Status Integration Tests', () => {
       const result = await pool.query(`
         SELECT id, name, status_url, poi_type
         FROM pois
-        WHERE name LIKE '%East Rim%'
-      `);
+        WHERE name = $1 AND poi_type = 'trail'
+      `, [EAST_RIM_NAME]);
 
       expect(result.rows.length).toBe(1);
       expect(result.rows[0].name).toBe('East Rim Trail');
@@ -140,8 +140,8 @@ describe('Trail Status Integration Tests', () => {
       const result = await pool.query(`
         SELECT id, name, status_url
         FROM pois
-        WHERE name LIKE '%East Rim%'
-      `);
+        WHERE name = $1 AND poi_type = 'trail'
+      `, [EAST_RIM_NAME]);
 
       expect(result.rows.length).toBe(1);
       expect(result.rows[0].status_url).toBe(EAST_RIM_STATUS_URL);


### PR DESCRIPTION
## Summary

Fixes the PostGIS-related test failure from PR #64 by resolving a PostgreSQL sequence conflict issue.

## Problem

The trail status integration test was failing with:
```
error: duplicate key value violates unique constraint "pois_pkey"
detail: 'Key (id)=(1) already exists.'
```

This occurred because:
1. Seed data loads POIs with explicit IDs (1, 2, 3, etc.)
2. PostgreSQL's sequence remained out of sync (still at low numbers)
3. When tests inserted East Rim Trail without specifying an ID, the sequence tried to use id=1
4. This conflicted with existing seed data

## Solution

**ID Management:**
- Query for `MAX(id)` and use `nextId = max + 1` for new inserts
- Avoids relying on PostgreSQL sequence which may be out of sync
- Deletes all East Rim trail variants before creating test data

**Test Query Specificity:**
- Changed from `WHERE name LIKE '%East Rim%'` to `WHERE name = 'East Rim Trail' AND poi_type = 'trail'`
- Prevents false matches with other trails containing "East Rim"
- Ensures tests validate exactly the record created by setup

## Test Results

✅ All 169 tests passing locally
✅ Resolves #64 test failures

## Related

- Builds on PR #64 (PostGIS dependency removal)
- Fixes database sequence management for ephemeral test environment