### PR TITLE
fix: increase sidebar.open timeout to 10000ms

### DIFF
--- a/backend/tests/issue63Regression.integration.test.js
+++ b/backend/tests/issue63Regression.integration.test.js
@@ -103,7 +103,7 @@ describe('Issue #63 Regression Tests', () => {
       await page.locator('.leaflet-marker-icon').first().click();
 
       // Wait for sidebar
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
 
       // Check sidebar positioning
       const sidebarPosition = await page.evaluate(() => {
@@ -133,7 +133,7 @@ describe('Issue #63 Regression Tests', () => {
       await page.locator('.leaflet-marker-icon').first().click();
 
       // Wait for sidebar and carousel
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
       await page.waitForSelector('.thumbnail-carousel', { timeout: 5000 });
 
       // Check carousel bottom padding - this provides the 16px spacing between carousel and content

--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -358,7 +358,7 @@ describe('UI Integration Tests', () => {
       await firstMarker.click();
 
       // Wait for sidebar to open
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
 
       // Wait for More Info link to appear (should be on Info tab by default)
       // Scroll to bottom of content to make link visible
@@ -431,7 +431,7 @@ describe('UI Integration Tests', () => {
       await page.locator('.leaflet-marker-icon').first().click();
 
       // Wait for sidebar to open
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
 
       // Wait for navigation buttons to appear
       await page.waitForSelector('.image-nav-btn', { timeout: 5000 });
@@ -522,7 +522,7 @@ describe('UI Integration Tests', () => {
       await page.locator('.leaflet-marker-icon').first().click();
 
       // Wait for sidebar to open
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
       await page.waitForSelector('.image-nav-btn', { timeout: 5000 });
 
       // Get initial POI name - re-query to avoid detachment
@@ -628,7 +628,7 @@ describe('UI Integration Tests', () => {
       await page.locator('.leaflet-marker-icon').first().click();
 
       // Wait for sidebar and carousel
-      await page.waitForSelector('.sidebar.open', { timeout: 5000 });
+      await page.waitForSelector('.sidebar.open', { timeout: 10000 });
       await page.waitForSelector('.thumbnail-carousel', { timeout: 5000 });
 
       // Verify carousel has thumbnails


### PR DESCRIPTION
## Summary

Fixes intermittent CI test failures by increasing sidebar open timeout from 5000ms to 10000ms.

## Changes

- **issue63Regression.integration.test.js**: Updated 2 instances
- **ui.integration.test.js**: Updated 4 instances

This ensures more reliable test execution in GitHub Actions CI where UI interactions can be slower than local environments.

## Test Plan

- [x] Tests pass locally (174/174 passing)
- [ ] CI validation in progress

Fixes #74