### PR TITLE
fix: match geminiService call signature

### DIFF
--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -401,7 +401,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
       .replace(/\{\{renderedContent\}\}/g, rendered.markdown);
 
     console.log(`[Trail Status] Extracting status with Gemini (${prompt.length} char prompt)...`);
-    const response = await generateTextWithCustomPrompt(pool, prompt, null, { useSearchGrounding: false });
+    const response = await generateTextWithCustomPrompt(pool, prompt, { useSearchGrounding: false });
 
     console.log(`[Trail Status] Received response (${response.length} chars)`);
 


### PR DESCRIPTION
## Summary

- Drop stale `null` sheets parameter from `generateTextWithCustomPrompt()` call
- Function signature is `(pool, prompt, options)` — not `(pool, prompt, sheets, options)`
- This caused every trail status Gemini call to fail with `Cannot read properties of null (reading 'useSearchGrounding')`

## Test plan

- [ ] Trail status collection completes without useSearchGrounding error
- [ ] Status badges update on frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)