### PR TITLE
fix: address Gemini code review findings from PRs #150-#159

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1791,7 +1791,7 @@ export function createAdminRouter(pool) {
             }
           }
 
-          driveFileId = await uploadImageToDrive(drive, pool, buffer, mimeType, poi.name);
+          driveFileId = await uploadImageToDrive(drive, pool, poi.name, buffer, mimeType);
 
           await pool.query(
             'UPDATE pois SET image_drive_file_id = $1 WHERE id = $2',

--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -204,7 +204,7 @@ async function listDriveImages(drive, imagesFolderId) {
   do {
     const params = {
       q: `'${imagesFolderId}' in parents and trashed = false`,
-      fields: 'nextPageToken,files(id,name)',
+      fields: 'nextPageToken,files(id,name,mimeType)',
       pageSize: 100
     };
     if (pageToken) params.pageToken = pageToken;
@@ -240,7 +240,7 @@ export async function triggerImageBackup(pool, drive) {
   let failed = 0;
 
   for (const asset of allAssets) {
-    const assetName = `asset-${asset.id}-${asset.original_filename || 'image.jpg'}`;
+    const assetName = `poi-${asset.poi_id}-asset-${asset.id}-${asset.original_filename || 'image.jpg'}`;
 
     if (driveFileNames.has(assetName)) {
       skipped++;
@@ -335,7 +335,7 @@ export async function restoreImagesFromDrive(pool, drive) {
 
   const driveFiles = await listDriveImages(drive, imagesFolderId);
   const existingAssets = await imageServerClient.listAllAssets();
-  const existingNames = new Set(existingAssets.map(a => `asset-${a.id}-${a.original_filename || 'image.jpg'}`));
+  const existingNames = new Set(existingAssets.map(a => `poi-${a.poi_id}-asset-${a.id}-${a.original_filename || 'image.jpg'}`));
 
   let restored = 0;
   let skipped = 0;
@@ -348,15 +348,23 @@ export async function restoreImagesFromDrive(pool, drive) {
       continue;
     }
 
-    // Parse asset info from filename: asset-{id}-{original_filename}
-    const match = file.name.match(/^asset-(\d+)-(.+)$/);
-    if (!match) {
+    // Parse asset info from filename: poi-{poi_id}-asset-{id}-{original_filename}
+    // Also supports legacy format: asset-{id}-{original_filename}
+    let poiId = 0;
+    let originalFilename;
+    const newMatch = file.name.match(/^poi-(\d+)-asset-(\d+)-(.+)$/);
+    const legacyMatch = file.name.match(/^asset-(\d+)-(.+)$/);
+
+    if (newMatch) {
+      poiId = parseInt(newMatch[1]);
+      originalFilename = newMatch[3];
+    } else if (legacyMatch) {
+      originalFilename = legacyMatch[2];
+    } else {
       console.warn(`[ImageRestore] Skipping unrecognized file: ${file.name}`);
       skipped++;
       continue;
     }
-
-    const originalFilename = match[2];
 
     try {
       const response = await drive.files.get(
@@ -365,13 +373,9 @@ export async function restoreImagesFromDrive(pool, drive) {
       );
 
       const buffer = Buffer.from(response.data);
-      const ext = originalFilename.split('.').pop()?.toLowerCase() || 'jpg';
-      const mimeMap = { jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', webp: 'image/webp', gif: 'image/gif' };
-      const mimeType = mimeMap[ext] || 'image/jpeg';
+      const mimeType = file.mimeType || 'image/jpeg';
 
-      // Upload to image server — poi_id 0 since we can't determine it from filename alone
-      // The asset will need to be reassociated if the DB was also restored
-      const result = await imageServerClient.uploadImage(buffer, 0, 'primary', originalFilename, mimeType);
+      const result = await imageServerClient.uploadImage(buffer, poiId, 'primary', originalFilename, mimeType);
 
       if (result.success) {
         restored++;

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -10,6 +10,11 @@ import { generateTextWithCustomPrompt } from './geminiService.js';
 import { extractPageContent } from './contentExtractor.js';
 import { fetchFacebookPosts, isFacebookUrl } from './apifyService.js';
 
+// Helper to detect Twitter/X URLs (used in multiple places)
+function isTwitterUrl(url) {
+  return url.includes('x.com') || url.includes('twitter.com');
+}
+
 // Dispatch interval: start one new trail job every N milliseconds
 const DISPATCH_INTERVAL_MS = 1500;
 // Maximum number of concurrent jobs in flight
@@ -232,7 +237,7 @@ export function isCancellationRequested(poiId) {
  * Increments on failure, resets on success. Logs a warning at 3+ failures.
  */
 async function trackTwitterResult(pool, statusUrl, success) {
-  if (!statusUrl.includes('x.com') && !statusUrl.includes('twitter.com')) return;
+  if (!isTwitterUrl(statusUrl)) return;
 
   try {
     if (success) {
@@ -241,11 +246,11 @@ async function trackTwitterResult(pool, statusUrl, success) {
          ON CONFLICT (key) DO UPDATE SET value = '0', updated_at = NOW()`
       );
     } else {
-      await pool.query(
+      const result = await pool.query(
         `INSERT INTO admin_settings (key, value, updated_at) VALUES ('twitter_consecutive_failures', '1', NOW())
-         ON CONFLICT (key) DO UPDATE SET value = (COALESCE(admin_settings.value, '0')::int + 1)::text, updated_at = NOW()`
+         ON CONFLICT (key) DO UPDATE SET value = (COALESCE(admin_settings.value, '0')::int + 1)::text, updated_at = NOW()
+         RETURNING value`
       );
-      const result = await pool.query(`SELECT value FROM admin_settings WHERE key = 'twitter_consecutive_failures'`);
       const failures = parseInt(result.rows[0]?.value) || 0;
       if (failures >= 3) {
         console.warn(`[Trail Status] WARNING: ${failures} consecutive Twitter failures — cookies may be stale. Refresh at Settings > Data Collection.`);
@@ -272,7 +277,7 @@ INSTRUCTIONS:
 - Find ALL posts or status indicators that mention trail status, conditions, or closures
 - This is the official trail status source - ANY post about trail conditions IS about "{{name}}"
 - Check the DATE of each post - look for timestamps, dates, or relative times (e.g., "2h ago", "Jan 14")
-- IGNORE posts older than 180 days
+- IGNORE posts older than 90 days
 - Select the MOST RECENT post within the allowed date range
 - Common trail status phrases: "trail is open", "trail is closed", "open for riding", "closed due to", "muddy", "dry"
 - Return ALL dates/times in ISO 8601 format: YYYY-MM-DD HH:MM:SS (in {{timezone}})
@@ -360,7 +365,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
     } else {
       // Playwright + Readability extraction (with cookies for Twitter/X)
       let cookies = null;
-      if (statusUrl.includes('x.com') || statusUrl.includes('twitter.com')) {
+      if (isTwitterUrl(statusUrl)) {
         try {
           const cookieResult = await pool.query(
             `SELECT value FROM admin_settings WHERE key = 'twitter_cookies'`
@@ -382,7 +387,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
       });
       rendered = await extractPageContent(statusUrl, {
         maxLength: 15000,
-        dynamicContentWait: statusUrl.includes('x.com') || statusUrl.includes('twitter.com') ? 8000 : 3000,
+        dynamicContentWait: isTwitterUrl(statusUrl) ? 8000 : 3000,
         cookies
       });
     }
@@ -500,7 +505,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
     // Override source_url with the POI's configured status_url
     status.source_url = poi.status_url;
     // Extract source name from the URL if not already set
-    if (poi.status_url.includes('x.com') || poi.status_url.includes('twitter.com')) {
+    if (isTwitterUrl(poi.status_url)) {
       status.source_name = 'Twitter/X';
     } else if (isFacebookUrl(poi.status_url)) {
       status.source_name = 'Facebook';

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -875,7 +875,7 @@ function DestinationMarker({ dest, icon, isSelected, isEditMode, onSelect, onDra
           permanent={isSelected}
         >
           <div className="tooltip-content">
-            {dest.image_mime_type && (
+            {dest.image_drive_file_id && (
               <div className="tooltip-thumbnail">
                 <img src={`/api/pois/${dest.id}/thumbnail?size=medium`} alt="" />
               </div>
@@ -1282,7 +1282,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
                     // Virtual POIs (organizations) don't count since they don't appear on the map
                     const hasAnySelection = (selectedDestination && selectedDestination.poi_type !== 'virtual') || selectedLinearFeature;
                     if (isSelected || !hasAnySelection) {
-                      const hasImage = feature.image_mime_type;
+                      const hasImage = feature.image_drive_file_id;
                       const imageUrl = hasImage ? `/api/pois/${feature.id}/thumbnail?size=medium` : null;
 
                       let tooltipHtml = '<div class="tooltip-content">';
@@ -1346,7 +1346,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
                   const hasAnySelection = selectedDestination || selectedLinearFeature;
                   if (isSelected || !hasAnySelection) {
                     // Build rich tooltip content (similar to destination tooltips)
-                    const hasImage = feature.image_mime_type;
+                    const hasImage = feature.image_drive_file_id;
                     const imageUrl = hasImage ? `/api/pois/${feature.id}/thumbnail?size=medium` : null;
 
                     let tooltipHtml = '<div class="tooltip-content">';

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -5,7 +5,7 @@ import { getIconUrlForPOI } from '../utils/iconUtils';
 const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual, isSelected, showStatusBadge, status, showStatusInfo, statusData, iconConfig }) {
   // Use thumbnail endpoint for fast, cached small images
   // Include updated_at for cache busting when image changes
-  const imageUrl = poi.image_mime_type
+  const imageUrl = poi.image_drive_file_id
     ? `/api/pois/${poi.id}/thumbnail?size=small&v=${poi.updated_at || Date.now()}`
     : null;
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -210,7 +210,7 @@ function EditableCellSignal({ level, onChange }) {
 function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, showImage = true, onShare, moreInfoLink, trailStatus = null, _showNpsMap, _onToggleNpsMap, onCollectStatus }) {
   // Use thumbnail service for faster loading
   // Include updated_at for cache busting when image changes
-  const imageUrl = destination.image_mime_type
+  const imageUrl = destination.image_drive_file_id
     ? `/api/pois/${destination.id}/thumbnail?size=medium&v=${destination.updated_at || Date.now()}`
     : null;
 
@@ -679,7 +679,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
         !isNewPOI && destination?.id ? (
           <ImageUploader
             destinationId={destination.id}
-            hasImage={!!editedData.image_mime_type}
+            hasImage={!!editedData.image_drive_file_id}
             pendingImage={pendingImage}
             onPendingImageChange={setPendingImage}
             updatedAt={editedData.updated_at}
@@ -1828,7 +1828,7 @@ function AssociationsModal({ isOpen, onClose, poi, associations, allDestinations
               {associatedPoisWithAssocId.map(associatedPoi => {
                 // Use thumbnail endpoint for fast, cached small images
                 // Include updated_at for cache busting when image changes
-                const imageUrl = associatedPoi.image_mime_type
+                const imageUrl = associatedPoi.image_drive_file_id
                   ? `/api/pois/${associatedPoi.id}/thumbnail?size=small&v=${associatedPoi.updated_at || Date.now()}`
                   : null;
 
@@ -2156,7 +2156,7 @@ function AssociationsTabContent({ poi, associations, allDestinations, allLinearF
             {associatedPoisWithAssocId.map(associatedPoi => {
               // Use thumbnail endpoint for fast, cached small images
               // Include updated_at for cache busting when image changes
-              const imageUrl = associatedPoi.image_mime_type
+              const imageUrl = associatedPoi.image_drive_file_id
                 ? `/api/pois/${associatedPoi.id}/thumbnail?size=small&v=${associatedPoi.updated_at || Date.now()}`
                 : null;
 
@@ -2976,7 +2976,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
   if (isLinearFeature) {
     // Use thumbnail service for faster loading
     // Include updated_at for cache busting when image changes
-    const linearImageUrl = linearFeature?.image_mime_type
+    const linearImageUrl = linearFeature?.image_drive_file_id
       ? `/api/pois/${linearFeature.id}/thumbnail?size=medium&v=${linearFeature.updated_at || Date.now()}`
       : null;
 
@@ -3076,7 +3076,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         {isEditing && linearFeature?.id ? (
           <ImageUploader
             destinationId={linearFeature.id}
-            hasImage={!!linearFeature.image_mime_type}
+            hasImage={!!linearFeature.image_drive_file_id}
             pendingImage={pendingImage}
             onPendingImageChange={setPendingImage}
             updatedAt={linearFeature.updated_at}
@@ -3188,8 +3188,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
                   if (onLinearFeatureUpdate) {
                     onLinearFeatureUpdate({
                       ...linearFeature,
-                      image_mime_type: hasImage ? 'image/jpeg' : null,
-                      image_drive_file_id: driveFileId
+                      image_drive_file_id: driveFileId || null
                     });
                   }
                 }}
@@ -3295,7 +3294,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
 
   // Use thumbnail service for faster loading
   // Include updated_at for cache busting when image changes
-  const imageUrl = destination?.image_mime_type
+  const imageUrl = destination?.image_drive_file_id
     ? `/api/pois/${destination.id}/thumbnail?size=medium&v=${destination.updated_at || Date.now()}`
     : null;
 
@@ -3377,7 +3376,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       {isEditing && destination?.id ? (
         <ImageUploader
           destinationId={destination.id}
-          hasImage={!!destination.image_mime_type}
+          hasImage={!!destination.image_drive_file_id}
           pendingImage={pendingImage}
           onPendingImageChange={setPendingImage}
           updatedAt={destination.updated_at}
@@ -3490,8 +3489,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
                 if (onDestinationUpdate) {
                   onDestinationUpdate({
                     ...destination,
-                    image_mime_type: hasImage ? 'image/jpeg' : null,
-                    image_drive_file_id: driveFileId
+                    image_drive_file_id: driveFileId || null
                   });
                 }
               }}

--- a/frontend/src/components/ThumbnailCarousel.jsx
+++ b/frontend/src/components/ThumbnailCarousel.jsx
@@ -97,7 +97,7 @@ function ThumbnailCarousel({ pois, currentIndex, onNavigate }) {
 
   // Get thumbnail image URL or default icon
   const getThumbnailUrl = (poi) => {
-    if (poi.image_mime_type) {
+    if (poi.image_drive_file_id) {
       return `/api/pois/${poi.id}/thumbnail?size=small&v=${poi.updated_at || Date.now()}`;
     }
 


### PR DESCRIPTION
## Summary

Batch fix for all critical, high, and medium findings from Gemini code reviews.

**Critical:**
- `uploadImageToDrive` arguments were swapped (buffer/filename) — image uploads would fail

**High:**
- `image_mime_type` column dropped in migration 008 but frontend still used it as "has image" flag — replaced with `image_drive_file_id` across 4 components (15 occurrences)
- Backup filenames now include `poi_id` for proper restore association
- Restore logic extracts `poi_id` from filename, uses Drive mimeType instead of manual ext mapping

**Medium:**
- `RETURNING` clause eliminates extra SELECT in twitter failure tracking
- `isTwitterUrl()` helper replaces 4 inline URL checks
- Gemini prompt window aligned to 90 days (was 180, mismatched with save threshold)

## Test plan

- [ ] POI images render (check any POI with an image on rootsofthevalley.org)
- [ ] Image upload works via admin panel
- [ ] Image backup creates files with `poi-{id}-asset-{id}-filename` format
- [ ] Image restore handles both new and legacy filename formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)