### PR TITLE
fix: throw on DB restore failure, graceful status

### DIFF
--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -326,8 +326,12 @@ export async function getImageBackupStatus(pool, drive) {
   let driveDbDumpCount = 0;
 
   if (imageServerClient.initialized) {
-    const mediaFiles = await imageServerClient.listMediaFiles();
-    mediaFileCount = mediaFiles.length;
+    try {
+      const mediaFiles = await imageServerClient.listMediaFiles();
+      mediaFileCount = mediaFiles.length;
+    } catch (error) {
+      console.warn('[ImageBackup] Could not list media files:', error.message);
+    }
   }
 
   if (imagesFolderId && drive) {
@@ -395,7 +399,7 @@ export async function restoreImagesFromDrive(pool, drive) {
       console.log('[ImageRestore] DB restored successfully');
     } else {
       console.error('[ImageRestore] DB restore failed:', restoreResult.error);
-      return { success: false, dbRestored: false, error: `Database restore failed: ${restoreResult.error}` };
+      throw new Error(`Database restore failed: ${restoreResult.error}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Address Gemini review feedback on PR #162
- `restoreImagesFromDrive`: throw `Error` on DB restore failure instead of returning object missing `restored`/`skipped`/`failed` fields
- `getImageBackupStatus`: wrap `listMediaFiles()` in try-catch so the Settings status page still loads when image server is unreachable

## Test plan
- [ ] Verify Settings page loads even if image server is down (shows 0 media files)
- [ ] Verify restore properly throws if DB restore fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)