### PR TITLE
feat: add pagination to News tab

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1423,7 +1423,7 @@ app.get('/api/trail-status/mtb-trails', async (req, res) => {
 // All recent news across the park (public)
 app.get('/api/news/recent', async (req, res) => {
   try {
-    const limit = parseInt(req.query.limit) || 20;
+    const limit = parseInt(req.query.limit) || 500;
     const recentNewsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.published_at, n.created_at, p.id as poi_id, p.name as poi_name, p.poi_type

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10641,6 +10641,40 @@ img.type-filter-icon {
   font-weight: 500;
 }
 
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px 0;
+  margin-top: 8px;
+}
+
+.pagination-btn {
+  padding: 8px 20px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: white;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
 .results-tab-list {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -14,6 +14,8 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
   const [error, setError] = useState(null);
   const stableBoundsRef = useRef(DEFAULT_PARK_BOUNDS);
   const [searchText, setSearchText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 50;
   const [typeFilters, setTypeFilters] = useState({
     general: true,
     alert: true,
@@ -30,7 +32,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/news/recent?limit=50');
+      const response = await fetch('/api/news/recent');
       if (response.ok) {
         const data = await response.json();
         setNews(data);
@@ -101,6 +103,12 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
     return filtered;
   }, [news, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, searchText, typeFilters]);
 
+  const totalPages = Math.ceil(filteredNews.length / PAGE_SIZE);
+  const paginatedNews = filteredNews.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
   if (loading) {
     return (
       <div className="park-news-tab">
@@ -132,7 +140,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
           className="results-search-input"
           placeholder="Search news by title, summary, or location..."
           value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
+          onChange={(e) => { setSearchText(e.target.value); setCurrentPage(1); }}
         />
         <div className="results-type-filters">
           {[
@@ -145,7 +153,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
             <div
               key={f.key}
               className={`type-filter-chip ${f.key} ${typeFilters[f.key] ? 'active' : 'inactive'}`}
-              onClick={() => setTypeFilters(prev => ({ ...prev, [f.key]: !prev[f.key] }))}
+              onClick={() => { setTypeFilters(prev => ({ ...prev, [f.key]: !prev[f.key] })); setCurrentPage(1); }}
             >
               <span className="type-filter-icon">{f.icon}</span>
               {f.label}
@@ -153,7 +161,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
           ))}
         </div>
         <div className="results-count">
-          Showing {filteredNews.length} of {news.length} news items
+          Showing {filteredNews.length === 0 ? '0' : `${((currentPage - 1) * PAGE_SIZE) + 1}-${Math.min(currentPage * PAGE_SIZE, filteredNews.length)}`} of {filteredNews.length} news items
         </div>
       </div>
 
@@ -167,7 +175,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
             </p>
           ) : (
           <div className="park-news-list">
-        {filteredNews.map(item => (
+        {paginatedNews.map(item => (
           <div key={item.id} className={`park-news-item ${item.news_type || 'general'}`}>
             <div className="park-news-header">
               <NewsTypeIcon type={item.news_type} />
@@ -200,6 +208,27 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
           </div>
         ))}
           </div>
+          )}
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p - 1)}
+                disabled={currentPage === 1}
+              >
+                Back
+              </button>
+              <span className="pagination-info">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p + 1)}
+                disabled={currentPage === totalPages}
+              >
+                Next
+              </button>
+            </div>
           )}
         </div>
         {/* Map thumbnail sidebar */}


### PR DESCRIPTION
## Summary
- Raised backend default limit on `/api/news/recent` from 20 to 500 to fetch all news
- Added client-side pagination with 50 items per page, Back/Next buttons, and range display
- Page resets to 1 when search text or type filters change

Closes #114

## Test plan
- [x] `./run.sh build` — container builds
- [x] `./run.sh test` — all tests pass
- [x] News tab shows first 50 items with "Showing 1-50 of N" count
- [x] Next/Back buttons navigate pages correctly
- [x] Search and type filters reset page to 1
- [x] Last page shows correct partial range

🤖 Generated with [Claude Code](https://claude.com/claude-code)