### PR TITLE
fix: allow tab navigation in edit mode for POIs and trails

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3086,45 +3086,39 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         <div className="sidebar-tabs">
           <button
             className={`sidebar-tab ${sidebarTab === 'view' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('view')}
-            disabled={isEditing && sidebarTab !== 'view'}
+            onClick={() => setSidebarTab('view')}
           >
             Info
           </button>
           {linearFeature?.status_url && (
             <button
               className={`sidebar-tab ${sidebarTab === 'status' ? 'active' : ''}`}
-              onClick={() => !isEditing && setSidebarTab('status')}
-              disabled={isEditing}
+              onClick={() => setSidebarTab('status')}
             >
               Status
             </button>
           )}
           <button
             className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('news')}
-            disabled={isEditing}
+            onClick={() => setSidebarTab('news')}
           >
             News
           </button>
           <button
             className={`sidebar-tab ${sidebarTab === 'events' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('events')}
-            disabled={isEditing}
+            onClick={() => setSidebarTab('events')}
           >
             Events
           </button>
           <button
             className={`sidebar-tab ${sidebarTab === 'history' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('history')}
-            disabled={isEditing}
+            onClick={() => setSidebarTab('history')}
           >
             History
           </button>
           <button
             className={`sidebar-tab ${sidebarTab === 'associations' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('associations')}
-            disabled={isEditing}
+            onClick={() => setSidebarTab('associations')}
           >
             Associations
           </button>
@@ -3403,45 +3397,39 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       <div className="sidebar-tabs">
         <button
           className={`sidebar-tab ${sidebarTab === 'view' ? 'active' : ''}`}
-          onClick={() => !isEditing && setSidebarTab('view')}
-          disabled={isEditing && sidebarTab !== 'view'}
+          onClick={() => setSidebarTab('view')}
         >
           Info
         </button>
         {destination?.status_url && (
           <button
             className={`sidebar-tab ${sidebarTab === 'status' ? 'active' : ''}`}
-            onClick={() => !isEditing && setSidebarTab('status')}
-            disabled={isEditing}
+            onClick={() => setSidebarTab('status')}
           >
             Status
           </button>
         )}
         <button
           className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
-          onClick={() => !isEditing && setSidebarTab('news')}
-          disabled={isEditing}
+          onClick={() => setSidebarTab('news')}
         >
           News
         </button>
         <button
           className={`sidebar-tab ${sidebarTab === 'events' ? 'active' : ''}`}
-          onClick={() => !isEditing && setSidebarTab('events')}
-          disabled={isEditing}
+          onClick={() => setSidebarTab('events')}
         >
           Events
         </button>
         <button
           className={`sidebar-tab ${sidebarTab === 'history' ? 'active' : ''}`}
-          onClick={() => !isEditing && setSidebarTab('history')}
-          disabled={isEditing}
+          onClick={() => setSidebarTab('history')}
         >
           History
         </button>
         <button
           className={`sidebar-tab ${sidebarTab === 'associations' ? 'active' : ''}`}
-          onClick={() => !isEditing && setSidebarTab('associations')}
-          disabled={isEditing}
+          onClick={() => setSidebarTab('associations')}
         >
           Associations
         </button>


### PR DESCRIPTION
Fixes #81 

## Problem
Users could not click on News, Events, History, and Associations tabs when in edit mode for POIs and trails. This prevented viewing these tabs while editing, making it impossible to verify or update related content.

## Solution
- Removed `!isEditing &&` condition from tab onClick handlers in both destination and linearFeature sections of Sidebar.jsx (lines 3086-3125 and 3396-3436)
- Removed `disabled={isEditing}` attributes from all sidebar tabs
- This allows users to freely navigate between tabs while in edit mode

## Testing
- All existing tests pass
- Manual testing recommended with Boston Cemetery or any POI in edit mode
- Verify tabs are clickable and functional in edit mode

## Changes
- `frontend/src/components/Sidebar.jsx` - Updated tab button onClick handlers and removed disabled attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)