### PR TITLE
fix: bump trail status age threshold from 30 to 90 days

### DIFF
--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -511,13 +511,13 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
  */
 async function saveTrailStatus(pool, poiId, status) {
   try {
-    // Validate that last_updated is not too old (reject status older than 30 days)
+    // Validate that last_updated is not too old (reject status older than 90 days)
     if (status.last_updated) {
       const lastUpdated = new Date(status.last_updated);
-      const thirtyDaysAgo = new Date();
-      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      const ninetyDaysAgo = new Date();
+      ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
 
-      if (lastUpdated < thirtyDaysAgo) {
+      if (lastUpdated < ninetyDaysAgo) {
         console.log(`[Trail Status] Skipping outdated status (last updated: ${status.last_updated})`);
         return false;
       }


### PR DESCRIPTION
## Summary

- Trail status posts older than 30 days were being rejected by `saveTrailStatus`
- @CVNPmtb last posted Feb 11 (48 days ago), so Apify fetched valid data but it got dropped
- Bumps threshold to 90 days to accommodate infrequent trail status accounts

## Test plan

- [ ] Trigger trail status for East Rim (5527) — should now save the Feb 11 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)