### PR TITLE
feat: multiple URLs per news/event item with merge UI

### DIFF
--- a/backend/migrations/007_news_multi_url.sql
+++ b/backend/migrations/007_news_multi_url.sql
@@ -1,0 +1,22 @@
+-- Migration 007: Add junction tables for multiple URLs per news/event item
+-- Allows dedup pipeline to merge URLs into existing items instead of creating duplicates
+
+CREATE TABLE IF NOT EXISTS poi_news_urls (
+    id SERIAL PRIMARY KEY,
+    news_id INTEGER NOT NULL REFERENCES poi_news(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    source_name VARCHAR(255),
+    discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_news_urls_unique ON poi_news_urls(news_id, url);
+CREATE INDEX IF NOT EXISTS idx_poi_news_urls_url ON poi_news_urls(url);
+
+CREATE TABLE IF NOT EXISTS poi_event_urls (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER NOT NULL REFERENCES poi_events(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    source_name VARCHAR(255),
+    discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_event_urls_unique ON poi_event_urls(event_id, url);
+CREATE INDEX IF NOT EXISTS idx_poi_event_urls_url ON poi_event_urls(url);

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -87,7 +87,11 @@ import {
   fixDate,
   createItem,
   purgeRejected,
-  processItem
+  processItem,
+  mergeItems,
+  getMergeCandidates,
+  addItemUrl,
+  removeItemUrl
 } from '../services/moderationService.js';
 import { getJobStats, resetJobUsage } from '../services/aiSearchFactory.js';
 import {
@@ -4591,6 +4595,21 @@ export function createAdminRouter(pool) {
     }
   });
 
+  // Save edits without publishing
+  router.post('/moderation/save', isAdmin, async (req, res) => {
+    try {
+      const { type, id, edits } = req.body;
+      if (!type || !id || !edits) {
+        return res.status(400).json({ error: 'type, id, and edits are required' });
+      }
+      await editAndPublish(pool, type, id, edits, req.user.id, { publish: false });
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error saving edits:', error);
+      res.status(500).json({ error: 'Failed to save edits' });
+    }
+  });
+
   // Requeue for re-review
   router.post('/moderation/requeue', isAdmin, async (req, res) => {
     try {
@@ -4671,6 +4690,69 @@ export function createAdminRouter(pool) {
     } catch (error) {
       console.error('Error creating content:', error);
       res.status(500).json({ error: 'Failed to create content' });
+    }
+  });
+
+  // Get merge candidates — other items from the same POI
+  router.get('/moderation/merge-candidates/:type/:id', isAdmin, async (req, res) => {
+    try {
+      const { type, id } = req.params;
+      if (!['news', 'event'].includes(type)) {
+        return res.status(400).json({ error: 'type must be news or event' });
+      }
+      const candidates = await getMergeCandidates(pool, type, parseInt(id));
+      res.json(candidates);
+    } catch (error) {
+      console.error('Error fetching merge candidates:', error);
+      res.status(500).json({ error: error.message || 'Failed to fetch merge candidates' });
+    }
+  });
+
+  // Merge two news/event items (moves source URLs into target, deletes source)
+  router.post('/moderation/merge', isAdmin, async (req, res) => {
+    try {
+      const { type, sourceId, targetId } = req.body;
+      if (!type || !sourceId || !targetId) {
+        return res.status(400).json({ error: 'type, sourceId, and targetId are required' });
+      }
+      if (!['news', 'event'].includes(type)) {
+        return res.status(400).json({ error: 'Merge is only supported for news and event items' });
+      }
+      const result = await mergeItems(pool, type, parseInt(sourceId), parseInt(targetId));
+      res.json({ success: true, ...result });
+    } catch (error) {
+      console.error('Error merging items:', error);
+      res.status(500).json({ error: error.message || 'Failed to merge items' });
+    }
+  });
+
+  // Add a URL to an existing news/event item
+  router.post('/moderation/add-url', isAdmin, async (req, res) => {
+    try {
+      const { type, id, url, sourceName } = req.body;
+      if (!type || !id || !url) {
+        return res.status(400).json({ error: 'type, id, and url are required' });
+      }
+      const result = await addItemUrl(pool, type, parseInt(id), url, sourceName || null);
+      res.json({ success: true, ...result });
+    } catch (error) {
+      console.error('Error adding URL:', error);
+      res.status(500).json({ error: error.message || 'Failed to add URL' });
+    }
+  });
+
+  // Remove a URL from a news/event item
+  router.post('/moderation/remove-url', isAdmin, async (req, res) => {
+    try {
+      const { type, id, urlId } = req.body;
+      if (!type || !id || !urlId) {
+        return res.status(400).json({ error: 'type, id, and urlId are required' });
+      }
+      const result = await removeItemUrl(pool, type, parseInt(id), parseInt(urlId));
+      res.json({ success: true, ...result });
+    } catch (error) {
+      console.error('Error removing URL:', error);
+      res.status(500).json({ error: error.message || 'Failed to remove URL' });
     }
   });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -563,6 +563,30 @@ async function initDatabase() {
     await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_events_poi_id ON poi_events(poi_id)`);
     await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_events_start_date ON poi_events(start_date)`);
 
+    // Junction tables for multiple URLs per news/event item
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS poi_news_urls (
+        id SERIAL PRIMARY KEY,
+        news_id INTEGER NOT NULL REFERENCES poi_news(id) ON DELETE CASCADE,
+        url TEXT NOT NULL,
+        source_name VARCHAR(255),
+        discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_news_urls_unique ON poi_news_urls(news_id, url)`);
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_news_urls_url ON poi_news_urls(url)`);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS poi_event_urls (
+        id SERIAL PRIMARY KEY,
+        event_id INTEGER NOT NULL REFERENCES poi_events(id) ON DELETE CASCADE,
+        url TEXT NOT NULL,
+        source_name VARCHAR(255),
+        discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_event_urls_unique ON poi_event_urls(event_id, url)`);
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_event_urls_url ON poi_event_urls(url)`);
+
     // News job status tracking
     await client.query(`
       CREATE TABLE IF NOT EXISTS news_job_status (
@@ -1268,14 +1292,16 @@ app.get('/api/pois/:id/news', async (req, res) => {
     const { id } = req.params;
     const limit = parseInt(req.query.limit) || 50;
     const newsQuery = await pool.query(`
-      SELECT id, title, summary, source_url, source_name, news_type,
-             published_at, publication_date, date_confidence, created_at
-      FROM poi_news
-      WHERE poi_id = $1
-        AND moderation_status IN ('published', 'auto_approved')
+      SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
+             n.published_at, n.publication_date, n.date_confidence, n.created_at,
+             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
+                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
+      FROM poi_news n
+      WHERE n.poi_id = $1
+        AND n.moderation_status IN ('published', 'auto_approved')
       ORDER BY
-        COALESCE(publication_date, created_at::date) DESC,
-        created_at DESC
+        COALESCE(n.publication_date, n.created_at::date) DESC,
+        n.created_at DESC
       LIMIT $2
     `, [id, limit]);
     res.json(newsQuery.rows);
@@ -1291,15 +1317,17 @@ app.get('/api/pois/:id/events', async (req, res) => {
     const upcomingOnly = req.query.upcoming !== 'false';
     const limit = parseInt(req.query.limit) || 50;
     let query = `
-      SELECT id, title, description, start_date, end_date, event_type, location_details, source_url, created_at
-      FROM poi_events
-      WHERE poi_id = $1
-        AND moderation_status IN ('published', 'auto_approved')
+      SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type, e.location_details, e.source_url, e.created_at,
+             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
+                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+      FROM poi_events e
+      WHERE e.poi_id = $1
+        AND e.moderation_status IN ('published', 'auto_approved')
     `;
     if (upcomingOnly) {
-      query += ` AND start_date >= CURRENT_DATE`;
+      query += ` AND e.start_date >= CURRENT_DATE`;
     }
-    query += ` ORDER BY start_date ASC LIMIT $2`;
+    query += ` ORDER BY e.start_date ASC LIMIT $2`;
 
     const eventsQuery = await pool.query(query, [id, limit]);
     res.json(eventsQuery.rows);
@@ -1432,7 +1460,9 @@ app.get('/api/news/recent', async (req, res) => {
     const recentNewsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.published_at, n.publication_date, n.date_confidence, n.created_at,
-             p.id as poi_id, p.name as poi_name, p.poi_type
+             p.id as poi_id, p.name as poi_name, p.poi_type,
+             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
+                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
       WHERE n.moderation_status IN ('published', 'auto_approved')
@@ -1452,7 +1482,9 @@ app.get('/api/events/upcoming', async (req, res) => {
   try {
     const upcomingEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
+             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
+                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
@@ -1473,7 +1505,9 @@ app.get('/api/events/past', async (req, res) => {
     const limit = parseInt(req.query.limit) || 50;
     const pastEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
+             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
+                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
       WHERE e.moderation_status IN ('published', 'auto_approved')

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -453,7 +453,7 @@ export async function bulkApprove(pool, items, adminUserId) {
   return { approved };
 }
 
-export async function editAndPublish(pool, contentType, contentId, edits, adminUserId) {
+export async function editAndPublish(pool, contentType, contentId, edits, adminUserId, { publish = true } = {}) {
   const EDITABLE_NEWS = ['title', 'summary', 'source_url', 'source_name', 'news_type', 'poi_id', 'publication_date'];
   const EDITABLE_EVENT = ['title', 'description', 'start_date', 'end_date', 'event_type', 'location_details', 'source_url', 'poi_id', 'publication_date'];
   const EDITABLE_PHOTO = ['caption', 'poi_id'];
@@ -479,7 +479,11 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
     setClauses.push(`date_confidence = 'exact'`);
   }
 
-  setClauses.push(`moderation_status = 'published'`, `moderated_by = $1`, `moderated_at = CURRENT_TIMESTAMP`);
+  if (publish) {
+    setClauses.push(`moderation_status = 'published'`, `moderated_by = $1`, `moderated_at = CURRENT_TIMESTAMP`);
+  }
+
+  if (setClauses.length === 0) return;
   await pool.query(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $2`, values);
 }
 
@@ -744,19 +748,22 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
     SELECT id, 'news' AS content_type, poi_id, title, summary AS description,
            moderation_status, confidence_score, ai_reasoning, ai_issues,
            submitted_by, moderated_by, moderated_at, created_at, source_url,
-           content_source, publication_date, date_confidence
+           content_source, publication_date, date_confidence,
+           (SELECT COUNT(*) FROM poi_news_urls WHERE news_id = poi_news.id)::int AS additional_url_count
     FROM poi_news WHERE moderation_status = ANY($1)
     UNION ALL
     SELECT id, 'event' AS content_type, poi_id, title, description,
            moderation_status, confidence_score, ai_reasoning, ai_issues,
            submitted_by, moderated_by, moderated_at, created_at, source_url,
-           content_source, publication_date, date_confidence
+           content_source, publication_date, date_confidence,
+           (SELECT COUNT(*) FROM poi_event_urls WHERE event_id = poi_events.id)::int AS additional_url_count
     FROM poi_events WHERE moderation_status = ANY($1)
     UNION ALL
     SELECT id, 'photo' AS content_type, poi_id, original_filename AS title, caption AS description,
            moderation_status, confidence_score, ai_reasoning, NULL AS ai_issues,
            submitted_by, moderated_by, moderated_at, created_at, NULL AS source_url,
-           NULL AS content_source, NULL::DATE AS publication_date, NULL::VARCHAR AS date_confidence
+           NULL AS content_source, NULL::DATE AS publication_date, NULL::VARCHAR AS date_confidence,
+           0 AS additional_url_count
     FROM photo_submissions WHERE moderation_status = ANY($1)`;
 
   const filters = [];
@@ -796,8 +803,14 @@ export async function getPendingCount(pool) {
 
 export async function getItemDetail(pool, contentType, contentId) {
   const queryMap = {
-    news: `SELECT n.*, p.name as poi_name FROM poi_news n LEFT JOIN pois p ON n.poi_id = p.id WHERE n.id = $1`,
-    event: `SELECT e.*, p.name as poi_name FROM poi_events e LEFT JOIN pois p ON e.poi_id = p.id WHERE e.id = $1`,
+    news: `SELECT n.*, p.name as poi_name,
+             COALESCE((SELECT json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name))
+                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
+           FROM poi_news n LEFT JOIN pois p ON n.poi_id = p.id WHERE n.id = $1 GROUP BY n.id, p.name`,
+    event: `SELECT e.*, p.name as poi_name,
+              COALESCE((SELECT json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name))
+                        FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+            FROM poi_events e LEFT JOIN pois p ON e.poi_id = p.id WHERE e.id = $1 GROUP BY e.id, p.name`,
     photo: `SELECT ps.*, p.name as poi_name FROM photo_submissions ps LEFT JOIN pois p ON ps.poi_id = p.id WHERE ps.id = $1`
   };
 
@@ -806,4 +819,158 @@ export async function getItemDetail(pool, contentType, contentId) {
 
   const detailQuery = await pool.query(sql, [contentId]);
   return detailQuery.rows[0] || null;
+}
+
+export async function mergeItems(pool, contentType, sourceId, targetId) {
+  if (!['news', 'event'].includes(contentType)) {
+    throw new Error('Merge is only supported for news and event items');
+  }
+  if (sourceId === targetId) {
+    throw new Error('Cannot merge an item into itself');
+  }
+
+  const table = contentType === 'news' ? 'poi_news' : 'poi_events';
+  const urlTable = contentType === 'news' ? 'poi_news_urls' : 'poi_event_urls';
+  const fkColumn = contentType === 'news' ? 'news_id' : 'event_id';
+
+  // Verify both items exist
+  const [sourceRow, targetRow] = await Promise.all([
+    pool.query(`SELECT id, source_url, source_name FROM ${table} WHERE id = $1`, [sourceId]),
+    pool.query(`SELECT id, source_url FROM ${table} WHERE id = $1`, [targetId])
+  ]);
+
+  if (sourceRow.rows.length === 0) throw new Error(`Source ${contentType} #${sourceId} not found`);
+  if (targetRow.rows.length === 0) throw new Error(`Target ${contentType} #${targetId} not found`);
+
+  const source = sourceRow.rows[0];
+  const target = targetRow.rows[0];
+  let movedUrls = 0;
+
+  // Move source's primary source_url to target's junction table
+  if (source.source_url && source.source_url !== target.source_url) {
+    const inserted = await pool.query(
+      `INSERT INTO ${urlTable} (${fkColumn}, url, source_name)
+       SELECT $1, $2, $3
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${urlTable} WHERE ${fkColumn} = $1 AND url = $2
+       )
+       RETURNING id`,
+      [targetId, source.source_url, source.source_name || null]
+    );
+    movedUrls += inserted.rows.length;
+  }
+
+  // Move any of source's junction table URLs to target
+  const sourceUrls = await pool.query(
+    `SELECT url, source_name FROM ${urlTable} WHERE ${fkColumn} = $1`,
+    [sourceId]
+  );
+  for (const row of sourceUrls.rows) {
+    if (row.url === target.source_url) continue;
+    const ins = await pool.query(
+      `INSERT INTO ${urlTable} (${fkColumn}, url, source_name)
+       SELECT $1, $2, $3
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${urlTable} WHERE ${fkColumn} = $1 AND url = $2
+       )
+       RETURNING id`,
+      [targetId, row.url, row.source_name]
+    );
+    movedUrls += ins.rows.length;
+  }
+
+  // Delete source item (CASCADE will clean up its junction table entries)
+  await pool.query(`DELETE FROM ${table} WHERE id = $1`, [sourceId]);
+
+  console.log(`[Moderation] Merged ${contentType} #${sourceId} into #${targetId} (${movedUrls} URLs moved)`);
+  return { merged: true, sourceId, targetId, movedUrls };
+}
+
+export async function getMergeCandidates(pool, contentType, contentId) {
+  if (!['news', 'event'].includes(contentType)) {
+    throw new Error('Merge is only supported for news and event items');
+  }
+
+  const table = contentType === 'news' ? 'poi_news' : 'poi_events';
+  const urlTable = contentType === 'news' ? 'poi_news_urls' : 'poi_event_urls';
+  const fkColumn = contentType === 'news' ? 'news_id' : 'event_id';
+
+  // Get the POI for this item
+  const item = await pool.query(`SELECT poi_id FROM ${table} WHERE id = $1`, [contentId]);
+  if (item.rows.length === 0) throw new Error(`${contentType} #${contentId} not found`);
+  const poiId = item.rows[0].poi_id;
+
+  // Get all other items from the same POI
+  const result = await pool.query(`
+    SELECT id, title, source_url, moderation_status, created_at,
+           publication_date,
+           (SELECT COUNT(*) FROM ${urlTable} WHERE ${fkColumn} = ${table}.id)::int AS additional_url_count
+    FROM ${table}
+    WHERE poi_id = $1 AND id != $2
+    ORDER BY created_at DESC
+    LIMIT 50
+  `, [poiId, contentId]);
+
+  return result.rows;
+}
+
+export async function addItemUrl(pool, contentType, contentId, url, sourceName) {
+  if (!['news', 'event'].includes(contentType)) {
+    throw new Error('Additional URLs are only supported for news and event items');
+  }
+  if (!url) throw new Error('URL is required');
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('URL must use http or https protocol');
+    }
+  } catch (e) {
+    if (e.message.includes('protocol')) throw e;
+    throw new Error('Invalid URL format');
+  }
+
+  const table = contentType === 'news' ? 'poi_news' : 'poi_events';
+  const urlTable = contentType === 'news' ? 'poi_news_urls' : 'poi_event_urls';
+  const fkColumn = contentType === 'news' ? 'news_id' : 'event_id';
+
+  // Verify item exists
+  const item = await pool.query(`SELECT id, source_url FROM ${table} WHERE id = $1`, [contentId]);
+  if (item.rows.length === 0) throw new Error(`${contentType} #${contentId} not found`);
+
+  // Don't add if it matches the primary source_url
+  if (item.rows[0].source_url === url) {
+    return { added: false, reason: 'URL matches primary source_url' };
+  }
+
+  const result = await pool.query(
+    `INSERT INTO ${urlTable} (${fkColumn}, url, source_name)
+     SELECT $1, $2, $3
+     WHERE NOT EXISTS (
+       SELECT 1 FROM ${urlTable} WHERE ${fkColumn} = $1 AND url = $2
+     )
+     RETURNING id`,
+    [contentId, url, sourceName || null]
+  );
+
+  if (result.rows.length === 0) {
+    return { added: false, reason: 'URL already exists' };
+  }
+
+  console.log(`[Moderation] Added URL to ${contentType} #${contentId}: ${url}`);
+  return { added: true, urlId: result.rows[0].id };
+}
+
+export async function removeItemUrl(pool, contentType, contentId, urlId) {
+  if (!['news', 'event'].includes(contentType)) {
+    throw new Error('Additional URLs are only supported for news and event items');
+  }
+
+  const urlTable = contentType === 'news' ? 'poi_news_urls' : 'poi_event_urls';
+  const fkColumn = contentType === 'news' ? 'news_id' : 'event_id';
+  const result = await pool.query(`DELETE FROM ${urlTable} WHERE id = $1 AND ${fkColumn} = $2 RETURNING id`, [urlId, contentId]);
+
+  if (result.rows.length === 0) throw new Error('URL not found');
+
+  console.log(`[Moderation] Removed URL #${urlId} from ${contentType} #${contentId}`);
+  return { removed: true };
 }

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1715,13 +1715,26 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
       );
 
       if (existing.rows.length > 0) {
-        duplicateCount++;
         const matchedUrl = normalizeUrl(existing.rows[0].source_url);
-        const reason = matchedUrl === normalizedUrl
-          ? (existing.rows[0].poi_id === poiId ? 'same URL' : 'same URL (different POI)')
-          : 'similar title';
-        console.log(`Skipping duplicate (${reason}): "${item.title}"`);
-        continue; // Skip duplicate
+        if (matchedUrl === normalizedUrl) {
+          // Exact same URL — truly skip
+          duplicateCount++;
+          console.log(`Skipping duplicate (same URL): "${item.title}"`);
+          continue;
+        }
+        // Different URL, similar title — merge URL into existing item
+        const existingId = existing.rows[0].id;
+        await pool.query(
+          `INSERT INTO poi_news_urls (news_id, url, source_name)
+           SELECT $1, $2, $3
+           WHERE NOT EXISTS (
+             SELECT 1 FROM poi_news_urls WHERE news_id = $1 AND url = $2
+           )`,
+          [existingId, resolvedUrl, item.source_name || null]
+        );
+        duplicateCount++;
+        console.log(`Merged URL into news #${existingId}: "${item.title}"`);
+        continue;
       }
 
       // Save the news item with the RESOLVED URL (not the redirect)
