### PR TITLE
fix: update Playwright user agent to Chrome 131

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -70,7 +70,7 @@ export async function extractPageContent(url, options = {}) {
       browser = await chromium.launch(launchOptions);
 
       const context = await browser.newContext({
-        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
         ignoreHTTPSErrors: true
       });
 

--- a/backend/services/jsRenderer.js
+++ b/backend/services/jsRenderer.js
@@ -70,7 +70,7 @@ export async function isJavaScriptHeavySite(url, options = {}) {
         const response = await fetch(url, {
           method: 'GET',
           headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
           },
           signal: AbortSignal.timeout(5000)
         });
@@ -295,7 +295,7 @@ async function renderJavaScriptPageInternal(url, options) {
     }
 
     const context = await browser.newContext({
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
       ignoreHTTPSErrors: true // Ignore SSL certificate errors for sites with invalid certs
     });
 


### PR DESCRIPTION
## Summary

- Update user agent string from Chrome/120 to Chrome/131 in all Playwright services
- CAMBA DualRates was returning 404 to the old user agent (bot detection)
- Also fixed CAMBA status URLs in production DB (stripped stale session= parameter)

## Test plan

- [ ] Camp Tuscazoar and West Branch trails render successfully
- [ ] Other trails continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)