### PR TITLE
fix: prefetch listing pages and remove timeout cap in deep crawl

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -83,7 +83,7 @@ export async function extractPageContent(url, options = {}) {
         await page.goto(url, { waitUntil: 'networkidle', timeout });
       } catch (navError) {
         if (navError.message.includes('imeout')) {
-          await page.goto(url, { waitUntil: 'domcontentloaded', timeout: Math.min(timeout, 10000) });
+          await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
         } else {
           throw navError;
         }

--- a/backend/services/deepCrawler.js
+++ b/backend/services/deepCrawler.js
@@ -46,6 +46,9 @@ export function isGenericUrl(url) {
  * @param {boolean} options.sameOriginOnly - Only follow same-origin links (default true)
  * @param {number} options.timeoutMs - Overall timeout in ms (default 60000)
  * @param {Function} options.extractor - Content extraction function (default: extractPageContent). Accepts (url, opts).
+ * @param {Object} options.prefetched - Pre-rendered listing page data to skip Level 0 render
+ * @param {string} options.prefetched.markdown - Page content as markdown
+ * @param {Array} options.prefetched.links - Extracted links from the page
  * @returns {Promise<{foundUrl: string|null, foundContent: string|null, pagesChecked: number}>}
  */
 export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
@@ -54,7 +57,8 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
     maxPages = 5,
     sameOriginOnly = true,
     timeoutMs = 60000,
-    extractor = extractPageContent
+    extractor = extractPageContent,
+    prefetched = null
   } = options;
 
   const visited = new Set();
@@ -115,8 +119,33 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
     return { candidateLinks };
   }
 