@@ -1801,13 +1814,26 @@ export async function saveEventItems(pool, poiId, eventItems) {
       );
 
       if (existing.rows.length > 0) {
-        duplicateCount++;
         const matchedEventUrl = normalizeUrl(existing.rows[0].source_url);
-        const reason = matchedEventUrl === normalizedEventUrl
-          ? (existing.rows[0].poi_id === poiId ? 'same URL' : 'same URL (different POI)')
-          : 'same title+date';
-        console.log(`Skipping duplicate event (${reason}): "${item.title}"`);
-        continue; // Skip duplicate
+        if (matchedEventUrl === normalizedEventUrl) {
+          // Exact same URL — truly skip
+          duplicateCount++;
+          console.log(`Skipping duplicate event (same URL): "${item.title}"`);
+          continue;
+        }
+        // Different URL, similar title+date — merge URL into existing item
+        const existingId = existing.rows[0].id;
+        await pool.query(
+          `INSERT INTO poi_event_urls (event_id, url, source_name)
+           SELECT $1, $2, $3
+           WHERE NOT EXISTS (
+             SELECT 1 FROM poi_event_urls WHERE event_id = $1 AND url = $2
+           )`,
+          [existingId, resolvedUrl, item.source_name || null]
+        );
+        duplicateCount++;
+        console.log(`Merged URL into event #${existingId}: "${item.title}"`);
+        continue;
       }
 
       // Save the event with the RESOLVED URL (not the redirect)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2117,6 +2117,12 @@ body {
   text-decoration: underline;
 }
 
