### PR TITLE
fix: address Gemini review feedback from PR #142

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -564,28 +564,7 @@ async function initDatabase() {
     await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_events_start_date ON poi_events(start_date)`);
 
     // Junction tables for multiple URLs per news/event item
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS poi_news_urls (
-        id SERIAL PRIMARY KEY,
-        news_id INTEGER NOT NULL REFERENCES poi_news(id) ON DELETE CASCADE,
-        url TEXT NOT NULL,
-        source_name VARCHAR(255),
-        discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_news_urls_unique ON poi_news_urls(news_id, url)`);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_news_urls_url ON poi_news_urls(url)`);
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS poi_event_urls (
-        id SERIAL PRIMARY KEY,
-        event_id INTEGER NOT NULL REFERENCES poi_events(id) ON DELETE CASCADE,
-        url TEXT NOT NULL,
-        source_name VARCHAR(255),
-        discovered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_event_urls_unique ON poi_event_urls(event_id, url)`);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_event_urls_url ON poi_event_urls(url)`);
+    // Schema managed by migration 007_news_multi_url.sql
 
     // News job status tracking
     await client.query(`
@@ -1294,11 +1273,12 @@ app.get('/api/pois/:id/news', async (req, res) => {
     const newsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.published_at, n.publication_date, n.date_confidence, n.created_at,
-             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
+      LEFT JOIN poi_news_urls u ON u.news_id = n.id
       WHERE n.poi_id = $1
         AND n.moderation_status IN ('published', 'auto_approved')
+      GROUP BY n.id
       ORDER BY
         COALESCE(n.publication_date, n.created_at::date) DESC,
         n.created_at DESC
@@ -1318,16 +1298,16 @@ app.get('/api/pois/:id/events', async (req, res) => {
     const limit = parseInt(req.query.limit) || 50;
     let query = `
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type, e.location_details, e.source_url, e.created_at,
-             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
+      LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.poi_id = $1
         AND e.moderation_status IN ('published', 'auto_approved')
     `;
     if (upcomingOnly) {
       query += ` AND e.start_date >= CURRENT_DATE`;
     }
-    query += ` ORDER BY e.start_date ASC LIMIT $2`;
+    query += ` GROUP BY e.id ORDER BY e.start_date ASC LIMIT $2`;
 
     const eventsQuery = await pool.query(query, [id, limit]);
     res.json(eventsQuery.rows);
@@ -1461,12 +1441,13 @@ app.get('/api/news/recent', async (req, res) => {
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.published_at, n.publication_date, n.date_confidence, n.created_at,
              p.id as poi_id, p.name as poi_name, p.poi_type,
-             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
+      LEFT JOIN poi_news_urls u ON u.news_id = n.id
       WHERE n.moderation_status IN ('published', 'auto_approved')
         AND (p.deleted IS NULL OR p.deleted = FALSE)
+      GROUP BY n.id, p.id, p.name, p.poi_type
       ORDER BY COALESCE(n.publication_date, n.created_at::date) DESC, n.created_at DESC
       LIMIT $1
     `, [limit]);
@@ -1483,13 +1464,14 @@ app.get('/api/events/upcoming', async (req, res) => {
     const upcomingEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
              e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
-             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
+      LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND e.start_date >= CURRENT_DATE
         AND (p.deleted IS NULL OR p.deleted = FALSE)
+      GROUP BY e.id, p.id, p.name, p.poi_type
       ORDER BY e.start_date ASC
     `);
     res.json(upcomingEventsQuery.rows);
@@ -1506,13 +1488,14 @@ app.get('/api/events/past', async (req, res) => {
     const pastEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
              e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
-             COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                       FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
+      LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND e.start_date < CURRENT_DATE
         AND (p.deleted IS NULL OR p.deleted = FALSE)
+      GROUP BY e.id, p.id, p.name, p.poi_type
       ORDER BY e.start_date DESC
       LIMIT $1
     `, [limit]);

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -120,10 +120,11 @@ function registerTools(server, pool, boss) {
         SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
                n.published_at, n.moderation_status, n.confidence_score, n.content_source,
                n.publication_date, n.date_confidence, n.created_at,
-               COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                         FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
+               COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
         FROM poi_news n
+        LEFT JOIN poi_news_urls u ON u.news_id = n.id
         WHERE n.poi_id = $1
+        GROUP BY n.id
         ORDER BY n.created_at DESC
         LIMIT $2
       `, [poi_id, limit]);
@@ -143,10 +144,11 @@ function registerTools(server, pool, boss) {
         SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
                e.location_details, e.source_url, e.moderation_status, e.confidence_score, e.content_source,
                e.publication_date, e.date_confidence, e.created_at,
-               COALESCE((SELECT json_agg(json_build_object('url', u.url, 'source_name', u.source_name))
-                         FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
+               COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
         FROM poi_events e
+        LEFT JOIN poi_event_urls u ON u.event_id = e.id
         WHERE e.poi_id = $1
+        GROUP BY e.id
         ORDER BY e.start_date DESC
         LIMIT $2
       `, [poi_id, limit]);

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -745,19 +745,25 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
       : [status];
 
   const baseQuery = `
-    SELECT id, 'news' AS content_type, poi_id, title, summary AS description,
-           moderation_status, confidence_score, ai_reasoning, ai_issues,
-           submitted_by, moderated_by, moderated_at, created_at, source_url,
-           content_source, publication_date, date_confidence,
-           (SELECT COUNT(*) FROM poi_news_urls WHERE news_id = poi_news.id)::int AS additional_url_count
-    FROM poi_news WHERE moderation_status = ANY($1)
+    SELECT n.id, 'news' AS content_type, n.poi_id, n.title, n.summary AS description,
+           n.moderation_status, n.confidence_score, n.ai_reasoning, n.ai_issues,
+           n.submitted_by, n.moderated_by, n.moderated_at, n.created_at, n.source_url,
+           n.content_source, n.publication_date, n.date_confidence,
+           COUNT(u.id)::int AS additional_url_count
+    FROM poi_news n
+    LEFT JOIN poi_news_urls u ON u.news_id = n.id
+    WHERE n.moderation_status = ANY($1)
+    GROUP BY n.id
     UNION ALL
-    SELECT id, 'event' AS content_type, poi_id, title, description,
-           moderation_status, confidence_score, ai_reasoning, ai_issues,
-           submitted_by, moderated_by, moderated_at, created_at, source_url,
-           content_source, publication_date, date_confidence,
-           (SELECT COUNT(*) FROM poi_event_urls WHERE event_id = poi_events.id)::int AS additional_url_count
-    FROM poi_events WHERE moderation_status = ANY($1)
+    SELECT e.id, 'event' AS content_type, e.poi_id, e.title, e.description,
+           e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
+           e.submitted_by, e.moderated_by, e.moderated_at, e.created_at, e.source_url,
+           e.content_source, e.publication_date, e.date_confidence,
+           COUNT(u.id)::int AS additional_url_count
+    FROM poi_events e
+    LEFT JOIN poi_event_urls u ON u.event_id = e.id
+    WHERE e.moderation_status = ANY($1)
+    GROUP BY e.id
     UNION ALL
     SELECT id, 'photo' AS content_type, poi_id, original_filename AS title, caption AS description,
            moderation_status, confidence_score, ai_reasoning, NULL AS ai_issues,
@@ -804,13 +810,11 @@ export async function getPendingCount(pool) {
 export async function getItemDetail(pool, contentType, contentId) {
   const queryMap = {
     news: `SELECT n.*, p.name as poi_name,
-             COALESCE((SELECT json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name))
-                       FROM poi_news_urls u WHERE u.news_id = n.id), '[]'::json) AS additional_urls
-           FROM poi_news n LEFT JOIN pois p ON n.poi_id = p.id WHERE n.id = $1 GROUP BY n.id, p.name`,
+             COALESCE(json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
+           FROM poi_news n LEFT JOIN pois p ON n.poi_id = p.id LEFT JOIN poi_news_urls u ON u.news_id = n.id WHERE n.id = $1 GROUP BY n.id, p.name`,
     event: `SELECT e.*, p.name as poi_name,
-              COALESCE((SELECT json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name))
-                        FROM poi_event_urls u WHERE u.event_id = e.id), '[]'::json) AS additional_urls
-            FROM poi_events e LEFT JOIN pois p ON e.poi_id = p.id WHERE e.id = $1 GROUP BY e.id, p.name`,
+              COALESCE(json_agg(json_build_object('id', u.id, 'url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
+            FROM poi_events e LEFT JOIN pois p ON e.poi_id = p.id LEFT JOIN poi_event_urls u ON u.event_id = e.id WHERE e.id = $1 GROUP BY e.id, p.name`,
     photo: `SELECT ps.*, p.name as poi_name FROM photo_submissions ps LEFT JOIN pois p ON ps.poi_id = p.id WHERE ps.id = $1`
   };
 
@@ -902,12 +906,14 @@ export async function getMergeCandidates(pool, contentType, contentId) {
 
   // Get all other items from the same POI
   const result = await pool.query(`
-    SELECT id, title, source_url, moderation_status, created_at,
-           publication_date,
-           (SELECT COUNT(*) FROM ${urlTable} WHERE ${fkColumn} = ${table}.id)::int AS additional_url_count
-    FROM ${table}
-    WHERE poi_id = $1 AND id != $2
-    ORDER BY created_at DESC
+    SELECT t.id, t.title, t.source_url, t.moderation_status, t.created_at,
+           t.publication_date,
+           COUNT(u.id)::int AS additional_url_count
+    FROM ${table} t
+    LEFT JOIN ${urlTable} u ON u.${fkColumn} = t.id
+    WHERE t.poi_id = $1 AND t.id != $2
+    GROUP BY t.id
+    ORDER BY t.created_at DESC
     LIMIT 50
   `, [poiId, contentId]);
 


### PR DESCRIPTION
## Summary

- Remove duplicated junction table schema (poi_news_urls, poi_event_urls) from `initDatabase()` — managed by migration 007
- Replace 12 correlated subqueries with `LEFT JOIN` + `GROUP BY` across `server.js`, `moderationService.js`, and `mcpServer.js` to eliminate N+1 query overhead

## Context

Addresses all remaining feedback from Gemini's code review on PR #142:
- **HIGH**: Schema DDL duplicated between `server.js` and migration file
- **MEDIUM**: Correlated subqueries for `additional_urls` and `additional_url_count` causing per-row subquery execution

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 216/216 tests pass, 16/16 test files
- [x] Verified API endpoints return correct JSON with `additional_urls` arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)