### PR TITLE
fix: bump classifier page limits and add render delay

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -707,7 +707,7 @@ function filterDetailLinks(detailLinks, sourceUrl) {
  * @returns {Object} - { pages: [{url, markdown, title}], totalPagesRendered, totalDetailPages }
  */
 async function crawlWithClassification(pool, startUrl, contentType, poi, sheets, checkCancellation, options = {}) {
-  const { maxDepth = 2, maxPages = 15, maxDetailPages = 10, extractor = extractPageContent } = options;
+  const { maxDepth = 2, maxPages = 50, maxDetailPages = 30, renderDelayMs = 1500, extractor = extractPageContent } = options;
   const visited = new Set();
   let totalPagesRendered = 0;
   const collectedPages = []; // { url, markdown, title }
@@ -719,6 +719,11 @@ async function crawlWithClassification(pool, startUrl, contentType, poi, sheets,
       if (visited.has(url) || totalPagesRendered >= maxPages || collectedPages.length >= maxDetailPages) break;
       visited.add(url);
       totalPagesRendered++;
+
+      // Delay between renders to avoid rate limiting (Wix, etc.)
+      if (totalPagesRendered > 1) {
+        await new Promise(resolve => setTimeout(resolve, renderDelayMs));
+      }
 
       console.log(`[Classifier] Rendering (depth=${depth}, page=${totalPagesRendered}): ${url}`);
       const extracted = await extractor(url, { timeout: 30000, hardTimeout: 60000, extractLinks: true });


### PR DESCRIPTION
## Summary
- Increase `maxPages` from 15 to 50 — CVSR's excursions tree has 38 pages and the old limit only covered family-fun-loop
- Increase `maxDetailPages` from 10 to 30 to match
- Add 1.5s delay between page renders to avoid Wix rate limiting (was causing 20% timeout rate on CVSR)

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 215/216 pass (1 flaky pre-existing UI test)
- [ ] Deploy, re-run CVSR events, verify all 6 categories are reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)