### PR TITLE
fix: reject auth when MCP_ADMIN_TOKEN is unset

### DIFF
--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -778,7 +778,7 @@ export function startMcpServer(pool, boss, port = 3001) {
     const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
     const expected = Buffer.from(process.env.MCP_ADMIN_TOKEN || '');
     const provided = Buffer.from(token || '');
-    if (expected.length !== provided.length || !crypto.timingSafeEqual(expected, provided)) {
+    if (expected.length === 0 || expected.length !== provided.length || !crypto.timingSafeEqual(expected, provided)) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;


### PR DESCRIPTION
## Summary
- Adds `expected.length === 0` guard before `timingSafeEqual` comparison
- Prevents unauthenticated access when `MCP_ADMIN_TOKEN` env var is missing or empty
- Flagged by Gemini code review on PR #129

## Test plan
- [x] If token is unset, all MCP requests return 401
- [x] If token is set, valid bearer tokens still authenticate

🤖 Generated with [Claude Code](https://claude.com/claude-code)