### PR TITLE
fix: abort restore on DB failure, throw on media list error

### DIFF
--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -395,6 +395,7 @@ export async function restoreImagesFromDrive(pool, drive) {
       console.log('[ImageRestore] DB restored successfully');
     } else {
       console.error('[ImageRestore] DB restore failed:', restoreResult.error);
+      return { success: false, dbRestored: false, error: `Database restore failed: ${restoreResult.error}` };
     }
   }
 

--- a/backend/services/imageServerClient.js
+++ b/backend/services/imageServerClient.js
@@ -541,25 +541,21 @@ class ImageServerClient {
   }
 
   /**
-   * List all media files on the image server
+   * List all media files on the image server.
+   * Throws on error so callers (backup job) can detect failures.
    * @returns {Array<{ subdir: string, filename: string, size: number, modified: number }>}
    */
   async listMediaFiles() {
     if (!this.initialized) {
-      return [];
+      throw new Error('Image server not configured');
     }
 
-    try {
-      const response = await fetch(`${this.serverUrl}/api/media/files`);
-      if (!response.ok) {
-        throw new Error(`List media failed: ${response.status}`);
-      }
-
-      return await response.json();
-    } catch (error) {
-      console.error('[ImageServer] Failed to list media files:', error);
-      return [];
+    const response = await fetch(`${this.serverUrl}/api/media/files`);
+    if (!response.ok) {
+      throw new Error(`List media failed: ${response.status}`);
     }
+
+    return await response.json();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Address Gemini review feedback from PR #161
- `restoreImagesFromDrive`: abort immediately if DB restore fails instead of continuing with media files (would create inconsistent state)
- `listMediaFiles`: throw on error instead of silently returning empty array (would make backup think there are zero files to back up)

## Test plan
- [ ] Verify backup still works normally from Settings page
- [ ] Verify restore aborts cleanly if image server DB restore fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)