### PR TITLE
fix: handle multiple dates on single event pages

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1052,6 +1052,11 @@ ${classifiedEventsContent}
 - Still exclude past events - only include upcoming/current events
 - Still require proper date formatting (YYYY-MM-DD) - interpret all dates in ${timezone} timezone
 
+**MULTIPLE DATES ON ONE PAGE**
+- If a single page lists multiple dates for the same event (e.g., "March 21" and "May 31"), create a SEPARATE event entry for each date
+- Each entry gets the same title, description, and source_url but a different start_date
+- This is common for recurring excursions — treat each date as its own event
+
 Extract ALL events from this content using these relaxed criteria.`;
   } else if (renderedEventsContent) {
     prompt += `\n\nEXTRACTED EVENTS PAGE CONTENT (markdown):\nWe rendered the events page and extracted this content:\n\n${renderedEventsContent}\n\n**SPECIAL INSTRUCTIONS FOR EXTRACTED EVENTS PAGE:**


### PR DESCRIPTION
## Summary
- Adds "MULTIPLE DATES ON ONE PAGE" instructions to the classifier extraction prompt
- When a single event page lists multiple dates (e.g., recurring excursions), Gemini now creates separate event entries for each date
- Each entry shares the same title, description, and source_url but gets a different start_date

## Test plan
- [ ] Delete CVSR events and re-run collection
- [ ] Verify trains-tracks-trails page produces two events (March 21 + May 31)
- [ ] Verify other multi-date pages also produce separate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)