### PR TITLE
fix: include night video URL in theme-config API response

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1178,6 +1178,14 @@ app.get('/api/theme-config', async (req, res) => {
         }
       }
 
+      // Also add night video if night mode is enabled
+      if (config.nightMode?.enabled) {
+        const nightUrl = await immichService.getThemeVideoUrl('night');
+        if (nightUrl) {
+          videoUrls['night'] = `/api/theme-video/night`;
+        }
+      }
+
       res.json({
         seasonal_themes: result.rows[0].value,
         video_urls: videoUrls


### PR DESCRIPTION
## Summary
- Fixed bug where night theme video wasn't loading because `/api/theme-config` didn't include the night video URL in the `video_urls` response
- The code only iterated through `config.themes[]` (7 seasonal themes) but didn't check `config.nightMode` for the night video

## Test plan
- [x] Verified `curl http://localhost:8080/api/theme-config | jq '.video_urls'` now includes `"night": "/api/theme-video/night"`
- [x] Verified `/api/theme-video/night` returns 200 OK with video/mp4 content
- [x] All tests pass (Vitest, Gourmand, ESLint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)