### PR TITLE
fix: centralize array validation in listMediaFiles

### DIFF
--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -328,7 +328,7 @@ export async function getImageBackupStatus(pool, drive) {
   if (imageServerClient.initialized) {
     try {
       const mediaFiles = await imageServerClient.listMediaFiles();
-      mediaFileCount = Array.isArray(mediaFiles) ? mediaFiles.length : 0;
+      mediaFileCount = mediaFiles.length;
     } catch (error) {
       console.warn('[ImageBackup] Could not list media files:', error);
     }

--- a/backend/services/imageServerClient.js
+++ b/backend/services/imageServerClient.js
@@ -555,7 +555,11 @@ class ImageServerClient {
       throw new Error(`List media failed: ${response.status}`);
     }
 
-    return await response.json();
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      throw new Error('Image server returned invalid media file list (expected array)');
+    }
+    return data;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Addresses Gemini high-priority review feedback from PR #164
- Move `Array.isArray()` validation into `imageServerClient.listMediaFiles()` to protect all callers
- Remove redundant guard in `backupService.js` (now handled by client)
- Invalid responses throw an error instead of silently defaulting to 0

## Test plan
- [ ] Settings page loads when image server returns unexpected response (caught by try-catch)
- [ ] `triggerImageBackup` and `restoreImagesFromDrive` get proper errors on invalid responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)