### PR TITLE
fix: use startUrls for Apify Twitter scraper

### DIFF
--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -99,7 +99,7 @@ export async function fetchTwitterPosts(pool, statusUrl, maxItems = 10) {
 
   try {
     const items = await runActorSync(TWITTER_ACTOR_ID, {
-      twitterHandles: [handle],
+      startUrls: [`https://x.com/${handle}`],
       maxItems,
       sort: 'Latest'
     }, token);


### PR DESCRIPTION
twitterHandles returns noResults. startUrls with profile URL works.