### PR TITLE
fix: mobile responsive sub-tabs and header overlap

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2715,6 +2715,13 @@ body {
     text-align: center;
   }
 
+  .results-subtab {
+    flex: 1;
+    padding: 0.5rem 0.25rem;
+    font-size: 0.8rem;
+    text-align: center;
+  }
+
   .sidebar-header {
     flex-shrink: 0;
     padding: 0.75rem 1rem;
@@ -4512,7 +4519,11 @@ body {
 
 /* Full-width content panels (News, Events, Results) */
 .main-content-full {
-  flex: 1;
+  position: fixed;
+  top: var(--header-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   background: #f5f5f5;
@@ -10472,6 +10483,21 @@ body {
   right: 0;
   height: 2px;
   background: #4CAF50;
+}
+
+/* Responsive sub-tab labels: full text on desktop, abbreviated on mobile */
+.subtab-label-short {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .subtab-label-full {
+    display: none;
+  }
+
+  .subtab-label-short {
+    display: inline;
+  }
 }
 
 /* Results filters */

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -188,7 +188,7 @@ END:VCALENDAR`;
   };
 
   const isLoading = activeSubTab === 'future' ? loading : pastLoading;
-  const tabLabel = activeSubTab === 'future' ? 'Future Events' : 'Past Events';
+  const tabLabel = 'Events';
 
   if (isLoading) {
     return (

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -381,19 +381,22 @@ const ResultsTab = memo(function ResultsTab({
             className={`results-subtab ${activeSubTab === 'all' ? 'active' : ''}`}
             onClick={() => handleSubTabChange('all')}
           >
-            Points of Interest
+            <span className="subtab-label-full">Points of Interest</span>
+            <span className="subtab-label-short">POIs</span>
           </button>
           <button
             className={`results-subtab ${activeSubTab === 'mtb' ? 'active' : ''}`}
             onClick={() => handleSubTabChange('mtb')}
           >
-            MTB Trail Status
+            <span className="subtab-label-full">MTB Trail Status</span>
+            <span className="subtab-label-short">MTB Status</span>
           </button>
           <button
             className={`results-subtab ${activeSubTab === 'organizations' ? 'active' : ''}`}
             onClick={() => handleSubTabChange('organizations')}
           >
-            Organizations
+            <span className="subtab-label-full">Organizations</span>
+            <span className="subtab-label-short">Orgs</span>
           </button>
         </div>
 
@@ -482,19 +485,22 @@ const ResultsTab = memo(function ResultsTab({
           className={`results-subtab ${activeSubTab === 'all' ? 'active' : ''}`}
           onClick={() => handleSubTabChange('all')}
         >
-          Points of Interest
+          <span className="subtab-label-full">Points of Interest</span>
+          <span className="subtab-label-short">POIs</span>
         </button>
         <button
           className={`results-subtab ${activeSubTab === 'mtb' ? 'active' : ''}`}
           onClick={() => handleSubTabChange('mtb')}
         >
-          MTB Trail Status
+          <span className="subtab-label-full">MTB Trail Status</span>
+          <span className="subtab-label-short">MTB Status</span>
         </button>
         <button
           className={`results-subtab ${activeSubTab === 'organizations' ? 'active' : ''}`}
           onClick={() => handleSubTabChange('organizations')}
         >
-          Organizations
+          <span className="subtab-label-full">Organizations</span>
+          <span className="subtab-label-short">Orgs</span>
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Abbreviate Results sub-tab labels on mobile (POIs, MTB Status, Orgs) to prevent text wrapping/cutoff
- Fix `.main-content-full` positioning to sit below the fixed header instead of overlapping it
- Simplify Events tab header to just "Events" since Future/Past is clear from the sub-tabs

## Test plan
- [ ] Verify Results sub-tabs show abbreviated labels on mobile (<768px) and full labels on desktop
- [ ] Verify Events sub-tabs (Future/Past) display correctly on mobile
- [ ] Verify content no longer overlaps the green header on mobile
- [ ] Verify Events tab header says "Events" not "Future Events"/"Past Events"

🤖 Generated with [Claude Code](https://claude.com/claude-code)