### PR TITLE
feat: add PLAYWRIGHT_PROXY env var for VPN egress

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -52,7 +52,7 @@ export async function extractPageContent(url, options = {}) {
     });
 
     const extractionPromise = (async () => {
-      browser = await chromium.launch({
+      const launchOptions = {
         headless: true,
         args: [
           '--no-sandbox',
@@ -61,7 +61,11 @@ export async function extractPageContent(url, options = {}) {
           '--disable-accelerated-2d-canvas',
           '--disable-gpu'
         ]
-      });
+      };
+      if (process.env.PLAYWRIGHT_PROXY) {
+        launchOptions.proxy = { server: process.env.PLAYWRIGHT_PROXY };
+      }
+      browser = await chromium.launch(launchOptions);
 
       const context = await browser.newContext({
         userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',


### PR DESCRIPTION
## Summary
- Read `PLAYWRIGHT_PROXY` env var and pass it to Playwright's browser launch options
- When set (e.g., `http://expressvpn-proxy:8888`), all Playwright renders route through the proxy
- When unset, behavior is unchanged (direct connection)
- Enables bypassing IP-based blocking from sites that block datacenter IPs

## Test plan
- [x] All tests pass (proxy is optional, no behavior change when unset)
- [ ] Deploy with `PLAYWRIGHT_PROXY` pointing to ExpressVPN container, verify cvsr.org is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)