### PR TITLE
fix: prevent Fix URL from auto-approving moderation items

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -86,7 +86,8 @@ import {
   researchItem,
   fixDate,
   createItem,
-  purgeRejected
+  purgeRejected,
+  processItem
 } from '../services/moderationService.js';
 import { getJobStats, resetJobUsage } from '../services/aiSearchFactory.js';
 import {
@@ -4618,8 +4619,6 @@ export function createAdminRouter(pool) {
         return res.status(400).json({ error: 'Fix URL is not available for photos' });
       }
       const result = await researchItem(pool, type, id);
-      // Queue a moderation job for the requeued item
-      await queueModerationJob(type, id);
       res.json({ success: true, ...result });
     } catch (error) {
       console.error('Error fixing URL:', error);

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -126,8 +126,8 @@ async function attemptDeepCrawl(pool, contentType, contentId, row, scoring) {
  * @param {string} contentType - 'news', 'event', or 'photo'
  * @param {number} contentId - ID of the content to moderate
  */
-export async function processItem(pool, contentType, contentId) {
-  console.log(`[Moderation] Processing ${contentType} #${contentId}`);
+export async function processItem(pool, contentType, contentId, { forceStatus = null } = {}) {
+  console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
     `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold', 'moderation_auto_reject_floor')`
@@ -223,7 +223,8 @@ export async function processItem(pool, contentType, contentId) {
     }
 
     // Hold items with unknown publication date for human review regardless of score
-    const resolvedStatus = newsDateConf === 'unknown' ? 'pending'
+    const resolvedStatus = forceStatus ? forceStatus
+      : newsDateConf === 'unknown' ? 'pending'
       : autoApproveEnabled && scoring.confidence_score >= threshold ? 'auto_approved'
       : 'pending';
 
@@ -320,7 +321,8 @@ export async function processItem(pool, contentType, contentId) {
     }
 
     // Hold items with unknown publication date for human review regardless of score
-    const resolvedStatus = eventDateConf === 'unknown' ? 'pending'
+    const resolvedStatus = forceStatus ? forceStatus
+      : eventDateConf === 'unknown' ? 'pending'
       : autoApproveEnabled && scoring.confidence_score >= threshold ? 'auto_approved'
       : 'pending';
 
@@ -349,7 +351,8 @@ export async function processItem(pool, contentType, contentId) {
       image_url: imageUrl
     });
 
-    const resolvedStatus = autoApproveEnabled && scoring.confidence_score >= threshold
+    const resolvedStatus = forceStatus ? forceStatus
+      : autoApproveEnabled && scoring.confidence_score >= threshold
       ? 'auto_approved' : 'pending';
 
     await pool.query(
@@ -631,8 +634,6 @@ Summarize what you found in 1-2 sentences.`;
   } else {
     console.log(`[Moderation] Fix URL for ${contentType} #${contentId}: no new URL found`);
   }
-
-  await requeueItem(pool, contentType, contentId);
 
   return {
     researched: true,


### PR DESCRIPTION
## Summary
- Fix URL was requeuing items and re-running AI moderation, which auto-approved items that scored above the threshold
- Now Fix URL only updates the `source_url` without requeuing or re-moderating — same behavior as Fix Date
- Adds `forceStatus` option to `processItem()` for future callers that need to override auto-approve

## Test plan
- [x] Full build passes
- [x] All 216 tests pass (16 test files)
- [ ] Verify Fix URL updates the URL but leaves item in pending status
- [ ] Verify Fix Date still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)