### PR TITLE
fix: address Gemini review feedback from PR #163

### DIFF
--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -328,9 +328,9 @@ export async function getImageBackupStatus(pool, drive) {
   if (imageServerClient.initialized) {
     try {
       const mediaFiles = await imageServerClient.listMediaFiles();
-      mediaFileCount = mediaFiles.length;
+      mediaFileCount = Array.isArray(mediaFiles) ? mediaFiles.length : 0;
     } catch (error) {
-      console.warn('[ImageBackup] Could not list media files:', error.message);
+      console.warn('[ImageBackup] Could not list media files:', error);
     }
   }
 


### PR DESCRIPTION
## Summary
- Addresses two inline Gemini code review comments from PR #163
- Add `Array.isArray()` guard on `listMediaFiles()` response before accessing `.length`
- Log full `error` object instead of just `error.message` for better debugging

## Test plan
- [ ] Settings page loads when image server returns unexpected response
- [ ] Error logs include stack traces when media file listing fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)