### PR TITLE
fix: consolidate image routes, add image backup/restore, clean up Immich

### DIFF
--- a/backend/migrations/009_cleanup_immich_settings.sql
+++ b/backend/migrations/009_cleanup_immich_settings.sql
@@ -1,0 +1,9 @@
+-- Migration 009: Clean up legacy Immich admin settings
+-- Immich was replaced by the lightweight image server in PR #104
+
+DELETE FROM admin_settings WHERE key IN (
+  'immich_api_key',
+  'immich_server_url',
+  'immich_album_id',
+  'immich_poi_album_id'
+);

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1370,13 +1370,10 @@ export function createAdminRouter(pool) {
       // Get Drive folder information
       try {
         const rootFolderId = await getDriveSetting(pool, 'root_folder_id');
-        const iconsFolderId = await getDriveSetting(pool, 'icons_folder_id');
         const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
-        const geospatialFolderId = await getDriveSetting(pool, 'geospatial_folder_id');
         const backupsFolderId = await getDriveSetting(pool, 'backups_folder_id');
 
         const folderLink = await getDriveFolderLink(pool);
-        const fileCounts = await countDriveFiles(drive, pool);
 
         status.drive_access_verified = true;
         status.drive = {
@@ -1388,23 +1385,10 @@ export function createAdminRouter(pool) {
               name: 'Roots of The Valley',
               url: `https://drive.google.com/drive/folders/${rootFolderId}`
             } : null,
-            icons: iconsFolderId ? {
-              id: iconsFolderId,
-              name: 'Icons',
-              file_count: fileCounts.iconsCount,
-              url: `https://drive.google.com/drive/folders/${iconsFolderId}`
-            } : null,
             images: imagesFolderId ? {
               id: imagesFolderId,
               name: 'Images',
-              file_count: fileCounts.imagesCount,
               url: `https://drive.google.com/drive/folders/${imagesFolderId}`
-            } : null,
-            geospatial: geospatialFolderId ? {
-              id: geospatialFolderId,
-              name: 'Geospatial',
-              file_count: fileCounts.geospatialCount,
-              url: `https://drive.google.com/drive/folders/${geospatialFolderId}`
             } : null,
             database: backupsFolderId ? {
               id: backupsFolderId,
@@ -1413,12 +1397,20 @@ export function createAdminRouter(pool) {
             } : null
           }
         };
+
+        // Get image backup status
+        try {
+          const { getImageBackupStatus } = await import('../services/backupService.js');
+          status.image_backup = await getImageBackupStatus(pool, drive);
+        } catch (e) {
+          status.image_backup = null;
+        }
       } catch (driveInfoError) {
         console.warn('Could not get Drive folder info:', driveInfoError.message);
         status.drive = { configured: false };
       }
 
-      // Get last backup info
+      // Get last database backup info
       try {
         const backupResult = await pool.query(
           "SELECT value FROM admin_settings WHERE key = 'last_backup'"
@@ -1523,6 +1515,73 @@ export function createAdminRouter(pool) {
     }
   });
 
+  // Trigger image backup to Drive
+  router.post('/backup/images/trigger', isAdmin, async (req, res) => {
+    try {
+      let credentials = req.user.oauth_credentials;
+      if (typeof credentials === 'string') {
+        try { credentials = JSON.parse(credentials); } catch (e) { credentials = null; }
+      }
+      if (!credentials || !credentials.access_token) {
+        return res.status(401).json({ error: 'Google authentication required' });
+      }
+
+      const drive = await createDriveServiceWithRefresh(credentials, pool, req.user.id);
+      const { triggerImageBackup } = await import('../services/backupService.js');
+      const result = await triggerImageBackup(pool, drive);
+
+      console.log(`Admin ${req.user.email} triggered image backup: ${result.uploaded} uploaded`);
+      res.json(result);
+    } catch (error) {
+      console.error('Error triggering image backup:', error);
+      res.status(500).json({ error: 'Failed to backup images', message: error.message });
+    }
+  });
+
+  // Get image backup status
+  router.get('/backup/images/status', isAdmin, async (req, res) => {
+    try {
+      let drive = null;
+      let credentials = req.user.oauth_credentials;
+      if (typeof credentials === 'string') {
+        try { credentials = JSON.parse(credentials); } catch (e) { credentials = null; }
+      }
+      if (credentials?.access_token) {
+        drive = await createDriveServiceWithRefresh(credentials, pool, req.user.id);
+      }
+
+      const { getImageBackupStatus } = await import('../services/backupService.js');
+      const status = await getImageBackupStatus(pool, drive);
+      res.json(status);
+    } catch (error) {
+      console.error('Error getting image backup status:', error);
+      res.status(500).json({ error: 'Failed to get image backup status' });
+    }
+  });
+
+  // Restore images from Drive
+  router.post('/backup/images/restore', isAdmin, async (req, res) => {
+    try {
+      let credentials = req.user.oauth_credentials;
+      if (typeof credentials === 'string') {
+        try { credentials = JSON.parse(credentials); } catch (e) { credentials = null; }
+      }
+      if (!credentials || !credentials.access_token) {
+        return res.status(401).json({ error: 'Google authentication required' });
+      }
+
+      const drive = await createDriveServiceWithRefresh(credentials, pool, req.user.id);
+      const { restoreImagesFromDrive } = await import('../services/backupService.js');
+      const result = await restoreImagesFromDrive(pool, drive);
+
+      console.log(`Admin ${req.user.email} restored images: ${result.restored} restored`);
+      res.json(result);
+    } catch (error) {
+      console.error('Error restoring images:', error);
+      res.status(500).json({ error: 'Failed to restore images', message: error.message });
+    }
+  });
+
   // Wipe the local database
   router.delete('/sync/wipe-database', isAdmin, async (req, res) => {
     try {
@@ -1542,10 +1601,10 @@ export function createAdminRouter(pool) {
   });
 
   // ============================================
-  // Destination Image Management Routes
+  // POI Image Management Routes (unified for all POI types)
   // ============================================
 
-  // Configure multer for memory storage (images stored in Drive, not filesystem)
+  // Configure multer for memory storage (images stored on image server + Drive backup)
   const imageUpload = multer({
     storage: multer.memoryStorage(),
     limits: {
@@ -1561,9 +1620,8 @@ export function createAdminRouter(pool) {
     }
   });
 
-  // Upload image for a destination
-  // Uploads to image server (primary) AND Drive (backup)
-  router.post('/destinations/:id/image', isAdmin, imageUpload.single('image'), async (req, res) => {
+  // Upload image for any POI (multipart form)
+  router.post('/pois/:id/image', isAdmin, imageUpload.single('image'), async (req, res) => {
     const { id } = req.params;
 
     if (!req.file) {
@@ -1571,19 +1629,17 @@ export function createAdminRouter(pool) {
     }
 
     try {
-      // Check if destination exists
-      const destCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
-      if (destCheck.rows.length === 0) {
-        return res.status(404).json({ error: 'Destination not found' });
+      const poiCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
+      if (poiCheck.rows.length === 0) {
+        return res.status(404).json({ error: 'POI not found' });
       }
 
-      const destination = destCheck.rows[0];
+      const poi = poiCheck.rows[0];
 
       // Upload to image server (primary storage)
       let imageServerAssetId = null;
       if (imageServerClient.initialized) {
         try {
-          // Delete existing primary asset from image server
           const existingAsset = await imageServerClient.getPrimaryAsset(id);
           if (existingAsset) {
             await imageServerClient.deleteAsset(existingAsset.id);
@@ -1591,7 +1647,7 @@ export function createAdminRouter(pool) {
           }
 
           const ext = req.file.mimetype.split('/')[1];
-          const sanitizedName = destination.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+          const sanitizedName = poi.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
           const filename = `${sanitizedName}-${Date.now()}.${ext}`;
 
           const result = await imageServerClient.uploadImage(
@@ -1609,27 +1665,23 @@ export function createAdminRouter(pool) {
         }
       }
 
-      // Track mime type in ROTV DB so frontend knows this POI has an image
       await pool.query(
-        `UPDATE pois
-         SET image_mime_type = $1,
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $2`,
-        [req.file.mimetype, id]
+        'UPDATE pois SET updated_at = CURRENT_TIMESTAMP WHERE id = $1',
+        [id]
       );
 
       // Also upload to Drive for backup (if user has OAuth credentials)
       let driveFileId = null;
       if (req.user.oauth_credentials) {
         try {
-          if (destination.image_drive_file_id) {
+          if (poi.image_drive_file_id) {
             const drive = createDriveService(req.user.oauth_credentials);
-            await deleteFileFromDrive(drive, destination.image_drive_file_id);
-            console.log(`Deleted old image from Drive: ${destination.image_drive_file_id}`);
+            await deleteFileFromDrive(drive, poi.image_drive_file_id);
+            console.log(`Deleted old image from Drive: ${poi.image_drive_file_id}`);
           }
 
           const ext = req.file.mimetype.split('/')[1];
-          const sanitizedName = destination.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+          const sanitizedName = poi.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
           const filename = `${sanitizedName}-${Date.now()}.${ext}`;
 
           const drive = createDriveService(req.user.oauth_credentials);
@@ -1646,16 +1698,15 @@ export function createAdminRouter(pool) {
         }
       }
 
-      console.log(`Admin ${req.user.email} uploaded image for destination ${id}`);
+      console.log(`Admin ${req.user.email} uploaded image for POI ${id}`);
       res.json({
         success: true,
         message: 'Image uploaded successfully',
-        image_url: `/api/destinations/${id}/image`,
         image_server_asset_id: imageServerAssetId,
         drive_file_id: driveFileId
       });
     } catch (error) {
-      console.error('Error uploading destination image:', error);
+      console.error('Error uploading POI image:', error);
       if (error.message?.includes('Invalid file type')) {
         return res.status(400).json({ error: error.message });
       }
@@ -1663,8 +1714,8 @@ export function createAdminRouter(pool) {
     }
   });
 
-  // Upload image for a destination (base64 JSON variant - for dev server issues)
-  router.post('/destinations/:id/image-base64', isAdmin, async (req, res) => {
+  // Upload image for any POI (base64 JSON variant)
+  router.post('/pois/:id/image-base64', isAdmin, async (req, res) => {
     const { id } = req.params;
     const { imageData, mimeType } = req.body;
 
@@ -1672,34 +1723,29 @@ export function createAdminRouter(pool) {
       return res.status(400).json({ error: 'No image data provided' });
     }
 
-    // Validate mime type
     const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
     if (!allowedTypes.includes(mimeType)) {
       return res.status(400).json({ error: 'Invalid file type. Only JPEG, PNG, WebP, and GIF are allowed.' });
     }
 
     try {
-      // Decode base64
       const buffer = Buffer.from(imageData, 'base64');
 
-      // Validate size (10MB max)
       if (buffer.length > 10 * 1024 * 1024) {
         return res.status(400).json({ error: 'Image must be less than 10MB' });
       }
 
-      // Check if destination exists
-      const destCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
-      if (destCheck.rows.length === 0) {
-        return res.status(404).json({ error: 'Destination not found' });
+      const poiCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
+      if (poiCheck.rows.length === 0) {
+        return res.status(404).json({ error: 'POI not found' });
       }
 
-      const destination = destCheck.rows[0];
+      const poi = poiCheck.rows[0];
 
       // Upload to image server (primary storage)
       let imageServerAssetId = null;
       if (imageServerClient.initialized) {
         try {
-          // Delete existing primary asset from image server
           const existingAsset = await imageServerClient.getPrimaryAsset(id);
           if (existingAsset) {
             await imageServerClient.deleteAsset(existingAsset.id);
@@ -1707,7 +1753,7 @@ export function createAdminRouter(pool) {
           }
 
           const ext = mimeType.split('/')[1];
-          const sanitizedName = destination.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+          const sanitizedName = poi.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
           const filename = `${sanitizedName}-${Date.now()}.${ext}`;
 
           const result = await imageServerClient.uploadImage(
@@ -1725,13 +1771,9 @@ export function createAdminRouter(pool) {
         }
       }
 
-      // Track mime type in ROTV DB so frontend knows this POI has an image
       await pool.query(
-        `UPDATE pois
-         SET image_mime_type = $1,
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $2`,
-        [mimeType, id]
+        'UPDATE pois SET updated_at = CURRENT_TIMESTAMP WHERE id = $1',
+        [id]
       );
 
       // Also upload to Drive as backup if user has OAuth
@@ -1740,16 +1782,16 @@ export function createAdminRouter(pool) {
         try {
           const drive = createDriveService(req.user.oauth_credentials);
 
-          if (destination.image_drive_file_id) {
+          if (poi.image_drive_file_id) {
             try {
-              await deleteFileFromDrive(drive, destination.image_drive_file_id);
-              console.log(`Deleted old image from Drive: ${destination.image_drive_file_id}`);
+              await deleteFileFromDrive(drive, poi.image_drive_file_id);
+              console.log(`Deleted old image from Drive: ${poi.image_drive_file_id}`);
             } catch (deleteError) {
               console.warn('Failed to delete old image from Drive (non-fatal):', deleteError.message);
             }
           }
 
-          driveFileId = await uploadImageToDrive(drive, pool, buffer, mimeType, destination.name);
+          driveFileId = await uploadImageToDrive(drive, pool, buffer, mimeType, poi.name);
 
           await pool.query(
             'UPDATE pois SET image_drive_file_id = $1 WHERE id = $2',
@@ -1762,7 +1804,7 @@ export function createAdminRouter(pool) {
         }
       }
 
-      console.log(`Admin ${req.user.email} uploaded image for destination ${id}`);
+      console.log(`Admin ${req.user.email} uploaded image for POI ${id}`);
       res.json({
         success: true,
         message: 'Image uploaded successfully',
@@ -1770,24 +1812,22 @@ export function createAdminRouter(pool) {
         drive_file_id: driveFileId
       });
     } catch (error) {
-      console.error('Error uploading destination image:', error);
+      console.error('Error uploading POI image:', error);
       res.status(500).json({ error: 'Failed to upload image' });
     }
   });
 
-  // Delete image from a destination
-  // Deletes from image server AND Drive backup
-  router.delete('/destinations/:id/image', isAdmin, async (req, res) => {
+  // Delete image from any POI
+  router.delete('/pois/:id/image', isAdmin, async (req, res) => {
     const { id } = req.params;
 
     try {
-      // Check if destination exists and has an image
-      const destCheck = await pool.query('SELECT id, name, image_drive_file_id, image_mime_type FROM pois WHERE id = $1', [id]);
-      if (destCheck.rows.length === 0) {
-        return res.status(404).json({ error: 'Destination not found' });
+      const poiCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
+      if (poiCheck.rows.length === 0) {
+        return res.status(404).json({ error: 'POI not found' });
       }
 
-      const destination = destCheck.rows[0];
+      const poi = poiCheck.rows[0];
 
       // Check image server for assets
       let hasImageServerAsset = false;
@@ -1804,37 +1844,36 @@ export function createAdminRouter(pool) {
         }
       }
 
-      if (!hasImageServerAsset && !destination.image_drive_file_id && !destination.image_mime_type) {
-        return res.status(400).json({ error: 'Destination has no image' });
+      if (!hasImageServerAsset && !poi.image_drive_file_id) {
+        return res.status(400).json({ error: 'POI has no image' });
       }
 
       // Delete from Drive if present and user has OAuth
-      if (destination.image_drive_file_id && req.user.oauth_credentials) {
+      if (poi.image_drive_file_id && req.user.oauth_credentials) {
         try {
           const drive = createDriveService(req.user.oauth_credentials);
-          await deleteFileFromDrive(drive, destination.image_drive_file_id);
-          console.log(`Deleted image from Drive: ${destination.image_drive_file_id}`);
+          await deleteFileFromDrive(drive, poi.image_drive_file_id);
+          console.log(`Deleted image from Drive: ${poi.image_drive_file_id}`);
         } catch (driveError) {
           console.warn(`Failed to delete from Drive (non-fatal):`, driveError.message);
         }
       }
 
-      // Clear image references from database
       await pool.query(
         `UPDATE pois
-         SET image_data = NULL, image_mime_type = NULL, image_drive_file_id = NULL, immich_primary_asset_id = NULL,
+         SET image_drive_file_id = NULL,
              updated_at = CURRENT_TIMESTAMP
          WHERE id = $1`,
         [id]
       );
 
-      console.log(`Admin ${req.user.email} deleted image for destination ${id}`);
+      console.log(`Admin ${req.user.email} deleted image for POI ${id}`);
       res.json({
         success: true,
         message: 'Image deleted successfully'
       });
     } catch (error) {
-      console.error('Error deleting destination image:', error);
+      console.error('Error deleting POI image:', error);
       res.status(500).json({ error: 'Failed to delete image' });
     }
   });
@@ -1912,7 +1951,8 @@ export function createAdminRouter(pool) {
         'root_folder_id',
         'icons_folder_id',
         'images_folder_id',
-        'geospatial_folder_id'
+        'geospatial_folder_id',
+        'backups_folder_id'
       ];
 
       if (!allowedKeys.includes(key)) {
@@ -2041,7 +2081,7 @@ export function createAdminRouter(pool) {
         RETURNING id, name, poi_type, latitude, longitude, property_owner,
                   brief_description, era, historical_description, primary_activities,
                   surface, pets, cell_signal, more_info_link, length_miles, difficulty,
-                  image_mime_type, image_drive_file_id, geometry_drive_file_id,
+                  image_drive_file_id, geometry_drive_file_id,
                   boundary_type, boundary_color, status_url, news_url, events_url,
                   deleted, created_at, updated_at
       `, values);
@@ -2078,146 +2118,6 @@ export function createAdminRouter(pool) {
     } catch (error) {
       console.error('Error deleting linear feature:', error);
       res.status(500).json({ error: 'Failed to delete linear feature' });
-    }
-  });
-
-  // Upload image for linear feature
-  router.post('/linear-features/:id/image', isAdmin, imageUpload.single('image'), async (req, res) => {
-    try {
-      const { id } = req.params;
-
-      if (!req.file) {
-        return res.status(400).json({ error: 'No image file provided' });
-      }
-
-      const result = await pool.query(`
-        UPDATE pois
-        SET image_data = $1, image_mime_type = $2, updated_at = CURRENT_TIMESTAMP
-        WHERE id = $3
-        RETURNING id, name, image_mime_type
-      `, [req.file.buffer, req.file.mimetype, id]);
-
-      if (result.rows.length === 0) {
-        return res.status(404).json({ error: 'Linear feature not found' });
-      }
-
-      console.log(`Admin ${req.user.email} uploaded image for linear feature ${id}`);
-      res.json({
-        success: true,
-        feature: result.rows[0]
-      });
-    } catch (error) {
-      console.error('Error uploading linear feature image:', error);
-      res.status(500).json({ error: 'Failed to upload image' });
-    }
-  });
-
-  // Upload image for linear feature (base64 JSON variant - for dev server issues)
-  router.post('/linear-features/:id/image-base64', isAdmin, async (req, res) => {
-    const { id } = req.params;
-    const { imageData, mimeType } = req.body;
-
-    if (!imageData || !mimeType) {
-      return res.status(400).json({ error: 'No image data provided' });
-    }
-
-    // Validate mime type
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-    if (!allowedTypes.includes(mimeType)) {
-      return res.status(400).json({ error: 'Invalid file type. Only JPEG, PNG, WebP, and GIF are allowed.' });
-    }
-
-    try {
-      // Decode base64
-      const buffer = Buffer.from(imageData, 'base64');
-
-      // Validate size (10MB max)
-      if (buffer.length > 10 * 1024 * 1024) {
-        return res.status(400).json({ error: 'Image must be less than 10MB' });
-      }
-
-      // Check if linear feature exists
-      const featureCheck = await pool.query('SELECT id, name, image_drive_file_id FROM pois WHERE id = $1', [id]);
-      if (featureCheck.rows.length === 0) {
-        return res.status(404).json({ error: 'Linear feature not found' });
-      }
-
-      const feature = featureCheck.rows[0];
-
-      // Store image in database
-      await pool.query(
-        `UPDATE pois
-         SET image_data = $1, image_mime_type = $2,
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $3`,
-        [buffer, mimeType, id]
-      );
-
-      // Also upload to Drive as backup if user has OAuth
-      let driveFileId = null;
-      if (req.user.oauth_credentials) {
-        try {
-          const drive = createDriveService(req.user.oauth_credentials);
-
-          // Delete old image from Drive if it exists
-          if (feature.image_drive_file_id) {
-            try {
-              await deleteFileFromDrive(drive, feature.image_drive_file_id);
-              console.log(`Deleted old image from Drive: ${feature.image_drive_file_id}`);
-            } catch (deleteError) {
-              console.warn('Failed to delete old image from Drive (non-fatal):', deleteError.message);
-            }
-          }
-
-          // Upload new image to Drive
-          driveFileId = await uploadImageToDrive(drive, pool, buffer, mimeType, feature.name);
-
-          // Update database with Drive file ID
-          await pool.query(
-            'UPDATE pois SET image_drive_file_id = $1 WHERE id = $2',
-            [driveFileId, id]
-          );
-
-          console.log(`Backed up image to Drive: ${driveFileId}`);
-        } catch (driveError) {
-          console.warn('Failed to backup to Drive (non-fatal):', driveError.message);
-        }
-      }
-
-      console.log(`Admin ${req.user.email} uploaded image for linear feature ${id}`);
-      res.json({
-        success: true,
-        message: 'Image uploaded successfully',
-        drive_file_id: driveFileId
-      });
-    } catch (error) {
-      console.error('Error uploading linear feature image:', error);
-      res.status(500).json({ error: 'Failed to upload image' });
-    }
-  });
-
-  // Delete image for linear feature
-  router.delete('/linear-features/:id/image', isAdmin, async (req, res) => {
-    try {
-      const { id } = req.params;
-
-      const result = await pool.query(`
-        UPDATE pois
-        SET image_data = NULL, image_mime_type = NULL, image_drive_file_id = NULL,
-            updated_at = CURRENT_TIMESTAMP
-        WHERE id = $1
-        RETURNING id, name
-      `, [id]);
-
-      if (result.rows.length === 0) {
-        return res.status(404).json({ error: 'Linear feature not found' });
-      }
-
-      console.log(`Admin ${req.user.email} deleted image for linear feature ${id}`);
-      res.json({ success: true });
-    } catch (error) {
-      console.error('Error deleting linear feature image:', error);
-      res.status(500).json({ error: 'Failed to delete image' });
     }
   });
 

--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import { Readable } from 'stream';
-import { getDriveSetting, setDriveSetting } from './driveImageService.js';
+import { getDriveSetting, setDriveSetting, uploadImageToDrive } from './driveImageService.js';
+import imageServerClient from './imageServerClient.js';
 
 const BACKUPS_FOLDER_NAME = 'Database';
 
@@ -191,4 +192,199 @@ export async function getBackupStatus(pool) {
     lastBackup: result.rows[0]?.value || null,
     backupsFolderId: backupsFolderId || null
   };
+}
+
+/**
+ * List files in the Drive Images folder
+ */
+async function listDriveImages(drive, imagesFolderId) {
+  const files = [];
+  let pageToken = null;
+
+  do {
+    const params = {
+      q: `'${imagesFolderId}' in parents and trashed = false`,
+      fields: 'nextPageToken,files(id,name)',
+      pageSize: 100
+    };
+    if (pageToken) params.pageToken = pageToken;
+
+    const response = await drive.files.list(params);
+    files.push(...(response.data.files || []));
+    pageToken = response.data.nextPageToken;
+  } while (pageToken);
+
+  return files;
+}
+
+/**
+ * Sync image server assets to Drive Images folder.
+ * Uploads any assets missing from Drive.
+ */
+export async function triggerImageBackup(pool, drive) {
+  const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
+  if (!imagesFolderId) {
+    throw new Error('Images folder not configured in Drive');
+  }
+
+  if (!imageServerClient.initialized) {
+    throw new Error('Image server not configured');
+  }
+
+  const allAssets = await imageServerClient.listAllAssets();
+  const driveFiles = await listDriveImages(drive, imagesFolderId);
+  const driveFileNames = new Set(driveFiles.map(f => f.name));
+
+  let uploaded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const asset of allAssets) {
+    const assetName = `asset-${asset.id}-${asset.original_filename || 'image.jpg'}`;
+
+    if (driveFileNames.has(assetName)) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const assetData = await imageServerClient.fetchAssetData(asset.id);
+      if (!assetData.success) {
+        failed++;
+        continue;
+      }
+
+      await drive.files.create({
+        requestBody: {
+          name: assetName,
+          mimeType: assetData.contentType,
+          parents: [imagesFolderId]
+        },
+        media: {
+          mimeType: assetData.contentType,
+          body: Readable.from([assetData.data])
+        },
+        fields: 'id'
+      });
+
+      uploaded++;
+    } catch (error) {
+      console.warn(`[ImageBackup] Failed to backup asset ${asset.id}:`, error.message);
+      failed++;
+    }
+  }
+
+  const now = new Date().toISOString();
+  await pool.query(`
+    INSERT INTO admin_settings (key, value, updated_at)
+    VALUES ('last_image_backup', $1, CURRENT_TIMESTAMP)
+    ON CONFLICT (key) DO UPDATE SET
+      value = EXCLUDED.value,
+      updated_at = CURRENT_TIMESTAMP
+  `, [now]);
+
+  console.log(`[ImageBackup] Done: ${uploaded} uploaded, ${skipped} skipped, ${failed} failed`);
+
+  return { success: true, uploaded, skipped, failed, timestamp: now };
+}
+
+/**
+ * Get image backup status — compare image server assets vs Drive Images files
+ */
+export async function getImageBackupStatus(pool, drive) {
+  const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
+
+  let imageServerCount = 0;
+  let driveCount = 0;
+
+  if (imageServerClient.initialized) {
+    const allAssets = await imageServerClient.listAllAssets();
+    imageServerCount = allAssets.length;
+  }
+
+  if (imagesFolderId && drive) {
+    const driveFiles = await listDriveImages(drive, imagesFolderId);
+    driveCount = driveFiles.length;
+  }
+
+  const lastBackupResult = await pool.query(
+    "SELECT value FROM admin_settings WHERE key = 'last_image_backup'"
+  );
+
+  return {
+    imageServerCount,
+    driveCount,
+    lastBackup: lastBackupResult.rows[0]?.value || null,
+    imagesFolderId: imagesFolderId || null
+  };
+}
+
+/**
+ * Restore images from Drive Images folder back into image server.
+ * Downloads each file from Drive and uploads to image server.
+ */
+export async function restoreImagesFromDrive(pool, drive) {
+  const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
+  if (!imagesFolderId) {
+    throw new Error('Images folder not configured in Drive');
+  }
+
+  if (!imageServerClient.initialized) {
+    throw new Error('Image server not configured');
+  }
+
+  const driveFiles = await listDriveImages(drive, imagesFolderId);
+  const existingAssets = await imageServerClient.listAllAssets();
+  const existingNames = new Set(existingAssets.map(a => `asset-${a.id}-${a.original_filename || 'image.jpg'}`));
+
+  let restored = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const file of driveFiles) {
+    // Skip files already on image server
+    if (existingNames.has(file.name)) {
+      skipped++;
+      continue;
+    }
+
+    // Parse asset info from filename: asset-{id}-{original_filename}
+    const match = file.name.match(/^asset-(\d+)-(.+)$/);
+    if (!match) {
+      console.warn(`[ImageRestore] Skipping unrecognized file: ${file.name}`);
+      skipped++;
+      continue;
+    }
+
+    const originalFilename = match[2];
+
+    try {
+      const response = await drive.files.get(
+        { fileId: file.id, alt: 'media' },
+        { responseType: 'arraybuffer' }
+      );
+
+      const buffer = Buffer.from(response.data);
+      const ext = originalFilename.split('.').pop()?.toLowerCase() || 'jpg';
+      const mimeMap = { jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', webp: 'image/webp', gif: 'image/gif' };
+      const mimeType = mimeMap[ext] || 'image/jpeg';
+
+      // Upload to image server — poi_id 0 since we can't determine it from filename alone
+      // The asset will need to be reassociated if the DB was also restored
+      const result = await imageServerClient.uploadImage(buffer, 0, 'primary', originalFilename, mimeType);
+
+      if (result.success) {
+        restored++;
+      } else {
+        failed++;
+      }
+    } catch (error) {
+      console.warn(`[ImageRestore] Failed to restore ${file.name}:`, error.message);
+      failed++;
+    }
+  }
+
+  console.log(`[ImageRestore] Done: ${restored} restored, ${skipped} skipped, ${failed} failed`);
+
+  return { success: true, restored, skipped, failed };
 }

--- a/backend/services/imageServerClient.js
+++ b/backend/services/imageServerClient.js
@@ -1,8 +1,8 @@
 /**
- * Image Server Client - replacement for immichService.js
+ * Image Server Client
  *
- * Talks to the purpose-built image server at image-server.rootsofthevalley.org
- * instead of Immich. No API key needed — image server is internal.
+ * Talks to the purpose-built image server at images.rootsofthevalley.org.
+ * No API key needed — image server is internal.
  */
 
 class ImageServerClient {
@@ -385,7 +385,6 @@ class ImageServerClient {
 
   /**
    * Get structured media data for a POI (photos + videos with roles)
-   * Replaces the combined Immich tags + DB columns approach
    */
   async getPoiMediaWithThemes(poiId) {
     if (!this.initialized) {
@@ -431,6 +430,28 @@ class ImageServerClient {
     });
 
     return { photos, videos, themePrimaries };
+  }
+
+  /**
+   * List all assets on the image server
+   */
+  async listAllAssets() {
+    if (!this.initialized) {
+      return [];
+    }
+
+    try {
+      const response = await fetch(`${this.serverUrl}/api/assets`);
+
+      if (!response.ok) {
+        throw new Error(`Fetch failed: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error(`[ImageServer] Failed to list all assets:`, error);
+      return [];
+    }
   }
 
   /**

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6767,10 +6767,20 @@ body {
   color: #c62828;
 }
 
-/* Sync buttons grid - 3 equal buttons */
+/* Backup section divider */
+.backup-section {
+  padding: 1rem 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.backup-section:last-of-type {
+  border-bottom: none;
+}
+
+/* Sync buttons grid - 2 equal buttons */
 .sync-buttons-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
   margin-bottom: 1rem;
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2799,13 +2799,13 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         if (pendingImage) {
           if (pendingImage.deleted) {
             // Delete the image
-            await fetch(`/api/admin/destinations/${destination.id}/image`, {
+            await fetch(`/api/admin/pois/${destination.id}/image`, {
               method: 'DELETE',
               credentials: 'include'
             });
           } else if (pendingImage.data) {
             // Upload new image
-            await fetch(`/api/admin/destinations/${destination.id}/image-base64`, {
+            await fetch(`/api/admin/pois/${destination.id}/image-base64`, {
               method: 'POST',
               credentials: 'include',
               headers: { 'Content-Type': 'application/json' },
@@ -2857,13 +2857,13 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       if (pendingImage) {
         if (pendingImage.deleted) {
           // Delete the image
-          await fetch(`/api/admin/linear-features/${linearFeature.id}/image`, {
+          await fetch(`/api/admin/pois/${linearFeature.id}/image`, {
             method: 'DELETE',
             credentials: 'include'
           });
         } else if (pendingImage.data) {
           // Upload new image
-          await fetch(`/api/admin/linear-features/${linearFeature.id}/image-base64`, {
+          await fetch(`/api/admin/pois/${linearFeature.id}/image-base64`, {
             method: 'POST',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/components/SyncSettings.jsx
+++ b/frontend/src/components/SyncSettings.jsx
@@ -8,15 +8,15 @@ function SyncSettings({ onDataRefresh }) {
   const [refreshing, setRefreshing] = useState(false);
   const [backingUp, setBackingUp] = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [backingUpImages, setBackingUpImages] = useState(false);
+  const [restoringImages, setRestoringImages] = useState(false);
   const [wiping, setWiping] = useState(false);
   const [backupsList, setBackupsList] = useState(null);
   const [showRestoreList, setShowRestoreList] = useState(false);
 
   // Editable Drive ID states
   const [driveIdEdits, setDriveIdEdits] = useState({
-    icons: '',
     images: '',
-    geospatial: '',
     database: ''
   });
   const [savingDriveId, setSavingDriveId] = useState(null);
@@ -59,9 +59,7 @@ function SyncSettings({ onDataRefresh }) {
   useEffect(() => {
     if (syncStatus) {
       setDriveIdEdits({
-        icons: syncStatus.drive?.folders?.icons?.id || '',
         images: syncStatus.drive?.folders?.images?.id || '',
-        geospatial: syncStatus.drive?.folders?.geospatial?.id || '',
         database: syncStatus.drive?.folders?.database?.id || ''
       });
     }
@@ -79,9 +77,7 @@ function SyncSettings({ onDataRefresh }) {
 
     try {
       const keyMap = {
-        icons: 'icons_folder_id',
         images: 'images_folder_id',
-        geospatial: 'geospatial_folder_id',
         database: 'backups_folder_id'
       };
       const response = await fetch(`/api/admin/drive/settings/${keyMap[key]}`, {
@@ -93,7 +89,7 @@ function SyncSettings({ onDataRefresh }) {
 
       const result = await response.json();
       if (response.ok) {
-        setMessage(`Updated ${key} ID`);
+        setMessage(`Updated ${key} folder ID`);
         fetchStatus();
       } else {
         setError(result.error || `Failed to update ${key} ID`);
@@ -124,13 +120,13 @@ function SyncSettings({ onDataRefresh }) {
 
       const result = await response.json();
       if (response.ok) {
-        setMessage(`Backup created: ${result.filename}`);
+        setMessage(`Database backup created: ${result.filename}`);
         fetchStatus();
       } else {
-        setError(result.error || 'Backup failed');
+        setError(result.error || 'Database backup failed');
       }
     } catch {
-      setError('Failed to create backup');
+      setError('Failed to create database backup');
     } finally {
       setBackingUp(false);
     }
@@ -193,6 +189,60 @@ function SyncSettings({ onDataRefresh }) {
     }
   };
 
+  const handleImageBackup = async () => {
+    setBackingUpImages(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/backup/images/trigger', {
+        method: 'POST',
+        credentials: 'include'
+      });
+
+      const result = await response.json();
+      if (response.ok) {
+        setMessage(`Image backup: ${result.uploaded} uploaded, ${result.skipped} already backed up`);
+        fetchStatus();
+      } else {
+        setError(result.error || 'Image backup failed');
+      }
+    } catch {
+      setError('Failed to backup images');
+    } finally {
+      setBackingUpImages(false);
+    }
+  };
+
+  const handleImageRestore = async () => {
+    if (!confirm('Restore images from Drive?\n\nThis will download images from Drive and upload them to the image server.')) {
+      return;
+    }
+
+    setRestoringImages(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/backup/images/restore', {
+        method: 'POST',
+        credentials: 'include'
+      });
+
+      const result = await response.json();
+      if (response.ok) {
+        setMessage(`Image restore: ${result.restored} restored, ${result.skipped} skipped`);
+        fetchStatus();
+      } else {
+        setError(result.error || 'Image restore failed');
+      }
+    } catch {
+      setError('Failed to restore images');
+    } finally {
+      setRestoringImages(false);
+    }
+  };
+
   const handleWipeDatabase = async () => {
     if (!confirm('WARNING: This will permanently delete ALL POIs from the local database.\n\nThis action cannot be undone!')) return;
     if (!confirm('FINAL WARNING: Click OK to confirm you want to wipe the database.')) return;
@@ -247,9 +297,6 @@ function SyncSettings({ onDataRefresh }) {
       <div className="drive-id-label">
         <span className="folder-icon">{icon}</span>
         <span>{label}</span>
-        {folderData?.file_count !== undefined && (
-          <span className="file-count">({folderData.file_count})</span>
-        )}
       </div>
       <input
         type="text"
@@ -271,6 +318,9 @@ function SyncSettings({ onDataRefresh }) {
     </div>
   );
 
+  const imageBackup = syncStatus?.image_backup;
+  const anyBusy = backingUp || restoring || backingUpImages || restoringImages;
+
   return (
     <div className="sync-settings">
       <h3>Google Drive</h3>
@@ -278,11 +328,10 @@ function SyncSettings({ onDataRefresh }) {
       {error && <div className="sync-error">{error}</div>}
       {message && <div className="sync-success">{message}</div>}
 
-      {/* Google Drive — folders + backup/restore */}
       {syncStatus?.drive?.configured && (
         <div className="sync-drive-info">
           <div className="sync-tile-header">
-            <h4>Folders</h4>
+            <h4>Backup & Restore</h4>
             <button
               className={`refresh-btn${refreshing ? ' spinning' : ''}`}
               onClick={handleManualRefresh}
@@ -292,9 +341,6 @@ function SyncSettings({ onDataRefresh }) {
               &#8635;
             </button>
           </div>
-          <p className="drive-info-description">
-            Edit folder IDs to connect to existing Drive folders.
-          </p>
 
           {syncStatus.drive.folders.root && (
             <div className="drive-root-header">
@@ -310,16 +356,13 @@ function SyncSettings({ onDataRefresh }) {
             </div>
           )}
 
-          <div className="drive-id-list">
-            {driveIdRow('icons', 'Icons', '\u{1F3A8}', syncStatus.drive.folders.icons)}
-            {driveIdRow('images', 'Images', '\u{1F5BC}\uFE0F', syncStatus.drive.folders.images)}
-            {driveIdRow('geospatial', 'Geospatial', '\u{1F5FA}\uFE0F', syncStatus.drive.folders.geospatial)}
-            {driveIdRow('database', 'Database', '\u{1F4BE}', syncStatus.drive.folders.database)}
-          </div>
-
-          {/* Backup & Restore controls */}
+          {/* Database Section */}
           {syncStatus.drive_access_verified && (
-            <div className="backup-controls">
+            <div className="backup-section">
+              <div className="backup-section-header">
+                {driveIdRow('database', 'Database', '\u{1F4BE}', syncStatus.drive.folders.database)}
+              </div>
+
               <div className="sync-status-row">
                 <div className="sync-status-item">
                   <label>Last Backup</label>
@@ -332,7 +375,7 @@ function SyncSettings({ onDataRefresh }) {
                   <button
                     className="sync-btn push-btn"
                     onClick={handleBackup}
-                    disabled={backingUp || restoring}
+                    disabled={anyBusy}
                   >
                     {backingUp ? 'Backing up...' : 'Backup'}
                   </button>
@@ -342,7 +385,7 @@ function SyncSettings({ onDataRefresh }) {
                   <button
                     className="sync-btn pull-btn"
                     onClick={handleShowRestore}
-                    disabled={restoring || backingUp}
+                    disabled={anyBusy}
                   >
                     {restoring ? 'Restoring...' : 'Restore'}
                   </button>
@@ -372,6 +415,53 @@ function SyncSettings({ onDataRefresh }) {
                   )}
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Images Section */}
+          {syncStatus.drive_access_verified && (
+            <div className="backup-section">
+              <div className="backup-section-header">
+                {driveIdRow('images', 'Images', '\u{1F5BC}\uFE0F', syncStatus.drive.folders.images)}
+              </div>
+
+              <div className="sync-status-row">
+                <div className="sync-status-item">
+                  <label>Image Server</label>
+                  <span>{imageBackup?.imageServerCount ?? '...'} assets</span>
+                </div>
+                <div className="sync-status-item">
+                  <label>Drive Backup</label>
+                  <span>{imageBackup?.driveCount ?? '...'} files</span>
+                </div>
+                <div className="sync-status-item">
+                  <label>Last Backup</label>
+                  <span>{formatDate(imageBackup?.lastBackup)}</span>
+                </div>
+              </div>
+
+              <div className="sync-buttons-grid">
+                <div className="sync-button-card">
+                  <button
+                    className="sync-btn push-btn"
+                    onClick={handleImageBackup}
+                    disabled={anyBusy}
+                  >
+                    {backingUpImages ? 'Backing up...' : 'Backup'}
+                  </button>
+                  <p className="button-description">Sync missing images to Drive</p>
+                </div>
+                <div className="sync-button-card">
+                  <button
+                    className="sync-btn pull-btn"
+                    onClick={handleImageRestore}
+                    disabled={anyBusy}
+                  >
+                    {restoringImages ? 'Restoring...' : 'Restore'}
+                  </button>
+                  <p className="button-description">Pull images from Drive to image server</p>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -70,11 +70,6 @@ justification = "News service has JSDoc function documentation"
 
 [[exceptions]]
 check = "verbose_comments"
-path = "backend/services/sheetsSync.js"
-justification = "Sheets sync service has JSDoc function documentation"
-
-[[exceptions]]
-check = "verbose_comments"
 path = "backend/services/trailStatusService.js"
 justification = "Trail status service has JSDoc function documentation"
 
@@ -509,11 +504,6 @@ check = "deferred_work"
 path = "frontend/src/components/UserMenu.jsx"
 justification = "HTML placeholder attribute on form inputs - standard HTML syntax"
 
-[[exceptions]]
-check = "deferred_work"
-path = "frontend/src/components/ImmichSettings.jsx"
-justification = "HTML placeholder attribute on form inputs - standard HTML syntax"
-
 # Random scripts - container entrypoint and OAuth utility
 
 [[exceptions]]
@@ -558,11 +548,6 @@ path = ".pre-commit-config.yaml"
 justification = "Node.js project uses standard pre-commit hooks without cognitive complexity thresholds (JavaScript ecosystem uses ESLint)"
 
 # Single-use helpers - Google Sheets sync operations (legitimate separation of concerns)
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "backend/services/sheetsSync.js"
-justification = "Google Sheets sync operations are separated into atomic helper functions (ensure*, read*, push*) for maintainability and testing. Each sheet type (Activities, Eras, Surfaces, Icons, etc.) requires its own schema validation, column mapping, and error handling. Inlining would create massive, unmaintainable functions."
 
 # Single-use helpers - Trail status service (slot architecture requires discrete phases)
 
@@ -664,11 +649,6 @@ justification = "Technical debt: Database query results and API responses use ge
 
 [[exceptions]]
 check = "generic_names"
-path = "backend/services/sheetsSync.js"
-justification = "Technical debt: Google Sheets API responses use generic 'result' and 'data' variable names. Should be refactored in future code quality PR."
-
-[[exceptions]]
-check = "generic_names"
 path = "backend/services/aiSearchFactory.js"
 justification = "Technical debt: AI API responses use generic 'result' variable name. Should be refactored in future code quality PR."
 
@@ -690,11 +670,6 @@ path = "frontend/src/utils/iconUtils.js"
 justification = "getDestinationIconTypeFromConfig is shared between Map.jsx (for map marker icons) and getIconUrlForPOI (for ResultsTile icons). Extracted from Map.jsx to avoid duplication when implementing Issue #73 (replacing letter badges with icons in Results lists). This is legitimate code reuse, not single-use extraction."
 
 # Migration script - one-time use, functions provide logical separation
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "backend/scripts/migrate-poi-images.js"
-justification = "One-time migration script for Issue #1 Part 3. Functions (loadImmichSettings, uploadToImmich, addToAlbum, tagAsset, migrate) provide logical separation for a complex sequential workflow. Script runs once and will be removed after migration is stable."
 
 # Theme hook - date calculation helpers improve readability
 


### PR DESCRIPTION
## Summary
- Unify 6 separate destination/linear-feature image routes into 3 `/pois/:id/image` routes
- Add image backup/restore to Google Drive (sync image server assets to Drive, restore from Drive)
- Remove all SQL references to dropped columns (`image_data`, `image_mime_type`, `immich_primary_asset_id`)
- Add migration 009 to clean up Immich `admin_settings` rows from production
- Simplify Drive UI from 4 folder rows to Database + Images sections with backup/restore buttons
- Remove stale gourmand exceptions for deleted files

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 214/216 pass (2 pre-existing flaky Playwright tests)
- [ ] Admin UI: Google Drive tab shows Database + Images sections
- [ ] Upload image to point POI — reaches image server
- [ ] Upload image to linear feature (trail) — uses image server, not BYTEA
- [ ] Database backup/restore buttons work as before
- [ ] Image backup button syncs missing files to Drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)