### PR TITLE
fix: show all job types in Jobs dashboard history

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4121,6 +4121,18 @@ export function createAdminRouter(pool) {
                  trails_processed AS items_processed, error_message,
                  created_at
           FROM trail_status_job_status
+          UNION ALL
+          SELECT job_id AS id, job_type, job_type AS sub_type,
+                 CASE WHEN bool_or(level = 'error') THEN 'failed' ELSE 'completed' END AS status,
+                 MIN(created_at) AS started_at,
+                 MAX(created_at) AS completed_at,
+                 COUNT(DISTINCT poi_id) FILTER (WHERE poi_id IS NOT NULL) AS items_total,
+                 COUNT(DISTINCT poi_id) FILTER (WHERE poi_id IS NOT NULL) AS items_processed,
+                 MAX(CASE WHEN level = 'error' THEN message END) AS error_message,
+                 MIN(created_at) AS created_at
+          FROM job_logs
+          WHERE job_type NOT IN ('news', 'trail_status')
+          GROUP BY job_type, job_id
         ) AS jobs
       `;
 

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -189,6 +189,9 @@ export default function JobsDashboard() {
           <option value="">All Types</option>
           <option value="news">News</option>
           <option value="trail_status">Trail Status</option>
+          <option value="moderation">Moderation</option>
+          <option value="newsletter">Newsletter</option>
+          <option value="backup">Backup</option>
         </select>
       </div>
 


### PR DESCRIPTION
## Summary
- History UNION only queried `news_job_status` and `trail_status_job_status`, making moderation/newsletter/backup jobs invisible
- Added third UNION branch deriving job runs from `job_logs` table for types without dedicated status tables
- Added Moderation, Newsletter, Backup filter options to the frontend dropdown

## Test plan
- [x] `./run.sh build` succeeds
- [ ] After moderation sweep runs (every 15min), verify it appears in Jobs history
- [ ] After image backup runs, verify it appears in Jobs history
- [ ] Filter dropdown shows all 5 types

🤖 Generated with [Claude Code](https://claude.com/claude-code)