### PR TITLE
feat: rework image backup for complete server state

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,8 @@ import {
   registerModerationSweepHandler,
   scheduleModerationSweep,
   registerNewsletterHandler,
+  registerImageBackupHandler,
+  scheduleImageBackup,
   stopJobScheduler
 } from './services/jobScheduler.js';
 import { processItem, processPendingItems } from './services/moderationService.js';
@@ -1912,6 +1914,36 @@ async function start() {
     await registerNewsletterHandler(async (emailId) => {
       await processNewsletterById(pool, emailId);
     });
+
+    // Register image backup handler (nightly backup of image server to Drive)
+    await registerImageBackupHandler(async () => {
+      console.log('Running scheduled image backup...');
+      const { createDriveServiceWithRefresh } = await import('./services/driveImageService.js');
+      const { triggerImageBackup } = await import('./services/backupService.js');
+
+      // Get admin user's OAuth credentials (refresh_token persists across sessions)
+      const adminResult = await pool.query(
+        'SELECT id, oauth_credentials FROM users WHERE is_admin = TRUE LIMIT 1'
+      );
+      if (!adminResult.rows[0]?.oauth_credentials) {
+        throw new Error('No admin with OAuth credentials found — cannot access Drive');
+      }
+
+      let credentials = adminResult.rows[0].oauth_credentials;
+      if (typeof credentials === 'string') {
+        credentials = JSON.parse(credentials);
+      }
+      if (!credentials.refresh_token) {
+        throw new Error('Admin OAuth credentials missing refresh_token');
+      }
+
+      const drive = await createDriveServiceWithRefresh(credentials, pool, adminResult.rows[0].id);
+      const result = await triggerImageBackup(pool, drive);
+      console.log(`Image backup completed: ${result.uploaded} uploaded, ${result.skipped} skipped, ${result.failed} failed`);
+    });
+
+    // Schedule nightly image backup at 2 AM Eastern
+    await scheduleImageBackup('0 2 * * *');
 
     // Make boss available to routes
     app.set('boss', await import('./services/jobScheduler.js').then(m => m.getJobScheduler()));

--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -195,7 +195,7 @@ export async function getBackupStatus(pool) {
 }
 
 /**
- * List files in the Drive Images folder
+ * List files in the Drive Images folder (paginated)
  */
 async function listDriveImages(drive, imagesFolderId) {
   const files = [];
@@ -218,8 +218,11 @@ async function listDriveImages(drive, imagesFolderId) {
 }
 
 /**
- * Sync image server assets to Drive Images folder.
- * Uploads any assets missing from Drive.
+ * Sync image server DB + all media files to Drive Images folder.
+ *
+ * 1. Fetch pg_dump from image server, upload as imageserver-backup-{timestamp}.sql
+ * 2. List all media files via listMediaFiles()
+ * 3. For each file not already in Drive, download and upload with flat name {subdir}--{filename}
  */
 export async function triggerImageBackup(pool, drive) {
   const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
@@ -231,7 +234,31 @@ export async function triggerImageBackup(pool, drive) {
     throw new Error('Image server not configured');
   }
 
-  const allAssets = await imageServerClient.listAllAssets();
+  // Step 1: Backup image server database
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '-').slice(0, 19);
+  const dbFilename = `imageserver-backup-${timestamp}.sql`;
+
+  const dbDump = await imageServerClient.fetchDbDump();
+  if (!dbDump.success) {
+    throw new Error(`Failed to fetch image server DB dump: ${dbDump.error}`);
+  }
+
+  await drive.files.create({
+    requestBody: {
+      name: dbFilename,
+      mimeType: 'application/sql',
+      parents: [imagesFolderId]
+    },
+    media: {
+      mimeType: 'application/sql',
+      body: Readable.from([dbDump.data])
+    },
+    fields: 'id'
+  });
+  console.log(`[ImageBackup] Uploaded DB dump: ${dbFilename}`);
+
+  // Step 2: List all media files and compare with Drive
+  const mediaFiles = await imageServerClient.listMediaFiles();
   const driveFiles = await listDriveImages(drive, imagesFolderId);
   const driveFileNames = new Set(driveFiles.map(f => f.name));
 
@@ -239,37 +266,37 @@ export async function triggerImageBackup(pool, drive) {
   let skipped = 0;
   let failed = 0;
 
-  for (const asset of allAssets) {
-    const assetName = `poi-${asset.poi_id}-asset-${asset.id}-${asset.original_filename || 'image.jpg'}`;
+  for (const media of mediaFiles) {
+    const driveName = `${media.subdir}--${media.filename}`;
 
-    if (driveFileNames.has(assetName)) {
+    if (driveFileNames.has(driveName)) {
       skipped++;
       continue;
     }
 
     try {
-      const assetData = await imageServerClient.fetchAssetData(asset.id);
-      if (!assetData.success) {
+      const fileData = await imageServerClient.fetchMediaFile(media.subdir, media.filename);
+      if (!fileData.success) {
         failed++;
         continue;
       }
 
       await drive.files.create({
         requestBody: {
-          name: assetName,
-          mimeType: assetData.contentType,
+          name: driveName,
+          mimeType: fileData.contentType,
           parents: [imagesFolderId]
         },
         media: {
-          mimeType: assetData.contentType,
-          body: Readable.from([assetData.data])
+          mimeType: fileData.contentType,
+          body: Readable.from([fileData.data])
         },
         fields: 'id'
       });
 
       uploaded++;
     } catch (error) {
-      console.warn(`[ImageBackup] Failed to backup asset ${asset.id}:`, error.message);
+      console.warn(`[ImageBackup] Failed to backup ${media.subdir}/${media.filename}:`, error.message);
       failed++;
     }
   }
@@ -289,22 +316,29 @@ export async function triggerImageBackup(pool, drive) {
 }
 
 /**
- * Get image backup status — compare image server assets vs Drive Images files
+ * Get image backup status — media files vs Drive files
  */
 export async function getImageBackupStatus(pool, drive) {
   const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
 
-  let imageServerCount = 0;
-  let driveCount = 0;
+  let mediaFileCount = 0;
+  let driveMediaCount = 0;
+  let driveDbDumpCount = 0;
 
   if (imageServerClient.initialized) {
-    const allAssets = await imageServerClient.listAllAssets();
-    imageServerCount = allAssets.length;
+    const mediaFiles = await imageServerClient.listMediaFiles();
+    mediaFileCount = mediaFiles.length;
   }
 
   if (imagesFolderId && drive) {
     const driveFiles = await listDriveImages(drive, imagesFolderId);
-    driveCount = driveFiles.length;
+    for (const f of driveFiles) {
+      if (f.name.startsWith('imageserver-backup-') && f.name.endsWith('.sql')) {
+        driveDbDumpCount++;
+      } else {
+        driveMediaCount++;
+      }
+    }
   }
 
   const lastBackupResult = await pool.query(
@@ -312,16 +346,19 @@ export async function getImageBackupStatus(pool, drive) {
   );
 
   return {
-    imageServerCount,
-    driveCount,
+    mediaFileCount,
+    driveMediaCount,
+    driveDbDumpCount,
     lastBackup: lastBackupResult.rows[0]?.value || null,
     imagesFolderId: imagesFolderId || null
   };
 }
 
 /**
- * Restore images from Drive Images folder back into image server.
- * Downloads each file from Drive and uploads to image server.
+ * Restore image server from Drive Images folder.
+ *
+ * 1. Find most recent imageserver-backup-*.sql, download, POST to image server /api/restore/db
+ * 2. For each {subdir}--{filename} file in Drive, download and PUT to image server
  */
 export async function restoreImagesFromDrive(pool, drive) {
   const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
@@ -334,34 +371,60 @@ export async function restoreImagesFromDrive(pool, drive) {
   }
 
   const driveFiles = await listDriveImages(drive, imagesFolderId);
-  const existingAssets = await imageServerClient.listAllAssets();
-  const existingNames = new Set(existingAssets.map(a => `poi-${a.poi_id}-asset-${a.id}-${a.original_filename || 'image.jpg'}`));
+
+  // Step 1: Find and restore the most recent DB dump
+  const dbDumps = driveFiles
+    .filter(f => f.name.startsWith('imageserver-backup-') && f.name.endsWith('.sql'))
+    .sort((a, b) => b.name.localeCompare(a.name)); // Newest first (timestamp in name)
+
+  let dbRestored = false;
+  if (dbDumps.length > 0) {
+    const latestDump = dbDumps[0];
+    console.log(`[ImageRestore] Restoring DB from: ${latestDump.name}`);
+
+    const response = await drive.files.get(
+      { fileId: latestDump.id, alt: 'media' },
+      { responseType: 'arraybuffer' }
+    );
+
+    const sqlBuffer = Buffer.from(response.data);
+    const restoreResult = await imageServerClient.restoreDb(sqlBuffer);
+
+    if (restoreResult.success) {
+      dbRestored = true;
+      console.log('[ImageRestore] DB restored successfully');
+    } else {
+      console.error('[ImageRestore] DB restore failed:', restoreResult.error);
+    }
+  }
+
+  // Step 2: Restore media files
+  const existingMedia = await imageServerClient.listMediaFiles();
+  const existingSet = new Set(existingMedia.map(m => `${m.subdir}--${m.filename}`));
 
   let restored = 0;
   let skipped = 0;
   let failed = 0;
 
   for (const file of driveFiles) {
-    // Skip files already on image server
-    if (existingNames.has(file.name)) {
+    // Skip DB dumps
+    if (file.name.startsWith('imageserver-backup-') && file.name.endsWith('.sql')) {
+      continue;
+    }
+
+    // Parse {subdir}--{filename} format
+    const separatorIdx = file.name.indexOf('--');
+    if (separatorIdx === -1) {
+      console.warn(`[ImageRestore] Skipping unrecognized file: ${file.name}`);
       skipped++;
       continue;
     }
 
-    // Parse asset info from filename: poi-{poi_id}-asset-{id}-{original_filename}
-    // Also supports legacy format: asset-{id}-{original_filename}
-    let poiId = 0;
-    let originalFilename;
-    const newMatch = file.name.match(/^poi-(\d+)-asset-(\d+)-(.+)$/);
-    const legacyMatch = file.name.match(/^asset-(\d+)-(.+)$/);
+    const subdir = file.name.substring(0, separatorIdx);
+    const filename = file.name.substring(separatorIdx + 2);
 
-    if (newMatch) {
-      poiId = parseInt(newMatch[1]);
-      originalFilename = newMatch[3];
-    } else if (legacyMatch) {
-      originalFilename = legacyMatch[2];
-    } else {
-      console.warn(`[ImageRestore] Skipping unrecognized file: ${file.name}`);
+    // Skip if already exists on image server
+    if (existingSet.has(file.name)) {
       skipped++;
       continue;
     }
@@ -373,9 +436,7 @@ export async function restoreImagesFromDrive(pool, drive) {
       );
 
       const buffer = Buffer.from(response.data);
-      const mimeType = file.mimeType || 'image/jpeg';
-
-      const result = await imageServerClient.uploadImage(buffer, poiId, 'primary', originalFilename, mimeType);
+      const result = await imageServerClient.uploadMediaFile(subdir, filename, buffer);
 
       if (result.success) {
         restored++;
@@ -388,7 +449,7 @@ export async function restoreImagesFromDrive(pool, drive) {
     }
   }
 
-  console.log(`[ImageRestore] Done: ${restored} restored, ${skipped} skipped, ${failed} failed`);
+  console.log(`[ImageRestore] Done: DB=${dbRestored ? 'yes' : 'no'}, ${restored} media restored, ${skipped} skipped, ${failed} failed`);
 
-  return { success: true, restored, skipped, failed };
+  return { success: true, dbRestored, restored, skipped, failed };
 }

--- a/backend/services/imageServerClient.js
+++ b/backend/services/imageServerClient.js
@@ -479,6 +479,149 @@ class ImageServerClient {
       return { success: false, error: error.message };
     }
   }
+
+  // -------------------------------------------------------------------
+  // Backup / Restore / Media endpoints
+  // -------------------------------------------------------------------
+
+  /**
+   * Fetch a pg_dump of the image server database
+   * @returns {{ success: boolean, data?: Buffer, error?: string }}
+   */
+  async fetchDbDump() {
+    if (!this.initialized) {
+      return { success: false, error: 'Image server not configured' };
+    }
+
+    try {
+      const response = await fetch(`${this.serverUrl}/api/backup/db`);
+      if (!response.ok) {
+        throw new Error(`DB dump failed: ${response.status}`);
+      }
+
+      const buffer = await response.arrayBuffer();
+      return { success: true, data: Buffer.from(buffer) };
+    } catch (error) {
+      console.error('[ImageServer] Failed to fetch DB dump:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
+   * Restore the image server database from a SQL dump
+   * @param {Buffer} sqlBuffer - SQL dump data
+   * @returns {{ success: boolean, output?: string, error?: string }}
+   */
+  async restoreDb(sqlBuffer) {
+    if (!this.initialized) {
+      return { success: false, error: 'Image server not configured' };
+    }
+
+    try {
+      const formData = new FormData();
+      const blob = new Blob([sqlBuffer], { type: 'application/sql' });
+      formData.append('file', blob, 'restore.sql');
+
+      const response = await fetch(`${this.serverUrl}/api/restore/db`, {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`DB restore failed: ${response.status} - ${errorText}`);
+      }
+
+      const result = await response.json();
+      return { success: true, output: result.output };
+    } catch (error) {
+      console.error('[ImageServer] Failed to restore DB:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
+   * List all media files on the image server
+   * @returns {Array<{ subdir: string, filename: string, size: number, modified: number }>}
+   */
+  async listMediaFiles() {
+    if (!this.initialized) {
+      return [];
+    }
+
+    try {
+      const response = await fetch(`${this.serverUrl}/api/media/files`);
+      if (!response.ok) {
+        throw new Error(`List media failed: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('[ImageServer] Failed to list media files:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Fetch a specific media file from the image server
+   * @param {string} subdir - Subdirectory (originals, thumbnails, videos, theme-videos)
+   * @param {string} filename - Filename
+   * @returns {{ success: boolean, data?: Buffer, contentType?: string, error?: string }}
+   */
+  async fetchMediaFile(subdir, filename) {
+    if (!this.initialized) {
+      return { success: false, error: 'Image server not configured' };
+    }
+
+    try {
+      const response = await fetch(`${this.serverUrl}/api/media/${subdir}/${filename}`);
+      if (!response.ok) {
+        throw new Error(`Fetch media failed: ${response.status}`);
+      }
+
+      const buffer = await response.arrayBuffer();
+      const contentType = response.headers.get('content-type') || 'application/octet-stream';
+
+      return { success: true, data: Buffer.from(buffer), contentType };
+    } catch (error) {
+      console.error(`[ImageServer] Failed to fetch media ${subdir}/${filename}:`, error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
+   * Upload a media file to the image server (for restore)
+   * @param {string} subdir - Subdirectory
+   * @param {string} filename - Filename
+   * @param {Buffer} buffer - File data
+   * @returns {{ success: boolean, error?: string }}
+   */
+  async uploadMediaFile(subdir, filename, buffer) {
+    if (!this.initialized) {
+      return { success: false, error: 'Image server not configured' };
+    }
+
+    try {
+      const formData = new FormData();
+      const blob = new Blob([buffer], { type: 'application/octet-stream' });
+      formData.append('file', blob, filename);
+
+      const response = await fetch(`${this.serverUrl}/api/media/${subdir}/${filename}`, {
+        method: 'PUT',
+        body: formData
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Upload media failed: ${response.status} - ${errorText}`);
+      }
+
+      return { success: true };
+    } catch (error) {
+      console.error(`[ImageServer] Failed to upload media ${subdir}/${filename}:`, error);
+      return { success: false, error: error.message };
+    }
+  }
 }
 
 export default new ImageServerClient();

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -15,7 +15,8 @@ const JOB_NAMES = {
   TRAIL_STATUS_BATCH: 'trail-status-batch-collect',    // Admin-triggered trail status batch
   CONTENT_MODERATION: 'content-moderation',            // LLM moderation for individual items
   CONTENT_MODERATION_SWEEP: 'content-moderation-sweep', // Scheduled sweep for unprocessed items
-  NEWSLETTER_PROCESS: 'newsletter-process'              // Process inbound newsletter email
+  NEWSLETTER_PROCESS: 'newsletter-process',              // Process inbound newsletter email
+  IMAGE_BACKUP: 'image-backup'                           // Scheduled image server backup to Drive
 };
 
 /**
@@ -435,6 +436,68 @@ export async function queueNewsletterJob(emailId) {
     retryDelay: 60,
     expireInMinutes: 30
   });
+}
+
+/**
+ * Schedule the nightly image backup job
+ * @param {string} cronExpression - Cron expression (default: 2 AM Eastern daily)
+ */
+export async function scheduleImageBackup(cronExpression = '0 2 * * *') {
+  const scheduler = getJobScheduler();
+
+  await scheduler.schedule(JOB_NAMES.IMAGE_BACKUP, cronExpression, {}, {
+    tz: 'America/New_York'
+  });
+
+  console.log(`Image backup scheduled with cron: ${cronExpression}`);
+}
+
+/**
+ * Register the image backup job handler
+ * @param {Function} handler - Async function to handle the job
+ */
+export async function registerImageBackupHandler(handler) {
+  const scheduler = getJobScheduler();
+
+  try {
+    await scheduler.createQueue(JOB_NAMES.IMAGE_BACKUP);
+    console.log(`Queue '${JOB_NAMES.IMAGE_BACKUP}' created`);
+  } catch (error) {
+    if (!error.message?.includes('already exists')) {
+      console.log(`Queue '${JOB_NAMES.IMAGE_BACKUP}' may already exist`);
+    }
+  }
+
+  await scheduler.work(JOB_NAMES.IMAGE_BACKUP, async (job) => {
+    console.log('Starting image backup job:', job.id);
+    try {
+      await handler(job.data);
+      console.log('Image backup job completed:', job.id);
+    } catch (error) {
+      console.error('Image backup job failed:', error);
+      throw error;
+    }
+  });
+}
+
+/**
+ * Manually submit an image backup job
+ * @returns {string} - pg-boss job ID
+ */
+export async function submitImageBackupJob() {
+  const scheduler = getJobScheduler();
+
+  const jobId = await scheduler.send(JOB_NAMES.IMAGE_BACKUP, {
+    triggeredManually: true,
+    triggeredAt: new Date().toISOString()
+  }, {
+    retryLimit: 2,
+    retryDelay: 60,
+    expireInMinutes: 120
+  });
+
+  console.log(`[pg-boss] Image backup job submitted: ${jobId}`);
+  return jobId;
 }
 
 /**

--- a/frontend/src/components/SyncSettings.jsx
+++ b/frontend/src/components/SyncSettings.jsx
@@ -427,12 +427,16 @@ function SyncSettings({ onDataRefresh }) {
 
               <div className="sync-status-row">
                 <div className="sync-status-item">
-                  <label>Image Server</label>
-                  <span>{imageBackup?.imageServerCount ?? '...'} assets</span>
+                  <label>Media Files</label>
+                  <span>{imageBackup?.mediaFileCount ?? '...'} files</span>
                 </div>
                 <div className="sync-status-item">
-                  <label>Drive Backup</label>
-                  <span>{imageBackup?.driveCount ?? '...'} files</span>
+                  <label>Drive Media</label>
+                  <span>{imageBackup?.driveMediaCount ?? '...'} files</span>
+                </div>
+                <div className="sync-status-item">
+                  <label>DB Dumps</label>
+                  <span>{imageBackup?.driveDbDumpCount ?? '...'}</span>
                 </div>
                 <div className="sync-status-item">
                   <label>Last Backup</label>
@@ -449,7 +453,7 @@ function SyncSettings({ onDataRefresh }) {
                   >
                     {backingUpImages ? 'Backing up...' : 'Backup'}
                   </button>
-                  <p className="button-description">Sync missing images to Drive</p>
+                  <p className="button-description">Sync DB + media files to Drive</p>
                 </div>
                 <div className="sync-button-card">
                   <button


### PR DESCRIPTION
## Summary
- Rewrite image backup to cover the entire image server state: database + all media files (originals, thumbnails, videos, theme-videos)
- Old system only backed up 100 DB-tracked original images; new system backs up all ~208 media files + a pg_dump of the image server database
- Add 5 new methods to `imageServerClient.js` for the new backup/restore/media API endpoints (deployed in image-server PR #1 + #2)
- Add nightly scheduled job at 2 AM Eastern via pg-boss, using admin's stored OAuth refresh_token for Drive access
- Update Settings UI to show Media Files / Drive Media / DB Dumps counts instead of the old "Image Server / X assets" display

## Files changed
- `backend/services/imageServerClient.js` — 5 new methods (fetchDbDump, restoreDb, listMediaFiles, fetchMediaFile, uploadMediaFile)
- `backend/services/backupService.js` — Rewritten triggerImageBackup, getImageBackupStatus, restoreImagesFromDrive
- `backend/services/jobScheduler.js` — IMAGE_BACKUP job name + schedule/register/submit functions
- `backend/server.js` — Register handler + schedule at 2 AM Eastern
- `frontend/src/components/SyncSettings.jsx` — Updated labels and counts

## Test plan
- [ ] Trigger image backup from Settings — should upload DB dump + ~208 media files to Drive Images folder
- [ ] Settings page should show: Media Files = ~208, Drive Media = ~208, DB Dumps = 1
- [ ] Verify Drive Images folder has files named like `originals--uuid.webp`, `thumbnails--uuid.jpg`, `theme-videos--winter.mp4`
- [ ] Test restore: wipe a test file, restore from Drive, verify it comes back
- [ ] Verify pg-boss queue has `image-backup` schedule via `SELECT * FROM pgboss.schedule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)