### PR TITLE
feat: add Future/Past sub-tabs to Events tab

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1461,6 +1461,28 @@ app.get('/api/events/upcoming', async (req, res) => {
   }
 });
 
+// All past events across the park (public)
+app.get('/api/events/past', async (req, res) => {
+  try {
+    const limit = parseInt(req.query.limit) || 50;
+    const pastEventsQuery = await pool.query(`
+      SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type
+      FROM poi_events e
+      JOIN pois p ON e.poi_id = p.id
+      WHERE e.moderation_status IN ('published', 'auto_approved')
+        AND e.start_date < CURRENT_DATE
+        AND (p.deleted IS NULL OR p.deleted = FALSE)
+      ORDER BY e.start_date DESC
+      LIMIT $1
+    `, [limit]);
+    res.json(pastEventsQuery.rows);
+  } catch (error) {
+    console.error('Error fetching past events:', error);
+    res.status(500).json({ error: 'Failed to fetch past events' });
+  }
+});
+
 // Serve generated icons from database (public endpoint)
 app.get('/api/icons/:name.svg', async (req, res) => {
   try {

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -21,6 +21,9 @@ function ParkEvents({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinea
   const [error, setError] = useState(null);
   const stableBoundsRef = useRef(DEFAULT_PARK_BOUNDS);
   const [searchText, setSearchText] = useState('');
+  const [activeSubTab, setActiveSubTab] = useState('future');
+  const [pastEvents, setPastEvents] = useState([]);
+  const [pastLoading, setPastLoading] = useState(false);
   const [typeFilters, setTypeFilters] = useState({
     'hike': true,
     'race': true,
@@ -56,6 +59,27 @@ function ParkEvents({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinea
     }
   };
 
+  useEffect(() => {
+    if (activeSubTab === 'past' && pastEvents.length === 0 && !pastLoading) {
+      fetchPastEvents();
+    }
+  }, [activeSubTab]);
+
+  const fetchPastEvents = async () => {
+    setPastLoading(true);
+    try {
+      const response = await fetch('/api/events/past?limit=50');
+      if (response.ok) {
+        const data = await response.json();
+        setPastEvents(data);
+      }
+    } catch (err) {
+      console.error('Error fetching past events:', err);
+    } finally {
+      setPastLoading(false);
+    }
+  };
+
   // Simple, direct bounds computation - matches ResultsTab pattern
   let currentBounds;
   if (bypassViewportFilter) {
@@ -81,13 +105,14 @@ function ParkEvents({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinea
   const thumbnailBounds = stableBoundsRef.current;
 
   // Filter events based on visible POIs (destinations, linear features, and organizations)
+  const sourceEvents = activeSubTab === 'future' ? events : pastEvents;
   const filteredEvents = React.useMemo(() => {
     const hasDestinations = Array.isArray(filteredDestinations);
     const hasLinearFeatures = Array.isArray(filteredLinearFeatures);
     const hasVirtualPois = Array.isArray(filteredVirtualPois);
 
     // Start with all events or filter by visible POIs
-    let filtered = events;
+    let filtered = sourceEvents;
 
     // If all filters are explicitly empty arrays, show no events (all filters deselected)
     if (hasDestinations && filteredDestinations.length === 0 &&
@@ -111,7 +136,7 @@ function ParkEvents({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinea
     filtered = filtered.filter(item => typeFilters[item.event_type || 'program'] !== false);
 
     return filtered;
-  }, [events, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, searchText, typeFilters]);
+  }, [sourceEvents, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, searchText, typeFilters]);
 
   const generateCalendarUrl = (event) => {
     const title = encodeURIComponent(event.title);
@@ -162,19 +187,36 @@ END:VCALENDAR`;
     URL.revokeObjectURL(url);
   };
 
-  if (loading) {
+  const isLoading = activeSubTab === 'future' ? loading : pastLoading;
+  const tabLabel = activeSubTab === 'future' ? 'Future Events' : 'Past Events';
+
+  if (isLoading) {
     return (
       <div className="park-events-tab">
-        <h2>Upcoming Events</h2>
+        <h2>{tabLabel}</h2>
+        <div className="results-subtabs">
+          <button
+            className={`results-subtab ${activeSubTab === 'future' ? 'active' : ''}`}
+            onClick={() => setActiveSubTab('future')}
+          >
+            Future
+          </button>
+          <button
+            className={`results-subtab ${activeSubTab === 'past' ? 'active' : ''}`}
+            onClick={() => setActiveSubTab('past')}
+          >
+            Past
+          </button>
+        </div>
         <div className="loading-indicator">Loading events...</div>
       </div>
     );
   }
 
-  if (error) {
+  if (error && activeSubTab === 'future') {
     return (
       <div className="park-events-tab">
-        <h2>Upcoming Events</h2>
+        <h2>{tabLabel}</h2>
         <div className="error-message">{error}</div>
       </div>
     );
@@ -183,8 +225,24 @@ END:VCALENDAR`;
   return (
     <div className="park-events-tab">
       <div className="news-events-header">
-        <h2>Upcoming Events</h2>
+        <h2>{tabLabel}</h2>
         <p className="tab-subtitle">Events across Cuyahoga Valley National Park</p>
+      </div>
+
+      {/* Sub-tabs */}
+      <div className="results-subtabs">
+        <button
+          className={`results-subtab ${activeSubTab === 'future' ? 'active' : ''}`}
+          onClick={() => setActiveSubTab('future')}
+        >
+          Future
+        </button>
+        <button
+          className={`results-subtab ${activeSubTab === 'past' ? 'active' : ''}`}
+          onClick={() => setActiveSubTab('past')}
+        >
+          Past
+        </button>
       </div>
 
       <div className="results-filters">
@@ -218,7 +276,7 @@ END:VCALENDAR`;
           ))}
         </div>
         <div className="results-count">
-          Showing {filteredEvents.length} of {events.length} events
+          Showing {filteredEvents.length} of {sourceEvents.length} events
         </div>
       </div>
 
@@ -226,9 +284,9 @@ END:VCALENDAR`;
         <div className="news-events-content">
           {filteredEvents.length === 0 ? (
             <p className="no-content">
-              {events.length > 0
+              {sourceEvents.length > 0
                 ? 'No events match the current filters. Try adjusting the type filters above or the map view.'
-                : 'No upcoming events found.'}
+                : activeSubTab === 'future' ? 'No upcoming events found.' : 'No past events found.'}
             </p>
           ) : (
           <div className="park-events-list">


### PR DESCRIPTION
## Summary
- Adds `/api/events/past` backend endpoint (mirrors upcoming, ordered DESC, parameterized limit)
- Adds Future/Past sub-tab buttons to the Events tab, reusing `.results-subtabs` CSS from ResultsTab
- Past events load on-demand when the user clicks "Past"; filters and search work identically

Closes #113

## Test plan
- [x] `./run.sh build` succeeds
- [x] `./run.sh test` passes (215/216, pre-existing Leaflet flake)
- [x] Events tab defaults to "Future" sub-tab with upcoming events
- [x] Clicking "Past" loads past events (most recent first)
- [x] Type filters and search work on both sub-tabs
- [x] Verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)