### PR TITLE
Fix: increase mobile nav test timeout to 20s for CI

### DIFF
--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -318,25 +318,26 @@ describe('UI Integration Tests', () => {
       // Wait for map markers to load (indicates data is fetched)
       await page.waitForSelector('.leaflet-marker-icon', { timeout: 10000 });
 
-      // Wait for sidebar to open from URL parameter with increased timeout
+      // Wait for sidebar to open from URL parameter
       // The sidebar opening depends on React effects coordinating after data loads
+      // GitHub Actions environment is slower, so we need a longer timeout
       try {
         await page.waitForSelector('.sidebar.open', {
-          timeout: 10000,  // Increased from 5000ms
+          timeout: 20000,  // Increased to 20s for GitHub Actions
           state: 'visible'
         });
       } catch (error) {
         // If sidebar didn't auto-open from URL, click a marker as fallback
-        console.log('[Test] Sidebar did not auto-open from URL parameter, trying marker click');
+        console.log('[Test] Sidebar did not auto-open from URL parameter after 20s, trying marker click');
         const markers = await page.locator('.leaflet-marker-icon').all();
         if (markers.length > 0) {
           await markers[0].click();
-          await page.waitForTimeout(500);
+          await page.waitForTimeout(1000);
         }
 
-        // Now wait for sidebar to open (increased timeout for marker click)
+        // Final attempt: wait for sidebar to open after marker click
         await page.waitForSelector('.sidebar.open', {
-          timeout: 10000,  // Increased to match primary wait
+          timeout: 15000,  // Give marker click plenty of time
           state: 'visible'
         });
       }


### PR DESCRIPTION
## Problem

The mobile navigation test keeps failing in GitHub Actions CI because the environment is slower than local development. Even with a 10-second timeout, the React effects don't complete in time.

## Solution

Increase timeouts significantly for the GitHub Actions environment:
- **Primary URL parameter wait:** 10s → 20s
- **Fallback marker click delay:** 500ms → 1000ms  
- **Fallback sidebar wait:** 10s → 15s

## Why This Works

Local tests pass quickly because the environment is fast. GitHub Actions CI runners are resource-constrained and take longer for:
- Data fetching from 
- React effect execution
- DOM updates and sidebar rendering

## Testing

This test consistently passes locally in 13 seconds. Giving it 20+15 seconds provides a safe buffer for slower CI environments while still catching actual failures within a reasonable time.

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>