### PR TITLE
fix: raise Readability fallback threshold to 200 chars

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -182,7 +182,7 @@ export async function extractPageContent(url, options = {}) {
       });
       const article = reader.parse();
 
-      if (!article || !article.content || article.content.trim().length < 50) {
+      if (!article || !article.content || article.content.trim().length < 200) {
         const fallbackDom = new JSDOM(html, { url });
         const body = fallbackDom.window.document.body;
         for (const tag of ['script', 'style', 'nav', 'header', 'footer', 'aside']) {


### PR DESCRIPTION
## Summary

- Raise contentExtractor Readability fallback threshold from 50 to 200 chars
- When Readability returns tiny fragments (SPA pages like Twitter), fall back to raw text extraction from the fully rendered DOM
- 200 chars matches the MIN_CONTENT_LENGTH check in trailStatusService.js

## Test plan

- [ ] Trail status collection for non-SPA sites (Cleveland Metroparks, Bluesky) works
- [ ] Twitter/Facebook pages fall back to raw text instead of returning tiny Readability fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)