+.news-sources-group, .event-sources-group {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .event-links {
   display: flex;
   gap: 1rem;

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -4,11 +4,11 @@ const FIELD_CONFIGS = {
   news: [
     { key: 'title', label: 'Title', type: 'text', required: true },
     { key: 'summary', label: 'Summary', type: 'textarea' },
-    { key: 'source_url', label: 'Source URL', type: 'text' },
     { key: 'source_name', label: 'Source Name', type: 'text' },
     { key: 'news_type', label: 'Type', type: 'select', options: ['general', 'closure', 'seasonal', 'maintenance', 'wildlife'] },
     { key: 'publication_date', label: 'Publication Date', type: 'date' },
     { key: 'poi_id', label: 'POI', type: 'poi' },
+    { key: 'source_url', label: 'Primary URL', type: 'text' },
   ],
   event: [
     { key: 'title', label: 'Title', type: 'text', required: true },
@@ -17,9 +17,9 @@ const FIELD_CONFIGS = {
     { key: 'end_date', label: 'End Date/Time', type: 'datetime-local' },
     { key: 'event_type', label: 'Event Type', type: 'text' },
     { key: 'location_details', label: 'Location Details', type: 'text' },
-    { key: 'source_url', label: 'Source URL', type: 'text' },
     { key: 'publication_date', label: 'Publication Date', type: 'date' },
     { key: 'poi_id', label: 'POI', type: 'poi' },
+    { key: 'source_url', label: 'Primary URL', type: 'text' },
   ],
   photo: [
     { key: 'caption', label: 'Caption', type: 'textarea' },
@@ -45,6 +45,12 @@ function ModerationInbox() {
   const [sourceFilter, setSourceFilter] = useState(null);
   const [researchingItem, setResearchingItem] = useState(null);
   const [fixingDateItem, setFixingDateItem] = useState(null);
+  const [mergingItem, setMergingItem] = useState(null); // { type, id, poiId }
+  const [mergeCandidates, setMergeCandidates] = useState([]);
+  const [merging, setMerging] = useState(false);
+  const [itemUrls, setItemUrls] = useState({}); // { "news:123": [{id, url, source_name}] }
+  const [newUrlInput, setNewUrlInput] = useState('');
+  const [addingUrl, setAddingUrl] = useState(false);
   const LIMIT = 20;
 
   const fetchQueue = useCallback(async () => {
@@ -183,8 +189,112 @@ function ModerationInbox() {
     finally { setFixingDateItem(null); }
   };
 
+  const startMerge = async (item) => {
+    setMergingItem({ type: item.content_type, id: item.id, poiId: item.poi_id });
+    setMergeCandidates([]);
+    try {
+      const response = await fetch(`/api/admin/moderation/merge-candidates/${item.content_type}/${item.id}`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const candidates = await response.json();
+        setMergeCandidates(candidates);
+      } else {
+        notify('error', 'Failed to load merge candidates');
+        setMergingItem(null);
+      }
+    } catch (err) {
+      notify('error', err.message);
+      setMergingItem(null);
+    }
+  };
+
+  const handleMerge = async (targetId) => {
+    if (!mergingItem) return;
+    setMerging(true);
+    try {
+      const response = await fetch('/api/admin/moderation/merge', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type: mergingItem.type, sourceId: mergingItem.id, targetId })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        notify('success', `Merged ${mergingItem.type} #${mergingItem.id} into #${targetId} (${data.movedUrls} URLs moved)`);
+        setMergingItem(null);
+        setMergeCandidates([]);
+        fetchQueue();
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Merge failed');
+      }
+    } catch (err) { notify('error', err.message); }
+    finally { setMerging(false); }
+  };
+
+  const fetchItemUrls = async (type, id) => {
+    const itemKey = `${type}:${id}`;
+    try {
+      const response = await fetch(`/api/admin/moderation/item/${type}/${id}`, { credentials: 'include' });
+      if (response.ok) {
+        const detail = await response.json();
+        setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
+      }
+    } catch (err) { console.error('Error fetching item URLs:', err); }
+  };
+
+  const handleAddUrl = async (type, id) => {
+    if (!newUrlInput.trim()) return;
+    setAddingUrl(true);
+    try {
+      const response = await fetch('/api/admin/moderation/add-url', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type, id, url: newUrlInput.trim() })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (data.added) {
+          notify('success', 'URL added');
+          setNewUrlInput('');
+          fetchItemUrls(type, id);
+          fetchQueue();
+        } else {
+          notify('error', data.reason || 'URL not added');
+        }
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Failed to add URL');
+      }
+    } catch (err) { notify('error', err.message); }
+    finally { setAddingUrl(false); }
+  };
+
+  const handleRemoveUrl = async (type, contentId, urlId) => {
+    try {
+      const response = await fetch('/api/admin/moderation/remove-url', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type, id: contentId, urlId })
+      });
+      if (response.ok) {
+        notify('success', 'URL removed');
+        fetchItemUrls(type, contentId);
+        fetchQueue();
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Failed to remove URL');
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
   const startEditing = async (item) => {
     const itemKey = `${item.content_type}:${item.id}`;
+    if (editingItem === itemKey) {
+      setEditingItem(null);
+      setEditFields({});
+      return;
+    }
     try {
       const response = await fetch(`/api/admin/moderation/item/${item.content_type}/${item.id}`, {
         credentials: 'include'
@@ -204,20 +314,24 @@ function ModerationInbox() {
         }
         setEditFields(fields);
         setEditingItem(itemKey);
+        // Load additional URLs for the edit form
+        if (item.content_type !== 'photo') {
+          setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
+        }
       }
     } catch (err) {
       notify('error', 'Failed to load item details');
     }
   };
 
-  const handleEditPublish = async (type, id) => {
+  const handleSave = async (type, id) => {
     try {
-      const response = await fetch('/api/admin/moderation/edit-publish', {
+      const response = await fetch('/api/admin/moderation/save', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         credentials: 'include', body: JSON.stringify({ type, id, edits: editFields })
       });
       if (response.ok) {
-        notify('success', `${type} #${id} edited and published`);
+        notify('success', `${type} #${id} saved`);
         setEditingItem(null);
         setEditFields({});
         fetchQueue();
@@ -593,6 +707,16 @@ function ModerationInbox() {
                         </span>
                       )}
 
+                      {item.additional_url_count > 0 && (
+                        <span style={{
+                          backgroundColor: '#1565c0', color: 'white',
+                          padding: '1px 8px', borderRadius: '10px',
+                          fontSize: '0.72rem', fontWeight: 'bold'
+                        }}>
+                          +{item.additional_url_count} URL{item.additional_url_count > 1 ? 's' : ''}
+                        </span>
+                      )}
+
                       <span style={{ fontWeight: 'bold', fontSize: '0.92rem', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: isExpanded ? 'normal' : 'nowrap' }}>
                         {item.title || '(untitled)'}
                       </span>
@@ -618,13 +742,22 @@ function ModerationInbox() {
                         {item.description}
                       </p>
                     )}
+                    <a onClick={() => setExpandedItem(isExpanded ? null : itemKey)}
+                      style={{ color: '#4a7c23', fontSize: '0.8rem', cursor: 'pointer', textDecoration: 'none', fontWeight: 500 }}>
+                      {isExpanded ? 'Show less' : 'Show more'}
+                    </a>
 
-                    {/* Source URL (expanded) */}
+                    {/* Source URL (expanded, read-only) */}
                     {isExpanded && item.source_url && (
                       <div style={{ margin: '4px 0', fontSize: '0.78rem' }}>
                         <a href={item.source_url} target="_blank" rel="noopener noreferrer" style={{ color: '#1976d2' }}>
                           {item.source_url}
                         </a>
+                        {item.additional_url_count > 0 && (
+                          <span style={{ color: '#888', fontSize: '0.72rem', marginLeft: '6px' }}>
+                            (+{item.additional_url_count} more — click Edit to manage)
+                          </span>
+                        )}
                       </div>
                     )}
 
@@ -681,9 +814,41 @@ function ModerationInbox() {
                             {renderFieldInput(fc, editFields, setEditFields)}
                           </div>
                         ))}
+                        {/* Additional URLs management */}
+                        {item.content_type !== 'photo' && (
+                          <div>
+                            <label style={{ fontSize: '0.78rem', color: '#666', fontWeight: '500', marginBottom: '2px', display: 'block' }}>
+                              Additional URLs
+                            </label>
+                            {(itemUrls[itemKey] || []).map(u => (
+                              <div key={u.id} style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '3px',
+                                padding: '4px 8px', backgroundColor: 'white', borderRadius: '4px', border: '1px solid #e0e0e0' }}>
+                                <a href={u.url} target="_blank" rel="noopener noreferrer"
+                                  style={{ color: '#1976d2', flex: 1, fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                  {u.url}
+                                </a>
+                                {u.source_name && <span style={{ color: '#888', fontSize: '0.7rem', flexShrink: 0 }}>({u.source_name})</span>}
+                                <button onClick={() => handleRemoveUrl(item.content_type, item.id, u.id)}
+                                  style={{ background: 'none', border: 'none', color: '#f44336', cursor: 'pointer',
+                                    padding: '0 4px', fontSize: '0.85rem', flexShrink: 0, lineHeight: 1 }}
+                                  title="Remove URL">x</button>
+                              </div>
+                            ))}
+                            <div style={{ display: 'flex', gap: '4px' }}>
+                              <input type="text" value={newUrlInput} onChange={e => setNewUrlInput(e.target.value)}
+                                placeholder="Add another source URL..."
+                                onKeyDown={e => e.key === 'Enter' && handleAddUrl(item.content_type, item.id)}
+                                style={{ flex: 1, padding: '5px 8px', fontSize: '0.78rem', border: '1px solid #ccc', borderRadius: '4px' }} />
+                              <button onClick={() => handleAddUrl(item.content_type, item.id)} disabled={addingUrl || !newUrlInput.trim()}
+                                style={btnStyle(addingUrl || !newUrlInput.trim() ? '#ccc' : '#1976d2')}>
+                                {addingUrl ? 'Adding...' : 'Add URL'}
+                              </button>
+                            </div>
+                          </div>
+                        )}
                         <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
-                          <button onClick={() => handleEditPublish(item.content_type, item.id)}
-                            style={btnStyle('#4caf50')}>Save & Publish</button>
+                          <button onClick={() => handleSave(item.content_type, item.id)}
+                            style={btnStyle('#4caf50')}>Save</button>
                           <button onClick={() => { setEditingItem(null); setEditFields({}); }}
                             style={btnStyle('transparent', '#666', '1px solid #ccc')}>Cancel</button>
                         </div>
@@ -694,10 +859,12 @@ function ModerationInbox() {
                   {/* Action buttons */}
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '3px', flexShrink: 0, alignItems: 'flex-end' }}>
                     <div style={{ display: 'flex', gap: '3px' }}>
-                      <button onClick={() => setExpandedItem(isExpanded ? null : itemKey)}
-                        style={actionBtn()}>{isExpanded ? 'Less' : 'More'}</button>
                       <button onClick={() => startEditing(item)}
                         style={actionBtn()}>Edit</button>
+                      {item.content_type !== 'photo' && (
+                        <button onClick={() => startMerge(item)}
+                          style={actionBtn()}>Merge</button>
+                      )}
                     </div>
                     <div style={{ display: 'flex', gap: '3px' }}>
                       {isPending && (
@@ -729,6 +896,53 @@ function ModerationInbox() {
                     )}
                   </div>
                 </div>
+
+                {/* Merge candidate selection */}
+                {mergingItem && mergingItem.type === item.content_type && mergingItem.id === item.id && (
+                  <div style={{ marginTop: '8px', padding: '10px', backgroundColor: '#e3f2fd',
+                    borderRadius: '6px', border: '1px solid #90caf9' }}>
+                    <div style={{ fontSize: '0.82rem', fontWeight: 'bold', marginBottom: '6px', color: '#1565c0' }}>
+                      Merge this item into (target keeps its title/summary):
+                    </div>
+                    {mergeCandidates.length === 0 ? (
+                      <div style={{ fontSize: '0.78rem', color: '#666' }}>
+                        {mergingItem ? 'Loading candidates...' : 'No other items found for this POI.'}
+                      </div>
+                    ) : (
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', maxHeight: '300px', overflowY: 'auto' }}>
+                        {mergeCandidates.map(c => (
+                          <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: '6px',
+                            padding: '6px 8px', backgroundColor: 'white', borderRadius: '4px',
+                            border: '1px solid #e0e0e0' }}>
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                              <div style={{ fontSize: '0.8rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: '500' }}>
+                                {c.title}
+                              </div>
+                              <div style={{ fontSize: '0.7rem', color: '#888', display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                                <span>#{c.id}</span>
+                                <span>{c.moderation_status}</span>
+                                {c.publication_date && <span>{new Date(c.publication_date).toLocaleDateString()}</span>}
+                                {c.additional_url_count > 0 && <span>+{c.additional_url_count} URLs</span>}
+                              </div>
+                              {c.source_url && (
+                                <div style={{ fontSize: '0.68rem', color: '#1976d2', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                  {c.source_url}
+                                </div>
+                              )}
+                            </div>
+                            <button onClick={() => handleMerge(c.id)} disabled={merging}
+                              style={{ ...actionBtn(merging), backgroundColor: merging ? '#ccc' : '#1565c0',
+                                color: 'white', flexShrink: 0 }}>
+                              {merging ? 'Merging...' : 'Merge Into'}
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <button onClick={() => { setMergingItem(null); setMergeCandidates([]); }}
+                      style={{ ...actionBtn(), marginTop: '6px', fontSize: '0.72rem' }}>Cancel</button>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -340,7 +340,16 @@ END:VCALENDAR`;
                   + Download .ics
                 </button>
               </div>
-              {item.source_url && (
+              {item.source_url && item.additional_urls && item.additional_urls.length > 0 ? (
+                <span className="event-sources-group">
+                  <a href={item.source_url} target="_blank" rel="noopener noreferrer" className="event-link">Source</a>
+                  {item.additional_urls.map((u, i) => (
+                    <a key={i} href={u.url} target="_blank" rel="noopener noreferrer" className="event-link">
+                      {u.source_name || `Source ${i + 2}`}
+                    </a>
+                  ))}
+                </span>
+              ) : item.source_url ? (
                 <a
                   href={item.source_url}
                   target="_blank"
@@ -349,7 +358,7 @@ END:VCALENDAR`;
                 >
                   More info
                 </a>
-              )}
+              ) : null}
             </div>
           </div>
             ))}

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -195,7 +195,16 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
               {item.source_name && <span className="news-source">{item.source_name}</span>}
               {item.publication_date && <span className="news-date">{formatPublicationDate(item.publication_date)}</span>}
               {!item.publication_date && item.published_at && <span className="news-date">{formatDate(item.published_at)}</span>}
-              {item.source_url && (
+              {item.source_url && item.additional_urls && item.additional_urls.length > 0 ? (
+                <span className="news-sources-group">
+                  <a href={item.source_url} target="_blank" rel="noopener noreferrer" className="news-link">Source</a>
+                  {item.additional_urls.map((u, i) => (
+                    <a key={i} href={u.url} target="_blank" rel="noopener noreferrer" className="news-link">
+                      {u.source_name || `Source ${i + 2}`}
+                    </a>
+                  ))}
+                </span>
+              ) : item.source_url ? (
                 <a
                   href={item.source_url}
                   target="_blank"
@@ -204,7 +213,7 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
                 >
                   Read more
                 </a>
-              )}
+              ) : null}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- Junction tables (`poi_news_urls`, `poi_event_urls`) store additional source URLs per item
- Dedup pipeline merges URLs into existing items on similar-title match instead of skipping
- All public API endpoints include `additional_urls` in responses
- Admin moderation queue: add/remove URLs, merge items, search same-POI candidates from DB
- Public display shows multiple source links when available
- Moderation UX: Save without publish, Edit toggle, "Show more" link, reorganized button layout

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 216/216 tests pass, 16/16 test files
- [x] Verified in browser: moderation queue URL management, merge flow, public display
- [ ] Run news collection and verify "Merged URL" log messages for similar-title items
- [ ] Test merge via moderation UI with real duplicate items

🤖 Generated with [Claude Code](https://claude.com/claude-code)