### PR TITLE
feat: disable search grounding for crawled dedicated URLs

### DIFF
--- a/backend/services/aiSearchFactory.js
+++ b/backend/services/aiSearchFactory.js
@@ -110,17 +110,17 @@ async function getConfig(pool) {
  * @param {Object} sheets - Optional Google Sheets API client (for Gemini API key restore)
  * @returns {Promise<{response: string, provider: string}>} - Generated text response and provider used
  */
-export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = null) {
+export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = null, options = {}) {
   const config = await getConfig(pool);
   debugLog(`[AI Search Factory] Config: primary=${config.primary}, fallback=${config.fallback}, limit=${config.primaryLimit}`);
 
   // Determine which provider to use
-  let provider = config.primary;
+  let provider = options.forceProvider || config.primary;
   const primaryUsage = currentJobUsage[config.primary] || 0;
   debugLog(`[AI Search Factory] Initial provider: ${provider}, usage: ${primaryUsage}`);
 
-  // Check if we've exceeded the primary limit
-  if (config.primaryLimit > 0 && primaryUsage >= config.primaryLimit) {
+  // Check if we've exceeded the primary limit (skip if provider was explicitly forced)
+  if (!options.forceProvider && config.primaryLimit > 0 && primaryUsage >= config.primaryLimit) {
     if (config.fallback && config.fallback !== 'none') {
       console.log(`[AI Search] Primary limit reached (${primaryUsage}/${config.primaryLimit}), switching to fallback: ${config.fallback}`);
       provider = config.fallback;
@@ -147,7 +147,7 @@ export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = 
     if (provider === 'gemini') {
       currentJobUsage.gemini++;
       console.log(`[AI Search] Calling Gemini (request #${currentJobUsage.gemini})`);
-      result = await geminiSearch(pool, customPrompt, sheets);
+      result = await geminiSearch(pool, customPrompt, sheets, options);
     } else {
       currentJobUsage.perplexity++;
       console.log(`[AI Search] Calling Perplexity (request #${currentJobUsage.perplexity})`);
@@ -171,7 +171,7 @@ export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = 
       try {
         if (fallbackProvider === 'gemini') {
           currentJobUsage.gemini++;
-          result = await geminiSearch(pool, customPrompt, sheets);
+          result = await geminiSearch(pool, customPrompt, sheets, options);
         } else {
           currentJobUsage.perplexity++;
           result = await perplexitySearch(pool, customPrompt, sheets);

--- a/backend/services/geminiService.js
+++ b/backend/services/geminiService.js
@@ -192,17 +192,20 @@ export async function generateText(pool, promptKey, destination, sheets = null) 
 /**
  * Generate text content using a custom prompt with Google Search grounding
  */
-export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = null) {
+export async function generateTextWithCustomPrompt(pool, customPrompt, sheets = null, options = {}) {
+  const { useSearchGrounding = true } = options;
   const genAI = await createGeminiClient(pool, sheets);
 
-  // Enable Google Search grounding
-  const model = genAI.getGenerativeModel({
+  const modelConfig = {
     model: 'gemini-2.5-flash',
-    tools: [{ googleSearch: {} }],
     generationConfig: { temperature: 0 }
-  });
+  };
+  if (useSearchGrounding) {
+    modelConfig.tools = [{ googleSearch: {} }];
+  }
+  const model = genAI.getGenerativeModel(modelConfig);
 
-  console.log(`Generating with custom prompt (${customPrompt.length} chars, with Google Search)`);
+  console.log(`Generating with custom prompt (${customPrompt.length} chars, ${useSearchGrounding ? 'with' : 'without'} Google Search)`);
 
   const generation = await model.generateContent(customPrompt);
   const response = generation.response;

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -884,14 +884,30 @@ Extract ALL news from this content using these relaxed criteria.`;
     const currentProgress = getCollectionProgress(poi.id);
     const initialProvider = currentProgress?.provider || 'perplexity';
 
+    // When we have rich crawled content from a dedicated URL, skip search grounding —
+    // the LLM just needs to extract structured data from what we already have
+    const hasDedicatedEventsContent = eventsUrl !== 'No dedicated events page' && renderedEventsContent;
+    const hasDedicatedNewsContent = newsUrl !== 'No dedicated news page' && renderedNewsContent;
+    const useSearchGrounding = !hasDedicatedEventsContent && !hasDedicatedNewsContent;
+
+    const aiOptions = {};
+    if (!useSearchGrounding) {
+      aiOptions.useSearchGrounding = false;
+      // Force Gemini for extraction — Perplexity always searches, defeating the purpose
+      aiOptions.forceProvider = 'gemini';
+      console.log(`[AI Research] Using Gemini without search grounding (have crawled content from dedicated URLs)`);
+    }
+
     updateProgress(poi.id, {
       phase: 'ai_search',
-      message: 'Searching with AI (Perplexity web search)...',
-      steps: ['Initialized', 'Rendered pages', 'Searching with AI']
+      message: useSearchGrounding
+        ? 'Searching with AI (web search)...'
+        : 'Extracting events/news from crawled content...',
+      steps: ['Initialized', 'Rendered pages', useSearchGrounding ? 'Searching with AI' : 'Extracting from content']
     });
 
-    debugLog(`[AI Research POI ${poi.id}] ====== BEFORE AI CALL (provider=${initialProvider}) ======`);
-    const aiResult = await generateTextWithCustomPrompt(pool, prompt, sheets);
+    debugLog(`[AI Research POI ${poi.id}] ====== BEFORE AI CALL (provider=${initialProvider}, searchGrounding=${useSearchGrounding}) ======`);
+    const aiResult = await generateTextWithCustomPrompt(pool, prompt, sheets, aiOptions);
     debugLog(`[AI Research POI ${poi.id}] ====== AFTER AI CALL ======`);
     debugLog(`[AI Research POI ${poi.id}] aiResult: ${JSON.stringify({
       type: typeof aiResult,


### PR DESCRIPTION
## Summary
- When a POI has a dedicated `events_url` or `news_url` with crawled content, skip Google Search grounding and force Gemini for pure LLM extraction
- Adds `useSearchGrounding` toggle to `geminiService.js` and `forceProvider` support to `aiSearchFactory.js`
- Reduces latency, cost, and hallucination risk when we already have 11K+ chars of source content

## Decision Logic
| Scenario | Search Grounding | Provider |
|----------|-----------------|----------|
| Dedicated URL + crawled content | OFF | Gemini (forced) |
| No dedicated URL (uses website) | ON | Config default |
| Dedicated URL but crawl empty | ON | Config default |

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` passes (0 errors, 79 pre-existing warnings)
- [ ] Deploy to Lotor, restart ROTV
- [ ] Delete existing CVSR events, kick off new collection
- [ ] Verify logs show `Using Gemini without search grounding` and `without Google Search`
- [ ] Confirm events extracted correctly from crawled content

🤖 Generated with [Claude Code](https://claude.com/claude-code)