### PR TITLE
fix: trail status runtime errors + cookie sameSite

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -75,6 +75,13 @@ export async function extractPageContent(url, options = {}) {
       });
 
       if (cookies && Array.isArray(cookies) && cookies.length > 0) {
+        const normalizeSameSite = (val) => {
+          if (!val || val === 'no_restriction' || val === 'unspecified') return 'None';
+          const lower = String(val).toLowerCase();
+          if (lower === 'strict') return 'Strict';
+          if (lower === 'lax') return 'Lax';
+          return 'None';
+        };
         const playwrightCookies = cookies.map(c => ({
           name: c.name,
           value: c.value,
@@ -82,7 +89,7 @@ export async function extractPageContent(url, options = {}) {
           path: c.path || '/',
           secure: c.secure !== false,
           httpOnly: c.httpOnly || false,
-          sameSite: c.sameSite || 'None'
+          sameSite: normalizeSameSite(c.sameSite)
         }));
         await context.addCookies(playwrightCookies);
       }

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -400,18 +400,10 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
       .replace(/\{\{timezone\}\}/g, timezone)
       .replace(/\{\{renderedContent\}\}/g, rendered.markdown);
 
-    console.log(`[Trail Status] Searching with AI for trail status...`);
-    const aiResult = await generateTextWithCustomPrompt(pool, prompt);
-    const response = aiResult.response;
-    const usedProvider = aiResult.provider;
+    console.log(`[Trail Status] Extracting status with Gemini (${prompt.length} char prompt)...`);
+    const response = await generateTextWithCustomPrompt(pool, prompt, null, { useSearchGrounding: false });
 
-    // Update provider if it changed (e.g., fallback was used)
-    if (usedProvider !== initialProvider) {
-      console.log(`[Trail Status] Provider changed from ${initialProvider} to ${usedProvider} (fallback used)`);
-      updateProgress(poi.id, { provider: usedProvider });
-    }
-
-    console.log(`[Trail Status] Received response (${response.length} chars) from ${usedProvider}`);
+    console.log(`[Trail Status] Received response (${response.length} chars)`);
 
     // Check for cancellation after AI search
     if (isCancellationRequested(poi.id)) {


### PR DESCRIPTION
## Summary

- Fix `initialProvider is not defined` error — bad merge re-introduced old aiSearchFactory calling convention. geminiService returns a plain string, not `{response, provider}`
- Normalize cookie `sameSite` values for Playwright — stored cookies have `no_restriction` or lowercase values that Playwright rejects (must be exactly `Strict`, `Lax`, or `None`)
- Also adds `useSearchGrounding: false` which was missing from the Gemini call

## Test plan

- [ ] Trail status collection completes without `initialProvider` errors
- [ ] East Rim (Twitter) renders successfully with normalized cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)