### PR TITLE
feat: Apify for Twitter/Facebook trail status, collapse Status tab

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -436,7 +436,7 @@ export function createAdminRouter(pool) {
       const settings = {};
       for (const row of result.rows) {
         // For API keys, only indicate if set (don't expose value)
-        if (row.key.includes('api_key')) {
+        if (row.key.includes('api_key') || row.key.includes('api_token')) {
           settings[row.key] = {
             isSet: !!row.value,
             updatedAt: row.updated_at
@@ -474,7 +474,8 @@ export function createAdminRouter(pool) {
       'moderation_enabled',
       'moderation_auto_approve_threshold',
       'moderation_auto_approve_enabled',
-      'photo_submissions_enabled'
+      'photo_submissions_enabled',
+      'apify_api_token'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -1,0 +1,209 @@
+/**
+ * Apify Service
+ * Fetches Twitter/X and Facebook posts via Apify cloud scrapers.
+ * Used by trailStatusService for URLs that can't be extracted with Playwright + Readability.
+ */
+
+const APIFY_BASE_URL = 'https://api.apify.com/v2';
+
+// Actor IDs for Twitter and Facebook scrapers
+const TWITTER_ACTOR_ID = 'apify~twitter-scraper';
+const FACEBOOK_ACTOR_ID = 'apify~facebook-posts-scraper';
+
+/**
+ * Load Apify API token from admin_settings table
+ * @param {Pool} pool - Database connection pool
+ * @returns {string|null} - API token or null if not configured
+ */
+async function getApifyToken(pool) {
+  try {
+    const result = await pool.query(
+      `SELECT value FROM admin_settings WHERE key = 'apify_api_token'`
+    );
+    if (result.rows.length > 0 && result.rows[0].value) {
+      return result.rows[0].value;
+    }
+  } catch (err) {
+    console.error('[Apify] Error loading API token:', err.message);
+  }
+  return null;
+}
+
+/**
+ * Call Apify actor sync API and return dataset items
+ * @param {string} actorId - Apify actor ID (e.g., 'apify~twitter-scraper')
+ * @param {Object} input - Actor input payload
+ * @param {string} token - Apify API token
+ * @returns {Array} - Array of result items
+ */
+async function runActorSync(actorId, input, token) {
+  const url = `${APIFY_BASE_URL}/acts/${actorId}/run-sync-get-dataset-items?token=${token}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+    signal: AbortSignal.timeout(120000) // 2 minute timeout
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'unknown error');
+    throw new Error(`Apify API error ${response.status}: ${errorText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Extract Twitter/X handle from a URL
+ * @param {string} url - Twitter/X URL (e.g., 'https://x.com/CVNPmtb')
+ * @returns {string|null} - Handle without @ prefix, or null
+ */
+function extractTwitterHandle(url) {
+  const match = url.match(/(?:x\.com|twitter\.com)\/([A-Za-z0-9_]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract Facebook page URL from a status URL
+ * Normalizes to https://www.facebook.com/pagename/ format
+ * @param {string} url - Facebook URL
+ * @returns {string|null} - Normalized page URL, or null
+ */
+function extractFacebookPageUrl(url) {
+  const match = url.match(/(?:www\.)?facebook\.com\/([A-Za-z0-9._-]+)/);
+  return match ? `https://www.facebook.com/${match[1]}/` : null;
+}
+
+/**
+ * Fetch recent Twitter/X posts for a user handle via Apify
+ * @param {Pool} pool - Database connection pool
+ * @param {string} statusUrl - Twitter/X URL (e.g., 'https://x.com/CVNPmtb')
+ * @param {number} maxItems - Maximum number of posts to fetch (default: 10)
+ * @returns {Object} - { markdown: string|null, reachable: boolean, reason?: string }
+ */
+export async function fetchTwitterPosts(pool, statusUrl, maxItems = 10) {
+  const handle = extractTwitterHandle(statusUrl);
+  if (!handle) {
+    console.log(`[Apify] Could not extract Twitter handle from: ${statusUrl}`);
+    return { markdown: null, reachable: false, reason: 'invalid Twitter URL' };
+  }
+
+  const token = await getApifyToken(pool);
+  if (!token) {
+    console.log('[Apify] No API token configured');
+    return { markdown: null, reachable: false, reason: 'Apify API token not configured' };
+  }
+
+  console.log(`[Apify] Fetching Twitter posts for @${handle} (max ${maxItems})...`);
+
+  try {
+    const items = await runActorSync(TWITTER_ACTOR_ID, {
+      handles: [handle],
+      maxItems,
+      addUserInfo: false
+    }, token);
+
+    if (!items || items.length === 0) {
+      console.log(`[Apify] No Twitter posts found for @${handle}`);
+      return { markdown: null, reachable: true, reason: 'no posts found' };
+    }
+
+    // Concatenate post text with timestamps
+    const posts = items
+      .map(item => {
+        const text = item.text || item.full_text || '';
+        const date = item.createdAt || item.created_at || '';
+        return date ? `[${date}] ${text}` : text;
+      })
+      .filter(text => text.trim().length > 0);
+
+    if (posts.length === 0) {
+      console.log(`[Apify] Twitter posts returned but no text content for @${handle}`);
+      return { markdown: null, reachable: true, reason: 'posts found but no text content' };
+    }
+
+    const markdown = posts.join('\n\n---\n\n');
+    console.log(`[Apify] Got ${posts.length} Twitter posts for @${handle} (${markdown.length} chars)`);
+
+    return { markdown, reachable: true };
+  } catch (err) {
+    console.error(`[Apify] Twitter fetch error for @${handle}:`, err.message);
+    return { markdown: null, reachable: false, reason: `Apify error: ${err.message}` };
+  }
+}
+
+/**
+ * Fetch recent Facebook posts for a page via Apify
+ * @param {Pool} pool - Database connection pool
+ * @param {string} statusUrl - Facebook page URL
+ * @param {number} maxItems - Maximum number of posts to fetch (default: 10)
+ * @returns {Object} - { markdown: string|null, reachable: boolean, reason?: string }
+ */
+export async function fetchFacebookPosts(pool, statusUrl, maxItems = 10) {
+  const pageUrl = extractFacebookPageUrl(statusUrl);
+  if (!pageUrl) {
+    console.log(`[Apify] Could not extract Facebook page from: ${statusUrl}`);
+    return { markdown: null, reachable: false, reason: 'invalid Facebook URL' };
+  }
+
+  const token = await getApifyToken(pool);
+  if (!token) {
+    console.log('[Apify] No API token configured');
+    return { markdown: null, reachable: false, reason: 'Apify API token not configured' };
+  }
+
+  console.log(`[Apify] Fetching Facebook posts for ${pageUrl} (max ${maxItems})...`);
+
+  try {
+    const items = await runActorSync(FACEBOOK_ACTOR_ID, {
+      startUrls: [{ url: pageUrl }],
+      maxPosts: maxItems
+    }, token);
+
+    if (!items || items.length === 0) {
+      console.log(`[Apify] No Facebook posts found for ${pageUrl}`);
+      return { markdown: null, reachable: true, reason: 'no posts found' };
+    }
+
+    // Concatenate post text with timestamps
+    const posts = items
+      .map(item => {
+        const text = item.text || item.message || item.postText || '';
+        const date = item.time || item.timestamp || item.date || '';
+        return date ? `[${date}] ${text}` : text;
+      })
+      .filter(text => text.trim().length > 0);
+
+    if (posts.length === 0) {
+      console.log(`[Apify] Facebook posts returned but no text content for ${pageUrl}`);
+      return { markdown: null, reachable: true, reason: 'posts found but no text content' };
+    }
+
+    const markdown = posts.join('\n\n---\n\n');
+    console.log(`[Apify] Got ${posts.length} Facebook posts for ${pageUrl} (${markdown.length} chars)`);
+
+    return { markdown, reachable: true };
+  } catch (err) {
+    console.error(`[Apify] Facebook fetch error for ${pageUrl}:`, err.message);
+    return { markdown: null, reachable: false, reason: `Apify error: ${err.message}` };
+  }
+}
+
+/**
+ * Check if a URL is a Twitter/X URL
+ * @param {string} url - URL to check
+ * @returns {boolean}
+ */
+export function isTwitterUrl(url) {
+  return url.includes('x.com') || url.includes('twitter.com');
+}
+
+/**
+ * Check if a URL is a Facebook URL
+ * @param {string} url - URL to check
+ * @returns {boolean}
+ */
+export function isFacebookUrl(url) {
+  return url.includes('facebook.com');
+}

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -8,6 +8,7 @@
 
 import { generateTextWithCustomPrompt } from './geminiService.js';
 import { extractPageContent } from './contentExtractor.js';
+import { fetchTwitterPosts, fetchFacebookPosts, isTwitterUrl, isFacebookUrl } from './apifyService.js';
 
 // Dispatch interval: start one new trail job every N milliseconds
 const DISPATCH_INTERVAL_MS = 1500;
@@ -315,35 +316,38 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
       return { statusFound: 0, statusSaved: 0 };
     }
 
-    // Load cookies for authenticated sites (Twitter/X)
-    let cookies = null;
-    if (statusUrl.includes('x.com') || statusUrl.includes('twitter.com')) {
-      try {
-        const cookieResult = await pool.query(
-          `SELECT value FROM admin_settings WHERE key = 'twitter_cookies'`
-        );
-        if (cookieResult.rows.length > 0 && cookieResult.rows[0].value) {
-          cookies = JSON.parse(cookieResult.rows[0].value);
-          console.log(`[Trail Status] Loaded ${cookies.length} Twitter cookies`);
-        }
-      } catch (cookieErr) {
-        console.log(`[Trail Status] No Twitter cookies available: ${cookieErr.message}`);
-      }
+    // Route by URL type: Twitter/Facebook use Apify, everything else uses Playwright
+    let rendered;
+
+    if (isTwitterUrl(statusUrl)) {
+      console.log(`[Trail Status] Fetching Twitter posts via Apify for: ${statusUrl}`);
+      updateProgress(poi.id, {
+        phase: 'rendering',
+        message: 'Fetching Twitter posts via Apify...',
+        steps: ['Initialized', 'Fetching Twitter posts']
+      });
+      rendered = await fetchTwitterPosts(pool, statusUrl);
+    } else if (isFacebookUrl(statusUrl)) {
+      console.log(`[Trail Status] Fetching Facebook posts via Apify for: ${statusUrl}`);
+      updateProgress(poi.id, {
+        phase: 'rendering',
+        message: 'Fetching Facebook posts via Apify...',
+        steps: ['Initialized', 'Fetching Facebook posts']
+      });
+      rendered = await fetchFacebookPosts(pool, statusUrl);
+    } else {
+      // Standard Playwright + Readability extraction
+      console.log(`[Trail Status] Rendering status page: ${statusUrl}`);
+      updateProgress(poi.id, {
+        phase: 'rendering',
+        message: 'Rendering status page...',
+        steps: ['Initialized', 'Rendering page']
+      });
+      rendered = await extractPageContent(statusUrl, {
+        maxLength: 15000,
+        dynamicContentWait: 3000
+      });
     }
-
-    // Render status page with Playwright + Readability
-    console.log(`[Trail Status] Rendering status page: ${statusUrl}`);
-    updateProgress(poi.id, {
-      phase: 'rendering',
-      message: 'Rendering status page...',
-      steps: ['Initialized', 'Rendering page']
-    });
-
-    const rendered = await extractPageContent(statusUrl, {
-      maxLength: 15000,
-      dynamicContentWait: 3000,
-      cookies
-    });
 
     if (!rendered.reachable || !rendered.markdown) {
       console.log(`[Trail Status] Page not reachable or no content extracted (reason: ${rendered.reason || 'unknown'})`);
@@ -352,7 +356,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
         message: `Page not reachable: ${rendered.reason || 'no content'}`,
         completed: true,
         statusFound: 0,
-        steps: ['Initialized', 'Rendering failed', 'Complete']
+        steps: ['Initialized', 'Extraction failed', 'Complete']
       });
       return { statusFound: 0, statusSaved: 0 };
     }
@@ -365,12 +369,12 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
         message: 'Insufficient page content',
         completed: true,
         statusFound: 0,
-        steps: ['Initialized', 'Rendering insufficient', 'Complete']
+        steps: ['Initialized', 'Extraction insufficient', 'Complete']
       });
       return { statusFound: 0, statusSaved: 0 };
     }
 
-    console.log(`[Trail Status] Rendered page (${rendered.markdown.length} chars)`);
+    console.log(`[Trail Status] Extracted content (${rendered.markdown.length} chars)`);
 
     // Check for cancellation after rendering
     if (isCancellationRequested(poi.id)) {
@@ -453,8 +457,10 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
     // Override source_url with the POI's configured status_url
     status.source_url = poi.status_url;
     // Extract source name from the URL if not already set
-    if (poi.status_url.includes('x.com') || poi.status_url.includes('twitter.com')) {
+    if (isTwitterUrl(poi.status_url)) {
       status.source_name = 'Twitter/X';
+    } else if (isFacebookUrl(poi.status_url)) {
+      status.source_name = 'Facebook';
     } else if (poi.status_url.includes('bsky.app')) {
       status.source_name = 'Bluesky';
     } else if (poi.status_url.includes('trailforks.com')) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12010,6 +12010,62 @@ svg.leaflet-zoom-animated {
   margin-top: 1rem;
 }
 
+/* Trail Status inline on Info tab */
+.trail-status-badges {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.trail-status-badge.source {
+  background: #6c757d;
+  color: white;
+  text-decoration: none;
+  transition: background-color 0.2s;
+}
+
+.trail-status-badge.source:hover {
+  background: #5a6268;
+}
+
+.trail-status-detail {
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.trail-status-detail.trail-status-seasonal {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+}
+
+.trail-status-updated {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: #999;
+}
+
+.collect-status-inline-btn {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.8em;
+  font-weight: 500;
+  background-color: #e9ecef;
+  color: #495057;
+  border: 1px solid #ced4da;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.collect-status-inline-btn:hover {
+  background-color: #dee2e6;
+}
+
 /* Status Tab - Main Tab View */
 .status-tab-content {
   width: 100%;

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -48,6 +48,11 @@ function DataCollectionSettings() {
   const [twitterCookiesJson, setTwitterCookiesJson] = useState('');
   const [showCookieInput, setShowCookieInput] = useState(false);
 
+  // Apify API token state
+  const [apifyToken, setApifyToken] = useState('');
+  const [apifyTokenSet, setApifyTokenSet] = useState(false);
+  const [apifySaving, setApifySaving] = useState(false);
+
   // Playwright status state
   const [playwrightStatus, setPlaywrightStatus] = useState(null);
   const [playwrightLoading, setPlaywrightLoading] = useState(true);
@@ -69,6 +74,7 @@ function DataCollectionSettings() {
     fetchAiConfig();
     fetchTwitterCredentials();
     fetchTwitterAuthStatus();
+    fetchApifyStatus();
     fetchPlaywrightStatus();
     fetchModerationConfig();
   }, []);
@@ -459,6 +465,49 @@ function DataCollectionSettings() {
     }
   };
 
+  const fetchApifyStatus = async () => {
+    try {
+      const response = await fetch('/api/admin/settings', {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const settings = await response.json();
+        setApifyTokenSet(settings.apify_api_token?.isSet || false);
+      }
+    } catch (err) {
+      console.error('Error fetching Apify status:', err);
+    }
+  };
+
+  const handleSaveApifyToken = async () => {
+    if (!apifyToken.trim()) {
+      setResult({ type: 'error', message: 'API token cannot be empty' });
+      return;
+    }
+    setApifySaving(true);
+    setResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/apify_api_token', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ value: apifyToken })
+      });
+      if (response.ok) {
+        setResult({ type: 'success', message: 'Apify API token saved successfully' });
+        setApifyToken('');
+        setApifyTokenSet(true);
+      } else {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to save token');
+      }
+    } catch (err) {
+      setResult({ type: 'error', message: `Failed to save Apify token: ${err.message}` });
+    } finally {
+      setApifySaving(false);
+    }
+  };
+
   const handleSaveAiConfig = async () => {
     setAiConfigSaving(true);
     setResult(null);
@@ -760,7 +809,7 @@ function DataCollectionSettings() {
     const phaseMap = {
       'starting': 'Starting...',
       'initializing': 'Initializing...',
-      'rendering': 'Rendering JavaScript page...',
+      'rendering': 'Fetching content...',
       'rendering_events': 'Rendering event links...',
       'rendering_news': 'Rendering news links...',
       'ai_search': 'Searching with AI...',
@@ -1377,6 +1426,51 @@ function DataCollectionSettings() {
             )}
           </>
         )}
+      </div>
+
+      {/* Apify API Token */}
+      <div className="ai-config-section">
+        <h4>Apify API Token</h4>
+        <p className="settings-description">
+          Required for scraping Twitter/X and Facebook trail status pages.
+          Used for East Rim (Twitter) and Reagan-Huffman (Facebook) trails.
+        </p>
+
+        <div className="config-row">
+          <label>Status:</label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <span className={`status-indicator ${apifyTokenSet ? 'configured' : 'not-configured'}`}></span>
+            <span>{apifyTokenSet ? 'API token configured' : 'API token not configured'}</span>
+          </div>
+        </div>
+
+        <div className="config-row">
+          <label>API Token:</label>
+          <input
+            type="password"
+            value={apifyToken}
+            onChange={e => setApifyToken(e.target.value)}
+            placeholder="Enter Apify API token..."
+            disabled={apifySaving || newsCollecting || trailCollecting}
+          />
+        </div>
+
+        <div style={{ display: 'flex', gap: '10px', marginTop: '0.5rem' }}>
+          <button
+            className="action-btn primary"
+            onClick={handleSaveApifyToken}
+            disabled={apifySaving || !apifyToken.trim() || newsCollecting || trailCollecting}
+          >
+            {apifySaving ? 'Saving...' : 'Save Token'}
+          </button>
+        </div>
+
+        <p className="settings-description" style={{ fontSize: '0.85rem', marginTop: '0.75rem' }}>
+          Get your token from{' '}
+          <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">
+            Apify Console &gt; Settings &gt; Integrations
+          </a>
+        </p>
       </div>
 
       {/* Moderation Configuration */}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -207,7 +207,7 @@ function EditableCellSignal({ level, onChange }) {
 }
 
 // Read-only view component - works for both destinations and linear features
-function ReadOnlyView({ destination, isLinearFeature, _isAdmin, showImage = true, onShare, moreInfoLink, trailStatus = null, _showNpsMap, _onToggleNpsMap }) {
+function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, showImage = true, onShare, moreInfoLink, trailStatus = null, _showNpsMap, _onToggleNpsMap, onCollectStatus }) {
   // Use thumbnail service for faster loading
   // Include updated_at for cache busting when image changes
   const imageUrl = destination.image_mime_type
@@ -276,13 +276,18 @@ function ReadOnlyView({ destination, isLinearFeature, _isAdmin, showImage = true
               {destination.owner_name || destination.property_owner}
             </span>
           )}
-          {destination.status_url && trailStatus && (
-            <span className={`trail-status-badge status-${trailStatus.status || 'unknown'}`}>
+          {destination.status_url && trailStatus && trailStatus.status !== 'unknown' && (
+            <span className={`trail-status-badge status-${trailStatus.status}`}>
               {trailStatus.status === 'open' ? 'Open' :
                trailStatus.status === 'closed' ? 'Closed' :
                trailStatus.status === 'limited' ? 'Limited' :
                trailStatus.status === 'maintenance' ? 'Maintenance' : 'Unknown'}
             </span>
+          )}
+          {destination.status_url && trailStatus && trailStatus.source_url && (
+            <a href={trailStatus.source_url} target="_blank" rel="noopener noreferrer" className="trail-status-badge source">
+              Source
+            </a>
           )}
           {/* Share button */}
           {onShare && (
@@ -294,6 +299,29 @@ function ReadOnlyView({ destination, isLinearFeature, _isAdmin, showImage = true
             </button>
           )}
         </div>
+
+        {/* Trail Status section - matches Overview section styling */}
+        {destination.status_url && trailStatus && trailStatus.status !== 'unknown' && (trailStatus.conditions || trailStatus.weather_impact || trailStatus.seasonal_closure || trailStatus.last_updated) && (
+          <div className="section">
+            <h3>Trail Status {isAdmin && editMode && onCollectStatus && (
+              <button className="collect-status-inline-btn" onClick={onCollectStatus} title="Refresh trail status">
+                Refresh
+              </button>
+            )}</h3>
+            {trailStatus.conditions && (
+              <p className="trail-status-detail">{trailStatus.conditions}</p>
+            )}
+            {trailStatus.weather_impact && (
+              <p className="trail-status-detail">{trailStatus.weather_impact}</p>
+            )}
+            {trailStatus.seasonal_closure && (
+              <p className="trail-status-detail trail-status-seasonal">Seasonal Closure in Effect</p>
+            )}
+            {trailStatus.last_updated && (
+              <p className="trail-status-updated">Updated: {formatDateTime(trailStatus.last_updated)}</p>
+            )}
+          </div>
+        )}
 
         {destination.brief_description && (
           <div className="section">
@@ -2597,9 +2625,8 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       // Auto-enter edit mode if admin and editMode is on, or if creating new POI
       const shouldEnterEditMode = (isAdmin && editMode) || isNewPOI;
       setIsEditing(shouldEnterEditMode);
-      // Stay on view tab if entering edit mode (EditView only renders on view tab)
-      // Otherwise: Status tab if selected from MTB list, Info tab otherwise
-      setSidebarTab(shouldEnterEditMode ? 'view' : (selectedFromMtbList ? 'status' : 'view'));
+      // Stay on view tab — trail status is now shown inline on the Info tab
+      setSidebarTab('view');
     } else {
       setIsEditing(false);
     }
@@ -2680,6 +2707,31 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [displayItem?.id, displayItem?.status_url]); // Only depend on specific properties, not whole displayItem object
+
+  // Handler for collecting trail status from the Info tab
+  const handleCollectStatusInline = async () => {
+    if (!displayItem?.id) return;
+    try {
+      const response = await fetch(`/api/admin/pois/${displayItem.id}/status/collect`, {
+        method: 'POST',
+        credentials: 'include'
+      });
+      if (response.ok) {
+        // Refresh status after collection
+        const statusResponse = await fetch(`/api/pois/${displayItem.id}/status`);
+        if (statusResponse.ok) {
+          const data = await statusResponse.json();
+          setTrailStatus(data);
+        }
+      } else {
+        const error = await response.json();
+        alert('Collection failed: ' + (error.error || 'Unknown error'));
+      }
+    } catch (err) {
+      console.error('[handleCollectStatusInline] Error:', err);
+      alert('Collection error: ' + err.message);
+    }
+  };
 
   // Handler for saving new organization
   const handleSaveNewOrganization = async () => {
@@ -3090,14 +3142,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
           >
             Info
           </button>
-          {linearFeature?.status_url && (
-            <button
-              className={`sidebar-tab ${sidebarTab === 'status' ? 'active' : ''}`}
-              onClick={() => setSidebarTab('status')}
-            >
-              Status
-            </button>
-          )}
           <button
             className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
             onClick={() => setSidebarTab('news')}
@@ -3155,12 +3199,14 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
                 destination={linearFeature}
                 isLinearFeature={true}
                 isAdmin={isAdmin}
+                editMode={editMode}
                 showImage={false}
                 onShare={() => setShowShareModal(true)}
                 moreInfoLink={linearFeature.more_info_link}
                 trailStatus={trailStatus}
                 showNpsMap={showNpsMap}
                 onToggleNpsMap={onToggleNpsMap}
+                onCollectStatus={handleCollectStatusInline}
               />
             )
           )}
@@ -3171,10 +3217,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
 
           {sidebarTab === 'events' && linearFeature && (
             <PoiEvents poiId={linearFeature.id} poiName={linearFeature.name} isAdmin={isAdmin} editMode={editMode} onCountChange={setEventsCount} />
-          )}
-
-          {sidebarTab === 'status' && linearFeature && linearFeature.status_url && (
-            <TrailStatus poiId={linearFeature.id} poiName={linearFeature.name} isAdmin={isAdmin} editMode={editMode} selectedFromMtbList={selectedFromMtbList} onBackToMtbList={onBackToMtbList} />
           )}
 
           {sidebarTab === 'history' && linearFeature && (
@@ -3401,14 +3443,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         >
           Info
         </button>
-        {destination?.status_url && (
-          <button
-            className={`sidebar-tab ${sidebarTab === 'status' ? 'active' : ''}`}
-            onClick={() => setSidebarTab('status')}
-          >
-            Status
-          </button>
-        )}
         <button
           className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
           onClick={() => setSidebarTab('news')}
@@ -3466,12 +3500,14 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
             <ReadOnlyView
               destination={destination}
               isAdmin={isAdmin}
+              editMode={editMode}
               showImage={false}
               onShare={() => setShowShareModal(true)}
               moreInfoLink={destination.more_info_link}
               trailStatus={trailStatus}
               showNpsMap={showNpsMap}
               onToggleNpsMap={onToggleNpsMap}
+              onCollectStatus={handleCollectStatusInline}
             />
           )
         )}
@@ -3482,10 +3518,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
 
         {sidebarTab === 'events' && destination && (
           <PoiEvents poiId={destination.id} poiName={destination.name} isAdmin={isAdmin} editMode={editMode} onCountChange={setEventsCount} />
-        )}
-
-        {sidebarTab === 'status' && destination && destination.status_url && (
-          <TrailStatus poiId={destination.id} poiName={destination.name} isAdmin={isAdmin} editMode={editMode} selectedFromMtbList={selectedFromMtbList} onBackToMtbList={onBackToMtbList} />
         )}
 
         {sidebarTab === 'history' && destination && (


### PR DESCRIPTION
## Summary

- **Apify integration** for Twitter/X (East Rim) and Facebook (Reagan-Huffman) trail status — these fail with Playwright because their JS SPAs don't yield extractable content via Readability. Apify cloud scrapers handle auth/anti-bot and return structured post data that feeds into the existing Gemini prompt pipeline.
- **Status tab collapsed into Info** — status badge + source link now appear in the badges row, conditions/weather/updated shown under a "Trail Status" heading matching the Overview section style. One fewer tab.
- **Apify API token** configurable via Settings > Data Collection, stored in `admin_settings`

## Files changed

| File | Change |
|------|--------|
| `backend/services/apifyService.js` | **NEW** — Apify API client for Twitter/Facebook |
| `backend/services/trailStatusService.js` | Route Twitter/Facebook URLs to Apify; remove cookie loading |
| `backend/routes/admin.js` | Allow `apify_api_token` key; mask `api_token` values |
| `frontend/src/components/Sidebar.jsx` | Move status into Info tab, remove Status tab |
| `frontend/src/components/DataCollectionSettings.jsx` | Add Apify API token field |
| `frontend/src/App.css` | Trail status inline styles |

## Test plan

- [ ] Container builds clean
- [ ] Set Apify API token via Settings > Data Collection
- [ ] Trigger trail status for East Rim (Twitter) — should log "Fetching Twitter posts via Apify"
- [ ] Trigger trail status for Reagan-Huffman (Facebook) — same pattern
- [ ] Verify other 5 trails still use Playwright (no regression)
- [ ] Click any MTB trail — Info tab shows status badge, source link, conditions inline
- [ ] No Status tab visible on MTB trail POIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)