### PR TITLE
Hotfix: increase mobile navigation test fallback timeout

### DIFF
--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -334,9 +334,9 @@ describe('UI Integration Tests', () => {
           await page.waitForTimeout(500);
         }
 
-        // Now wait for sidebar to open
+        // Now wait for sidebar to open (increased timeout for marker click)
         await page.waitForSelector('.sidebar.open', {
-          timeout: 5000,
+          timeout: 10000,  // Increased to match primary wait
           state: 'visible'
         });
       }


### PR DESCRIPTION
## Problem

The mobile navigation test failed in GitHub Actions because the fallback timeout was only 5 seconds, while the primary URL parameter wait was 10 seconds.

When the sidebar doesn't auto-open from the URL parameter (`?poi=trail-mix`), the test falls back to clicking a marker. But the marker click needs more time to open the sidebar.

## Fix

Increased the fallback `.waitForSelector('.sidebar.open')` timeout from 5000ms to 10000ms to match the primary wait.

## Testing

This is a 2-line change that only increases a timeout value. Low risk.

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>