-  const level0 = await crawlLevel([sourceUrl], 0);
-  if (level0.foundUrl) return { ...level0, pagesChecked };
+  let level0;
+  if (prefetched && prefetched.markdown) {
+    visited.add(sourceUrl);
+    if (contentMatchesItem(prefetched.markdown, item)) {
+      console.log(`[Deep Crawler] Match found at depth 0 (prefetched): ${sourceUrl}`);
+      return { foundUrl: sourceUrl, foundContent: prefetched.markdown, pagesChecked: 0 };
+    }
+    const candidateLinks = [];
+    if (prefetched.links && maxDepth > 0) {
+      for (const link of prefetched.links) {
+        if (sameOriginOnly) {
+          try {
+            if (new URL(link.url).origin !== sourceOrigin) continue;
+          } catch { continue; }
+        }
+        const desc = item.summary || item.description;
+        const score =
+          (item.title ? calculateSimilarity(item.title, link.text) * 3 + calculateSimilarity(item.title, link.context) * 2 : 0) +
+          (desc ? calculateSimilarity(desc, link.text) + calculateSimilarity(desc, link.context) * 0.5 : 0);
+        candidateLinks.push({ ...link, score });
+      }
+    }
+    level0 = { candidateLinks };
+  } else {
+    level0 = await crawlLevel([sourceUrl], 0);
+    if (level0.foundUrl) return { ...level0, pagesChecked };
+  }
 
   let currentCandidates = level0.candidateLinks || [];
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -967,27 +967,60 @@ Extract ALL news from this content using these relaxed criteria.`;
       console.log(`[Deep Crawl] ${deepCrawlCandidates.length} items have generic source URLs, attempting deep crawl...`);
       let deepCrawlFixed = 0;
 
+      // Group candidates by source_url to avoid rendering the same listing page multiple times
+      const bySourceUrl = new Map();
       for (const item of deepCrawlCandidates) {
+        const group = bySourceUrl.get(item.source_url) || [];
+        group.push(item);
+        bySourceUrl.set(item.source_url, group);
+      }
+
+      for (const [sourceUrl, items] of bySourceUrl) {
         checkCancellation();
+        console.log(`[Deep Crawl] Crawling ${sourceUrl} for ${items.length} items...`);
+
+        let prefetched = null;
         try {
-          const crawlResult = await deepCrawlForArticle(item.source_url, item, {
-            maxDepth: 2,
-            maxPages: 5,
-            timeoutMs: 45000
+          const listingPage = await extractPageContent(sourceUrl, {
+            timeout: 25000,
+            hardTimeout: 45000,
+            extractLinks: true
           });
-          if (crawlResult.foundUrl) {
-            console.log(`[Deep Crawl] ✓ "${item.title.substring(0, 50)}..." → ${crawlResult.foundUrl}`);
-            const sourceArray = item._type === 'event' ? result.events : result.news;
-            const original = sourceArray.find(i => i.title === item.title && i.source_url === item.source_url);
-            if (original) {
-              original.source_url = crawlResult.foundUrl;
-              deepCrawlFixed++;
-            }
+          if (listingPage.reachable) {
+            prefetched = { markdown: listingPage.markdown, links: listingPage.links || [] };
+            console.log(`[Deep Crawl] Extracted ${prefetched.links.length} links from listing page`);
           } else {
-            console.log(`[Deep Crawl] ✗ No match for "${item.title.substring(0, 50)}..." (checked ${crawlResult.pagesChecked} pages)`);
+            console.log(`[Deep Crawl] Failed to render listing page: ${listingPage.reason || 'no content'}`);
+            continue;
           }
         } catch (error) {
-          console.error(`[Deep Crawl] Error crawling for "${item.title.substring(0, 50)}...": ${error.message}`);
+          console.error(`[Deep Crawl] Error rendering listing page ${sourceUrl}: ${error.message}`);
+          continue;
+        }
+
+        for (const item of items) {
+          checkCancellation();
+          try {
+            const crawlResult = await deepCrawlForArticle(sourceUrl, item, {
+              maxDepth: 2,
+              maxPages: 5,
+              timeoutMs: 45000,
+              prefetched
+            });
+            if (crawlResult.foundUrl) {
+              console.log(`[Deep Crawl] ✓ "${item.title.substring(0, 50)}..." → ${crawlResult.foundUrl}`);
+              const sourceArray = item._type === 'event' ? result.events : result.news;
+              const original = sourceArray.find(i => i.title === item.title && i.source_url === item.source_url);
+              if (original) {
+                original.source_url = crawlResult.foundUrl;
+                deepCrawlFixed++;
+              }
+            } else {
+              console.log(`[Deep Crawl] ✗ No match for "${item.title.substring(0, 50)}..." (checked ${crawlResult.pagesChecked} pages)`);
+            }
+          } catch (error) {
+            console.error(`[Deep Crawl] Error crawling for "${item.title.substring(0, 50)}...": ${error.message}`);
+          }
         }
       }
 

--- a/backend/tests/deepCrawler.unit.test.js
+++ b/backend/tests/deepCrawler.unit.test.js
@@ -267,4 +267,63 @@ describe('deepCrawlForArticle', () => {
     expect(result.foundUrl).toBeNull();
     expect(result.pagesChecked).toBe(0);
   });
+
+  it('should use prefetched data and skip Level 0 render', async () => {
+    let renderCalls = [];
+    const extractor = async (url) => {
+      renderCalls.push(url);
+      if (url === 'https://example.com/news/trail-closure') {
+        return {
+          reachable: true,
+          markdown: 'Brandywine Falls trail closure announced for this weekend. Hikers should plan alternate routes.',
+          links: []
+        };
+      }
+      return { reachable: false, markdown: null, reason: 'not found' };
+    };
+
+    const result = await deepCrawlForArticle(
+      'https://example.com',
+      { title: 'Brandywine Falls Trail Closure This Weekend' },
+      {
+        maxDepth: 1,
+        maxPages: 3,
+        extractor,
+        prefetched: {
+          markdown: 'Welcome to our park. See latest news below.',
+          links: [
+            { url: 'https://example.com/news/trail-closure', text: 'Brandywine Falls Trail Closure', context: 'Trail closure notice for this weekend', className: '', parentClassName: '' }
+          ]
+        }
+      }
+    );
+
+    expect(result.foundUrl).toBe('https://example.com/news/trail-closure');
+    expect(renderCalls).not.toContain('https://example.com');
+    expect(result.pagesChecked).toBe(1);
+  });
+
+  it('should match on prefetched page content without rendering', async () => {
+    let renderCalls = [];
+    const extractor = async (url) => {
+      renderCalls.push(url);
+      return { reachable: false, markdown: null, reason: 'not found' };
+    };
+
+    const result = await deepCrawlForArticle(
+      'https://example.com/article',
+      { title: 'Brandywine Falls Trail Closure This Weekend' },
+      {
+        extractor,
+        prefetched: {
+          markdown: 'Brandywine Falls trail closure announced for this weekend. Hikers should plan alternate routes during maintenance.',
+          links: []
+        }
+      }
+    );
+
+    expect(result.foundUrl).toBe('https://example.com/article');
+    expect(renderCalls).toHaveLength(0);
+    expect(result.pagesChecked).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Group deep crawl candidates by source_url so listing pages are rendered once and shared via new `prefetched` option on `deepCrawlForArticle`, eliminating redundant Playwright renders (e.g., 6 events from /excursions no longer render /excursions 6 times)
- Remove the 10s cap on `domcontentloaded` fallback timeout in `contentExtractor.js` that was causing slow sites like cvsr.org/excursions to fail
- Add 2 new unit tests covering the prefetched data path

## Test plan
- [x] All existing tests pass (197 tests across 16 files)
- [x] 0 Gourmand violations, 0 ESLint errors
- [ ] Deploy to production and re-test CVSR events collection to verify deep crawl finds article pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)