### PR TITLE
feat: Playwright proxy support + fix link preservation from thin pages

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -676,7 +676,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
           steps: ['Initialized', 'Extracted events page']
         });
       } else {
-        console.log(`[AI Research] ⚠️ Events page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+)`);
+        eventsLinks = extracted.links || [];
+        console.log(`[AI Research] ⚠️ Events page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+), kept ${eventsLinks.length} links`);
       }
     } else {
       console.log(`[AI Research] ❌ Failed to extract events page: ${extracted.reason || 'no content'}`);
@@ -714,7 +715,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
           steps: ['Initialized', 'Extracted news page']
         });
       } else {
-        console.log(`[AI Research] ⚠️ News page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+)`);
+        newsLinks = extracted.links || [];
+        console.log(`[AI Research] ⚠️ News page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+), kept ${newsLinks.length} links`);
       }
     } else {
       console.log(`[AI Research] ❌ Failed to extract news page: ${extracted.reason || 'no content'}`);


### PR DESCRIPTION
## Summary

- Add `PLAYWRIGHT_PROXY` env var support to contentExtractor.js so Playwright can route traffic through an HTTP proxy (e.g. ExpressVPN container for bypassing IP-based blocks)
- Fix link preservation from listing pages with insufficient text content — card/tile layout pages like `/excursions` have 142+ links but only ~147 chars of extractable text, causing both links AND text to be discarded when content falls below MIN_CONTENT_LENGTH threshold

## Test plan

- [x] `./run.sh build` succeeds
- [x] `./run.sh test` passes (215/216, 1 pre-existing trail status timeout)
- [ ] Deploy to Lotor and re-run CVSR events collection to verify deep event pages (e.g. `/excursions/themed-events/sail-by-rail`) are now discovered via preserved links

🤖 Generated with [Claude Code](https://claude.com/claude-code)