### PR TITLE
fix: increase sidebar timeout in flaky CI test

### DIFF
--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -393,8 +393,8 @@ describe('UI Integration Tests', () => {
       await page.waitForTimeout(1000);
       await page.locator('.leaflet-marker-icon').first().click();
 
-      // Wait for sidebar to open
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      // Wait for sidebar to open (increased timeout for CI environment)
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
 
       // More Info link is at bottom of scrollable content, so scroll down to see it
       const tabContent = await page.locator('.sidebar-tab-content');


### PR DESCRIPTION
## Summary
- Increase sidebar.open wait timeout from 5000ms to 10000ms
- Fixes intermittent test failure in GitHub Actions CI

## Test plan
- [x] Test passes locally
- CI will validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)