### PR TITLE
feat: unified Jobs dashboard, job logging, and admin UX improvements

### DIFF
--- a/backend/migrations/011_add_moderation_search_index.sql
+++ b/backend/migrations/011_add_moderation_search_index.sql
@@ -1,0 +1,9 @@
+-- Migration 011: Add trigram index for moderation queue search
+-- Enables fast ILIKE searches on news titles/summaries and event titles/descriptions.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_poi_news_title_trgm ON poi_news USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_poi_news_summary_trgm ON poi_news USING GIN (summary gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_poi_events_title_trgm ON poi_events USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_poi_events_desc_trgm ON poi_events USING GIN (description gin_trgm_ops);

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -43,7 +43,7 @@ import {
   requestCancellation,
   getDisplaySlots as getNewsDisplaySlots
 } from '../services/newsService.js';
-import { submitBatchNewsJob, queueModerationJob, getJobScheduler, JOB_NAMES } from '../services/jobScheduler.js';
+import { submitBatchNewsJob, queueModerationJob, getJobScheduler, JOB_NAMES, updateSchedule } from '../services/jobScheduler.js';
 import {
   getQueue as getModerationQueue,
   getPendingCount as getModerationPendingCount,
@@ -476,7 +476,10 @@ export function createAdminRouter(pool) {
       'moderation_auto_approve_threshold',
       'moderation_auto_approve_enabled',
       'photo_submissions_enabled',
-      'apify_api_token'
+      'apify_api_token',
+      'news_collection_prompt',
+      'trail_status_prompt',
+      'results_subtabs_config'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });
@@ -3773,13 +3776,14 @@ export function createAdminRouter(pool) {
   // Get paginated moderation queue
   router.get('/moderation/queue', isAdmin, async (req, res) => {
     try {
-      const { page = 1, limit = 20, type, status = 'pending', source } = req.query;
+      const { page = 1, limit = 20, type, status = 'pending', source, search } = req.query;
       const result = await getModerationQueue(pool, {
         page: parseInt(page),
         limit: parseInt(limit),
         contentType: type || null,
         status,
-        contentSource: source || null
+        contentSource: source || null,
+        search: search || null
       });
       res.json(result);
     } catch (error) {
@@ -4108,6 +4112,9 @@ export function createAdminRouter(pool) {
       const limit = Math.max(1, Math.min(parseInt(req.query.limit) || 20, 100));
       const offset = Math.max(0, parseInt(req.query.offset) || 0);
 
+      // Perf: date-bound each subquery to avoid full table scans.
+      // Fix: exclude job_id=0 from GROUP BY to prevent collapsing unrelated entries.
+      // Fix: infer 'running' status for jobs with recent activity (within 1 hour).
       let query = `
         SELECT * FROM (
           SELECT id, 'news' AS job_type, job_type AS sub_type, status,
@@ -4115,15 +4122,22 @@ export function createAdminRouter(pool) {
                  pois_processed AS items_processed, error_message,
                  created_at
           FROM news_job_status
+          WHERE created_at > NOW() - INTERVAL '90 days'
           UNION ALL
           SELECT id, 'trail_status' AS job_type, job_type AS sub_type, status,
                  started_at, completed_at, total_trails AS items_total,
                  trails_processed AS items_processed, error_message,
                  created_at
           FROM trail_status_job_status
+          WHERE created_at > NOW() - INTERVAL '90 days'
           UNION ALL
           SELECT job_id AS id, job_type, job_type AS sub_type,
-                 CASE WHEN bool_or(level = 'error') THEN 'failed' ELSE 'completed' END AS status,
+                 CASE
+                   WHEN bool_or(level = 'error') THEN 'failed'
+                   WHEN bool_or((details->>'completed')::boolean) THEN 'completed'
+                   WHEN MAX(created_at) > NOW() - INTERVAL '2 minutes' THEN 'running'
+                   ELSE 'stale'
+                 END AS status,
                  MIN(created_at) AS started_at,
                  MAX(created_at) AS completed_at,
                  COUNT(DISTINCT poi_id) FILTER (WHERE poi_id IS NOT NULL) AS items_total,
@@ -4132,6 +4146,8 @@ export function createAdminRouter(pool) {
                  MIN(created_at) AS created_at
           FROM job_logs
           WHERE job_type NOT IN ('news', 'trail_status')
+            AND job_id > 0
+            AND created_at > NOW() - INTERVAL '90 days'
           GROUP BY job_type, job_id
         ) AS jobs
       `;
@@ -4228,6 +4244,129 @@ export function createAdminRouter(pool) {
     }
   });
 
+  // GET /admin/jobs/scheduled - List all job types with schedule, queue size, last run, and prompt info
+  router.get('/jobs/scheduled', isAdmin, async (req, res) => {
+    try {
+      const { COLLECTION_TYPES, getDefaultPrompt } = await import('../services/collection/registry.js');
+      const boss = getJobScheduler();
+
+      const jobs = await Promise.all(COLLECTION_TYPES.map(async (type) => {
+        // Get current schedule from admin_settings (overrides default)
+        const schedResult = await pool.query(
+          'SELECT value FROM admin_settings WHERE key = $1',
+          [`schedule_${type.scheduleJobName}`]
+        );
+        const currentSchedule = schedResult.rows.length > 0
+          ? schedResult.rows[0].value
+          : type.schedule;
+
+        // Get queue size
+        let queueSize = 0;
+        try {
+          queueSize = await boss.getQueueSize(type.scheduleJobName) || 0;
+        } catch { /* queue may not exist yet */ }
+
+        // Get last job info from status table
+        let lastJob = null;
+        if (type.statusTable) {
+          try {
+            const jobResult = await pool.query(
+              `SELECT id, status, started_at, completed_at FROM ${type.statusTable} ORDER BY id DESC LIMIT 1`
+            );
+            if (jobResult.rows.length > 0) lastJob = jobResult.rows[0];
+          } catch { /* table may not exist */ }
+        }
+
+        // Get prompt info for AI-powered jobs
+        let prompts = [];
+        if (type.hasPrompt && type.promptKeys.length > 0) {
+          for (const pk of type.promptKeys) {
+            const currentResult = await pool.query(
+              'SELECT value FROM admin_settings WHERE key = $1',
+              [pk.key]
+            );
+            const currentValue = currentResult.rows.length > 0 ? currentResult.rows[0].value : null;
+            const defaultValue = await getDefaultPrompt(pk.key);
+            prompts.push({
+              key: pk.key,
+              label: pk.label,
+              placeholders: pk.placeholders,
+              currentValue: currentValue || defaultValue,
+              defaultValue,
+              isCustomized: currentValue !== null
+            });
+          }
+        }
+
+        return {
+          id: type.id,
+          label: type.label,
+          description: type.description,
+          icon: type.icon,
+          scheduleJobName: type.scheduleJobName,
+          currentSchedule,
+          defaultSchedule: type.schedule,
+          queueSize,
+          lastJob,
+          triggerEndpoint: type.triggerEndpoint,
+          manualTriggerMethod: type.manualTriggerMethod,
+          hasPrompt: type.hasPrompt,
+          historyTypes: type.historyTypes || [],
+          prompts
+        };
+      }));
+
+      res.json(jobs);
+    } catch (error) {
+      console.error('Error fetching scheduled jobs:', error);
+      res.status(500).json({ error: 'Failed to fetch scheduled jobs' });
+    }
+  });
+
+  // PUT /admin/jobs/:name/schedule - Update cron schedule for a job
+  router.put('/jobs/:name/schedule', isAdmin, async (req, res) => {
+    const { name } = req.params;
+    const { cronExpression } = req.body;
+
+    // Validate job name exists in registry
+    const { COLLECTION_TYPES } = await import('../services/collection/registry.js');
+    const jobType = COLLECTION_TYPES.find(t => t.scheduleJobName === name);
+    if (!jobType) {
+      return res.status(400).json({ error: `Unknown job name: ${name}` });
+    }
+
+    // Validate cron expression format (basic check: 5 space-separated fields)
+    if (!cronExpression || !cronExpression.trim()) {
+      return res.status(400).json({ error: 'cronExpression is required' });
+    }
+    const parts = cronExpression.trim().split(/\s+/);
+    if (parts.length !== 5) {
+      return res.status(400).json({ error: 'Invalid cron expression: must have exactly 5 fields (minute hour day month weekday)' });
+    }
+
+    try {
+      // Update pg-boss schedule immediately
+      await updateSchedule(name, cronExpression.trim());
+
+      // Persist to admin_settings so it survives container restarts
+      await pool.query(
+        `INSERT INTO admin_settings (key, value, updated_at, updated_by)
+         VALUES ($1, $2, CURRENT_TIMESTAMP, $3)
+         ON CONFLICT (key) DO UPDATE SET
+           value = EXCLUDED.value,
+           updated_at = CURRENT_TIMESTAMP,
+           updated_by = EXCLUDED.updated_by`,
+        [`schedule_${name}`, cronExpression.trim(), req.user.id]
+      );
+
+      console.log(`Admin ${req.user.email} updated schedule for ${name}: ${cronExpression.trim()}`);
+      res.json({ success: true, jobName: name, schedule: cronExpression.trim() });
+    } catch (error) {
+      console.error('Error updating job schedule:', error);
+      res.status(500).json({ error: 'Failed to update schedule' });
+    }
+  });
+
   // Manual log retention cleanup
   router.delete('/jobs/logs/cleanup', isAdmin, async (req, res) => {
     try {
@@ -4240,6 +4379,170 @@ export function createAdminRouter(pool) {
     } catch (error) {
       console.error('Error cleaning up job logs:', error);
       res.status(500).json({ error: 'Failed to cleanup job logs' });
+    }
+  });
+
+  // ============================================
+  // Collection Config Routes
+  // ============================================
+
+  // Default sub-tabs configuration (matches current hardcoded tabs in ResultsTab.jsx)
+  const DEFAULT_SUBTABS = [
+    { id: 'all', label: 'Points of Interest', shortLabel: 'POIs', route: '/', filterTypes: null, protected: true },
+    { id: 'mtb', label: 'MTB Trail Status', shortLabel: 'MTB Status', route: '/mtb-trail-status', filterTypes: ['mtb-trailhead'], protected: false },
+    { id: 'organizations', label: 'Organizations', shortLabel: 'Orgs', route: '/organizations', filterTypes: ['organization'], protected: false }
+  ];
+
+  // GET /admin/collection-types - List registered collection types with last job info
+  router.get('/collection-types', isAdmin, async (req, res) => {
+    try {
+      const { COLLECTION_TYPES } = await import('../services/collection/registry.js');
+
+      const enriched = await Promise.all(COLLECTION_TYPES.map(async (type) => {
+        let lastJob = null;
+        try {
+          const jobResult = await pool.query(
+            `SELECT id, status, started_at, completed_at FROM ${type.statusTable} ORDER BY id DESC LIMIT 1`
+          );
+          if (jobResult.rows.length > 0) {
+            lastJob = jobResult.rows[0];
+          }
+        } catch (err) {
+          // Table might not exist yet
+        }
+        return { ...type, lastJob };
+      }));
+
+      res.json(enriched);
+    } catch (error) {
+      console.error('Error fetching collection types:', error);
+      res.status(500).json({ error: 'Failed to fetch collection types' });
+    }
+  });
+
+  // GET /admin/prompts - Get all collection prompt templates with current/default values
+  router.get('/prompts', isAdmin, async (req, res) => {
+    try {
+      const { COLLECTION_TYPES, getDefaultPrompt } = await import('../services/collection/registry.js');
+
+      const prompts = [];
+      for (const type of COLLECTION_TYPES) {
+        for (const pk of type.promptKeys) {
+          const currentResult = await pool.query(
+            'SELECT value FROM admin_settings WHERE key = $1',
+            [pk.key]
+          );
+          const currentValue = currentResult.rows.length > 0 ? currentResult.rows[0].value : null;
+          const defaultValue = await getDefaultPrompt(pk.key);
+
+          prompts.push({
+            key: pk.key,
+            label: pk.label,
+            placeholders: pk.placeholders,
+            collectionTypeId: type.id,
+            collectionTypeLabel: type.label,
+            currentValue: currentValue || defaultValue,
+            defaultValue,
+            isCustomized: currentValue !== null
+          });
+        }
+      }
+
+      res.json(prompts);
+    } catch (error) {
+      console.error('Error fetching prompts:', error);
+      res.status(500).json({ error: 'Failed to fetch prompts' });
+    }
+  });
+
+  // PUT /admin/prompts/:key - Update or reset a prompt template
+  router.put('/prompts/:key', isAdmin, async (req, res) => {
+    const { key } = req.params;
+    const { value, reset } = req.body;
+
+    try {
+      const { COLLECTION_TYPES } = await import('../services/collection/registry.js');
+
+      // Validate key exists in registry
+      const validKeys = COLLECTION_TYPES.flatMap(t => t.promptKeys.map(pk => pk.key));
+      if (!validKeys.includes(key)) {
+        return res.status(400).json({ error: `Invalid prompt key: ${key}` });
+      }
+
+      if (reset) {
+        // Delete custom value to revert to default
+        await pool.query('DELETE FROM admin_settings WHERE key = $1', [key]);
+        console.log(`Admin ${req.user.email} reset prompt: ${key}`);
+      } else {
+        if (!value || !value.trim()) {
+          return res.status(400).json({ error: 'Prompt value cannot be empty' });
+        }
+        await pool.query(
+          `INSERT INTO admin_settings (key, value, updated_at, updated_by)
+           VALUES ($1, $2, CURRENT_TIMESTAMP, $3)
+           ON CONFLICT (key) DO UPDATE SET
+             value = EXCLUDED.value,
+             updated_at = CURRENT_TIMESTAMP,
+             updated_by = EXCLUDED.updated_by`,
+          [key, value, req.user.id]
+        );
+        console.log(`Admin ${req.user.email} updated prompt: ${key}`);
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error updating prompt:', error);
+      res.status(500).json({ error: 'Failed to update prompt' });
+    }
+  });
+
+  // GET /admin/results-subtabs - Get sub-tab configuration
+  router.get('/results-subtabs', isAdmin, async (req, res) => {
+    try {
+      const result = await pool.query(
+        "SELECT value FROM admin_settings WHERE key = 'results_subtabs_config'"
+      );
+      if (result.rows.length > 0 && result.rows[0].value) {
+        res.json(JSON.parse(result.rows[0].value));
+      } else {
+        res.json({ subtabs: DEFAULT_SUBTABS });
+      }
+    } catch (error) {
+      console.error('Error fetching results subtabs:', error);
+      res.status(500).json({ error: 'Failed to fetch results subtabs config' });
+    }
+  });
+
+  // PUT /admin/results-subtabs - Update sub-tab configuration
+  router.put('/results-subtabs', isAdmin, async (req, res) => {
+    const { subtabs } = req.body;
+
+    if (!Array.isArray(subtabs) || subtabs.length === 0) {
+      return res.status(400).json({ error: 'subtabs must be a non-empty array' });
+    }
+
+    // Validate first tab is 'all' and protected
+    if (subtabs[0].id !== 'all') {
+      return res.status(400).json({ error: 'First sub-tab must be "all" (Points of Interest)' });
+    }
+
+    try {
+      const config = JSON.stringify({ subtabs });
+      await pool.query(
+        `INSERT INTO admin_settings (key, value, updated_at, updated_by)
+         VALUES ('results_subtabs_config', $1, CURRENT_TIMESTAMP, $2)
+         ON CONFLICT (key) DO UPDATE SET
+           value = EXCLUDED.value,
+           updated_at = CURRENT_TIMESTAMP,
+           updated_by = EXCLUDED.updated_by`,
+        [config, req.user.id]
+      );
+
+      console.log(`Admin ${req.user.email} updated results subtabs config`);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error updating results subtabs:', error);
+      res.status(500).json({ error: 'Failed to update results subtabs config' });
     }
   });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -798,23 +798,7 @@ async function initDatabase() {
       ON CONFLICT (key) DO NOTHING
     `);
 
-    // Job logs table for structured per-job logging
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS job_logs (
-        id SERIAL PRIMARY KEY,
-        job_id INTEGER NOT NULL,
-        job_type VARCHAR(50) NOT NULL,
-        poi_id INTEGER,
-        poi_name VARCHAR(255),
-        level VARCHAR(10) NOT NULL DEFAULT 'info',
-        message TEXT NOT NULL,
-        details JSONB,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_job_logs_job ON job_logs(job_type, job_id)`);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_job_logs_created ON job_logs(created_at DESC)`);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_job_logs_level ON job_logs(level) WHERE level IN ('warn', 'error')`);
+    // job_logs table is created by migration 010_add_job_logs.sql
 
     console.log('Database initialized');
   } finally {
@@ -1381,6 +1365,28 @@ app.get('/api/trails/mtb', async (req, res) => {
   } catch (error) {
     console.error('Error fetching MTB trails:', error);
     res.status(500).json({ error: 'Failed to fetch MTB trails' });
+  }
+});
+
+// Get results sub-tab configuration (public, for ResultsTab.jsx)
+app.get('/api/results-subtabs', async (req, res) => {
+  const DEFAULT_SUBTABS = [
+    { id: 'all', label: 'Points of Interest', shortLabel: 'POIs', route: '/', filterTypes: null, protected: true },
+    { id: 'mtb', label: 'MTB Trail Status', shortLabel: 'MTB Status', route: '/mtb-trail-status', filterTypes: ['mtb-trailhead'], protected: false },
+    { id: 'organizations', label: 'Organizations', shortLabel: 'Orgs', route: '/organizations', filterTypes: ['organization'], protected: false }
+  ];
+  try {
+    const result = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'results_subtabs_config'"
+    );
+    if (result.rows.length > 0 && result.rows[0].value) {
+      res.json(JSON.parse(result.rows[0].value));
+    } else {
+      res.json({ subtabs: DEFAULT_SUBTABS });
+    }
+  } catch (error) {
+    console.error('Error fetching results subtabs:', error);
+    res.json({ subtabs: DEFAULT_SUBTABS });
   }
 });
 

--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -52,8 +52,11 @@ async function ensureBackupsFolder(drive, pool) {
  * Run pg_dump and upload the SQL dump to Google Drive
  */
 export async function triggerBackup(pool, drive) {
+  const runId = Math.floor(Date.now() / 1000);
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '-').slice(0, 19);
   const filename = `rotv-backup-${timestamp}.sql`;
+
+  logInfo(runId, 'database_backup', null, null, 'Starting database backup');
 
   // Stream pg_dump output to avoid buffering large dumps in memory
   const pgHost = process.env.PGHOST || 'localhost';
@@ -75,6 +78,8 @@ export async function triggerBackup(pool, drive) {
     });
     proc.on('error', reject);
   });
+
+  logInfo(runId, 'database_backup', null, null, `pg_dump complete, uploading ${filename} to Drive`);
 
   // Ensure backups folder exists
   const backupsFolderId = await ensureBackupsFolder(drive, pool);
@@ -106,7 +111,7 @@ export async function triggerBackup(pool, drive) {
   `, [now]);
 
   console.log(`Backup uploaded to Drive: ${filename} (${driveFileId})`);
-  logInfo(null, 'database_backup', null, null, `Complete: ${filename} uploaded to Drive`, { filename, driveFileId });
+  logInfo(runId, 'database_backup', null, null, `Complete: ${filename} uploaded to Drive`, { completed: true, filename, driveFileId });
   await flushJobLogs();
 
   return {
@@ -142,6 +147,9 @@ export async function listBackups(drive, pool) {
  * Restore a database from a Drive backup file
  */
 export async function restoreBackup(pool, drive, fileId) {
+  const runId = Math.floor(Date.now() / 1000);
+  logInfo(runId, 'database_backup', null, null, 'Starting database restore from Drive');
+
   // Download the SQL dump from Drive
   const response = await drive.files.get(
     { fileId, alt: 'media' },
@@ -152,6 +160,8 @@ export async function restoreBackup(pool, drive, fileId) {
   if (!sqlDump || typeof sqlDump !== 'string') {
     throw new Error('Downloaded file is empty or not valid SQL');
   }
+
+  logInfo(runId, 'database_backup', null, null, `Downloaded backup (${Math.round(sqlDump.length / 1024)} KB), restoring via psql`);
 
   const pgHost = process.env.PGHOST || 'localhost';
   const pgPort = process.env.PGPORT || '5432';
@@ -170,12 +180,16 @@ export async function restoreBackup(pool, drive, fileId) {
     proc.stdin.write(sqlDump);
     proc.stdin.end();
 
-    proc.on('close', (code) => {
+    proc.on('close', async (code) => {
       if (code !== 0) {
         console.error('[Restore] psql stderr:', stderr);
+        logError(runId, 'database_backup', null, null, `Restore failed: psql exit code ${code}`, { error_stack: stderr.slice(0, 2000) });
+        await flushJobLogs();
         return reject(new Error(`psql exited with code ${code}: ${stderr.slice(0, 500)}`));
       }
       console.log('[Restore] Database restored successfully');
+      logInfo(runId, 'database_backup', null, null, 'Database restore complete', { completed: true });
+      await flushJobLogs();
       resolve({ success: true });
     });
     proc.on('error', reject);
@@ -228,6 +242,7 @@ async function listDriveImages(drive, imagesFolderId) {
  * 3. For each file not already in Drive, download and upload with flat name {subdir}--{filename}
  */
 export async function triggerImageBackup(pool, drive) {
+  const runId = Math.floor(Date.now() / 1000);
   const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
   if (!imagesFolderId) {
     throw new Error('Images folder not configured in Drive');
@@ -236,6 +251,8 @@ export async function triggerImageBackup(pool, drive) {
   if (!imageServerClient.initialized) {
     throw new Error('Image server not configured');
   }
+
+  logInfo(runId, 'backup', null, null, 'Starting image server backup');
 
   // Step 1: Backup image server database
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '-').slice(0, 19);
@@ -258,6 +275,7 @@ export async function triggerImageBackup(pool, drive) {
     },
     fields: 'id'
   });
+  logInfo(runId, 'backup', null, null, `Uploaded DB dump: ${dbFilename}`);
   console.log(`[ImageBackup] Uploaded DB dump: ${dbFilename}`);
 
   // Step 2: List all media files and compare with Drive
@@ -314,7 +332,7 @@ export async function triggerImageBackup(pool, drive) {
   `, [now]);
 
   console.log(`[ImageBackup] Done: ${uploaded} uploaded, ${skipped} skipped, ${failed} failed`);
-  logInfo(null, 'backup', null, null, `Complete: ${uploaded} uploaded, ${skipped} skipped, ${failed} failed`, { uploaded, skipped, failed });
+  logInfo(runId, 'backup', null, null, `Complete: ${uploaded} uploaded, ${skipped} skipped, ${failed} failed`, { completed: true, uploaded, skipped, failed });
   await flushJobLogs();
 
   return { success: true, uploaded, skipped, failed, timestamp: now };
@@ -339,26 +357,34 @@ export async function getImageBackupStatus(pool, drive) {
     }
   }
 
+  let latestDriveBackupDate = null;
+
   if (imagesFolderId && drive) {
     const driveFiles = await listDriveImages(drive, imagesFolderId);
     for (const f of driveFiles) {
       if (f.name.startsWith('imageserver-backup-') && f.name.endsWith('.sql')) {
         driveDbDumpCount++;
+        // Track the most recent .sql file by createdTime
+        if (f.createdTime && (!latestDriveBackupDate || new Date(f.createdTime) > new Date(latestDriveBackupDate))) {
+          latestDriveBackupDate = f.createdTime;
+        }
       } else {
         driveMediaCount++;
       }
     }
   }
 
+  // Use admin_settings timestamp if available, otherwise fall back to latest Drive .sql file date
   const lastBackupResult = await pool.query(
     "SELECT value FROM admin_settings WHERE key = 'last_image_backup'"
   );
+  const lastBackup = lastBackupResult.rows[0]?.value || latestDriveBackupDate || null;
 
   return {
     mediaFileCount,
     driveMediaCount,
     driveDbDumpCount,
-    lastBackup: lastBackupResult.rows[0]?.value || null,
+    lastBackup,
     imagesFolderId: imagesFolderId || null
   };
 }
@@ -370,6 +396,7 @@ export async function getImageBackupStatus(pool, drive) {
  * 2. For each {subdir}--{filename} file in Drive, download and PUT to image server
  */
 export async function restoreImagesFromDrive(pool, drive) {
+  const runId = Math.floor(Date.now() / 1000);
   const imagesFolderId = await getDriveSetting(pool, 'images_folder_id');
   if (!imagesFolderId) {
     throw new Error('Images folder not configured in Drive');
@@ -379,6 +406,7 @@ export async function restoreImagesFromDrive(pool, drive) {
     throw new Error('Image server not configured');
   }
 
+  logInfo(runId, 'backup', null, null, 'Starting image restore from Drive');
   const driveFiles = await listDriveImages(drive, imagesFolderId);
 
   // Step 1: Find and restore the most recent DB dump
@@ -460,6 +488,8 @@ export async function restoreImagesFromDrive(pool, drive) {
   }
 
   console.log(`[ImageRestore] Done: DB=${dbRestored ? 'yes' : 'no'}, ${restored} media restored, ${skipped} skipped, ${failed} failed`);
+  logInfo(runId, 'backup', null, null, `Restore complete: DB=${dbRestored ? 'yes' : 'no'}, ${restored} media restored, ${skipped} skipped, ${failed} failed`, { completed: true, dbRestored, restored, skipped, failed });
+  await flushJobLogs();
 
   return { success: true, dbRestored, restored, skipped, failed };
 }

--- a/backend/services/collection/BatchRunner.js
+++ b/backend/services/collection/BatchRunner.js
@@ -85,8 +85,12 @@ export async function runBatch({
     const item = items[index];
     inFlight++;
 
-    // Find available slot (null if all occupied, fallback to 0)
-    const slotId = tracker.findFirstAvailableSlot(jobId) ?? 0;
+    // Find available slot. Returns null if all slots occupied (maxConcurrency
+    // should prevent this, but handle gracefully to avoid overwriting slot 0).
+    const slotId = tracker.findFirstAvailableSlot(jobId);
+    if (slotId === null) {
+      console.warn(`[${label} Job ${jobId}] No available display slot for item ${index} — all ${maxConcurrency} slots occupied`);
+    }
     const context = { slotId, jobId, index, total: items.length };
 
     if (onItemStart) {

--- a/backend/services/collection/CollectionTracker.js
+++ b/backend/services/collection/CollectionTracker.js
@@ -105,7 +105,8 @@ export class CollectionTracker {
    */
   findFirstAvailableSlot(jobId) {
     const slots = this.jobDisplaySlots.get(jobId);
-    if (!slots) return 0;
+    // Fix: return null (not 0) when uninitialized to avoid overwriting slot 0 (PR #168 review)
+    if (!slots) return null;
 
     const availableIndex = slots.findIndex(slot =>
       !slot.poiId || slot.status === 'completed'

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -1,0 +1,165 @@
+/**
+ * Collection Type Registry
+ * Static registry of all data collection types with metadata.
+ * Used by the admin UI to display collection type info, manage prompt templates,
+ * and provide trigger/schedule configuration for the Jobs dashboard.
+ *
+ * historyTypes: array of job_type values used in job_logs / status tables.
+ * The Jobs dashboard uses these to fetch per-job-type history inline.
+ */
+
+export const COLLECTION_TYPES = [
+  {
+    id: 'news',
+    label: 'News & Events',
+    description: 'AI-powered news and event discovery for POIs',
+    icon: '\u{1F4F0}',
+    promptKeys: [{
+      key: 'news_collection_prompt',
+      label: 'News Collection Prompt',
+      placeholders: ['{{name}}', '{{poi_type}}', '{{timezone}}', '{{website}}', '{{eventsUrl}}', '{{newsUrl}}']
+    }],
+    scheduleJobName: 'news-collection',
+    schedule: '0 6 * * *',
+    statusTable: 'news_job_status',
+    historyTypes: ['news'],
+    triggerEndpoint: '/api/admin/news/collect',
+    manualTriggerMethod: 'POST',
+    hasPrompt: true
+  },
+  {
+    id: 'trail_status',
+    label: 'MTB Trail Status',
+    description: 'Page rendering + AI extraction for trail conditions',
+    icon: '\u{1F6B5}',
+    promptKeys: [{
+      key: 'trail_status_prompt',
+      label: 'Trail Status Extraction Prompt',
+      placeholders: ['{{name}}', '{{trailSystem}}', '{{currentDate}}', '{{timezone}}', '{{statusUrl}}', '{{renderedContent}}']
+    }],
+    scheduleJobName: 'trail-status-collection',
+    schedule: '*/30 * * * *',
+    statusTable: 'trail_status_job_status',
+    historyTypes: ['trail_status'],
+    triggerEndpoint: '/api/admin/trail-status/collect-batch',
+    manualTriggerMethod: 'POST',
+    hasPrompt: true
+  },
+  {
+    id: 'moderation_sweep',
+    label: 'Moderation Sweep',
+    description: 'Re-checks unscored items missed by per-item queue',
+    icon: '\u{1F50D}',
+    promptKeys: [],
+    scheduleJobName: 'content-moderation-sweep',
+    schedule: '*/15 * * * *',
+    statusTable: null,
+    historyTypes: ['moderation'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'newsletter',
+    label: 'Email Ingestion',
+    description: 'Extracts news and events from inbound newsletters',
+    icon: '\u{1F4E7}',
+    promptKeys: [],
+    scheduleJobName: 'newsletter-process',
+    schedule: null,
+    statusTable: null,
+    historyTypes: ['newsletter'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'image_backup',
+    label: 'Image Server Backup',
+    description: 'Syncs image server media files to Google Drive',
+    icon: '\u{1F4BE}',
+    promptKeys: [],
+    scheduleJobName: 'image-backup',
+    schedule: '0 2 * * *',
+    statusTable: null,
+    historyTypes: ['backup'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'database_backup',
+    label: 'Database Backup',
+    description: 'Uploads PostgreSQL dump to Google Drive',
+    icon: '\u{1F5C4}',
+    promptKeys: [],
+    scheduleJobName: 'database-backup',
+    schedule: '0 3 * * *',
+    statusTable: null,
+    historyTypes: ['database_backup'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'moderation_item',
+    label: 'AI Moderation',
+    description: 'Scores new content with Gemini when inserted',
+    icon: '\u{2696}',
+    promptKeys: [],
+    scheduleJobName: 'content-moderation',
+    schedule: null,
+    statusTable: null,
+    historyTypes: ['moderation'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'research',
+    label: 'POI Research',
+    description: 'AI research for POI metadata and icon generation',
+    icon: '\u{1F50D}',
+    promptKeys: [],
+    scheduleJobName: null,
+    schedule: null,
+    statusTable: null,
+    historyTypes: ['research'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  },
+  {
+    id: 'cleanup',
+    label: 'Content Cleanup',
+    description: 'Deletes old news and past events',
+    icon: '\u{1F9F9}',
+    promptKeys: [],
+    scheduleJobName: null,
+    schedule: null,
+    statusTable: null,
+    historyTypes: ['cleanup'],
+    triggerEndpoint: null,
+    manualTriggerMethod: null,
+    hasPrompt: false
+  }
+];
+
+/**
+ * Get the default (hardcoded) prompt for a given prompt key.
+ * Lazy-imports the constants from service files to avoid circular dependencies.
+ */
+export async function getDefaultPrompt(key) {
+  switch (key) {
+    case 'news_collection_prompt': {
+      const { NEWS_COLLECTION_PROMPT } = await import('../newsService.js');
+      return NEWS_COLLECTION_PROMPT;
+    }
+    case 'trail_status_prompt': {
+      const { TRAIL_STATUS_PROMPT } = await import('../trailStatusService.js');
+      return TRAIL_STATUS_PROMPT;
+    }
+    default:
+      return null;
+  }
+}

--- a/backend/services/geminiService.js
+++ b/backend/services/geminiService.js
@@ -8,6 +8,7 @@ if (!globalThis.fetch) {
 }
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 
 // Gemini model — configurable via environment variable, defaults to gemini-2.5-flash
 export const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
@@ -237,7 +238,9 @@ export async function researchLocation(pool, destination, availableActivities = 
 
   const prompt = interpolatePrompt(promptTemplate, destination);
 
+  const runId = Math.floor(Date.now() / 1000);
   console.log(`Researching location: ${destination.name} (with Google Search, ${availableActivities.length} activities, ${availableEras.length} eras, ${availableSurfaces.length} surfaces available)`);
+  logInfo(runId, 'research', null, destination.name, `Research: ${destination.name}`);
 
   const generation = await model.generateContent(prompt);
   const response = generation.response;
@@ -277,10 +280,14 @@ export async function researchLocation(pool, destination, availableActivities = 
     }
 
     const researchData = JSON.parse(jsonText);
+    logInfo(runId, 'research', null, destination.name, `Research complete: ${destination.name}`, { completed: true, fields: Object.keys(researchData) });
+    await flushJobLogs();
     return researchData;
   } catch (e) {
     console.error('Failed to parse research response as JSON:', e);
     console.error('Raw response:', text);
+    logError(runId, 'research', null, destination.name, `Research failed: invalid AI response for ${destination.name}`, { completed: true, error_stack: text.slice(0, 500) });
+    await flushJobLogs();
     throw new Error('AI returned invalid format. Please try again.');
   }
 }
@@ -356,7 +363,9 @@ ${EXAMPLE_SVGS}
 
 Generate ONLY the SVG code now, starting with <svg and ending with </svg>:`;
 
+  const runId = Math.floor(Date.now() / 1000);
   console.log(`Generating icon SVG for: ${description} (color: ${color})`);
+  logInfo(runId, 'research', null, null, `Icon generation: ${description} (${color})`);
 
   const iconGeneration = await model.generateContent(prompt);
   const response = iconGeneration.response;
@@ -392,6 +401,8 @@ Generate ONLY the SVG code now, starting with <svg and ending with </svg>:`;
     text = text.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
   }
 
+  logInfo(runId, 'research', null, null, `Icon generated: ${description}`, { completed: true });
+  await flushJobLogs();
   return text;
 }
 

--- a/backend/services/jobLogger.js
+++ b/backend/services/jobLogger.js
@@ -18,6 +18,7 @@ const BATCH_SIZE = 50;
  */
 export function initJobLogger(dbPool) {
   pool = dbPool;
+  // Fix: clear existing timer before creating new one to prevent leaks (PR #166 review)
   if (flushTimer) clearInterval(flushTimer);
   flushTimer = setInterval(() => {
     if (buffer.length > 0) flush();
@@ -103,6 +104,8 @@ export async function flush() {
 
     for (const entry of entries) {
       placeholders.push(`($${idx}, $${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6})`);
+      // node-postgres handles JS objects natively for JSONB columns —
+      // no manual JSON.stringify needed (would cause double-encoding)
       values.push(
         entry.jobId,
         entry.jobType,
@@ -110,7 +113,7 @@ export async function flush() {
         entry.poiName,
         entry.level,
         entry.message,
-        entry.details ? JSON.stringify(entry.details) : null
+        entry.details || null
       );
       idx += 7;
     }

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -544,6 +544,17 @@ export async function registerDatabaseBackupHandler(handler) {
 }
 
 /**
+ * Update the cron schedule for any job type (live update via pg-boss)
+ * @param {string} jobName - pg-boss job name
+ * @param {string} cronExpression - New cron expression
+ */
+export async function updateSchedule(jobName, cronExpression) {
+  const scheduler = getJobScheduler();
+  await scheduler.schedule(jobName, cronExpression, {}, { tz: 'America/New_York' });
+  console.log(`Schedule updated: ${jobName} → ${cronExpression}`);
+}
+
+/**
  * Stop the job scheduler gracefully
  */
 export async function stopJobScheduler() {

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -471,9 +471,9 @@ function registerTools(server, pool, boss) {
 
   server.tool(
     'job_list',
-    'Recent jobs with status, counts, and timing',
+    'Recent jobs with status, counts, and timing. Covers all job types: news, trail_status (from status tables), plus moderation, backup, database_backup, research, cleanup, newsletter (from job_logs).',
     {
-      type: z.enum(['news', 'trail_status']).optional().describe('Filter by job type'),
+      type: z.enum(['news', 'trail_status', 'moderation', 'backup', 'database_backup', 'research', 'cleanup', 'newsletter']).optional().describe('Filter by job type'),
       limit: z.number().optional().default(10).describe('Max jobs to return')
     },
     async ({ type, limit }) => {
@@ -499,6 +499,33 @@ function registerTools(server, pool, boss) {
           LIMIT $1
         `, [limit]);
         results.trail_status_jobs = trailJobs.rows;
+      }
+      // job_logs-based types: moderation, backup, database_backup, research, cleanup, newsletter
+      const logTypes = ['moderation', 'backup', 'database_backup', 'research', 'cleanup', 'newsletter'];
+      const matchingLogTypes = type ? logTypes.filter(t => t === type) : logTypes;
+      if (matchingLogTypes.length > 0) {
+        const logJobs = await pool.query(`
+          SELECT job_id AS id, job_type,
+                 CASE
+                   WHEN bool_or(level = 'error') THEN 'failed'
+                   WHEN bool_or((details->>'completed')::boolean) THEN 'completed'
+                   WHEN MAX(created_at) > NOW() - INTERVAL '2 minutes' THEN 'running'
+                   ELSE 'stale'
+                 END AS status,
+                 MIN(created_at) AS started_at,
+                 MAX(created_at) AS completed_at,
+                 COUNT(*) AS log_entries,
+                 MAX(CASE WHEN level = 'error' THEN message END) AS error_message,
+                 MAX(message) FILTER (WHERE (details->>'completed')::boolean) AS summary
+          FROM job_logs
+          WHERE job_type = ANY($1)
+            AND job_id > 0
+            AND created_at > NOW() - INTERVAL '90 days'
+          GROUP BY job_type, job_id
+          ORDER BY MIN(created_at) DESC
+          LIMIT $2
+        `, [matchingLogTypes, limit]);
+        results.other_jobs = logJobs.rows;
       }
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     }
@@ -547,7 +574,7 @@ function registerTools(server, pool, boss) {
     'job_logs',
     'Structured log entries from collection jobs',
     {
-      job_type: z.enum(['news', 'trail_status', 'moderation', 'newsletter', 'backup', 'database_backup', 'news_single', 'events_single']).optional().describe('Filter by job type'),
+      job_type: z.enum(['news', 'trail_status', 'moderation', 'newsletter', 'backup', 'database_backup', 'research', 'cleanup', 'news_single', 'events_single']).optional().describe('Filter by job type'),
       job_id: z.number().optional().describe('Filter by job ID'),
       poi_id: z.number().optional().describe('Filter by POI ID'),
       level: z.enum(['info', 'warn', 'error']).optional().describe('Filter by log level'),

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -127,7 +127,8 @@ async function attemptDeepCrawl(pool, contentType, contentId, row, scoring) {
  * @param {string} contentType - 'news', 'event', or 'photo'
  * @param {number} contentId - ID of the content to moderate
  */
-export async function processItem(pool, contentType, contentId, { forceStatus = null } = {}) {
+export async function processItem(pool, contentType, contentId, { forceStatus = null, runId = null } = {}) {
+  const itemRunId = runId || Math.floor(Date.now() / 1000);
   console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
@@ -161,6 +162,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         [`Rejected: duplicate of approved news #${dupCheck.rows[0].id}`, contentId]
       );
       console.log(`[Moderation] news #${contentId}: rejected (duplicate of #${dupCheck.rows[0].id})`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected news #${contentId}: duplicate of #${dupCheck.rows[0].id}`, { completed: true });
       return;
     }
 
@@ -171,6 +173,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         [scoring.confidence_score, scoring.reasoning, contentId]
       );
       console.log(`[Moderation] news #${contentId}: rejected (no source URL)`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected news #${contentId}: no source URL`, { completed: true });
       return;
     }
 
@@ -181,6 +184,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         [`Rejected: source URL unreachable (${sourceCheck.reason})`, contentId]
       );
       console.log(`[Moderation] news #${contentId}: rejected (source URL unreachable: ${sourceCheck.reason})`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected news #${contentId}: URL unreachable (${sourceCheck.reason})`, { completed: true });
       return;
     }
 
@@ -256,6 +260,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         [`Rejected: duplicate of approved event #${dupCheck.rows[0].id}`, contentId]
       );
       console.log(`[Moderation] event #${contentId}: rejected (duplicate of #${dupCheck.rows[0].id})`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected event #${contentId}: duplicate of #${dupCheck.rows[0].id}`, { completed: true });
       return;
     }
 
@@ -265,6 +270,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         ['Rejected: non-human event without source URL', contentId]
       );
       console.log(`[Moderation] event #${contentId}: rejected (non-human, no source URL)`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected event #${contentId}: no source URL`, { completed: true });
       return;
     }
 
@@ -277,6 +283,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
           [`Rejected: source URL unreachable (${sourceCheck.reason})`, contentId]
         );
         console.log(`[Moderation] event #${contentId}: rejected (source URL unreachable: ${sourceCheck.reason})`);
+        logInfo(itemRunId, 'moderation', null, row.title, `Rejected event #${contentId}: URL unreachable (${sourceCheck.reason})`, { completed: true });
         return;
       }
       eventSourceContent = sourceCheck.markdown;
@@ -362,13 +369,19 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     );
   }
 
+  const decision = scoring?.confidence_score >= threshold ? 'auto_approved'
+    : scoring?.confidence_score < rejectFloor ? 'rejected' : 'pending';
   console.log(`[Moderation] ${contentType} #${contentId}: score=${scoring?.confidence_score}`);
+  logInfo(itemRunId || 0, 'moderation', null, null,
+    `Score ${contentType} #${contentId}: ${scoring?.confidence_score?.toFixed(2)} → ${decision}`,
+    { content_type: contentType, content_id: contentId, score: scoring?.confidence_score, decision });
 }
 
 /**
  * Process all unscored pending items (sweep job, runs every 15 minutes)
  */
 export async function processPendingItems(pool) {
+  const runId = Math.floor(Date.now() / 1000);
   const enabledQuery = await pool.query(
     "SELECT value FROM admin_settings WHERE key = 'moderation_enabled'"
   );
@@ -377,51 +390,57 @@ export async function processPendingItems(pool) {
     return { processed: 0 };
   }
 
-  let processed = 0;
-  let approved = 0;
-  let rejected = 0;
-
   const pendingNews = await pool.query(
     `SELECT id FROM poi_news WHERE moderation_status = 'pending' AND confidence_score IS NULL LIMIT 20`
   );
+  const pendingEvents = await pool.query(
+    `SELECT id FROM poi_events WHERE moderation_status = 'pending' AND confidence_score IS NULL LIMIT 20`
+  );
+  const pendingPhotos = await pool.query(
+    `SELECT id FROM photo_submissions WHERE moderation_status = 'pending' AND confidence_score IS NULL LIMIT 20`
+  );
+  const totalPending = pendingNews.rows.length + pendingEvents.rows.length + pendingPhotos.rows.length;
+
+  if (totalPending === 0) {
+    console.log('[Moderation] Sweep complete: 0 items processed');
+    return { processed: 0 };
+  }
+
+  logInfo(runId, 'moderation', null, null, `Sweep starting: ${totalPending} unscored items (${pendingNews.rows.length} news, ${pendingEvents.rows.length} events, ${pendingPhotos.rows.length} photos)`);
+
+  let processed = 0;
   for (const row of pendingNews.rows) {
     try {
-      await processItem(pool, 'news', row.id);
+      await processItem(pool, 'news', row.id, { runId });
       processed++;
     } catch (error) {
+      logError(runId, 'moderation', null, null, `Failed to process news #${row.id}: ${error.message}`);
       console.error(`[Moderation] Failed to process news #${row.id}:`, error.message);
     }
   }
 
-  const pendingEvents = await pool.query(
-    `SELECT id FROM poi_events WHERE moderation_status = 'pending' AND confidence_score IS NULL LIMIT 20`
-  );
   for (const row of pendingEvents.rows) {
     try {
-      await processItem(pool, 'event', row.id);
+      await processItem(pool, 'event', row.id, { runId });
       processed++;
     } catch (error) {
+      logError(runId, 'moderation', null, null, `Failed to process event #${row.id}: ${error.message}`);
       console.error(`[Moderation] Failed to process event #${row.id}:`, error.message);
     }
   }
 
-  const pendingPhotos = await pool.query(
-    `SELECT id FROM photo_submissions WHERE moderation_status = 'pending' AND confidence_score IS NULL LIMIT 20`
-  );
   for (const row of pendingPhotos.rows) {
     try {
-      await processItem(pool, 'photo', row.id);
+      await processItem(pool, 'photo', row.id, { runId });
       processed++;
     } catch (error) {
+      logError(runId, 'moderation', null, null, `Failed to process photo #${row.id}: ${error.message}`);
       console.error(`[Moderation] Failed to process photo #${row.id}:`, error.message);
     }
   }
 
-  const totalPending = pendingNews.rows.length + pendingEvents.rows.length + pendingPhotos.rows.length;
-  if (totalPending > 0) {
-    logInfo(null, 'moderation', null, null, `Sweep complete: ${processed} processed`, { pending: totalPending, processed });
-    await flushJobLogs();
-  }
+  logInfo(runId, 'moderation', null, null, `Sweep complete: ${processed}/${totalPending} processed`, { completed: true, pending: totalPending, processed });
+  await flushJobLogs();
   console.log(`[Moderation] Sweep complete: ${processed} items processed`);
   return { processed };
 }
@@ -471,13 +490,15 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
   const table = TABLE_MAP[contentType];
 
   const setClauses = [];
-  const values = [adminUserId, contentId];
-  let idx = 3;
+  const values = [contentId];
+  let idx = 2;
 
+  const DATE_FIELDS = ['publication_date', 'start_date', 'end_date'];
   for (const field of allowedFields) {
     if (edits[field] !== undefined) {
       setClauses.push(`${field} = $${idx}`);
-      values.push(edits[field]);
+      // Coerce empty strings to null for date/timestamp columns
+      values.push(DATE_FIELDS.includes(field) && edits[field] === '' ? null : edits[field]);
       idx++;
     }
   }
@@ -488,11 +509,13 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
   }
 
   if (publish) {
-    setClauses.push(`moderation_status = 'published'`, `moderated_by = $1`, `moderated_at = CURRENT_TIMESTAMP`);
+    setClauses.push(`moderation_status = 'published'`, `moderated_by = $${idx}`, `moderated_at = CURRENT_TIMESTAMP`);
+    values.push(adminUserId);
+    idx++;
   }
 
   if (setClauses.length === 0) return;
-  await pool.query(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $2`, values);
+  await pool.query(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $1`, values);
 }
 
 export async function createItem(pool, contentType, fields, adminUserId) {
@@ -524,12 +547,15 @@ export async function createItem(pool, contentType, fields, adminUserId) {
 }
 
 export async function purgeRejected(pool, contentType) {
+  const runId = Math.floor(Date.now() / 1000);
   if (contentType) {
     const table = TABLE_MAP[contentType];
     if (!table) throw new Error(`Unknown content type: ${contentType}`);
     const result = await pool.query(
       `DELETE FROM ${table} WHERE moderation_status = 'rejected'`
     );
+    logInfo(runId, 'cleanup', null, null, `Purge rejected: deleted ${result.rowCount} ${contentType} items`, { completed: true, deleted: result.rowCount, type: contentType });
+    await flushJobLogs();
     return { deleted: result.rowCount };
   }
   // Purge all three tables
@@ -540,6 +566,8 @@ export async function purgeRejected(pool, contentType) {
     );
     total += result.rowCount;
   }
+  logInfo(runId, 'cleanup', null, null, `Purge rejected: deleted ${total} items (all types)`, { completed: true, deleted: total, type: 'all' });
+  await flushJobLogs();
   return { deleted: total };
 }
 
@@ -578,6 +606,7 @@ export async function researchItem(pool, contentType, contentId) {
   }
   const item = itemQuery.rows[0];
   const oldUrl = item.source_url || null;
+  const runId = Math.floor(Date.now() / 1000);
 
   const typeLabel = contentType === 'news' ? 'news article' : 'event';
   const prompt = `Search the web for this ${typeLabel} and tell me what you find:
@@ -590,6 +619,7 @@ Tell me: Did you find this specific ${typeLabel}? What website is it on? Is it s
 Summarize what you found in 1-2 sentences.`;
 
   console.log(`[Moderation] Fixing URL for ${contentType} #${contentId}: "${item.title}"`);
+  logInfo(runId, 'moderation', null, item.title, `Fix URL: searching for ${contentType} #${contentId}`);
 
   const genAI = await createGeminiClient(pool);
   const model = genAI.getGenerativeModel({
@@ -643,9 +673,12 @@ Summarize what you found in 1-2 sentences.`;
     );
     sourceUrlUpdated = true;
     console.log(`[Moderation] Fix URL updated ${contentType} #${contentId}: ${oldUrl || '(none)'} -> ${newUrl}`);
+    logInfo(runId, 'moderation', null, item.title, `Fix URL: updated ${contentType} #${contentId}`, { completed: true, old_url: oldUrl, new_url: newUrl });
   } else {
     console.log(`[Moderation] Fix URL for ${contentType} #${contentId}: no new URL found`);
+    logInfo(runId, 'moderation', null, item.title, `Fix URL: no new URL found for ${contentType} #${contentId}`, { completed: true });
   }
+  await flushJobLogs();
 
   return {
     researched: true,
@@ -679,6 +712,69 @@ export async function fixDate(pool, contentType, contentId) {
     throw new Error(`${contentType} #${contentId} not found`);
   }
   const item = itemQuery.rows[0];
+  const runId = Math.floor(Date.now() / 1000);
+
+  console.log(`[Moderation] Fixing date for ${contentType} #${contentId}: "${item.title}"`);
+  logInfo(runId, 'moderation', null, item.title, `Fix Date: ${contentType} #${contentId}`);
+
+  // Fetch actual page content if source URL exists
+  let pageContent = '';
+  let htmlDateHints = '';
+  if (item.source_url && isSafePublicUrl(item.source_url)) {
+    try {
+      // Simple fetch to get raw HTML for date metadata extraction
+      const res = await fetch(item.source_url, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ROTV/1.0)' },
+        signal: AbortSignal.timeout(10000)
+      });
+      if (res.ok) {
+        const html = await res.text();
+        // Extract date hints from HTML metadata and structured elements
+        const datePatterns = [];
+        const metaMatch = html.match(/<meta[^>]+(?:property|name)=["'](?:article:published_time|og:article:published_time|datePublished|date|DC\.date)["'][^>]+content=["']([^"']+)["']/i);
+        if (metaMatch) datePatterns.push(metaMatch[1]);
+        const timeMatch = html.match(/<time[^>]+datetime=["']([^"']+)["']/i);
+        if (timeMatch) datePatterns.push(timeMatch[1]);
+        const ldMatch = html.match(/"datePublished"\s*:\s*"([^"]+)"/);
+        if (ldMatch) datePatterns.push(ldMatch[1]);
+
+        // If we found a machine-readable date, use it directly — skip Gemini
+        if (datePatterns.length > 0) {
+          for (const raw of datePatterns) {
+            const isoMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+            if (isoMatch) {
+              const dateStr = `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+              const [y, m, d] = [parseInt(isoMatch[1]), parseInt(isoMatch[2]), parseInt(isoMatch[3])];
+              if (m >= 1 && m <= 12 && d >= 1 && d <= 31 && y >= 1900 && y <= 2100) {
+                await pool.query(
+                  `UPDATE ${table} SET publication_date = $1, date_confidence = 'exact' WHERE id = $2`,
+                  [dateStr, contentId]
+                );
+                console.log(`[Moderation] Fix date from HTML metadata: ${contentType} #${contentId} → ${dateStr}`);
+                logInfo(runId, 'moderation', null, item.title, `Fix Date: ${dateStr} (from HTML metadata)`, { completed: true, publication_date: dateStr });
+                await flushJobLogs();
+                return { date_updated: true, publication_date: dateStr, date_confidence: 'exact', reasoning: 'Extracted from HTML metadata' };
+              }
+            }
+          }
+          // Have hints but couldn't parse — pass to Gemini
+          htmlDateHints = '\nDate metadata found in HTML:\n' + datePatterns.join('\n');
+        }
+      }
+    } catch (fetchErr) {
+      console.warn(`[Moderation] Could not fetch raw HTML for fix-date: ${fetchErr.message}`);
+    }
+
+    // Also get readable content via Playwright + Readability
+    try {
+      const extracted = await extractPageContent(item.source_url, { maxLength: 4000, timeout: 15000 });
+      if (extracted.markdown) {
+        pageContent = extracted.markdown;
+      }
+    } catch (err) {
+      console.warn(`[Moderation] Could not fetch page for fix-date: ${err.message}`);
+    }
+  }
 
   const typeLabel = contentType === 'news' ? 'news article' : 'event';
   const prompt = `Find the publication date for this ${typeLabel}:
@@ -687,9 +783,11 @@ Title: "${item.title}"
 ${item.description ? `Description: "${item.description}"` : ''}
 ${item.source_url ? `Source URL: ${item.source_url}` : ''}
 ${item.poi_name ? `Location/Organization: ${item.poi_name}` : ''}
+${htmlDateHints}
+${pageContent ? `\nPage Content:\n${pageContent}` : ''}
 
-Search the web and find when this was published. Look for:
-- Publication date, byline date, or article timestamp on the source page
+Look for:
+- Publication date, byline date, or article timestamp in the page content
 - Date in the URL pattern (e.g., /2025/03/article-name)
 - References to specific dated events that pin down the timeframe
 
@@ -700,24 +798,38 @@ If exact date found, use date_confidence "exact".
 If estimated from context, use "estimated".
 If truly impossible to determine, use "unknown" and set publication_date to null.`;
 
-  console.log(`[Moderation] Fixing date for ${contentType} #${contentId}: "${item.title}"`);
-
   const genAI = await createGeminiClient(pool);
   const model = genAI.getGenerativeModel({
     model: GEMINI_MODEL,
-    tools: [{ googleSearch: {} }],
     generationConfig: { temperature: 0 }
   });
 
-  const generation = await model.generateContent(prompt);
-  const text = generation.response.text().trim();
+  let text;
+  try {
+    const generation = await model.generateContent(prompt);
+    text = generation.response.text().trim();
+  } catch (genErr) {
+    console.error('[Moderation] Fix-date generation failed:', genErr.message);
+    logError(runId, 'moderation', null, item.title, `Fix Date: AI generation failed`, { completed: true });
+    await flushJobLogs();
+    return { date_updated: false, reasoning: 'AI generation failed' };
+  }
+
+  if (!text) {
+    console.error('[Moderation] Fix-date: empty response from AI');
+    logError(runId, 'moderation', null, item.title, `Fix Date: AI returned empty response`, { completed: true });
+    await flushJobLogs();
+    return { date_updated: false, reasoning: 'AI returned empty response' };
+  }
 
   const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, text];
   let result;
   try {
     result = JSON.parse(jsonMatch[1].trim());
   } catch {
-    console.error('[Moderation] Failed to parse fix-date response:', text);
+    console.error('[Moderation] Failed to parse fix-date response:', text.slice(0, 500));
+    logError(runId, 'moderation', null, item.title, `Fix Date: failed to parse AI response`, { completed: true });
+    await flushJobLogs();
     return { date_updated: false, reasoning: 'Failed to parse AI response' };
   }
 
@@ -729,6 +841,8 @@ If truly impossible to determine, use "unknown" and set publication_date to null
       [publicationDate, dateConfidence, contentId]
     );
     console.log(`[Moderation] Fix date updated ${contentType} #${contentId}: ${publicationDate} (${dateConfidence})`);
+    logInfo(runId, 'moderation', null, item.title, `Fix Date: ${publicationDate} (${dateConfidence}, via AI)`, { completed: true, publication_date: publicationDate, date_confidence: dateConfidence });
+    await flushJobLogs();
     return {
       date_updated: true,
       publication_date: publicationDate,
@@ -738,13 +852,15 @@ If truly impossible to determine, use "unknown" and set publication_date to null
   }
 
   console.log(`[Moderation] Fix date for ${contentType} #${contentId}: no date found`);
+  logInfo(runId, 'moderation', null, item.title, `Fix Date: no date found for ${contentType} #${contentId}`, { completed: true });
+  await flushJobLogs();
   return {
     date_updated: false,
     reasoning: result.reasoning || 'Could not determine publication date'
   };
 }
 
-export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null } = {}) {
+export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null, search = null } = {}) {
   const offset = (page - 1) * limit;
   const statusList = status === 'all'
     ? ['pending', 'published', 'auto_approved', 'rejected']
@@ -792,6 +908,11 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
   if (contentSource) {
     filters.push(`content_source = $${paramIdx}`);
     params.push(contentSource);
+    paramIdx++;
+  }
+  if (search) {
+    filters.push(`(title ILIKE $${paramIdx} OR description ILIKE $${paramIdx})`);
+    params.push(`%${search}%`);
     paramIdx++;
   }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -173,8 +173,8 @@ export async function findIncompleteJobs(pool) {
   return result.rows;
 }
 
-// Prompt template for news collection
-const NEWS_COLLECTION_PROMPT = `You are a precise news researcher for Cuyahoga Valley National Park and surrounding areas in Northeast Ohio.
+// Prompt template for news collection (exported for registry.js default prompt access)
+export const NEWS_COLLECTION_PROMPT = `You are a precise news researcher for Cuyahoga Valley National Park and surrounding areas in Northeast Ohio.
 
 TIMEZONE CONTEXT:
 - The current timezone is: {{timezone}}
@@ -817,7 +817,11 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
   }
 
   // Build prompt with extracted content if available
-  let prompt = NEWS_COLLECTION_PROMPT
+  // Use custom prompt from admin_settings if configured, otherwise fall back to hardcoded default
+  const { getPromptTemplate } = await import('./geminiService.js');
+  const promptTemplate = await getPromptTemplate(pool, 'news_collection_prompt');
+  const basePrompt = promptTemplate || NEWS_COLLECTION_PROMPT;
+  let prompt = basePrompt
     .replace(/\{\{timezone\}\}/g, timezone)
     .replace('{{name}}', poi.name)
     .replace('{{poi_type}}', poi.poi_type)
@@ -1338,7 +1342,9 @@ IMPORTANT:
       news: allNews,
       events: result.events || [],
       metadata: {
-        usedDedicatedNewsUrl
+        usedDedicatedNewsUrl,
+        provider: usedProvider,
+        ai_response: response
       }
     };
   } catch (error) {
@@ -1898,7 +1904,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
         const savedNews = await saveNewsItems(pool, poi.id, news, { skipDateFilter: metadata.usedDedicatedNewsUrl });
         const savedEvents = await saveEventItems(pool, poi.id, events);
         console.log(`[News Job ${jobId}] [${index + 1}/${total}] ${poi.name}: ${savedNews} news, ${savedEvents} events`);
-        logInfo(jobId, 'news', poi.id, poi.name, `${savedNews} news, ${savedEvents} events saved`, { news_found: news.length, events_found: events.length, news_saved: savedNews, events_saved: savedEvents, provider: metadata?.provider });
+        logInfo(jobId, 'news', poi.id, poi.name, `${savedNews} news, ${savedEvents} events saved`, { news_found: news.length, events_found: events.length, news_saved: savedNews, events_saved: savedEvents, provider: metadata?.provider, ai_response: metadata?.ai_response });
 
         // Update last_news_collection timestamp
         await pool.query(`
@@ -2163,11 +2169,14 @@ export async function getLatestJobStatus(pool) {
  * @param {number} daysOld - Delete news older than this many days
  */
 export async function cleanupOldNews(pool, daysOld = 90) {
+  const runId = Math.floor(Date.now() / 1000);
   const result = await pool.query(`
     DELETE FROM poi_news
     WHERE created_at < CURRENT_DATE - INTERVAL '1 day' * $1
   `, [daysOld]);
 
+  logInfo(runId, 'cleanup', null, null, `Cleanup: deleted ${result.rowCount} news older than ${daysOld} days`, { completed: true, deleted: result.rowCount, type: 'news', days_old: daysOld });
+  await flushJobLogs();
   return result.rowCount;
 }
 
@@ -2177,11 +2186,14 @@ export async function cleanupOldNews(pool, daysOld = 90) {
  * @param {number} daysOld - Delete events older than this many days
  */
 export async function cleanupPastEvents(pool, daysOld = 30) {
+  const runId = Math.floor(Date.now() / 1000);
   const result = await pool.query(`
     DELETE FROM poi_events
     WHERE end_date < CURRENT_DATE - INTERVAL '1 day' * $1
        OR (end_date IS NULL AND start_date < CURRENT_DATE - INTERVAL '1 day' * $1)
   `, [daysOld]);
 
+  logInfo(runId, 'cleanup', null, null, `Cleanup: deleted ${result.rowCount} events older than ${daysOld} days`, { completed: true, deleted: result.rowCount, type: 'events', days_old: daysOld });
+  await flushJobLogs();
   return result.rowCount;
 }

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -66,8 +66,8 @@ async function trackTwitterResult(pool, statusUrl, success) {
   }
 }
 
-// Prompt template for trail status extraction from rendered page content
-const TRAIL_STATUS_PROMPT = `You are a trail status extractor. Extract the current mountain bike trail status from the following page content.
+// Prompt template for trail status extraction (exported for registry.js default prompt access)
+export const TRAIL_STATUS_PROMPT = `You are a trail status extractor. Extract the current mountain bike trail status from the following page content.
 
 Trail: "{{name}}"
 Trail System: {{trailSystem}}
@@ -245,7 +245,11 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
     });
 
     const currentDate = new Date().toISOString().split('T')[0];
-    const prompt = TRAIL_STATUS_PROMPT
+    // Use custom prompt from admin_settings if configured, otherwise fall back to hardcoded default
+    const { getPromptTemplate } = await import('./geminiService.js');
+    const promptTemplate = await getPromptTemplate(pool, 'trail_status_prompt');
+    const basePrompt = promptTemplate || TRAIL_STATUS_PROMPT;
+    const prompt = basePrompt
       .replace(/\{\{currentDate\}\}/g, currentDate)
       .replace(/\{\{name\}\}/g, poi.name)
       .replace(/\{\{trailSystem\}\}/g, trailSystem)
@@ -340,7 +344,7 @@ export async function collectTrailStatus(pool, poi, sheets = null, timezone = 'A
       steps: ['Initialized', 'Rendered', 'Extracting', 'Saving', 'Complete']
     });
 
-    return { statusFound: 1, statusSaved: saved ? 1 : 0 };
+    return { statusFound: 1, statusSaved: saved ? 1 : 0, rendered_content: rendered.markdown, ai_response: response };
 
   } catch (error) {
     console.error(`[Trail Status] Error collecting status for ${poi.name}:`, error.message);
@@ -618,7 +622,7 @@ export async function processTrailStatusCollectionJob(pool, jobId, poiIds, sheet
 
         console.log(`[Trail Status Job ${jobId}] [${index + 1}/${total}] ${poi.name}: ${statusCollection.statusFound} status found`);
         if (statusCollection.statusFound > 0) {
-          logInfo(jobId, 'trail_status', poi.id, poi.name, `Status found: ${statusCollection.statusSaved ? 'saved' : 'unchanged'}`, { status_found: statusCollection.statusFound, status_saved: statusCollection.statusSaved });
+          logInfo(jobId, 'trail_status', poi.id, poi.name, `Status found: ${statusCollection.statusSaved ? 'saved' : 'unchanged'}`, { status_found: statusCollection.statusFound, status_saved: statusCollection.statusSaved, rendered_content: statusCollection.rendered_content, ai_response: statusCollection.ai_response });
         }
 
         return { statusFound: statusCollection.statusFound, statusSaved: statusCollection.statusSaved, poiName: poi.name };

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4588,10 +4588,14 @@ body {
   display: flex;
   gap: 0;
   margin-bottom: 0;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
   background: transparent;
   padding: 0;
   flex-wrap: wrap;
+}
+
+.settings-tabs.settings-tabs-row2 {
+  border-bottom: 2px solid #e0e0e0;
 }
 
 .settings-tab-btn {
@@ -6803,6 +6807,30 @@ body {
   font-size: 0.75rem;
   color: #666;
   line-height: 1.3;
+}
+
+.job-link-inline {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #1565c0;
+  text-decoration: none;
+}
+
+.job-link-inline:hover {
+  text-decoration: underline;
+}
+
+.job-link-active {
+  color: #1565c0;
+  font-weight: 600;
+  text-decoration: none;
+  animation: pulse-badge 2s ease-in-out infinite;
+}
+
+.job-link-active:hover {
+  text-decoration: underline;
 }
 
 .sync-clear-row {
@@ -12641,4 +12669,342 @@ svg.leaflet-zoom-animated {
 
 .load-more-btn:hover {
   background: #e2e8f0;
+}
+
+/* Scheduled Jobs Grid */
+.scheduled-jobs-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scheduled-job-card {
+  background: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.scheduled-job-header {
+  padding: 12px 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.scheduled-job-header:hover {
+  background: #edf2f7;
+}
+
+.scheduled-job-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.scheduled-job-icon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.scheduled-job-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #2d3748;
+}
+
+.scheduled-job-desc {
+  font-size: 0.78rem;
+  color: #718096;
+  margin-top: 1px;
+}
+
+.scheduled-job-badges {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.schedule-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: #e3f2fd;
+  color: #1565c0;
+  white-space: nowrap;
+}
+
+.scheduled-job-detail {
+  padding: 0 14px 14px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.scheduled-job-lastrun {
+  font-size: 0.85rem;
+  color: #4a5568;
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+}
+
+.schedule-editor {
+  margin-top: 10px;
+}
+
+.schedule-edit-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.schedule-input {
+  padding: 4px 8px;
+  border: 1px solid #cbd5e0;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  width: 180px;
+}
+
+.schedule-display-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.schedule-cron {
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  background: #f5f5f5;
+  border-radius: 3px;
+  color: #555;
+}
+
+.schedule-custom-badge {
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.prompt-section {
+  margin-top: 12px;
+  border-top: 1px solid #e2e8f0;
+  padding-top: 12px;
+}
+
+/* Structured log details */
+.log-details-structured {
+  grid-column: 1 / -1;
+  margin: 4px 0;
+}
+
+.log-detail-section {
+  margin-bottom: 6px;
+}
+
+.log-detail-section.collapsible {
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.log-detail-pairs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  padding: 6px 0;
+}
+
+.log-detail-pair {
+  font-size: 0.78rem;
+}
+
+.log-detail-key {
+  color: #718096;
+  text-transform: capitalize;
+  margin-right: 4px;
+}
+
+.log-detail-value {
+  color: #2d3748;
+  font-weight: 500;
+}
+
+.log-detail-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #4a5568;
+  margin-bottom: 4px;
+}
+
+.log-detail-label.clickable {
+  cursor: pointer;
+  padding: 6px 8px;
+  user-select: none;
+}
+
+.log-detail-label.clickable:hover {
+  background: #f7fafc;
+}
+
+.log-detail-pre {
+  background: #edf2f7;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  overflow-x: auto;
+  max-height: 300px;
+  overflow-y: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-detail-pre.error {
+  background: #fff5f5;
+  color: #c53030;
+}
+
+/* Running job card highlight */
+.scheduled-job-card.running {
+  border-color: #2196f3;
+  border-width: 2px;
+}
+
+.queue-badge-running {
+  background: #e3f2fd;
+  color: #1565c0;
+  animation: pulse-badge 2s ease-in-out infinite;
+}
+
+@keyframes pulse-badge {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* Running job section inside card */
+.running-job-section {
+  margin-top: 10px;
+  padding: 10px;
+  background: #e3f2fd;
+  border-radius: 6px;
+  border: 1px solid #bbdefb;
+}
+
+.running-job-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1565c0;
+}
+
+.running-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2196f3;
+  display: inline-block;
+}
+
+/* Active slots table */
+.active-slots-table {
+  margin-top: 8px;
+  font-size: 0.78rem;
+}
+
+.slots-header {
+  display: grid;
+  grid-template-columns: 1fr 100px 100px;
+  gap: 4px;
+  padding: 4px 6px;
+  font-weight: 600;
+  color: #1565c0;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.slots-row {
+  display: grid;
+  grid-template-columns: 1fr 100px 100px;
+  gap: 4px;
+  padding: 3px 6px;
+  border-radius: 3px;
+}
+
+.slots-row.active {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.slots-row.empty-slot {
+  color: #90caf9;
+}
+
+.slot-poi {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Inline run history inside scheduled job card */
+.job-runs-section {
+  margin-top: 12px;
+  border-top: 1px solid #e2e8f0;
+  padding-top: 10px;
+}
+
+.job-runs-header {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #4a5568;
+  margin-bottom: 6px;
+}
+
+.job-runs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.job-run-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+
+.job-run-row:hover {
+  background: #edf2f7;
+}
+
+.job-run-row.expanded {
+  background: #edf2f7;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.run-items {
+  color: #4a5568;
+  min-width: 50px;
+}
+
+.run-time {
+  color: #718096;
+  font-size: 0.78rem;
+}
+
+.run-duration {
+  color: #a0aec0;
+  font-size: 0.78rem;
+  margin-left: auto;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -108,6 +108,7 @@ function AppContent() {
 
   // Settings sub-tab state: 'general', 'activities', 'news', 'google'
   const [settingsTab, setSettingsTab] = useState('general');
+  const [jobsExpandTarget, setJobsExpandTarget] = useState(null);
 
   // Moderation queue pending count for badge
   const [moderationCount, setModerationCount] = useState(0);
@@ -1678,12 +1679,8 @@ function AppContent() {
               >
                 Icons
               </button>
-              <button
-                className={`settings-tab-btn ${settingsTab === 'dataCollection' ? 'active' : ''}`}
-                onClick={() => setSettingsTab('dataCollection')}
-              >
-                Data Collection
-              </button>
+            </nav>
+            <nav className="settings-tabs settings-tabs-row2">
               <button
                 className={`settings-tab-btn ${settingsTab === 'moderation' ? 'active' : ''}`}
                 onClick={() => setSettingsTab('moderation')}
@@ -1709,6 +1706,12 @@ function AppContent() {
                 Jobs
               </button>
               <button
+                className={`settings-tab-btn ${settingsTab === 'dataCollection' ? 'active' : ''}`}
+                onClick={() => setSettingsTab('dataCollection')}
+              >
+                Data Collection
+              </button>
+              <button
                 className={`settings-tab-btn ${settingsTab === 'google' ? 'active' : ''}`}
                 onClick={() => setSettingsTab('google')}
               >
@@ -1725,10 +1728,10 @@ function AppContent() {
               {settingsTab === 'icons' && <IconsSettings />}
               {settingsTab === 'dataCollection' && <DataCollectionSettings />}
               {settingsTab === 'moderation' && <ModerationInbox />}
-              {settingsTab === 'jobs' && <JobsDashboard />}
+              {settingsTab === 'jobs' && <JobsDashboard expandTarget={jobsExpandTarget} onExpandTargetConsumed={() => setJobsExpandTarget(null)} />}
               {settingsTab === 'google' && (
                 <div className="google-integration-tab">
-                  <SyncSettings onDataRefresh={refreshAllData} />
+                  <SyncSettings onDataRefresh={refreshAllData} onNavigateToJobs={(jobId) => { setJobsExpandTarget(jobId); setSettingsTab('jobs'); }} />
                   <div className="settings-divider"></div>
                   <AISettings />
                 </div>

--- a/frontend/src/components/AISettings.jsx
+++ b/frontend/src/components/AISettings.jsx
@@ -1,22 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-const DEFAULT_PROMPTS = {
-  gemini_prompt_brief: `Generate a concise 2-3 sentence overview for a historical location in Cuyahoga Valley National Park.
-Location: {{name}}
-Era: {{era}}
-Owner: {{property_owner}}
-Activities: {{primary_activities}}
-
-Focus on what makes this place special for visitors today.`,
-
-  gemini_prompt_historical: `Write a detailed historical description (2-3 paragraphs) for a destination in the Cuyahoga Valley, written in the style of Arcadia Publishing's "Images of America" series.
-Location: {{name}}
-Era: {{era}}
-Owner: {{property_owner}}
-
-Use a warm, narrative tone typical of local history books. Focus on human stories and community significance. Reference the Ohio & Erie Canal era when relevant.`
-};
-
 function AISettings() {
   const [settings, setSettings] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -27,11 +10,6 @@ function AISettings() {
 
   // Form state
   const [apiKey, setApiKey] = useState('');
-  const [prompts, setPrompts] = useState({
-    gemini_prompt_brief: '',
-    gemini_prompt_historical: ''
-  });
-  const [editingPrompt, setEditingPrompt] = useState(null);
 
   const fetchSettings = useCallback(async () => {
     try {
@@ -41,12 +19,6 @@ function AISettings() {
       if (response.ok) {
         const data = await response.json();
         setSettings(data);
-
-        // Initialize prompts from settings or defaults
-        setPrompts({
-          gemini_prompt_brief: data.gemini_prompt_brief?.value || DEFAULT_PROMPTS.gemini_prompt_brief,
-          gemini_prompt_historical: data.gemini_prompt_historical?.value || DEFAULT_PROMPTS.gemini_prompt_historical
-        });
         setError(null);
       } else if (response.status === 401 || response.status === 403) {
         setError('Please log in as admin to view AI settings');
@@ -119,40 +91,6 @@ function AISettings() {
     }
   };
 
-  const handleSavePrompt = async (key) => {
-    setSaving(true);
-    setError(null);
-    setMessage(null);
-
-    try {
-      const response = await fetch(`/api/admin/settings/${key}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ value: prompts[key] })
-      });
-
-      if (response.ok) {
-        setMessage('Prompt saved successfully');
-        setEditingPrompt(null);
-        fetchSettings();
-      } else {
-        setError('Failed to save prompt');
-      }
-    } catch {
-      setError('Failed to save prompt');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleResetPrompt = (key) => {
-    setPrompts(prev => ({
-      ...prev,
-      [key]: DEFAULT_PROMPTS[key]
-    }));
-  };
-
   if (loading) {
     return (
       <div className="ai-settings">
@@ -213,119 +151,6 @@ function AISettings() {
         </p>
       </div>
 
-      {/* Prompt Templates Section */}
-      <div className="ai-section">
-        <h4>Prompt Templates</h4>
-        <p className="section-description">
-          Customize the prompts used for AI generation. Use placeholders like{' '}
-          <code>{'{{name}}'}</code>, <code>{'{{era}}'}</code>,{' '}
-          <code>{'{{property_owner}}'}</code>, <code>{'{{primary_activities}}'}</code>.
-        </p>
-
-        {/* Brief Description Prompt */}
-        <div className="prompt-editor">
-          <div className="prompt-header">
-            <label>Brief Description Prompt</label>
-            <div className="prompt-actions">
-              {editingPrompt === 'gemini_prompt_brief' ? (
-                <>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => handleSavePrompt('gemini_prompt_brief')}
-                    disabled={saving}
-                  >
-                    Save
-                  </button>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => {
-                      setEditingPrompt(null);
-                      setPrompts(prev => ({
-                        ...prev,
-                        gemini_prompt_brief: settings?.gemini_prompt_brief?.value || DEFAULT_PROMPTS.gemini_prompt_brief
-                      }));
-                    }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => handleResetPrompt('gemini_prompt_brief')}
-                  >
-                    Reset to Default
-                  </button>
-                </>
-              ) : (
-                <button
-                  className="sync-btn-small"
-                  onClick={() => setEditingPrompt('gemini_prompt_brief')}
-                >
-                  Edit
-                </button>
-              )}
-            </div>
-          </div>
-          <textarea
-            value={prompts.gemini_prompt_brief}
-            onChange={(e) => setPrompts(prev => ({ ...prev, gemini_prompt_brief: e.target.value }))}
-            disabled={editingPrompt !== 'gemini_prompt_brief'}
-            rows={6}
-            className="prompt-textarea"
-          />
-        </div>
-
-        {/* Historical Description Prompt */}
-        <div className="prompt-editor">
-          <div className="prompt-header">
-            <label>Historical Description Prompt</label>
-            <div className="prompt-actions">
-              {editingPrompt === 'gemini_prompt_historical' ? (
-                <>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => handleSavePrompt('gemini_prompt_historical')}
-                    disabled={saving}
-                  >
-                    Save
-                  </button>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => {
-                      setEditingPrompt(null);
-                      setPrompts(prev => ({
-                        ...prev,
-                        gemini_prompt_historical: settings?.gemini_prompt_historical?.value || DEFAULT_PROMPTS.gemini_prompt_historical
-                      }));
-                    }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    className="sync-btn-small"
-                    onClick={() => handleResetPrompt('gemini_prompt_historical')}
-                  >
-                    Reset to Default
-                  </button>
-                </>
-              ) : (
-                <button
-                  className="sync-btn-small"
-                  onClick={() => setEditingPrompt('gemini_prompt_historical')}
-                >
-                  Edit
-                </button>
-              )}
-            </div>
-          </div>
-          <textarea
-            value={prompts.gemini_prompt_historical}
-            onChange={(e) => setPrompts(prev => ({ ...prev, gemini_prompt_historical: e.target.value }))}
-            disabled={editingPrompt !== 'gemini_prompt_historical'}
-            rows={8}
-            className="prompt-textarea"
-          />
-        </div>
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -1,43 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { formatDateTime } from './NewsEventsShared';
+import React, { useState, useEffect, useCallback } from 'react';
 
-// Unified data collection settings for News/Events and Trail Status
+// Data collection configuration: AI providers, credentials, moderation, infrastructure, sub-tabs.
+// Job triggering, progress, and history are in the Jobs tab (JobsDashboard.jsx).
 function DataCollectionSettings() {
-  // State for News & Events collection
-  const [newsCollecting, setNewsCollecting] = useState(false);
-  const [newsProgress, setNewsProgress] = useState(null);
-  const [newsActiveJobId, setNewsActiveJobId] = useState(null);
-
-  // State for Trail Status collection
-  const [trailCollecting, setTrailCollecting] = useState(false);
-  const [trailProgress, setTrailProgress] = useState(null);
-  const [trailActiveJobId, setTrailActiveJobId] = useState(null);
-
-  // Shared state
-  const [jobHistory, setJobHistory] = useState([]);
   const [result, setResult] = useState(null);
-  const [newsAiStats, setNewsAiStats] = useState(null);
-  const [trailAiStats, setTrailAiStats] = useState(null);
-
-  // Fixed slot arrays for job display (jobs never move between slots)
-  const MAX_SLOTS = 10;
-  const [newsJobSlots, setNewsJobSlots] = useState(Array(MAX_SLOTS).fill(null));
-  const [trailJobSlots, setTrailJobSlots] = useState(Array(MAX_SLOTS).fill(null));
 
   // AI provider configuration state
-  const [aiConfig, setAiConfig] = useState({
-    primary: 'perplexity',
-    fallback: 'none',
-    primaryLimit: 0
-  });
+  const [aiConfig, setAiConfig] = useState({ primary: 'perplexity', fallback: 'none', primaryLimit: 0 });
   const [aiConfigLoading, setAiConfigLoading] = useState(true);
   const [aiConfigSaving, setAiConfigSaving] = useState(false);
 
   // Twitter credentials state
-  const [twitterCredentials, setTwitterCredentials] = useState({
-    username: '',
-    password: ''
-  });
+  const [twitterCredentials, setTwitterCredentials] = useState({ username: '', password: '' });
   const [twitterLoading, setTwitterLoading] = useState(true);
   const [twitterSaving, setTwitterSaving] = useState(false);
 
@@ -60,23 +34,54 @@ function DataCollectionSettings() {
 
   // Moderation configuration state
   const [moderationConfig, setModerationConfig] = useState({
-    enabled: true,
-    autoApproveEnabled: true,
-    autoApproveThreshold: 0.9,
-    photoSubmissionsEnabled: false
+    enabled: true, autoApproveEnabled: true, autoApproveThreshold: 0.9, photoSubmissionsEnabled: false
   });
   const [moderationConfigLoading, setModerationConfigLoading] = useState(true);
   const [moderationConfigSaving, setModerationConfigSaving] = useState(false);
 
+  // Results Sub-tabs state
+  const [subtabs, setSubtabs] = useState([]);
+  const [subtabsLoading, setSubtabsLoading] = useState(true);
+  const [subtabsSaving, setSubtabsSaving] = useState(false);
+  const [editingSubtab, setEditingSubtab] = useState(null);
+  const [addingSubtab, setAddingSubtab] = useState(false);
+  const [subtabForm, setSubtabForm] = useState({ id: '', label: '', shortLabel: '', route: '/', filterTypes: [] });
+
+  const KNOWN_ROUTES = [
+    { value: '/', label: '/ (Home / All Results)' },
+    { value: '/mtb-trail-status', label: '/mtb-trail-status (MTB Trails)' },
+    { value: '/organizations', label: '/organizations (Organizations)' }
+  ];
+
+  const fetchSubtabs = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/results-subtabs', { credentials: 'include' });
+      if (res.ok) { const data = await res.json(); setSubtabs(data.subtabs || []); }
+    } catch (err) { console.error('Failed to fetch subtabs:', err); }
+    finally { setSubtabsLoading(false); }
+  }, []);
+
+  const handleSaveSubtabs = async () => {
+    setSubtabsSaving(true);
+    try {
+      const res = await fetch('/api/admin/results-subtabs', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ subtabs })
+      });
+      if (res.ok) { setResult({ type: 'success', message: 'Results sub-tabs saved successfully' }); await fetchSubtabs(); }
+      else { const err = await res.json(); setResult({ type: 'error', message: err.error || 'Failed to save sub-tabs' }); }
+    } catch (err) { setResult({ type: 'error', message: 'Failed to save sub-tabs: ' + err.message }); }
+    finally { setSubtabsSaving(false); }
+  };
+
   useEffect(() => {
-    checkForRunningJobs();
-    fetchJobHistory();
     fetchAiConfig();
     fetchTwitterCredentials();
     fetchTwitterAuthStatus();
     fetchApifyStatus();
     fetchPlaywrightStatus();
     fetchModerationConfig();
+    fetchSubtabs();
   }, []);
 
   // Auto-dismiss result notifications after 5 seconds
@@ -86,351 +91,9 @@ function DataCollectionSettings() {
     return () => clearTimeout(timer);
   }, [result]);
 
-  // Poll for active job status
-  useEffect(() => {
-    if (!newsActiveJobId && !trailActiveJobId) return;
-
-    // Define polling functions inside effect to avoid exhaustive-deps warnings
-    const pollNewsStatus = async () => {
-      try {
-        const response = await fetch(`/api/admin/news/job/${newsActiveJobId}`, {
-          credentials: 'include'
-        });
-        if (response.ok) {
-          const status = await response.json();
-
-          // Fetch AI stats FIRST to prevent badge flicker
-          if (status.status === 'running' || status.status === 'completed' || status.status === 'cancelled') {
-            try {
-              const statsResponse = await fetch('/api/admin/news/ai-stats', {
-                credentials: 'include'
-              });
-              if (statsResponse.ok) {
-                const stats = await statsResponse.json();
-                setNewsAiStats(stats);
-              }
-            } catch (statsErr) {
-              console.error('Error fetching news AI stats:', statsErr);
-            }
-          }
-
-          // Update progress and slots AFTER stats are fetched
-          setNewsProgress(status);
-
-          // Backend-managed slots: Just use what the backend sends
-          if (status.displaySlots) {
-            setNewsJobSlots(status.displaySlots);
-          }
-
-          // Stop polling only when job is done AND all display slots have finished
-          const isJobDone = status.status === 'completed' || status.status === 'cancelled';
-          const noActiveSlots = !status.displaySlots || status.displaySlots.every(s => !s.poiId || s.status === 'completed');
-
-          if (isJobDone && noActiveSlots) {
-            setNewsCollecting(false);
-            setNewsActiveJobId(null); // Clear job ID to stop polling
-            fetchJobHistory();
-          } else if (isJobDone && !noActiveSlots) {
-            // Job is done but there are still active slots
-          }
-        }
-      } catch (err) {
-        console.error('Error polling news status:', err);
-      }
-    };
-
-    const pollTrailStatus = async () => {
-      try {
-        const response = await fetch(`/api/admin/trail-status/job-status/${trailActiveJobId}`, {
-          credentials: 'include'
-        });
-        if (response.ok) {
-          const status = await response.json();
-
-          // Fetch AI stats FIRST to prevent badge flicker
-          if (status.status === 'running' || status.status === 'completed' || status.status === 'cancelled') {
-            try {
-              const statsResponse = await fetch('/api/admin/trail-status/ai-stats', {
-                credentials: 'include'
-              });
-              if (statsResponse.ok) {
-                const stats = await statsResponse.json();
-                setTrailAiStats(stats);
-              }
-            } catch (statsErr) {
-              console.error('Error fetching trail AI stats:', statsErr);
-            }
-          }
-
-          // Update progress and slots AFTER stats are fetched
-          setTrailProgress(status);
-
-          // Backend-managed slots: Just use what the backend sends
-          if (status.displaySlots) {
-            setTrailJobSlots(status.displaySlots);
-          }
-
-          // Stop polling only when job is done AND all display slots have finished
-          const isJobDone = status.status === 'completed' || status.status === 'cancelled';
-          const noActiveSlots = !status.displaySlots || status.displaySlots.every(s => !s.poiId || s.status === 'completed');
-
-          if (isJobDone && noActiveSlots) {
-            setTrailCollecting(false);
-            setTrailActiveJobId(null); // Clear job ID to stop polling
-            fetchJobHistory();
-          } else if (isJobDone && !noActiveSlots) {
-            // Job is done but there are still active slots
-          }
-        }
-      } catch (err) {
-        console.error('Error polling trail status:', err);
-      }
-    };
-
-    const pollInterval = setInterval(async () => {
-      if (newsActiveJobId) {
-        await pollNewsStatus();
-      }
-      if (trailActiveJobId) {
-        await pollTrailStatus();
-      }
-    }, 2000);
-
-    return () => clearInterval(pollInterval);
-  }, [newsActiveJobId, trailActiveJobId]);
-
-  const checkForRunningJobs = async () => {
-    try {
-      // Check for running news job
-      const newsResponse = await fetch('/api/admin/news/status', {
-        credentials: 'include'
-      });
-      if (newsResponse.ok) {
-        const data = await newsResponse.json();
-        if (data.status === 'running') {
-          setNewsActiveJobId(data.id);
-          setNewsCollecting(true);
-          setNewsProgress(data);
-          // Fetch AI stats for running job
-          try {
-            const statsResponse = await fetch('/api/admin/news/ai-stats', { credentials: 'include' });
-            if (statsResponse.ok) {
-              const stats = await statsResponse.json();
-              setNewsAiStats(stats);
-            }
-          } catch (statsErr) {
-            console.error('Error fetching news AI stats:', statsErr);
-          }
-        }
-      }
-
-      // Check for running trail status job
-      const trailResponse = await fetch('/api/admin/trail-status/job-status/latest', {
-        credentials: 'include'
-      });
-      if (trailResponse.ok) {
-        const data = await trailResponse.json();
-        if (data && data.status === 'running') {
-          setTrailActiveJobId(data.jobId);
-          setTrailCollecting(true);
-          setTrailProgress(data);
-          // Fetch AI stats for running job
-          try {
-            const statsResponse = await fetch('/api/admin/trail-status/ai-stats', { credentials: 'include' });
-            if (statsResponse.ok) {
-              const stats = await statsResponse.json();
-              setTrailAiStats(stats);
-            }
-          } catch (statsErr) {
-            console.error('Error fetching trail AI stats:', statsErr);
-          }
-        }
-      }
-    } catch (err) {
-      console.error('Error checking for running jobs:', err);
-    }
-  };
-
-  const fetchJobHistory = async () => {
-    try {
-      // Fetch last 10 jobs from both systems
-      const newsResponse = await fetch('/api/admin/news/status', {
-        credentials: 'include'
-      });
-      const trailResponse = await fetch('/api/admin/trail-status/job-status/latest', {
-        credentials: 'include'
-      });
-
-      const jobs = [];
-
-      if (newsResponse.ok) {
-        const newsData = await newsResponse.json();
-        if (newsData) {
-          jobs.push({
-            type: 'news',
-            ...newsData,
-            timestamp: newsData.completed_at || newsData.started_at || newsData.createdAt
-          });
-        }
-      }
-
-      if (trailResponse.ok) {
-        const trailData = await trailResponse.json();
-        if (trailData) {
-          jobs.push({
-            type: 'trails',
-            ...trailData,
-            timestamp: trailData.completed_at || trailData.started_at
-          });
-        }
-      }
-
-      // Sort by timestamp descending
-      jobs.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-      setJobHistory(jobs.slice(0, 10));
-    } catch (err) {
-      console.error('Error fetching job history:', err);
-    }
-  };
-
-  const handleCollectNews = async () => {
-    setNewsCollecting(true);
-    setResult(null);
-    setNewsProgress({ status: 'starting', pois_processed: 0, news_found: 0, events_found: 0 });
-    setNewsAiStats({ usage: { gemini: 0, perplexity: 0 }, errors: { gemini429: 0, perplexity429: 0 }, activeProvider: null });
-    setNewsJobSlots(Array(MAX_SLOTS).fill(null));  // Clear slots for new job
-
-    try {
-      const response = await fetch('/api/admin/news/collect', {
-        method: 'POST',
-        credentials: 'include'
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setNewsActiveJobId(data.jobId);
-        setNewsProgress({
-          status: 'running',
-          total_pois: data.totalPois,
-          pois_processed: 0,
-          news_found: 0,
-          events_found: 0
-        });
-      } else {
-        const error = await response.json();
-        setResult({
-          type: 'error',
-          message: error.error || 'Failed to start news collection'
-        });
-        setNewsCollecting(false);
-        setNewsProgress(null);
-      }
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: err.message
-      });
-      setNewsCollecting(false);
-      setNewsProgress(null);
-    }
-  };
-
-  const handleCollectTrailStatus = async () => {
-    setTrailCollecting(true);
-    setResult(null);
-    setTrailProgress({ status: 'starting', trails_processed: 0, status_found: 0 });
-    setTrailAiStats({ usage: { gemini: 0, perplexity: 0 }, errors: { gemini429: 0, perplexity429: 0 }, activeProvider: null });
-    setTrailJobSlots(Array(MAX_SLOTS).fill(null));  // Clear slots for new job
-
-    try {
-      const response = await fetch('/api/admin/trail-status/collect-batch', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({})
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setTrailActiveJobId(data.jobId);
-        setTrailProgress({
-          status: 'running',
-          total_trails: data.totalTrails,
-          trails_processed: 0,
-          status_found: 0
-        });
-      } else {
-        const error = await response.json();
-        setResult({
-          type: 'error',
-          message: error.error || 'Failed to start trail status collection'
-        });
-        setTrailCollecting(false);
-        setTrailProgress(null);
-      }
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: err.message
-      });
-      setTrailCollecting(false);
-      setTrailProgress(null);
-    }
-  };
-
-  const handleCancelNewsJob = async () => {
-    try {
-      await fetch(`/api/admin/news/job/${newsActiveJobId}/cancel`, {
-        method: 'POST',
-        credentials: 'include'
-      });
-
-      // Immediately fetch AI stats after cancel to prevent badge flicker
-      try {
-        const statsResponse = await fetch('/api/admin/news/ai-stats', {
-          credentials: 'include'
-        });
-        if (statsResponse.ok) {
-          const stats = await statsResponse.json();
-          setNewsAiStats(stats);
-        }
-      } catch (statsErr) {
-        console.error('Error fetching news AI stats after cancel:', statsErr);
-      }
-    } catch (err) {
-      console.error('Error cancelling news job:', err);
-    }
-  };
-
-  const handleCancelTrailJob = async () => {
-    try {
-      await fetch(`/api/admin/trail-status/batch-collect/${trailActiveJobId}/cancel`, {
-        method: 'PUT',
-        credentials: 'include'
-      });
-
-      // Immediately fetch AI stats after cancel to prevent badge flicker
-      try {
-        const statsResponse = await fetch('/api/admin/trail-status/ai-stats', {
-          credentials: 'include'
-        });
-        if (statsResponse.ok) {
-          const stats = await statsResponse.json();
-          setTrailAiStats(stats);
-        }
-      } catch (statsErr) {
-        console.error('Error fetching trail AI stats after cancel:', statsErr);
-      }
-    } catch (err) {
-      console.error('Error cancelling trail job:', err);
-    }
-  };
-
   const fetchAiConfig = async () => {
     try {
-      const response = await fetch('/api/admin/settings', {
-        credentials: 'include'
-      });
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
       if (response.ok) {
         const settings = await response.json();
         setAiConfig({
@@ -439,190 +102,96 @@ function DataCollectionSettings() {
           primaryLimit: parseInt(settings.ai_search_primary_limit?.value) || 0
         });
       }
-    } catch (err) {
-      console.error('Error fetching AI config:', err);
-    } finally {
-      setAiConfigLoading(false);
-    }
+    } catch (err) { console.error('Error fetching AI config:', err); }
+    finally { setAiConfigLoading(false); }
   };
 
   const fetchTwitterCredentials = async () => {
     try {
-      const response = await fetch('/api/admin/settings', {
-        credentials: 'include'
-      });
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
       if (response.ok) {
         const settings = await response.json();
-        setTwitterCredentials({
-          username: settings.twitter_username?.value || '',
-          password: settings.twitter_password?.value || ''
-        });
+        setTwitterCredentials({ username: settings.twitter_username?.value || '', password: settings.twitter_password?.value || '' });
       }
-    } catch (err) {
-      console.error('Error fetching Twitter credentials:', err);
-    } finally {
-      setTwitterLoading(false);
-    }
+    } catch (err) { console.error('Error fetching Twitter credentials:', err); }
+    finally { setTwitterLoading(false); }
   };
 
   const fetchApifyStatus = async () => {
     try {
-      const response = await fetch('/api/admin/settings', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const settings = await response.json();
-        setApifyTokenSet(settings.apify_api_token?.isSet || false);
-      }
-    } catch (err) {
-      console.error('Error fetching Apify status:', err);
-    }
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
+      if (response.ok) { const settings = await response.json(); setApifyTokenSet(settings.apify_api_token?.isSet || false); }
+    } catch (err) { console.error('Error fetching Apify status:', err); }
   };
 
   const handleSaveApifyToken = async () => {
-    if (!apifyToken.trim()) {
-      setResult({ type: 'error', message: 'API token cannot be empty' });
-      return;
-    }
-    setApifySaving(true);
-    setResult(null);
+    if (!apifyToken.trim()) { setResult({ type: 'error', message: 'API token cannot be empty' }); return; }
+    setApifySaving(true); setResult(null);
     try {
       const response = await fetch('/api/admin/settings/apify_api_token', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
         body: JSON.stringify({ value: apifyToken })
       });
-      if (response.ok) {
-        setResult({ type: 'success', message: 'Apify API token saved successfully' });
-        setApifyToken('');
-        setApifyTokenSet(true);
-      } else {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to save token');
-      }
-    } catch (err) {
-      setResult({ type: 'error', message: `Failed to save Apify token: ${err.message}` });
-    } finally {
-      setApifySaving(false);
-    }
+      if (response.ok) { setResult({ type: 'success', message: 'Apify API token saved successfully' }); setApifyToken(''); setApifyTokenSet(true); }
+      else { const error = await response.json(); throw new Error(error.error || 'Failed to save token'); }
+    } catch (err) { setResult({ type: 'error', message: `Failed to save Apify token: ${err.message}` }); }
+    finally { setApifySaving(false); }
   };
 
   const handleSaveAiConfig = async () => {
-    setAiConfigSaving(true);
-    setResult(null);
-
+    setAiConfigSaving(true); setResult(null);
     try {
       const settings = [
         { key: 'ai_search_primary', value: aiConfig.primary },
         { key: 'ai_search_fallback', value: aiConfig.fallback },
         { key: 'ai_search_primary_limit', value: String(aiConfig.primaryLimit) }
       ];
-
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
+          method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
           body: JSON.stringify({ value: setting.value })
         });
-
-        if (!response.ok) {
-          const error = await response.json();
-          throw new Error(error.error || 'Failed to save setting');
-        }
+        if (!response.ok) { const error = await response.json(); throw new Error(error.error || 'Failed to save setting'); }
       }
-
-      setResult({
-        type: 'success',
-        message: 'AI provider configuration saved successfully'
-      });
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: `Failed to save AI config: ${err.message}`
-      });
-    } finally {
-      setAiConfigSaving(false);
-    }
+      setResult({ type: 'success', message: 'AI provider configuration saved successfully' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save AI config: ${err.message}` }); }
+    finally { setAiConfigSaving(false); }
   };
 
   const handleSaveTwitterCredentials = async () => {
-    setTwitterSaving(true);
-    setResult(null);
-
+    setTwitterSaving(true); setResult(null);
     try {
       const settings = [
         { key: 'twitter_username', value: twitterCredentials.username },
         { key: 'twitter_password', value: twitterCredentials.password }
       ];
-
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
+          method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
           body: JSON.stringify({ value: setting.value })
         });
-
-        if (!response.ok) {
-          const error = await response.json();
-          throw new Error(error.error || 'Failed to save setting');
-        }
+        if (!response.ok) { const error = await response.json(); throw new Error(error.error || 'Failed to save setting'); }
       }
-
-      setResult({
-        type: 'success',
-        message: 'Twitter credentials saved successfully'
-      });
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: `Failed to save Twitter credentials: ${err.message}`
-      });
-    } finally {
-      setTwitterSaving(false);
-    }
+      setResult({ type: 'success', message: 'Twitter credentials saved successfully' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save Twitter credentials: ${err.message}` }); }
+    finally { setTwitterSaving(false); }
   };
 
   const fetchTwitterAuthStatus = async () => {
     try {
-      const response = await fetch('/api/admin/twitter/auth-status', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const status = await response.json();
-        setTwitterAuthStatus(status);
-      }
-    } catch (err) {
-      console.error('Error fetching Twitter auth status:', err);
-    }
+      const response = await fetch('/api/admin/twitter/auth-status', { credentials: 'include' });
+      if (response.ok) setTwitterAuthStatus(await response.json());
+    } catch (err) { console.error('Error fetching Twitter auth status:', err); }
   };
 
   const fetchPlaywrightStatus = async () => {
     setPlaywrightLoading(true);
     try {
-      const response = await fetch('/api/admin/playwright/status', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const status = await response.json();
-        setPlaywrightStatus(status);
-      } else {
-        setPlaywrightStatus({
-          status: 'error',
-          message: 'Failed to check Playwright status'
-        });
-      }
-    } catch (err) {
-      console.error('Error fetching Playwright status:', err);
-      setPlaywrightStatus({
-        status: 'error',
-        message: err.message
-      });
-    } finally {
-      setPlaywrightLoading(false);
-    }
+      const response = await fetch('/api/admin/playwright/status', { credentials: 'include' });
+      if (response.ok) setPlaywrightStatus(await response.json());
+      else setPlaywrightStatus({ status: 'error', message: 'Failed to check Playwright status' });
+    } catch (err) { setPlaywrightStatus({ status: 'error', message: err.message }); }
+    finally { setPlaywrightLoading(false); }
   };
 
   const fetchModerationConfig = async () => {
@@ -637,16 +206,12 @@ function DataCollectionSettings() {
           photoSubmissionsEnabled: settings.photo_submissions_enabled?.value === 'true'
         });
       }
-    } catch (err) {
-      console.error('Error fetching moderation config:', err);
-    } finally {
-      setModerationConfigLoading(false);
-    }
+    } catch (err) { console.error('Error fetching moderation config:', err); }
+    finally { setModerationConfigLoading(false); }
   };
 
   const handleSaveModerationConfig = async () => {
-    setModerationConfigSaving(true);
-    setResult(null);
+    setModerationConfigSaving(true); setResult(null);
     try {
       const settings = [
         { key: 'moderation_enabled', value: String(moderationConfig.enabled) },
@@ -656,624 +221,108 @@ function DataCollectionSettings() {
       ];
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
+          method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
           body: JSON.stringify({ value: setting.value })
         });
-        if (!response.ok) {
-          const error = await response.json();
-          throw new Error(error.error || 'Failed to save setting');
-        }
+        if (!response.ok) { const error = await response.json(); throw new Error(error.error || 'Failed to save setting'); }
       }
       setResult({ type: 'success', message: 'Moderation configuration saved' });
-    } catch (err) {
-      setResult({ type: 'error', message: `Failed to save moderation config: ${err.message}` });
-    } finally {
-      setModerationConfigSaving(false);
-    }
+    } catch (err) { setResult({ type: 'error', message: `Failed to save moderation config: ${err.message}` }); }
+    finally { setModerationConfigSaving(false); }
   };
 
   const handleTestPlaywright = async () => {
-    setPlaywrightTesting(true);
-    setResult(null);
+    setPlaywrightTesting(true); setResult(null);
     try {
       const response = await fetch('/api/admin/playwright/test', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
         body: JSON.stringify({ url: 'https://example.com' })
       });
       const data = await response.json();
-
       if (data.status === 'success') {
-        setResult({
-          type: 'success',
-          message: `Playwright test passed! Rendered "${data.title}" (${data.text_length} chars, ${data.links_found} links) in ${data.elapsed_ms}ms`
-        });
+        setResult({ type: 'success', message: `Playwright test passed! Rendered "${data.title}" (${data.text_length} chars, ${data.links_found} links) in ${data.elapsed_ms}ms` });
       } else {
-        setResult({
-          type: 'error',
-          message: `Playwright test failed: ${data.message}`
-        });
+        setResult({ type: 'error', message: `Playwright test failed: ${data.message}` });
       }
-
-      // Refresh status after test
       await fetchPlaywrightStatus();
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: `Playwright test error: ${err.message}`
-      });
-    } finally {
-      setPlaywrightTesting(false);
-    }
+    } catch (err) { setResult({ type: 'error', message: `Playwright test error: ${err.message}` }); }
+    finally { setPlaywrightTesting(false); }
   };
 
   const handleTwitterLogin = () => {
-    // Open Twitter login in a new tab
     window.open('https://x.com/login', '_blank');
-
-    // Show cookie input section
     setShowCookieInput(true);
-
-    setResult({
-      type: 'info',
-      message: 'Twitter login opened in new tab. After logging in, use a browser extension like "Cookie-Editor" to export cookies from x.com as JSON, then paste below.'
-    });
+    setResult({ type: 'info', message: 'Twitter login opened in new tab. After logging in, use a browser extension like "Cookie-Editor" to export cookies from x.com as JSON, then paste below.' });
   };
 
   const handleSaveCookies = async () => {
-    setTwitterAuthLoading(true);
-    setResult(null);
-
+    setTwitterAuthLoading(true); setResult(null);
     try {
-      if (!twitterCookiesJson.trim()) {
-        setResult({
-          type: 'error',
-          message: 'Please paste cookies JSON'
-        });
-        setTwitterAuthLoading(false);
-        return;
-      }
-
+      if (!twitterCookiesJson.trim()) { setResult({ type: 'error', message: 'Please paste cookies JSON' }); setTwitterAuthLoading(false); return; }
       const response = await fetch('/api/admin/twitter/save-cookies', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
         body: JSON.stringify({ cookies: twitterCookiesJson })
       });
-
       const data = await response.json();
-
       if (data.success) {
-        setResult({
-          type: 'success',
-          message: `Twitter cookies saved! Expires: ${new Date(data.expires).toLocaleDateString()}`
-        });
-        setTwitterCookiesJson('');
-        setShowCookieInput(false);
-        await fetchTwitterAuthStatus();
-      } else {
-        setResult({
-          type: 'error',
-          message: data.error || 'Failed to save cookies'
-        });
-      }
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: `Save error: ${err.message}`
-      });
-    } finally {
-      setTwitterAuthLoading(false);
-    }
+        setResult({ type: 'success', message: `Twitter cookies saved! Expires: ${new Date(data.expires).toLocaleDateString()}` });
+        setTwitterCookiesJson(''); setShowCookieInput(false); await fetchTwitterAuthStatus();
+      } else { setResult({ type: 'error', message: data.error || 'Failed to save cookies' }); }
+    } catch (err) { setResult({ type: 'error', message: `Save error: ${err.message}` }); }
+    finally { setTwitterAuthLoading(false); }
   };
 
   const handleTestTwitterAuth = async () => {
-    setTwitterAuthTesting(true);
-    setResult(null);
-
+    setTwitterAuthTesting(true); setResult(null);
     try {
-      const response = await fetch('/api/admin/twitter/test-cookies', {
-        method: 'POST',
-        credentials: 'include'
-      });
-
+      const response = await fetch('/api/admin/twitter/test-cookies', { method: 'POST', credentials: 'include' });
       const data = await response.json();
-
-      if (data.success && data.logged_in) {
-        setResult({
-          type: 'success',
-          message: 'Twitter authentication is working! Cookies are valid.'
-        });
-      } else {
-        setResult({
-          type: 'error',
-          message: data.message || 'Twitter cookies have expired. Please log in again.'
-        });
-      }
-
+      if (data.success && data.logged_in) { setResult({ type: 'success', message: 'Twitter authentication is working! Cookies are valid.' }); }
+      else { setResult({ type: 'error', message: data.message || 'Twitter cookies have expired. Please log in again.' }); }
       await fetchTwitterAuthStatus();
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: `Test failed: ${err.message}`
-      });
-    } finally {
-      setTwitterAuthTesting(false);
-    }
-  };
-
-  const formatPhase = (phase) => {
-    const phaseMap = {
-      'starting': 'Starting...',
-      'initializing': 'Initializing...',
-      'rendering': 'Fetching content...',
-      'rendering_events': 'Rendering event links...',
-      'rendering_news': 'Rendering news links...',
-      'ai_search': 'Searching with AI...',
-      'processing_results': 'Processing results...',
-      'matching_links': 'Matching links...',
-      'google_news': 'Searching Google News...',
-      'saving': 'Saving results...',
-      'complete': 'Complete',
-      'error': 'Error',
-      'cancelled': 'Cancelled'
-    };
-    return phaseMap[phase] || phase;
+    } catch (err) { setResult({ type: 'error', message: `Test failed: ${err.message}` }); }
+    finally { setTwitterAuthTesting(false); }
   };
 
   return (
     <div className="data-collection-settings">
-      <h3>Data Collection</h3>
-
-      {/* Collection Actions */}
-      <div className="collection-actions-section">
-        <h4>Start Collection</h4>
-        <div className="collection-buttons">
-          <button
-            className="collection-btn news-btn"
-            onClick={handleCollectNews}
-            disabled={newsCollecting || trailCollecting}
-          >
-            <span className="btn-icon">📰</span>
-            <span className="btn-text">
-              {newsCollecting ? 'Collecting News & Events...' : 'Collect News & Events'}
-            </span>
-          </button>
-
-          <button
-            className="collection-btn trails-btn"
-            onClick={handleCollectTrailStatus}
-            disabled={newsCollecting || trailCollecting}
-          >
-            <span className="btn-icon">🚵</span>
-            <span className="btn-text">
-              {trailCollecting ? 'Collecting Trail Status...' : 'Collect MTB Trail Status'}
-            </span>
-          </button>
-        </div>
-      </div>
-
-      {/* News & Events Progress Widget */}
-      {newsProgress && (
-        <div className="collection-progress-card">
-          <div className="progress-card-header">
-            <div className="progress-phase">
-              <span className={`phase-icon ${newsProgress.status !== 'completed' && newsProgress.status !== 'cancelled' ? 'pulse' : ''}`}>
-                {newsProgress.status === 'completed' ? '✓' :
-                 newsProgress.status === 'cancelled' ? '✗' : '🔍'}
-              </span>
-              <div className="phase-text">
-                <span className="phase-label">
-                  {newsProgress.status === 'completed' ? 'News & Events Collection Complete' :
-                   newsProgress.status === 'cancelled' ? 'News & Events Collection Cancelled' :
-                   'Collecting News & Events'}
-                </span>
-                {newsProgress.phase && newsProgress.status !== 'completed' && newsProgress.status !== 'cancelled' && (
-                  <span className="phase-detail">{formatPhase(newsProgress.phase)}</span>
-                )}
-              </div>
-            </div>
-            <div className="progress-header-actions">
-              {newsCollecting && newsProgress.status === 'running' && (
-                <button className="status-cancel-btn" onClick={handleCancelNewsJob} title="Cancel job">
-                  Cancel
-                </button>
-              )}
-              {(newsProgress.status === 'completed' ||
-                (newsProgress.status === 'cancelled' && (!newsProgress.displaySlots || !newsProgress.displaySlots.some(s => s.poiId && s.status === 'active')))) && (
-                <button className="status-close-btn" onClick={() => {
-                  setNewsProgress(null);
-                  setNewsActiveJobId(null);
-                  setNewsJobSlots(Array(MAX_SLOTS).fill(null)); // Clear slots for next run
-                }} title="Close">
-                  ×
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className="progress-bar-wrapper">
-            <div
-              className="progress-bar-fill"
-              style={{
-                width: newsProgress.total_pois > 0
-                  ? `${(newsProgress.pois_processed / newsProgress.total_pois) * 100}%`
-                  : '0%',
-                background: newsProgress.status === 'completed'
-                  ? 'linear-gradient(90deg, #4caf50, #8bc34a)'
-                  : 'linear-gradient(90deg, #fff, rgba(255,255,255,0.7))'
-              }}
-            />
-          </div>
-
-          <div className="progress-counts">
-            <div className="count-badge">
-              <span className="count-icon">📍</span>
-              <div className="count-details">
-                <span className="count-value">{newsProgress.pois_processed || 0}</span>
-                <span className="count-label">
-                  {newsProgress.total_pois > 0 ? ` / ${newsProgress.total_pois}` : ''} POIs
-                </span>
-              </div>
-            </div>
-            <div className="count-badge">
-              <span className="count-icon">📰</span>
-              <div className="count-details">
-                <span className="count-value">{newsProgress.news_found || 0}</span>
-                <span className="count-label">News</span>
-              </div>
-            </div>
-            <div className="count-badge">
-              <span className="count-icon">📅</span>
-              <div className="count-details">
-                <span className="count-value">{newsProgress.events_found || 0}</span>
-                <span className="count-label">Events</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Active Jobs Table - shows each concurrent POI being processed */}
-          {(() => {
-            const isJobRunning = newsProgress.status === 'running';
-
-            // Use fixed slots (jobs never move between slots)
-            const slots = newsJobSlots;
-
-            // Calculate total 429 errors and usage stats
-            const total429 = (newsAiStats?.errors?.gemini429 || 0) + (newsAiStats?.errors?.perplexity429 || 0);
-            const geminiUsage = newsAiStats?.usage?.gemini || 0;
-            const perplexityUsage = newsAiStats?.usage?.perplexity || 0;
-
-            // Determine if we should show the table
-            const hasJobs = slots.some(s => s !== null);
-            const hasAiStats = geminiUsage > 0 || perplexityUsage > 0 || total429 > 0;
-
-            // Show table if: job running, OR jobs in slots, OR AI stats exist
-            // This ensures badges don't flicker when transitioning between states
-            if (!isJobRunning && !hasJobs && !hasAiStats) return null;
-
-            return (
-              <div className="ai-stats-table">
-                {/* Provider usage counters */}
-                {(geminiUsage > 0 || perplexityUsage > 0 || total429 > 0) && (
-                  <div className="ai-usage-counters">
-                    {geminiUsage > 0 && <span className="usage-badge gemini">🔷 Gemini: {geminiUsage}</span>}
-                    {perplexityUsage > 0 && <span className="usage-badge perplexity">🔮 Perplexity: {perplexityUsage}</span>}
-                    {total429 > 0 && <span className="usage-badge error">⚠️ 429 Errors: {total429}</span>}
-                  </div>
-                )}
-                <div className="ai-stats-header">
-                  <div>POI</div>
-                  <div>STATUS</div>
-                  <div>PROVIDER</div>
-                  <div></div>
-                </div>
-                {slots.map((job, idx) => {
-                  // Job status is stored in the slot itself
-                  const isThisJobActive = job && job.status === 'active';
-
-                  return (
-                    <div key={idx} className={`ai-stats-row ${isThisJobActive ? 'active' : ''} ${!job || !job.poiName ? 'empty-slot' : ''}`}>
-                      <div className="ai-col-poi">{job && job.poiName ? job.poiName : (isJobRunning ? 'Waiting' : '—')}</div>
-                      <div className="ai-col-status">
-                        {!job || !job.poiName
-                          ? (isJobRunning ? 'Waiting' : '—')
-                          : job.status === 'completed'
-                          ? '✓ Done'
-                          : job.phase === 'error'
-                          ? '❌ Error'
-                          : job.phase === 'rendering_events' || job.phase === 'rendering_news' || job.phase === 'rendering'
-                          ? '📄 Rendering'
-                          : job.phase === 'ai_search'
-                          ? '🔍 Searching'
-                          : job.phase === 'matching_links'
-                          ? '🔗 Matching'
-                          : job.phase === 'google_news'
-                          ? '📰 Google News'
-                          : job.phase === 'initializing'
-                          ? '⏳ Starting'
-                          : job.phase || '—'}
-                      </div>
-                      <div className="ai-col-provider">
-                        {!job || !job.poiName
-                          ? '—'
-                          : job.provider === 'gemini' ? '🔷 Gemini'
-                          : job.provider === 'perplexity' ? '🔮 Perplexity'
-                          : '—'}
-                      </div>
-                      <div className="ai-col-spacer"></div>
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })()}
-        </div>
-      )}
-
-      {/* Trail Status Progress Widget */}
-      {trailProgress && (
-        <div className="collection-progress-card">
-          <div className="progress-card-header">
-            <div className="progress-phase">
-              <span className={`phase-icon ${trailProgress.status !== 'completed' && trailProgress.status !== 'cancelled' ? 'pulse' : ''}`}>
-                {trailProgress.status === 'completed' ? '✓' :
-                 trailProgress.status === 'cancelled' ? '✗' : '🔍'}
-              </span>
-              <div className="phase-text">
-                <span className="phase-label">
-                  {trailProgress.status === 'completed' ? 'MTB Trail Status Collection Complete' :
-                   trailProgress.status === 'cancelled' ? 'MTB Trail Status Collection Cancelled' :
-                   'Collecting MTB Trail Status'}
-                </span>
-                {trailProgress.phase && trailProgress.status !== 'completed' && trailProgress.status !== 'cancelled' && (
-                  <span className="phase-detail">{formatPhase(trailProgress.phase)}</span>
-                )}
-              </div>
-            </div>
-            <div className="progress-header-actions">
-              {trailCollecting && trailProgress.status === 'running' && (
-                <button className="status-cancel-btn" onClick={handleCancelTrailJob} title="Cancel job">
-                  Cancel
-                </button>
-              )}
-              {(trailProgress.status === 'completed' ||
-                (trailProgress.status === 'cancelled' && (!trailProgress.displaySlots || !trailProgress.displaySlots.some(s => s.poiId && s.status === 'active')))) && (
-                <button className="status-close-btn" onClick={() => {
-                  setTrailProgress(null);
-                  setTrailActiveJobId(null);
-                  setTrailJobSlots(Array(MAX_SLOTS).fill(null)); // Clear slots for next run
-                }} title="Close">
-                  ×
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className="progress-bar-wrapper">
-            <div
-              className="progress-bar-fill"
-              style={{
-                width: trailProgress.total_trails > 0
-                  ? `${(trailProgress.trails_processed / trailProgress.total_trails) * 100}%`
-                  : '0%',
-                background: trailProgress.status === 'completed'
-                  ? 'linear-gradient(90deg, #4caf50, #8bc34a)'
-                  : 'linear-gradient(90deg, #fff, rgba(255,255,255,0.7))'
-              }}
-            />
-          </div>
-
-          <div className="progress-counts">
-            <div className="count-badge">
-              <span className="count-icon">🚵</span>
-              <div className="count-details">
-                <span className="count-value">{trailProgress.trails_processed || 0}</span>
-                <span className="count-label">
-                  {trailProgress.total_trails > 0 ? ` / ${trailProgress.total_trails}` : ''} Trails
-                </span>
-              </div>
-            </div>
-            <div className="count-badge">
-              <span className="count-icon">📊</span>
-              <div className="count-details">
-                <span className="count-value">{trailProgress.status_found || 0}</span>
-                <span className="count-label">Status Updates</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Active Jobs Table - shows each concurrent trail being processed */}
-          {(() => {
-            const isJobRunning = trailProgress.status === 'running';
-
-            // Use fixed slots (jobs never move between slots)
-            const slots = trailJobSlots;
-
-            // Calculate total 429 errors and usage stats
-            const total429 = (trailAiStats?.errors?.gemini429 || 0) + (trailAiStats?.errors?.perplexity429 || 0);
-            const geminiUsage = trailAiStats?.usage?.gemini || 0;
-            const perplexityUsage = trailAiStats?.usage?.perplexity || 0;
-
-            // Show table if job is running OR if we have any jobs in slots OR if there are AI stats to display
-            const hasJobs = slots.some(s => s !== null);
-            const hasAiStats = geminiUsage > 0 || perplexityUsage > 0 || total429 > 0;
-            if (!isJobRunning && !hasJobs && !hasAiStats) return null;
-
-            return (
-              <div className="ai-stats-table">
-                {/* Provider usage counters */}
-                {(geminiUsage > 0 || perplexityUsage > 0 || total429 > 0) && (
-                  <div className="ai-usage-counters">
-                    {geminiUsage > 0 && <span className="usage-badge gemini">🔷 Gemini: {geminiUsage}</span>}
-                    {perplexityUsage > 0 && <span className="usage-badge perplexity">🔮 Perplexity: {perplexityUsage}</span>}
-                    {total429 > 0 && <span className="usage-badge error">⚠️ 429 Errors: {total429}</span>}
-                  </div>
-                )}
-                <div className="ai-stats-header">
-                  <div>TRAIL</div>
-                  <div>STATUS</div>
-                  <div>PROVIDER</div>
-                  <div></div>
-                </div>
-                {slots.map((job, idx) => {
-                  // Job status is stored in the slot itself
-                  const isThisJobActive = job && job.status === 'active';
-
-                  return (
-                    <div key={idx} className={`ai-stats-row ${isThisJobActive ? 'active' : ''} ${!job || !job.poiName ? 'empty-slot' : ''}`}>
-                      <div className="ai-col-poi">{job && job.poiName ? job.poiName : (isJobRunning ? 'Waiting' : '—')}</div>
-                      <div className="ai-col-status">
-                        {!job || !job.poiName
-                          ? (isJobRunning ? 'Waiting' : '—')
-                          : job.status === 'completed'
-                          ? '✓ Done'
-                          : job.phase === 'error'
-                          ? '❌ Error'
-                          : job.phase === 'rendering'
-                          ? '📄 Rendering'
-                          : job.phase === 'ai_search'
-                          ? '🔍 Searching'
-                          : job.phase === 'starting'
-                          ? '⏳ Starting'
-                          : job.phase || '—'}
-                      </div>
-                      <div className="ai-col-provider">
-                        {!job || !job.poiName
-                          ? '—'
-                          : job.provider === 'gemini' ? '🔷 Gemini'
-                          : job.provider === 'perplexity' ? '🔮 Perplexity'
-                          : '—'}
-                      </div>
-                      <div className="ai-col-spacer"></div>
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })()}
-        </div>
-      )}
-
-      {/* Job History */}
-      <div className="job-history-section">
-        <h4>Recent Collection Jobs</h4>
-        {jobHistory.length === 0 ? (
-          <p className="no-history">No recent collection jobs</p>
-        ) : (
-          <div className="job-history-list">
-            {jobHistory.map((job, idx) => (
-              <div key={idx} className={`job-history-item ${job.type}`}>
-                <div className="job-icon">
-                  {job.type === 'news' ? '📰' : '🚵'}
-                </div>
-                <div className="job-details">
-                  <div className="job-title">
-                    {job.type === 'news' ? 'News & Events' : 'MTB Trail Status'}
-                  </div>
-                  <div className="job-meta">
-                    {job.status === 'completed' && (
-                      <span className="job-status completed">✓ Completed</span>
-                    )}
-                    {job.status === 'running' && (
-                      <span className="job-status running">⏳ Running</span>
-                    )}
-                    {job.status === 'cancelled' && (
-                      <span className="job-status cancelled">✗ Cancelled</span>
-                    )}
-                    {job.status === 'failed' && (
-                      <span className="job-status failed">❌ Failed</span>
-                    )}
-                    <span className="job-time">
-                      {formatDateTime(job.timestamp)}
-                    </span>
-                  </div>
-                  <div className="job-stats">
-                    {job.type === 'news' ? (
-                      <>
-                        {job.pois_processed || 0} POIs • {job.news_found || 0} News • {job.events_found || 0} Events
-                      </>
-                    ) : (
-                      <>
-                        {job.trails_processed || 0} Trails • {job.status_found || 0} Status Updates
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+      <h3>Data Collection Configuration</h3>
+      <p className="settings-description" style={{ marginBottom: '16px' }}>
+        Configure AI providers, credentials, and infrastructure for data collection jobs.
+        To trigger and monitor jobs, use the <strong>Jobs</strong> tab.
+      </p>
 
       {/* AI Provider Configuration */}
       <div className="ai-config-section">
         <h4>AI Search Provider</h4>
-        <p className="settings-description">
-          Configure which AI provider to use for news/events web search.
-        </p>
-
-        {aiConfigLoading ? (
-          <p>Loading configuration...</p>
-        ) : (
+        <p className="settings-description">Configure which AI provider to use for news/events web search.</p>
+        {aiConfigLoading ? <p>Loading configuration...</p> : (
           <>
             <div className="config-row">
               <label>Primary Provider:</label>
-              <select
-                value={aiConfig.primary}
-                onChange={e => setAiConfig({...aiConfig, primary: e.target.value})}
-                disabled={aiConfigSaving}
-              >
+              <select value={aiConfig.primary} onChange={e => setAiConfig({...aiConfig, primary: e.target.value})} disabled={aiConfigSaving}>
                 <option value="gemini">Google Gemini (with Google Search)</option>
                 <option value="perplexity">Perplexity Sonar (with web search)</option>
               </select>
             </div>
-
             <div className="config-row">
               <label>Fallback Provider:</label>
-              <select
-                value={aiConfig.fallback}
-                onChange={e => setAiConfig({...aiConfig, fallback: e.target.value})}
-                disabled={aiConfigSaving}
-              >
+              <select value={aiConfig.fallback} onChange={e => setAiConfig({...aiConfig, fallback: e.target.value})} disabled={aiConfigSaving}>
                 <option value="none">None (no fallback)</option>
                 <option value="gemini">Google Gemini</option>
                 <option value="perplexity">Perplexity Sonar</option>
               </select>
-              <span className="config-hint">
-                Used if primary provider fails or hits its limit
-              </span>
+              <span className="config-hint">Used if primary provider fails or hits its limit</span>
             </div>
-
             <div className="config-row">
               <label>Primary Limit (0 = unlimited):</label>
-              <input
-                type="number"
-                value={aiConfig.primaryLimit === 0 ? '' : aiConfig.primaryLimit}
+              <input type="number" value={aiConfig.primaryLimit === 0 ? '' : aiConfig.primaryLimit}
                 onChange={e => setAiConfig({...aiConfig, primaryLimit: e.target.value === '' ? 0 : parseInt(e.target.value) || 0})}
-                onBlur={e => {
-                  if (e.target.value === '') {
-                    setAiConfig({...aiConfig, primaryLimit: 0});
-                  }
-                }}
-                placeholder="0"
-                min="0"
-                step="100"
-                disabled={aiConfigSaving}
-              />
-              <span className="config-hint">
-                Switch to fallback after this many requests per job (helps stay under rate limits)
-              </span>
+                onBlur={e => { if (e.target.value === '') setAiConfig({...aiConfig, primaryLimit: 0}); }}
+                placeholder="0" min="0" step="100" disabled={aiConfigSaving} />
+              <span className="config-hint">Switch to fallback after this many requests per job</span>
             </div>
-
-            <button
-              className="action-btn primary"
-              onClick={handleSaveAiConfig}
-              disabled={aiConfigSaving || newsCollecting || trailCollecting}
-            >
+            <button className="action-btn primary" onClick={handleSaveAiConfig} disabled={aiConfigSaving}>
               {aiConfigSaving ? 'Saving...' : 'Save AI Configuration'}
             </button>
           </>
@@ -1283,108 +332,43 @@ function DataCollectionSettings() {
       {/* Twitter Credentials Configuration */}
       <div className="ai-config-section">
         <h4>Twitter/X Credentials</h4>
-        <p className="settings-description">
-          Login credentials for scraping Twitter content (used for News, Events, and Trail Status).
-        </p>
-
-        {twitterLoading ? (
-          <p>Loading credentials...</p>
-        ) : (
+        <p className="settings-description">Login credentials for scraping Twitter content (used for Trail Status).</p>
+        {twitterLoading ? <p>Loading credentials...</p> : (
           <>
-            <div className="config-row">
-              <label>Username:</label>
-              <input
-                type="text"
-                value={twitterCredentials.username}
-                onChange={e => setTwitterCredentials({...twitterCredentials, username: e.target.value})}
-                disabled={twitterSaving || newsCollecting || trailCollecting}
-                placeholder="Twitter username (legacy - not used)"
-              />
-            </div>
-
-            <div className="config-row">
-              <label>Password:</label>
-              <input
-                type="password"
-                value={twitterCredentials.password}
-                onChange={e => setTwitterCredentials({...twitterCredentials, password: e.target.value})}
-                disabled={twitterSaving || newsCollecting || trailCollecting}
-                placeholder="Twitter password (legacy - not used)"
-              />
-            </div>
-
-            <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid #ddd' }}>
+            <div style={{ marginTop: '0.5rem' }}>
               <h5 style={{ marginBottom: '0.5rem' }}>Authentication Status</h5>
               <p className="settings-description" style={{ fontSize: '0.85rem', marginBottom: '1rem' }}>
                 Twitter authentication uses browser cookies. Log in to Twitter in your browser, then export cookies below. Cookies last 30-90 days.
               </p>
-
               {twitterAuthStatus && (
                 <div className="config-row" style={{ marginBottom: '1rem' }}>
                   <label>Status:</label>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                     {twitterAuthStatus.authenticated ? (
                       <>
-                        <span style={{ color: '#4caf50', fontWeight: 'bold' }}>✓ Authenticated</span>
-                        <span style={{ fontSize: '0.85rem', color: '#666' }}>
-                          Expires: {new Date(twitterAuthStatus.expires).toLocaleDateString()}
-                        </span>
+                        <span style={{ color: '#4caf50', fontWeight: 'bold' }}>Authenticated</span>
+                        <span style={{ fontSize: '0.85rem', color: '#666' }}>Expires: {new Date(twitterAuthStatus.expires).toLocaleDateString()}</span>
                       </>
                     ) : (
-                      <span style={{ color: '#f44336', fontWeight: 'bold' }}>✗ Not Authenticated</span>
+                      <span style={{ color: '#f44336', fontWeight: 'bold' }}>Not Authenticated</span>
                     )}
                   </div>
                 </div>
               )}
-
               {twitterAuthStatus && twitterAuthStatus.cookies_possibly_stale && (
                 <div style={{ padding: '0.75rem', backgroundColor: '#fff3cd', border: '1px solid #ffc107', borderRadius: '4px', marginBottom: '1rem', fontSize: '0.85rem' }}>
-                  <strong>Cookies may be stale.</strong> Twitter trail status collection has failed {twitterAuthStatus.consecutive_failures} times in a row.
-                  Re-export cookies from x.com using Cookie-Editor and save them below.
-                </div>
-              )}
-
-              {twitterAuthStatus && twitterAuthStatus.auth_token_preview && (
-                <div className="config-row">
-                  <label>Auth Token:</label>
-                  <input
-                    type="text"
-                    value={twitterAuthStatus.auth_token_preview}
-                    disabled
-                    style={{ backgroundColor: '#f5f5f5', color: '#666', fontSize: '0.85rem' }}
-                  />
+                  <strong>Cookies may be stale.</strong> Trail status collection has failed {twitterAuthStatus.consecutive_failures} times in a row.
                 </div>
               )}
             </div>
-
-            <div style={{ display: 'flex', gap: '10px', marginTop: '1.5rem' }}>
-              <button
-                className="action-btn primary"
-                onClick={handleSaveTwitterCredentials}
-                disabled={twitterSaving || newsCollecting || trailCollecting}
-              >
-                {twitterSaving ? 'Saving...' : 'Save Twitter Credentials'}
-              </button>
-
-              <button
-                className="action-btn primary"
-                onClick={handleTwitterLogin}
-                disabled={twitterAuthLoading || newsCollecting || trailCollecting}
-              >
-                Login to Twitter
-              </button>
-
+            <div style={{ display: 'flex', gap: '10px', marginTop: '0.5rem' }}>
+              <button className="action-btn primary" onClick={handleTwitterLogin} disabled={twitterAuthLoading}>Login to Twitter</button>
               {twitterAuthStatus && twitterAuthStatus.authenticated && (
-                <button
-                  className="action-btn secondary"
-                  onClick={handleTestTwitterAuth}
-                  disabled={twitterAuthTesting || newsCollecting || trailCollecting}
-                >
+                <button className="action-btn secondary" onClick={handleTestTwitterAuth} disabled={twitterAuthTesting}>
                   {twitterAuthTesting ? 'Testing...' : 'Test Authentication'}
                 </button>
               )}
             </div>
-
             {showCookieInput && (
               <div style={{ marginTop: '1.5rem', padding: '1rem', backgroundColor: '#f9f9f9', borderRadius: '4px' }}>
                 <h5 style={{ marginBottom: '0.5rem', fontSize: '0.95rem' }}>Export Cookies from Browser</h5>
@@ -1392,42 +376,17 @@ function DataCollectionSettings() {
                   <li>Install browser extension: <a href="https://chrome.google.com/webstore/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm" target="_blank" rel="noopener noreferrer">Cookie-Editor for Chrome</a> or <a href="https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/" target="_blank" rel="noopener noreferrer">Firefox</a></li>
                   <li>Log in to Twitter in the opened tab</li>
                   <li>Click the Cookie-Editor extension icon</li>
-                  <li>Click &quot;Export&quot; button (bottom right)</li>
-                  <li>Select &quot;JSON&quot; format</li>
-                  <li>Copy the JSON and paste below</li>
+                  <li>Click &quot;Export&quot; &gt; &quot;JSON&quot; format</li>
+                  <li>Paste the JSON below</li>
                 </ol>
-                <textarea
-                  value={twitterCookiesJson}
-                  onChange={e => setTwitterCookiesJson(e.target.value)}
-                  placeholder='Paste cookies JSON here... should look like: [{"name":"auth_token","value":"...","domain":".x.com",...}]'
-                  rows="8"
-                  style={{
-                    width: '100%',
-                    fontFamily: 'monospace',
-                    fontSize: '0.8rem',
-                    padding: '0.75rem',
-                    border: '1px solid #ccc',
-                    borderRadius: '4px',
-                    marginBottom: '1rem'
-                  }}
-                />
+                <textarea value={twitterCookiesJson} onChange={e => setTwitterCookiesJson(e.target.value)}
+                  placeholder='Paste cookies JSON here...' rows="6"
+                  style={{ width: '100%', fontFamily: 'monospace', fontSize: '0.8rem', padding: '0.75rem', border: '1px solid #ccc', borderRadius: '4px', marginBottom: '1rem' }} />
                 <div style={{ display: 'flex', gap: '10px' }}>
-                  <button
-                    className="action-btn primary"
-                    onClick={handleSaveCookies}
-                    disabled={twitterAuthLoading || !twitterCookiesJson.trim()}
-                  >
+                  <button className="action-btn primary" onClick={handleSaveCookies} disabled={twitterAuthLoading || !twitterCookiesJson.trim()}>
                     {twitterAuthLoading ? 'Saving...' : 'Save Cookies'}
                   </button>
-                  <button
-                    className="action-btn secondary"
-                    onClick={() => {
-                      setShowCookieInput(false);
-                      setTwitterCookiesJson('');
-                    }}
-                  >
-                    Cancel
-                  </button>
+                  <button className="action-btn secondary" onClick={() => { setShowCookieInput(false); setTwitterCookiesJson(''); }}>Cancel</button>
                 </div>
               </div>
             )}
@@ -1438,11 +397,7 @@ function DataCollectionSettings() {
       {/* Apify API Token */}
       <div className="ai-config-section">
         <h4>Apify API Token</h4>
-        <p className="settings-description">
-          Required for scraping Twitter/X and Facebook trail status pages.
-          Used for East Rim (Twitter) and Reagan-Huffman (Facebook) trails.
-        </p>
-
+        <p className="settings-description">Required for scraping Twitter/X and Facebook trail status pages.</p>
         <div className="config-row">
           <label>Status:</label>
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
@@ -1450,138 +405,68 @@ function DataCollectionSettings() {
             <span>{apifyTokenSet ? 'API token configured' : 'API token not configured'}</span>
           </div>
         </div>
-
         <div className="config-row">
           <label>API Token:</label>
-          <input
-            type="password"
-            value={apifyToken}
-            onChange={e => setApifyToken(e.target.value)}
-            placeholder="Enter Apify API token..."
-            disabled={apifySaving || newsCollecting || trailCollecting}
-          />
+          <input type="password" value={apifyToken} onChange={e => setApifyToken(e.target.value)} placeholder="Enter Apify API token..." disabled={apifySaving} />
         </div>
-
-        <div style={{ display: 'flex', gap: '10px', marginTop: '0.5rem' }}>
-          <button
-            className="action-btn primary"
-            onClick={handleSaveApifyToken}
-            disabled={apifySaving || !apifyToken.trim() || newsCollecting || trailCollecting}
-          >
-            {apifySaving ? 'Saving...' : 'Save Token'}
-          </button>
-        </div>
-
+        <button className="action-btn primary" onClick={handleSaveApifyToken} disabled={apifySaving || !apifyToken.trim()}>
+          {apifySaving ? 'Saving...' : 'Save Token'}
+        </button>
         <p className="settings-description" style={{ fontSize: '0.85rem', marginTop: '0.75rem' }}>
-          Get your token from{' '}
-          <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">
-            Apify Console &gt; Settings &gt; Integrations
-          </a>
+          Get your token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
         </p>
       </div>
 
       {/* Moderation Configuration */}
       <div className="ai-config-section">
         <h4>Content Moderation</h4>
-        <p className="settings-description">
-          Configure AI-powered moderation for news, events, and photo submissions.
-          New content is reviewed by LLM before publishing.
-        </p>
-
-        {moderationConfigLoading ? (
-          <p>Loading configuration...</p>
-        ) : (
+        <p className="settings-description">Configure AI-powered moderation for news, events, and photo submissions.</p>
+        {moderationConfigLoading ? <p>Loading configuration...</p> : (
           <>
             <div className="config-row">
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <input
-                  type="checkbox"
-                  checked={moderationConfig.enabled}
-                  onChange={e => setModerationConfig({...moderationConfig, enabled: e.target.checked})}
-                  disabled={moderationConfigSaving}
-                />
+                <input type="checkbox" checked={moderationConfig.enabled} onChange={e => setModerationConfig({...moderationConfig, enabled: e.target.checked})} disabled={moderationConfigSaving} />
                 Enable Moderation
               </label>
-              <span className="config-hint">
-                When disabled, new content auto-publishes without review
-              </span>
+              <span className="config-hint">When disabled, new content auto-publishes without review</span>
             </div>
-
             <div className="config-row">
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <input
-                  type="checkbox"
-                  checked={moderationConfig.autoApproveEnabled}
-                  onChange={e => setModerationConfig({...moderationConfig, autoApproveEnabled: e.target.checked})}
-                  disabled={moderationConfigSaving || !moderationConfig.enabled}
-                />
+                <input type="checkbox" checked={moderationConfig.autoApproveEnabled} onChange={e => setModerationConfig({...moderationConfig, autoApproveEnabled: e.target.checked})} disabled={moderationConfigSaving || !moderationConfig.enabled} />
                 Auto-Approve High Confidence
               </label>
-              <span className="config-hint">
-                Automatically publish items scoring above the threshold
-              </span>
+              <span className="config-hint">Automatically publish items scoring above the threshold</span>
             </div>
-
             <div className="config-row">
               <label>Auto-Approve Threshold:</label>
-              <input
-                type="number"
-                value={moderationConfig.autoApproveThreshold}
-                onChange={e => setModerationConfig({...moderationConfig, autoApproveThreshold: parseFloat(e.target.value) || 0})}
-                min="0"
-                max="1"
-                step="0.05"
-                disabled={moderationConfigSaving || !moderationConfig.enabled || !moderationConfig.autoApproveEnabled}
-                style={{ width: '80px' }}
-              />
-              <span className="config-hint">
-                Score 0.0-1.0 (recommended: 0.9)
-              </span>
+              <input type="number" value={moderationConfig.autoApproveThreshold} onChange={e => setModerationConfig({...moderationConfig, autoApproveThreshold: parseFloat(e.target.value) || 0})}
+                min="0" max="1" step="0.05" disabled={moderationConfigSaving || !moderationConfig.enabled || !moderationConfig.autoApproveEnabled} style={{ width: '80px' }} />
+              <span className="config-hint">Score 0.0-1.0 (recommended: 0.9)</span>
             </div>
-
             <div className="config-row">
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <input
-                  type="checkbox"
-                  checked={moderationConfig.photoSubmissionsEnabled}
-                  onChange={e => setModerationConfig({...moderationConfig, photoSubmissionsEnabled: e.target.checked})}
-                  disabled={moderationConfigSaving}
-                />
+                <input type="checkbox" checked={moderationConfig.photoSubmissionsEnabled} onChange={e => setModerationConfig({...moderationConfig, photoSubmissionsEnabled: e.target.checked})} disabled={moderationConfigSaving} />
                 Allow Photo Submissions
               </label>
-              <span className="config-hint">
-                Let authenticated users submit photos for POIs
-              </span>
+              <span className="config-hint">Let authenticated users submit photos for POIs</span>
             </div>
-
-            <button
-              className="action-btn primary"
-              onClick={handleSaveModerationConfig}
-              disabled={moderationConfigSaving || newsCollecting || trailCollecting}
-            >
+            <button className="action-btn primary" onClick={handleSaveModerationConfig} disabled={moderationConfigSaving}>
               {moderationConfigSaving ? 'Saving...' : 'Save Moderation Configuration'}
             </button>
           </>
         )}
       </div>
 
-      {/* Playwright Status - Infrastructure Check (at bottom) */}
+      {/* Playwright Status */}
       <div className="playwright-status-section" style={{ marginTop: '2rem', padding: '1rem', backgroundColor: '#f8f9fa', borderRadius: '8px', border: '1px solid #e9ecef' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
           <h4 style={{ margin: 0, fontSize: '1rem' }}>Browser Rendering (Playwright)</h4>
-          <button
-            className="action-btn secondary"
-            onClick={handleTestPlaywright}
-            disabled={playwrightLoading || playwrightTesting || newsCollecting || trailCollecting}
-            style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}
-          >
+          <button className="action-btn secondary" onClick={handleTestPlaywright} disabled={playwrightLoading || playwrightTesting}
+            style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}>
             {playwrightTesting ? 'Testing...' : 'Test'}
           </button>
         </div>
-        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.75rem' }}>
-          Required for Twitter/X status pages and JavaScript-heavy websites.
-        </p>
-
+        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.75rem' }}>Required for Twitter/X status pages and JavaScript-heavy websites.</p>
         {playwrightLoading ? (
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <span className="pulse" style={{ display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%', backgroundColor: '#ffc107' }}></span>
@@ -1591,17 +476,13 @@ function DataCollectionSettings() {
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
             {playwrightStatus.status === 'working' ? (
               <>
-                <span style={{ color: '#28a745', fontWeight: 'bold', fontSize: '0.95rem' }}>✓ Working</span>
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>
-                  Chromium {playwrightStatus.browser_version} • Launch: {playwrightStatus.launch_time_ms}ms
-                </span>
+                <span style={{ color: '#28a745', fontWeight: 'bold', fontSize: '0.95rem' }}>Working</span>
+                <span style={{ fontSize: '0.85rem', color: '#666' }}>Chromium {playwrightStatus.browser_version} - Launch: {playwrightStatus.launch_time_ms}ms</span>
               </>
             ) : (
               <>
-                <span style={{ color: '#dc3545', fontWeight: 'bold', fontSize: '0.95rem' }}>✗ Not Working</span>
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>
-                  {playwrightStatus.message}
-                </span>
+                <span style={{ color: '#dc3545', fontWeight: 'bold', fontSize: '0.95rem' }}>Not Working</span>
+                <span style={{ fontSize: '0.85rem', color: '#666' }}>{playwrightStatus.message}</span>
                 {playwrightStatus.suggestion && (
                   <div style={{ width: '100%', marginTop: '0.5rem', padding: '0.5rem', backgroundColor: '#fff3cd', borderRadius: '4px', fontSize: '0.85rem' }}>
                     <strong>Fix:</strong> {playwrightStatus.suggestion}
@@ -1610,17 +491,102 @@ function DataCollectionSettings() {
               </>
             )}
           </div>
-        ) : (
-          <span style={{ color: '#6c757d', fontSize: '0.9rem' }}>Status unknown</span>
+        ) : <span style={{ color: '#6c757d', fontSize: '0.9rem' }}>Status unknown</span>}
+      </div>
+
+      {/* Results Sub-tabs Configuration */}
+      <div className="ai-config-section">
+        <h4>Results Sub-tabs</h4>
+        <p className="settings-description">Configure which sub-tabs appear in the public Results tab.</p>
+        {subtabsLoading ? <p>Loading sub-tabs...</p> : (
+          <>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '12px' }}>
+              {subtabs.map(tab => (
+                <div key={tab.id} style={{
+                  border: '1px solid #ddd', borderRadius: '6px', padding: '10px 14px',
+                  backgroundColor: editingSubtab === tab.id ? '#fff8e1' : '#fafafa',
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px'
+                }}>
+                  {editingSubtab === tab.id ? (
+                    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                        <input type="text" value={subtabForm.label} onChange={(e) => setSubtabForm(prev => ({ ...prev, label: e.target.value }))}
+                          placeholder="Label" style={{ flex: 1, minWidth: '120px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }} />
+                        <input type="text" value={subtabForm.shortLabel} onChange={(e) => setSubtabForm(prev => ({ ...prev, shortLabel: e.target.value }))}
+                          placeholder="Short label" style={{ width: '120px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }} />
+                        <select value={subtabForm.route} onChange={(e) => setSubtabForm(prev => ({ ...prev, route: e.target.value }))}
+                          style={{ width: '220px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }}>
+                          {KNOWN_ROUTES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+                        </select>
+                      </div>
+                      <div style={{ display: 'flex', gap: '8px' }}>
+                        <button className="sync-btn-small" onClick={() => {
+                          setSubtabs(prev => prev.map(t => t.id === editingSubtab ? { ...t, label: subtabForm.label, shortLabel: subtabForm.shortLabel || subtabForm.label, route: subtabForm.route } : t));
+                          setEditingSubtab(null); setSubtabForm({ id: '', label: '', shortLabel: '', route: '/', filterTypes: [] });
+                        }}>Save</button>
+                        <button className="sync-btn-small" onClick={() => { setEditingSubtab(null); setSubtabForm({ id: '', label: '', shortLabel: '', route: '/', filterTypes: [] }); }}>Cancel</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flex: 1 }}>
+                        <span style={{ fontWeight: 500 }}>{tab.label}</span>
+                        <code style={{ fontSize: '0.75rem', color: '#888' }}>{tab.route}</code>
+                        {tab.shortLabel && tab.shortLabel !== tab.label && <span style={{ fontSize: '0.75rem', color: '#aaa' }}>({tab.shortLabel})</span>}
+                        {tab.protected && <span style={{ fontSize: '0.7rem', padding: '1px 6px', borderRadius: '3px', backgroundColor: '#e3f2fd', color: '#1565c0' }}>Protected</span>}
+                      </div>
+                      <div style={{ display: 'flex', gap: '4px' }}>
+                        {!tab.protected ? (
+                          <>
+                            <button className="sync-btn-small" onClick={() => { setEditingSubtab(tab.id); setSubtabForm({ id: tab.id, label: tab.label, shortLabel: tab.shortLabel || '', route: tab.route, filterTypes: tab.filterTypes || [] }); }}>Edit</button>
+                            <button className="sync-btn-small" onClick={() => setSubtabs(prev => prev.filter(t => t.id !== tab.id))} style={{ color: '#c62828' }}>Delete</button>
+                          </>
+                        ) : <span style={{ fontSize: '0.75rem', color: '#999', fontStyle: 'italic' }}>Locked</span>}
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {addingSubtab ? (
+              <div style={{ border: '1px dashed #aaa', borderRadius: '6px', padding: '12px', marginBottom: '12px' }}>
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '8px', flexWrap: 'wrap' }}>
+                  <input type="text" value={subtabForm.id} onChange={(e) => setSubtabForm(prev => ({ ...prev, id: e.target.value.replace(/\s+/g, '-').toLowerCase() }))}
+                    placeholder="ID (e.g. my-tab)" style={{ width: '120px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }} />
+                  <input type="text" value={subtabForm.label} onChange={(e) => setSubtabForm(prev => ({ ...prev, label: e.target.value }))}
+                    placeholder="Label" style={{ flex: 1, minWidth: '120px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }} />
+                  <input type="text" value={subtabForm.shortLabel} onChange={(e) => setSubtabForm(prev => ({ ...prev, shortLabel: e.target.value }))}
+                    placeholder="Short label" style={{ width: '120px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }} />
+                  <select value={subtabForm.route} onChange={(e) => setSubtabForm(prev => ({ ...prev, route: e.target.value }))}
+                    style={{ width: '220px', padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }}>
+                    {KNOWN_ROUTES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+                  </select>
+                </div>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  <button className="sync-btn-small" onClick={() => {
+                    if (!subtabForm.id || !subtabForm.label) return;
+                    setSubtabs(prev => [...prev, { id: subtabForm.id, label: subtabForm.label, shortLabel: subtabForm.shortLabel || subtabForm.label, route: subtabForm.route, filterTypes: subtabForm.filterTypes.length > 0 ? subtabForm.filterTypes : null, protected: false }]);
+                    setSubtabForm({ id: '', label: '', shortLabel: '', route: '/', filterTypes: [] }); setAddingSubtab(false);
+                  }}>Add</button>
+                  <button className="sync-btn-small" onClick={() => { setAddingSubtab(false); setSubtabForm({ id: '', label: '', shortLabel: '', route: '/', filterTypes: [] }); }}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <button className="sync-btn-small" onClick={() => setAddingSubtab(true)}>+ Add Sub-tab</button>
+            )}
+
+            <div style={{ marginTop: '12px' }}>
+              <button className="action-btn primary" onClick={handleSaveSubtabs} disabled={subtabsSaving}>
+                {subtabsSaving ? 'Saving...' : 'Save Sub-tab Configuration'}
+              </button>
+            </div>
+          </>
         )}
       </div>
 
       {/* Result message */}
-      {result && (
-        <div className={`result-message ${result.type}`}>
-          {result.message}
-        </div>
-      )}
+      {result && <div className={`result-message ${result.type}`}>{result.message}</div>}
     </div>
   );
 }

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -2,35 +2,34 @@ import React, { useState, useEffect, useCallback } from 'react';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
-const JOB_TYPE_LABELS = {
-  news: 'News',
-  trail_status: 'Trail Status',
-  moderation: 'Moderation',
-  newsletter: 'Newsletter',
-  backup: 'Backup',
-  database_backup: 'DB Backup',
-  news_single: 'News (Single)',
-  events_single: 'Events (Single)'
-};
-
-const JOB_TYPE_ICONS = {
-  news: '\u{1F4F0}',
-  trail_status: '\u{1F6B5}',
-  moderation: '\u{1F50D}',
-  newsletter: '\u{1F4E7}',
-  backup: '\u{1F4BE}',
-  database_backup: '\u{1F5C4}',
-  news_single: '\u{1F4F0}',
-  events_single: '\u{1F4C5}'
-};
-
 const STATUS_COLORS = {
   completed: '#4caf50',
   running: '#2196f3',
   failed: '#f44336',
   cancelled: '#ff9800',
+  stale: '#795548',
   queued: '#9e9e9e',
   pending: '#9e9e9e'
+};
+
+const CANCEL_ENDPOINTS = {
+  news: { url: '/api/admin/news/job/:id/cancel', method: 'POST' },
+  trail_status: { url: '/api/admin/trail-status/batch-collect/:id/cancel', method: 'PUT' }
+};
+
+const STATUS_ENDPOINTS = {
+  news: '/api/admin/news/status',
+  trail_status: '/api/admin/trail-status/job-status/latest'
+};
+
+const SLOTS_ENDPOINTS = {
+  news: '/api/admin/news/job/:id',
+  trail_status: '/api/admin/trail-status/job-status/:id'
+};
+
+const AI_STATS_ENDPOINTS = {
+  news: '/api/admin/news/ai-stats',
+  trail_status: '/api/admin/trail-status/ai-stats'
 };
 
 function formatDuration(startedAt, completedAt) {
@@ -55,249 +54,640 @@ function formatTime(isoString) {
   });
 }
 
-export default function JobsDashboard() {
-  const [queues, setQueues] = useState([]);
-  const [history, setHistory] = useState([]);
-  const [expandedJob, setExpandedJob] = useState(null);
-  const [jobLogs, setJobLogs] = useState([]);
+function formatCronHuman(cron) {
+  if (!cron) return 'Event-driven';
+  const parts = cron.split(/\s+/);
+  if (parts.length !== 5) return cron;
+  const [min, hour, dom] = parts;
+
+  if (cron === '0 6 * * *') return 'Daily at 6:00 AM';
+  if (cron === '0 2 * * *') return 'Daily at 2:00 AM';
+  if (cron === '0 3 * * *') return 'Daily at 3:00 AM';
+  if (cron.startsWith('*/')) return `Every ${min.slice(2)} minutes`;
+  if (hour !== '*' && min !== '*' && dom === '*') return `Daily at ${hour}:${min.padStart(2, '0')}`;
+  return cron;
+}
+
+export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) {
+  const [scheduledJobs, setScheduledJobs] = useState([]);
+  const [scheduledLoading, setScheduledLoading] = useState(true);
+  const [expandedScheduled, setExpandedScheduled] = useState(null);
+  const [editingSchedule, setEditingSchedule] = useState(null);
+  const [scheduleInput, setScheduleInput] = useState('');
+  const [scheduleSaving, setScheduleSaving] = useState(false);
+  const [triggeringJob, setTriggeringJob] = useState(null);
+
+  const [editingPrompt, setEditingPrompt] = useState(null);
+  const [promptInput, setPromptInput] = useState('');
+  const [promptSaving, setPromptSaving] = useState(false);
+
+  const [jobHistory, setJobHistory] = useState({});
+  const [jobHistoryLoading, setJobHistoryLoading] = useState({});
+
+  const [expandedRun, setExpandedRun] = useState(null);
+  const [runLogs, setRunLogs] = useState([]);
   const [logLevelFilter, setLogLevelFilter] = useState('all');
   const [logDetailsExpanded, setLogDetailsExpanded] = useState(new Set());
-  const [historyFilter, setHistoryFilter] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [historyOffset, setHistoryOffset] = useState(0);
-  const [hasMore, setHasMore] = useState(true);
 
-  const fetchQueues = useCallback(async () => {
+  const [runningJobs, setRunningJobs] = useState({});
+  const [activeSlots, setActiveSlots] = useState({});
+  const [aiStats, setAiStats] = useState({});
+  const [cancellingJob, setCancellingJob] = useState(null);
+
+  // Track recently-completed jobs for dismiss UX
+  const [completedJobs, setCompletedJobs] = useState({});
+
+  const [loading, setLoading] = useState(true);
+
+  const fetchScheduledJobs = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/admin/jobs/queues`, { credentials: 'include' });
-      if (res.ok) setQueues(await res.json());
+      const res = await fetch(`${API_BASE}/api/admin/jobs/scheduled`, { credentials: 'include' });
+      if (res.ok) setScheduledJobs(await res.json());
     } catch (err) {
-      console.error('Failed to fetch queues:', err);
+      console.error('Failed to fetch scheduled jobs:', err);
+    } finally {
+      setScheduledLoading(false);
     }
   }, []);
 
-  const fetchHistory = useCallback(async (offset = 0, append = false) => {
+  const fetchJobHistory = useCallback(async (jobId, historyTypes) => {
+    if (!historyTypes || historyTypes.length === 0) return;
+    setJobHistoryLoading(prev => ({ ...prev, [jobId]: true }));
     try {
-      const params = new URLSearchParams({ limit: '20', offset: String(offset) });
-      if (historyFilter) params.set('type', historyFilter);
-      const res = await fetch(`${API_BASE}/api/admin/jobs/history?${params}`, { credentials: 'include' });
-      if (res.ok) {
-        const data = await res.json();
-        if (append) {
-          setHistory(prev => [...prev, ...data]);
-        } else {
-          setHistory(data);
-        }
-        setHasMore(data.length === 20);
+      const allRuns = [];
+      for (const type of historyTypes) {
+        const params = new URLSearchParams({ limit: '10', offset: '0', type });
+        const res = await fetch(`${API_BASE}/api/admin/jobs/history?${params}`, { credentials: 'include' });
+        if (res.ok) allRuns.push(...(await res.json()));
       }
+      allRuns.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      setJobHistory(prev => ({ ...prev, [jobId]: allRuns.slice(0, 10) }));
     } catch (err) {
-      console.error('Failed to fetch history:', err);
+      console.error('Failed to fetch job history:', err);
+    } finally {
+      setJobHistoryLoading(prev => ({ ...prev, [jobId]: false }));
     }
-  }, [historyFilter]);
+  }, []);
 
-  const fetchJobLogs = useCallback(async (jobType, jobId) => {
+  const fetchRunLogs = useCallback(async (jobType, runId) => {
     try {
       const params = new URLSearchParams({ limit: '200' });
       if (logLevelFilter !== 'all') params.set('level', logLevelFilter);
-      const res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${jobId}/logs?${params}`, { credentials: 'include' });
-      if (res.ok) setJobLogs(await res.json());
+      const res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${runId}/logs?${params}`, { credentials: 'include' });
+      if (res.ok) setRunLogs(await res.json());
     } catch (err) {
-      console.error('Failed to fetch job logs:', err);
+      console.error('Failed to fetch run logs:', err);
     }
   }, [logLevelFilter]);
 
-  // Initial load
-  useEffect(() => {
-    Promise.all([fetchQueues(), fetchHistory()]).then(() => setLoading(false));
-  }, [fetchQueues, fetchHistory]);
+  const checkRunningJobs = useCallback(async () => {
+    const running = {};
+    const slots = {};
+    const stats = {};
 
-  // Auto-refresh queues
+    for (const [registryId, endpoint] of Object.entries(STATUS_ENDPOINTS)) {
+      try {
+        const res = await fetch(`${API_BASE}${endpoint}`, { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          const isRunning = data && data.status === 'running';
+          if (isRunning) {
+            const runId = data.id || data.jobId;
+            running[registryId] = { ...data, runId };
+
+            // Fetch active slots
+            const slotsEndpoint = SLOTS_ENDPOINTS[registryId];
+            if (slotsEndpoint && runId) {
+              try {
+                const slotsUrl = slotsEndpoint.replace(':id', runId);
+                const slotsRes = await fetch(`${API_BASE}${slotsUrl}`, { credentials: 'include' });
+                if (slotsRes.ok) {
+                  const slotsData = await slotsRes.json();
+                  if (slotsData.displaySlots) slots[registryId] = slotsData.displaySlots;
+                }
+              } catch { /* ignore */ }
+            }
+
+            // Fetch AI stats
+            const statsEndpoint = AI_STATS_ENDPOINTS[registryId];
+            if (statsEndpoint) {
+              try {
+                const statsRes = await fetch(`${API_BASE}${statsEndpoint}`, { credentials: 'include' });
+                if (statsRes.ok) stats[registryId] = await statsRes.json();
+              } catch { /* ignore */ }
+            }
+          }
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Detect jobs that just completed (were running, now aren't)
+    setRunningJobs(prev => {
+      for (const id of Object.keys(prev)) {
+        if (!running[id]) {
+          // Job just finished — mark as completed for dismiss UX
+          setCompletedJobs(c => ({ ...c, [id]: prev[id] }));
+          // Refresh history for this job
+          const job = scheduledJobs.find(j => j.id === id);
+          if (job) {
+            setJobHistory(h => ({ ...h, [id]: undefined }));
+            fetchJobHistory(id, job.historyTypes);
+          }
+        }
+      }
+      return running;
+    });
+
+    setActiveSlots(slots);
+    setAiStats(stats);
+  }, [scheduledJobs, fetchJobHistory]);
+
   useEffect(() => {
-    const interval = setInterval(fetchQueues, 10000);
+    Promise.all([fetchScheduledJobs(), checkRunningJobs()]).then(() => setLoading(false));
+  }, [fetchScheduledJobs, checkRunningJobs]);
+
+  // Auto-expand a specific job card when navigated from another tab
+  useEffect(() => {
+    if (expandTarget && !scheduledLoading) {
+      setExpandedScheduled(expandTarget);
+      setJobHistory(prev => { const next = { ...prev }; delete next[expandTarget]; return next; });
+      if (onExpandTargetConsumed) onExpandTargetConsumed();
+    }
+  }, [expandTarget, scheduledLoading, onExpandTargetConsumed]);
+
+  // Poll faster when jobs are running
+  useEffect(() => {
+    const hasRunning = Object.keys(runningJobs).length > 0;
+    const interval = setInterval(() => {
+      if (hasRunning) checkRunningJobs();
+      else fetchScheduledJobs();
+    }, hasRunning ? 2000 : 15000);
     return () => clearInterval(interval);
-  }, [fetchQueues]);
+  }, [fetchScheduledJobs, checkRunningJobs, runningJobs]);
 
-  // Reload history when filter changes
+  // Also refresh scheduled jobs periodically even when polling running jobs
   useEffect(() => {
-    setHistoryOffset(0);
-    fetchHistory(0);
-  }, [historyFilter, fetchHistory]);
+    if (Object.keys(runningJobs).length === 0) return;
+    const interval = setInterval(fetchScheduledJobs, 15000);
+    return () => clearInterval(interval);
+  }, [fetchScheduledJobs, runningJobs]);
 
-  // Reload logs when filter or expanded job changes
   useEffect(() => {
-    if (expandedJob) {
-      fetchJobLogs(expandedJob.job_type, expandedJob.id);
+    if (expandedScheduled) {
+      const job = scheduledJobs.find(j => j.id === expandedScheduled);
+      if (job && !jobHistory[job.id]) fetchJobHistory(job.id, job.historyTypes);
     }
-  }, [expandedJob, logLevelFilter, fetchJobLogs]);
+  }, [expandedScheduled, scheduledJobs, fetchJobHistory, jobHistory]);
 
-  const handleExpandJob = (job) => {
-    if (expandedJob?.id === job.id && expandedJob?.job_type === job.job_type) {
-      setExpandedJob(null);
-      setJobLogs([]);
-      setLogLevelFilter('all');
+  useEffect(() => {
+    if (expandedRun) fetchRunLogs(expandedRun.jobType, expandedRun.runId);
+  }, [expandedRun, logLevelFilter, fetchRunLogs]);
+
+  const handleExpandRun = (jobType, run) => {
+    const key = `${jobType}-${run.id}`;
+    if (expandedRun && `${expandedRun.jobType}-${expandedRun.runId}` === key) {
+      setExpandedRun(null); setRunLogs([]); setLogLevelFilter('all');
     } else {
-      setExpandedJob(job);
-      setLogLevelFilter('all');
-      setLogDetailsExpanded(new Set());
+      setExpandedRun({ jobType, runId: run.id }); setLogLevelFilter('all'); setLogDetailsExpanded(new Set());
     }
-  };
-
-  const handleLoadMore = () => {
-    const newOffset = historyOffset + 20;
-    setHistoryOffset(newOffset);
-    fetchHistory(newOffset, true);
   };
 
   const toggleLogDetails = (logId) => {
-    setLogDetailsExpanded(prev => {
-      const next = new Set(prev);
-      if (next.has(logId)) next.delete(logId);
-      else next.add(logId);
-      return next;
-    });
+    setLogDetailsExpanded(prev => { const next = new Set(prev); if (next.has(logId)) next.delete(logId); else next.add(logId); return next; });
   };
 
-  if (loading) {
-    return <div className="jobs-dashboard"><p>Loading job data...</p></div>;
-  }
+  const handleSaveSchedule = async (jobName) => {
+    setScheduleSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/jobs/${jobName}/schedule`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ cronExpression: scheduleInput })
+      });
+      if (res.ok) { setEditingSchedule(null); await fetchScheduledJobs(); }
+      else { const err = await res.json(); alert(err.error || 'Failed to save schedule'); }
+    } catch (err) { alert('Failed to save schedule: ' + err.message); }
+    finally { setScheduleSaving(false); }
+  };
+
+  const handleRunNow = async (job) => {
+    if (!job.triggerEndpoint) return;
+    setTriggeringJob(job.id);
+    try {
+      const res = await fetch(`${API_BASE}${job.triggerEndpoint}`, {
+        method: job.manualTriggerMethod || 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({})
+      });
+      if (res.ok) {
+        // Auto-expand the card so user sees progress
+        setExpandedScheduled(job.id);
+        await fetchScheduledJobs();
+        await checkRunningJobs();
+        setJobHistory(prev => ({ ...prev, [job.id]: undefined }));
+      } else { const err = await res.json(); alert(err.error || 'Failed to trigger job'); }
+    } catch (err) { alert('Failed to trigger job: ' + err.message); }
+    finally { setTriggeringJob(null); }
+  };
+
+  const handleCancelJob = async (registryId) => {
+    const cancelInfo = CANCEL_ENDPOINTS[registryId];
+    const runInfo = runningJobs[registryId];
+    if (!cancelInfo || !runInfo) return;
+    const runId = runInfo.runId || runInfo.id || runInfo.jobId;
+    if (!runId) return;
+
+    setCancellingJob(registryId);
+    try {
+      const url = cancelInfo.url.replace(':id', runId);
+      await fetch(`${API_BASE}${url}`, { method: cancelInfo.method, headers: { 'Content-Type': 'application/json' }, credentials: 'include' });
+      await checkRunningJobs();
+    } catch (err) { console.error('Failed to cancel job:', err); }
+    finally { setCancellingJob(null); }
+  };
+
+  const handleSavePrompt = async (key) => {
+    setPromptSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/prompts/${key}`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: promptInput })
+      });
+      if (res.ok) { setEditingPrompt(null); await fetchScheduledJobs(); }
+    } catch (err) { console.error('Failed to save prompt:', err); }
+    finally { setPromptSaving(false); }
+  };
+
+  const handleResetPrompt = async (key) => {
+    setPromptSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/prompts/${key}`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ reset: true })
+      });
+      if (res.ok) { setEditingPrompt(null); await fetchScheduledJobs(); }
+    } catch (err) { console.error('Failed to reset prompt:', err); }
+    finally { setPromptSaving(false); }
+  };
+
+  const renderLogDetails = (entry) => {
+    if (!entry.details) return null;
+    const details = entry.details;
+    const hasAiResponse = details.ai_response && details.ai_response.length > 0;
+    const hasRenderedContent = details.rendered_content && details.rendered_content.length > 0;
+    const summaryDetails = { ...details };
+    delete summaryDetails.ai_response; delete summaryDetails.rendered_content; delete summaryDetails.error_stack;
+
+    return (
+      <div className="log-details-structured">
+        {Object.keys(summaryDetails).length > 0 && (
+          <div className="log-detail-section"><div className="log-detail-pairs">
+            {Object.entries(summaryDetails).map(([key, value]) => (
+              <span key={key} className="log-detail-pair">
+                <span className="log-detail-key">{key.replace(/_/g, ' ')}:</span>
+                <span className="log-detail-value">{typeof value === 'object' ? JSON.stringify(value) : String(value)}</span>
+              </span>
+            ))}
+          </div></div>
+        )}
+        {details.error_stack && (<div className="log-detail-section"><div className="log-detail-label">Error Stack</div><pre className="log-detail-pre error">{details.error_stack}</pre></div>)}
+        {hasAiResponse && (<CollapsibleSection title={`AI Response (${details.ai_response.length} chars)`}><pre className="log-detail-pre">{details.ai_response}</pre></CollapsibleSection>)}
+        {hasRenderedContent && (<CollapsibleSection title={`Rendered Content (${details.rendered_content.length} chars)`}><pre className="log-detail-pre">{details.rendered_content}</pre></CollapsibleSection>)}
+      </div>
+    );
+  };
+
+  // Render the running job progress section (progress bar, counts, AI stats, slots, cancel)
+  const renderRunningSection = (job) => {
+    const runInfo = runningJobs[job.id];
+    const completed = completedJobs[job.id];
+    const info = runInfo || completed;
+    if (!info) return null;
+
+    const isStillRunning = !!runInfo;
+    const canCancel = isStillRunning && !!CANCEL_ENDPOINTS[job.id];
+    const slots = activeSlots[job.id];
+    const stats = aiStats[job.id];
+
+    // Progress values
+    const isNews = job.id === 'news';
+    const processed = isNews ? (info.pois_processed || 0) : (info.trails_processed || 0);
+    const total = isNews ? (info.total_pois || 0) : (info.total_trails || 0);
+    const pct = total > 0 ? (processed / total) * 100 : 0;
+
+    const geminiUsage = stats?.usage?.gemini || 0;
+    const perplexityUsage = stats?.usage?.perplexity || 0;
+    const total429 = (stats?.errors?.gemini429 || 0) + (stats?.errors?.perplexity429 || 0);
+
+    return (
+      <div className="running-job-section">
+        <div className="running-job-header">
+          <span className={`running-indicator ${isStillRunning ? 'pulse' : ''}`}
+            style={{ background: isStillRunning ? '#2196f3' : (info.status === 'cancelled' ? '#ff9800' : '#4caf50') }}
+          ></span>
+          <span>{isStillRunning ? 'Job in progress' : info.status === 'cancelled' ? 'Job cancelled' : 'Job completed'}</span>
+          {canCancel && (
+            <button className="status-cancel-btn" onClick={(e) => { e.stopPropagation(); handleCancelJob(job.id); }} disabled={cancellingJob === job.id}>
+              {cancellingJob === job.id ? 'Cancelling...' : 'Cancel'}
+            </button>
+          )}
+          {!isStillRunning && (
+            <button className="status-close-btn" onClick={(e) => { e.stopPropagation(); setCompletedJobs(prev => { const next = { ...prev }; delete next[job.id]; return next; }); }} title="Dismiss">
+              &times;
+            </button>
+          )}
+        </div>
+
+        {/* Progress bar */}
+        {total > 0 && (
+          <div className="progress-bar-wrapper" style={{ marginTop: '8px' }}>
+            <div className="progress-bar-fill" style={{
+              width: `${pct}%`,
+              background: !isStillRunning
+                ? 'linear-gradient(90deg, #4caf50, #8bc34a)'
+                : 'linear-gradient(90deg, #2196f3, #64b5f6)'
+            }} />
+          </div>
+        )}
+
+        {/* Count badges */}
+        <div className="progress-counts" style={{ marginTop: '6px' }}>
+          <div className="count-badge">
+            <span className="count-icon">{isNews ? '\u{1F4CD}' : '\u{1F6B5}'}</span>
+            <div className="count-details">
+              <span className="count-value">{processed}</span>
+              <span className="count-label">{total > 0 ? ` / ${total}` : ''} {isNews ? 'POIs' : 'Trails'}</span>
+            </div>
+          </div>
+          {isNews && (
+            <>
+              <div className="count-badge">
+                <span className="count-icon">{'\u{1F4F0}'}</span>
+                <div className="count-details">
+                  <span className="count-value">{info.news_found || 0}</span>
+                  <span className="count-label">News</span>
+                </div>
+              </div>
+              <div className="count-badge">
+                <span className="count-icon">{'\u{1F4C5}'}</span>
+                <div className="count-details">
+                  <span className="count-value">{info.events_found || 0}</span>
+                  <span className="count-label">Events</span>
+                </div>
+              </div>
+            </>
+          )}
+          {!isNews && (
+            <div className="count-badge">
+              <span className="count-icon">{'\u{1F4CA}'}</span>
+              <div className="count-details">
+                <span className="count-value">{info.status_found || 0}</span>
+                <span className="count-label">Status Updates</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* AI usage counters + Active Slots */}
+        {(slots || geminiUsage > 0 || perplexityUsage > 0 || total429 > 0) && (
+          <div className="active-slots-table" style={{ marginTop: '8px' }}>
+            {(geminiUsage > 0 || perplexityUsage > 0 || total429 > 0) && (
+              <div className="ai-usage-counters">
+                {geminiUsage > 0 && <span className="usage-badge gemini">{'\u{1F537}'} Gemini: {geminiUsage}</span>}
+                {perplexityUsage > 0 && <span className="usage-badge perplexity">{'\u{1F52E}'} Perplexity: {perplexityUsage}</span>}
+                {total429 > 0 && <span className="usage-badge error">{'\u26A0\uFE0F'} 429 Errors: {total429}</span>}
+              </div>
+            )}
+            {slots && slots.some(s => s !== null) && (
+              <>
+                <div className="slots-header">
+                  <div>{isNews ? 'POI' : 'Trail'}</div>
+                  <div>Status</div>
+                  <div>Provider</div>
+                </div>
+                {slots.map((slot, idx) => {
+                  if (!slot || !slot.poiName) return (
+                    <div key={idx} className="slots-row empty-slot"><div>Waiting</div><div>--</div><div>--</div></div>
+                  );
+                  return (
+                    <div key={idx} className={`slots-row ${slot.status === 'active' ? 'active' : ''}`}>
+                      <div className="slot-poi">{slot.poiName}</div>
+                      <div className="slot-status">
+                        {slot.status === 'completed' ? '\u2713 Done'
+                          : slot.phase === 'error' ? '\u274C Error'
+                          : slot.phase === 'rendering' || slot.phase === 'rendering_events' || slot.phase === 'rendering_news' ? '\u{1F4C4} Rendering'
+                          : slot.phase === 'ai_search' || slot.phase === 'ai_extraction' ? '\u{1F50D} AI'
+                          : slot.phase === 'matching_links' ? '\u{1F517} Matching'
+                          : slot.phase === 'google_news' ? '\u{1F4F0} Google'
+                          : slot.phase || '--'}
+                      </div>
+                      <div className="slot-provider">
+                        {slot.provider === 'gemini' ? '\u{1F537} Gemini'
+                          : slot.provider === 'perplexity' ? '\u{1F52E} Perplexity' : '--'}
+                      </div>
+                    </div>
+                  );
+                })}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  if (loading) return <div className="jobs-dashboard"><p>Loading job data...</p></div>;
 
   return (
     <div className="jobs-dashboard">
-      {/* Queue Status */}
-      <h3>Queue Status</h3>
-      <div className="queue-status-grid">
-        {queues.map(q => (
-          <div key={q.name} className="queue-card" title={q.description}>
-            <div className="queue-card-label">{q.label}</div>
-            <div className="queue-card-count">
-              {q.size > 0 ? (
-                <span className="queue-badge queue-badge-active">{q.size} queued</span>
-              ) : (
-                <span className="queue-badge queue-badge-idle">idle</span>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Job History */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginTop: '24px' }}>
-        <h3 style={{ margin: 0 }}>Job History</h3>
-        <select
-          value={historyFilter}
-          onChange={(e) => setHistoryFilter(e.target.value)}
-          className="job-filter-select"
-        >
-          <option value="">All Types</option>
-          <option value="news">News</option>
-          <option value="trail_status">Trail Status</option>
-          <option value="moderation">Moderation</option>
-          <option value="newsletter">Newsletter</option>
-          <option value="backup">Backup</option>
-          <option value="database_backup">DB Backup</option>
-        </select>
-      </div>
-
-      {history.length === 0 ? (
-        <p style={{ color: '#999', padding: '16px 0' }}>No jobs found.</p>
+      <h3>Scheduled Jobs</h3>
+      {scheduledLoading ? (
+        <p style={{ color: '#999' }}>Loading scheduled jobs...</p>
       ) : (
-        <table className="job-history-table">
-          <thead>
-            <tr>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Items</th>
-              <th>Started</th>
-              <th>Duration</th>
-            </tr>
-          </thead>
-          <tbody>
-            {history.map(job => (
-              <React.Fragment key={`${job.job_type}-${job.id}`}>
-                <tr
-                  className={`job-row expandable ${expandedJob?.id === job.id && expandedJob?.job_type === job.job_type ? 'expanded' : ''}`}
-                  onClick={() => handleExpandJob(job)}
+        <div className="scheduled-jobs-grid">
+          {scheduledJobs.map(job => {
+            const isRunning = !!runningJobs[job.id];
+            const isCompleted = !!completedJobs[job.id];
+            const showProgress = isRunning || isCompleted;
+            const runs = jobHistory[job.id] || [];
+            const historyLoading = jobHistoryLoading[job.id];
+
+            return (
+              <div key={job.id} className={`scheduled-job-card ${isRunning ? 'running' : ''}`}>
+                <div className="scheduled-job-header"
+                  onClick={() => {
+                    const newId = expandedScheduled === job.id ? null : job.id;
+                    setExpandedScheduled(newId);
+                    setExpandedRun(null);
+                    setRunLogs([]);
+                    if (newId) setJobHistory(prev => { const next = { ...prev }; delete next[newId]; return next; });
+                  }}
+                  style={{ cursor: 'pointer' }}
                 >
-                  <td>
-                    <span className="job-type-icon">{JOB_TYPE_ICONS[job.job_type] || '\u{2699}'}</span>
-                    {JOB_TYPE_LABELS[job.job_type] || job.job_type}
-                  </td>
-                  <td>
-                    <span
-                      className="status-badge"
-                      style={{ backgroundColor: STATUS_COLORS[job.status] || '#9e9e9e' }}
-                    >
-                      {job.status}
-                    </span>
-                  </td>
-                  <td>
-                    {job.items_processed != null ? `${job.items_processed}/${job.items_total}` : '--'}
-                  </td>
-                  <td>{formatTime(job.started_at || job.created_at)}</td>
-                  <td>{formatDuration(job.started_at, job.completed_at)}</td>
-                </tr>
+                  <div className="scheduled-job-info">
+                    <span className="scheduled-job-icon">{job.icon}</span>
+                    <div>
+                      <div className="scheduled-job-label">{job.label}</div>
+                      <div className="scheduled-job-desc">{job.description}</div>
+                    </div>
+                  </div>
+                  <div className="scheduled-job-badges">
+                    {isRunning && <span className="queue-badge queue-badge-running">running</span>}
+                    {job.currentSchedule && <span className="schedule-badge" title={job.currentSchedule}>{formatCronHuman(job.currentSchedule)}</span>}
+                    {!isRunning && job.queueSize > 0 ? <span className="queue-badge queue-badge-active">{job.queueSize} queued</span>
+                      : !isRunning ? <span className="queue-badge queue-badge-idle">idle</span> : null}
+                  </div>
+                </div>
 
-                {expandedJob?.id === job.id && expandedJob?.job_type === job.job_type && (
-                  <tr className="job-logs-row">
-                    <td colSpan={5}>
-                      <div className="job-logs-panel">
-                        <div className="log-level-filters">
-                          {['all', 'error', 'warn'].map(level => (
-                            <button
-                              key={level}
-                              className={`log-filter-btn ${logLevelFilter === level ? 'active' : ''}`}
-                              onClick={(e) => { e.stopPropagation(); setLogLevelFilter(level); }}
-                            >
-                              {level === 'all' ? 'All' : level === 'error' ? 'Errors' : 'Warnings'}
-                            </button>
-                          ))}
-                        </div>
+                {expandedScheduled === job.id && (
+                  <div className="scheduled-job-detail">
+                    {/* Running/Completed progress */}
+                    {showProgress && renderRunningSection(job)}
 
-                        {job.error_message && (
-                          <div className="job-error-banner">
-                            {job.error_message}
+                    {/* Schedule Editor */}
+                    {job.currentSchedule && (
+                      <div className="schedule-editor">
+                        {editingSchedule === job.scheduleJobName ? (
+                          <div className="schedule-edit-row">
+                            <input type="text" value={scheduleInput} onChange={(e) => setScheduleInput(e.target.value)} placeholder="e.g. */30 * * * *" className="schedule-input" />
+                            <button className="sync-btn-small" onClick={() => handleSaveSchedule(job.scheduleJobName)} disabled={scheduleSaving}>{scheduleSaving ? 'Saving...' : 'Save'}</button>
+                            <button className="sync-btn-small" onClick={() => setEditingSchedule(null)}>Cancel</button>
                           </div>
-                        )}
-
-                        {jobLogs.length === 0 ? (
-                          <p style={{ color: '#999', padding: '8px 0', margin: 0 }}>
-                            No log entries{logLevelFilter !== 'all' ? ` with level "${logLevelFilter}"` : ''}.
-                          </p>
                         ) : (
-                          <div className="job-logs-scroll">
-                            {jobLogs.map(entry => (
-                              <div
-                                key={entry.id}
-                                className={`job-log-entry ${entry.level}`}
-                                onClick={(e) => { e.stopPropagation(); if (entry.details) toggleLogDetails(entry.id); }}
-                                style={{ cursor: entry.details ? 'pointer' : 'default' }}
-                              >
-                                <span className={`log-level-dot ${entry.level}`}></span>
-                                <span className="log-poi">{entry.poi_name || '--'}</span>
-                                <span className="log-message">{entry.message}</span>
-                                <span className="log-time">{formatTime(entry.created_at)}</span>
-                                {logDetailsExpanded.has(entry.id) && entry.details && (
-                                  <pre className="log-details">{JSON.stringify(entry.details, null, 2)}</pre>
-                                )}
-                              </div>
-                            ))}
+                          <div className="schedule-display-row">
+                            <code className="schedule-cron">{job.currentSchedule}</code>
+                            {job.currentSchedule !== job.defaultSchedule && <span className="schedule-custom-badge">custom</span>}
+                            <button className="sync-btn-small" onClick={() => { setEditingSchedule(job.scheduleJobName); setScheduleInput(job.currentSchedule); }}>Edit</button>
                           </div>
                         )}
                       </div>
-                    </td>
-                  </tr>
-                )}
-              </React.Fragment>
-            ))}
-          </tbody>
-        </table>
-      )}
+                    )}
 
-      {hasMore && history.length > 0 && (
-        <button className="load-more-btn" onClick={handleLoadMore}>
-          Load More
-        </button>
+                    {/* Run Now */}
+                    {job.triggerEndpoint && !isRunning && (
+                      <button className="action-btn primary" onClick={() => handleRunNow(job)} disabled={triggeringJob === job.id}
+                        style={{ marginTop: '8px', padding: '4px 12px', fontSize: '0.85rem' }}>
+                        {triggeringJob === job.id ? 'Starting...' : 'Run Now'}
+                      </button>
+                    )}
+
+                    {/* Prompt Template Editor */}
+                    {job.hasPrompt && job.prompts && job.prompts.length > 0 && (
+                      <div className="prompt-section">
+                        {job.prompts.map(p => (
+                          <div key={p.key} className="prompt-editor">
+                            <div className="prompt-header">
+                              <label>
+                                {p.label}
+                                <span style={{ marginLeft: '8px', fontSize: '0.75rem', padding: '2px 6px', borderRadius: '4px',
+                                  backgroundColor: p.isCustomized ? '#fff3e0' : '#e8f5e9', color: p.isCustomized ? '#e65100' : '#2e7d32' }}>
+                                  {p.isCustomized ? 'Customized' : 'Using default'}
+                                </span>
+                              </label>
+                              <div className="prompt-actions">
+                                {editingPrompt === p.key ? (
+                                  <>
+                                    <button className="sync-btn-small" onClick={() => handleSavePrompt(p.key)} disabled={promptSaving}>Save</button>
+                                    <button className="sync-btn-small" onClick={() => setEditingPrompt(null)}>Cancel</button>
+                                    {p.isCustomized && <button className="sync-btn-small" onClick={() => handleResetPrompt(p.key)} disabled={promptSaving}>Reset to Default</button>}
+                                  </>
+                                ) : (
+                                  <>
+                                    <button className="sync-btn-small" onClick={() => { setEditingPrompt(p.key); setPromptInput(p.currentValue); }}>Edit</button>
+                                    {p.isCustomized && <button className="sync-btn-small" onClick={() => handleResetPrompt(p.key)} disabled={promptSaving}>Reset to Default</button>}
+                                  </>
+                                )}
+                              </div>
+                            </div>
+                            <textarea value={editingPrompt === p.key ? promptInput : p.currentValue} onChange={(e) => setPromptInput(e.target.value)}
+                              disabled={editingPrompt !== p.key} rows={8} className="prompt-textarea" />
+                            {p.placeholders && p.placeholders.length > 0 && (
+                              <div style={{ marginTop: '6px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                                {p.placeholders.map(ph => <code key={ph} style={{ fontSize: '0.75rem', padding: '2px 6px', backgroundColor: '#f5f5f5', borderRadius: '3px', color: '#555' }}>{ph}</code>)}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Recent Runs */}
+                    <div className="job-runs-section">
+                      <div className="job-runs-header">Recent Runs</div>
+                      {historyLoading ? (
+                        <p style={{ color: '#999', fontSize: '0.85rem', margin: '4px 0' }}>Loading...</p>
+                      ) : runs.length === 0 ? (
+                        <p style={{ color: '#999', fontSize: '0.85rem', margin: '4px 0' }}>No recent runs.</p>
+                      ) : (
+                        <div className="job-runs-list">
+                          {runs.map(run => {
+                            const isExpanded = expandedRun && expandedRun.jobType === run.job_type && expandedRun.runId === run.id;
+                            return (
+                              <div key={`${run.job_type}-${run.id}`} className="job-run-item">
+                                <div className={`job-run-row ${isExpanded ? 'expanded' : ''}`}
+                                  onClick={(e) => { e.stopPropagation(); handleExpandRun(run.job_type, run); }}>
+                                  <span className="status-badge" style={{ backgroundColor: STATUS_COLORS[run.status] || '#9e9e9e' }}>{run.status}</span>
+                                  <span className="run-items">{run.items_processed != null ? `${run.items_processed}/${run.items_total}` : '--'}</span>
+                                  <span className="run-time">{formatTime(run.started_at || run.created_at)}</span>
+                                  <span className="run-duration">{formatDuration(run.started_at, run.completed_at)}</span>
+                                </div>
+
+                                {isExpanded && (
+                                  <div className="job-logs-panel">
+                                    <div className="log-level-filters">
+                                      {['all', 'error', 'warn'].map(level => (
+                                        <button key={level} className={`log-filter-btn ${logLevelFilter === level ? 'active' : ''}`}
+                                          onClick={(e) => { e.stopPropagation(); setLogLevelFilter(level); }}>
+                                          {level === 'all' ? 'All' : level === 'error' ? 'Errors' : 'Warnings'}
+                                        </button>
+                                      ))}
+                                    </div>
+                                    {run.error_message && <div className="job-error-banner">{run.error_message}</div>}
+                                    {runLogs.length === 0 ? (
+                                      <p style={{ color: '#999', padding: '8px 0', margin: 0, fontSize: '0.82rem' }}>
+                                        No log entries{logLevelFilter !== 'all' ? ` with level "${logLevelFilter}"` : ''}.
+                                      </p>
+                                    ) : (
+                                      <div className="job-logs-scroll">
+                                        {runLogs.map(entry => (
+                                          <div key={entry.id} className={`job-log-entry ${entry.level}`}
+                                            onClick={(e) => { e.stopPropagation(); if (entry.details) toggleLogDetails(entry.id); }}
+                                            style={{ cursor: entry.details ? 'pointer' : 'default' }}>
+                                            <span className={`log-level-dot ${entry.level}`}></span>
+                                            <span className="log-poi">{entry.poi_name || '--'}</span>
+                                            <span className="log-message">{entry.message}</span>
+                                            <span className="log-time">{formatTime(entry.created_at)}</span>
+                                            {logDetailsExpanded.has(entry.id) && entry.details && renderLogDetails(entry)}
+                                          </div>
+                                        ))}
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
       )}
+    </div>
+  );
+}
+
+function CollapsibleSection({ title, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="log-detail-section collapsible">
+      <div className="log-detail-label clickable" onClick={(e) => { e.stopPropagation(); setOpen(!open); }}>
+        <span style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.2s', display: 'inline-block', marginRight: '6px' }}>&#9654;</span>
+        {title}
+      </div>
+      {open && children}
     </div>
   );
 }

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -51,6 +51,8 @@ function ModerationInbox() {
   const [itemUrls, setItemUrls] = useState({}); // { "news:123": [{id, url, source_name}] }
   const [newUrlInput, setNewUrlInput] = useState('');
   const [addingUrl, setAddingUrl] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchInput, setSearchInput] = useState('');
   const LIMIT = 20;
 
   const fetchQueue = useCallback(async () => {
@@ -59,6 +61,7 @@ function ModerationInbox() {
       const params = new URLSearchParams({ page, limit: LIMIT, status: statusFilter });
       if (filter) params.set('type', filter);
       if (sourceFilter) params.set('source', sourceFilter);
+      if (searchQuery) params.set('search', searchQuery);
       const response = await fetch(`/api/admin/moderation/queue?${params}`, {
         credentials: 'include'
       });
@@ -72,7 +75,7 @@ function ModerationInbox() {
     } finally {
       setLoading(false);
     }
-  }, [page, filter, statusFilter, sourceFilter]);
+  }, [page, filter, statusFilter, sourceFilter, searchQuery]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
 
@@ -335,6 +338,9 @@ function ModerationInbox() {
         setEditingItem(null);
         setEditFields({});
         fetchQueue();
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Save failed');
       }
     } catch (err) { notify('error', err.message); }
   };
@@ -543,6 +549,21 @@ function ModerationInbox() {
         </div>
       </div>
 
+      {/* Search bar */}
+      <div style={{ marginBottom: '8px' }}>
+        <input
+          type="text"
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { setSearchQuery(searchInput); setPage(1); } }}
+          placeholder="Search by title or description..."
+          style={{
+            width: '100%', padding: '8px 12px', fontSize: '0.88rem',
+            border: '1px solid #d0d0d0', borderRadius: '6px', boxSizing: 'border-box'
+          }}
+        />
+      </div>
+
       {/* Filter rows — stacked: Types, Sources, Status */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '12px' }}>
         {/* Row 1: Type filters */}
@@ -605,7 +626,7 @@ function ModerationInbox() {
           <div style={{ display: 'flex', gap: '6px', marginBottom: '12px' }}>
             {['news', 'event', 'photo'].map(t => (
               <button key={t} onClick={() => { setCreating(t); setCreateFields({}); }}
-                style={pillActive(creating === t)}>
+                style={filterBtn(creating === t)}>
                 {t.charAt(0).toUpperCase() + t.slice(1)}
               </button>
             ))}

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -43,6 +43,28 @@ const ResultsTab = memo(function ResultsTab({
   );
   const [searchText, setSearchText] = useState('');
 
+  // Sub-tab configuration (fetched from server, with hardcoded fallback)
+  const DEFAULT_SUBTABS = [
+    { id: 'all', label: 'Points of Interest', shortLabel: 'POIs', route: '/', filterTypes: null, protected: true },
+    { id: 'mtb', label: 'MTB Trail Status', shortLabel: 'MTB Status', route: '/mtb-trail-status', filterTypes: ['mtb-trailhead'], protected: false },
+    { id: 'organizations', label: 'Organizations', shortLabel: 'Orgs', route: '/organizations', filterTypes: ['organization'], protected: false }
+  ];
+  const [subtabConfig, setSubtabConfig] = useState(null);
+
+  // Fetch sub-tab config on mount
+  useEffect(() => {
+    fetch('/api/results-subtabs')
+      .then(res => res.json())
+      .then(data => {
+        if (data.subtabs && data.subtabs.length > 0) {
+          setSubtabConfig(data.subtabs);
+        }
+      })
+      .catch(err => console.error('Failed to fetch subtab config:', err));
+  }, []);
+
+  const activeSubtabs = subtabConfig || DEFAULT_SUBTABS;
+
   // Generate initial filter types from iconConfig + layer types
   const allFilterTypes = useMemo(() => {
     const types = new Set(['trails', 'rivers', 'boundaries']); // Layer types
@@ -356,11 +378,10 @@ const ResultsTab = memo(function ResultsTab({
     // Don't clear bypass filter here - let App.jsx MTB Route Effect handle it
     // This prevents flickering when switching from MTB to All Results
 
-    // Navigate to appropriate URL
-    if (tab === 'mtb') {
-      navigate('/mtb-trail-status');
-    } else if (tab === 'organizations') {
-      navigate('/organizations');
+    // Navigate to config-driven route
+    const tabConfig = activeSubtabs.find(t => t.id === tab);
+    if (tabConfig) {
+      navigate(tabConfig.route);
     } else {
       navigate('/');
     }
@@ -375,29 +396,18 @@ const ResultsTab = memo(function ResultsTab({
           <p className="tab-subtitle">Points of interest visible in the current map area</p>
         </div>
 
-        {/* Sub-tabs */}
+        {/* Sub-tabs (data-driven from config) */}
         <div className="results-subtabs">
-          <button
-            className={`results-subtab ${activeSubTab === 'all' ? 'active' : ''}`}
-            onClick={() => handleSubTabChange('all')}
-          >
-            <span className="subtab-label-full">Points of Interest</span>
-            <span className="subtab-label-short">POIs</span>
-          </button>
-          <button
-            className={`results-subtab ${activeSubTab === 'mtb' ? 'active' : ''}`}
-            onClick={() => handleSubTabChange('mtb')}
-          >
-            <span className="subtab-label-full">MTB Trail Status</span>
-            <span className="subtab-label-short">MTB Status</span>
-          </button>
-          <button
-            className={`results-subtab ${activeSubTab === 'organizations' ? 'active' : ''}`}
-            onClick={() => handleSubTabChange('organizations')}
-          >
-            <span className="subtab-label-full">Organizations</span>
-            <span className="subtab-label-short">Orgs</span>
-          </button>
+          {activeSubtabs.map(tab => (
+            <button
+              key={tab.id}
+              className={`results-subtab ${activeSubTab === tab.id ? 'active' : ''}`}
+              onClick={() => handleSubTabChange(tab.id)}
+            >
+              <span className="subtab-label-full">{tab.label}</span>
+              <span className="subtab-label-short">{tab.shortLabel || tab.label}</span>
+            </button>
+          ))}
         </div>
 
         {/* Filter badges - always visible even when no results */}
@@ -479,29 +489,18 @@ const ResultsTab = memo(function ResultsTab({
         <p className="tab-subtitle">Points of interest visible in the current map area</p>
       </div>
 
-      {/* Sub-tabs */}
+      {/* Sub-tabs (data-driven from config) */}
       <div className="results-subtabs">
-        <button
-          className={`results-subtab ${activeSubTab === 'all' ? 'active' : ''}`}
-          onClick={() => handleSubTabChange('all')}
-        >
-          <span className="subtab-label-full">Points of Interest</span>
-          <span className="subtab-label-short">POIs</span>
-        </button>
-        <button
-          className={`results-subtab ${activeSubTab === 'mtb' ? 'active' : ''}`}
-          onClick={() => handleSubTabChange('mtb')}
-        >
-          <span className="subtab-label-full">MTB Trail Status</span>
-          <span className="subtab-label-short">MTB Status</span>
-        </button>
-        <button
-          className={`results-subtab ${activeSubTab === 'organizations' ? 'active' : ''}`}
-          onClick={() => handleSubTabChange('organizations')}
-        >
-          <span className="subtab-label-full">Organizations</span>
-          <span className="subtab-label-short">Orgs</span>
-        </button>
+        {activeSubtabs.map(tab => (
+          <button
+            key={tab.id}
+            className={`results-subtab ${activeSubTab === tab.id ? 'active' : ''}`}
+            onClick={() => handleSubTabChange(tab.id)}
+          >
+            <span className="subtab-label-full">{tab.label}</span>
+            <span className="subtab-label-short">{tab.shortLabel || tab.label}</span>
+          </button>
+        ))}
       </div>
 
       <div className="results-filters">

--- a/frontend/src/components/SyncSettings.jsx
+++ b/frontend/src/components/SyncSettings.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-function SyncSettings({ onDataRefresh }) {
+function SyncSettings({ onDataRefresh, onNavigateToJobs }) {
   const [syncStatus, setSyncStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [message, setMessage] = useState(null);
+  const [actionJobLinks, setActionJobLinks] = useState({}); // keyed by action: 'db_backup', 'db_restore', 'img_backup', 'img_restore'
   const [refreshing, setRefreshing] = useState(false);
   const [backingUp, setBackingUp] = useState(false);
   const [restoring, setRestoring] = useState(false);
@@ -121,6 +122,7 @@ function SyncSettings({ onDataRefresh }) {
       const result = await response.json();
       if (response.ok) {
         setMessage(`Database backup created: ${result.filename}`);
+        setActionJobLinks(prev => ({ ...prev, db_backup: 'database_backup' }));
         fetchStatus();
       } else {
         setError(result.error || 'Database backup failed');
@@ -177,6 +179,7 @@ function SyncSettings({ onDataRefresh }) {
       const result = await response.json();
       if (response.ok) {
         setMessage('Database restored successfully');
+        setActionJobLinks(prev => ({ ...prev, db_restore: 'database_backup' }));
         setShowRestoreList(false);
         if (onDataRefresh) await onDataRefresh();
       } else {
@@ -203,6 +206,7 @@ function SyncSettings({ onDataRefresh }) {
       const result = await response.json();
       if (response.ok) {
         setMessage(`Image backup: ${result.uploaded} uploaded, ${result.skipped} already backed up`);
+        setActionJobLinks(prev => ({ ...prev, img_backup: 'image_backup' }));
         fetchStatus();
       } else {
         setError(result.error || 'Image backup failed');
@@ -283,15 +287,6 @@ function SyncSettings({ onDataRefresh }) {
     return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(parseInt(bytes) / 1024).toFixed(0)} KB`;
   };
 
-  if (loading) {
-    return (
-      <div className="sync-settings">
-        <h3>Google Drive</h3>
-        <p>Loading status...</p>
-      </div>
-    );
-  }
-
   const driveIdRow = (key, label, icon, folderData) => (
     <div className="drive-id-row">
       <div className="drive-id-label">
@@ -328,148 +323,179 @@ function SyncSettings({ onDataRefresh }) {
       {error && <div className="sync-error">{error}</div>}
       {message && <div className="sync-success">{message}</div>}
 
-      {syncStatus?.drive?.configured && (
-        <div className="sync-drive-info">
-          <div className="sync-tile-header">
-            <h4>Backup & Restore</h4>
-            <button
-              className={`refresh-btn${refreshing ? ' spinning' : ''}`}
-              onClick={handleManualRefresh}
-              disabled={loading || refreshing}
-              title="Refresh status"
+      <div className="sync-drive-info">
+        <div className="sync-tile-header">
+          <h4>Backup & Restore</h4>
+          <button
+            className={`refresh-btn${(refreshing || (loading && !syncStatus)) ? ' spinning' : ''}`}
+            onClick={handleManualRefresh}
+            disabled={loading || refreshing}
+            title="Refresh status"
+          >
+            &#8635;
+          </button>
+        </div>
+
+        <div className="drive-root-header">
+          {syncStatus?.drive?.folders?.root ? (
+            <a
+              href={syncStatus.drive.folders.root.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="folder-link root-link"
             >
-              &#8635;
-            </button>
+              <span className="folder-icon">&#128193;</span>
+              <span className="folder-name">{syncStatus.drive.folders.root.name}</span>
+            </a>
+          ) : (
+            <span className="folder-link root-link">
+              <span className="folder-icon">&#128193;</span>
+              <span className="folder-name" style={{ color: '#999' }}>...</span>
+            </span>
+          )}
+        </div>
+
+        {/* Database Section */}
+        <div className="backup-section">
+          <div className="backup-section-header">
+            {driveIdRow('database', 'Database', '\u{1F4BE}', syncStatus?.drive?.folders?.database)}
           </div>
 
-          {syncStatus.drive.folders.root && (
-            <div className="drive-root-header">
-              <a
-                href={syncStatus.drive.folders.root.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="folder-link root-link"
-              >
-                <span className="folder-icon">&#128193;</span>
-                <span className="folder-name">{syncStatus.drive.folders.root.name}</span>
-              </a>
+          <div className="sync-status-row">
+            <div className="sync-status-item">
+              <label>Last Backup</label>
+              <span>
+                {backingUp || restoring ? (
+                  <a href="#" className="job-link-active" onClick={(e) => { e.preventDefault(); if (onNavigateToJobs) onNavigateToJobs('database_backup'); }}>Active</a>
+                ) : syncStatus?.last_backup ? (
+                  <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); if (onNavigateToJobs) onNavigateToJobs('database_backup'); }}>{formatDate(syncStatus.last_backup)}</a>
+                ) : syncStatus ? 'Never' : '...'}
+              </span>
             </div>
-          )}
+          </div>
 
-          {/* Database Section */}
-          {syncStatus.drive_access_verified && (
-            <div className="backup-section">
-              <div className="backup-section-header">
-                {driveIdRow('database', 'Database', '\u{1F4BE}', syncStatus.drive.folders.database)}
-              </div>
+          <div className="sync-buttons-grid">
+            <div className="sync-button-card">
+              <button
+                className="sync-btn push-btn"
+                onClick={handleBackup}
+                disabled={anyBusy || !syncStatus?.drive_access_verified}
+              >
+                {backingUp ? 'Backing up...' : 'Backup'}
+              </button>
+              <p className="button-description">pg_dump to Database folder</p>
+              {actionJobLinks.db_backup && onNavigateToJobs && (
+                <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); onNavigateToJobs(actionJobLinks.db_backup); }}>
+                  View in Jobs &rarr;
+                </a>
+              )}
+            </div>
+            <div className="sync-button-card">
+              <button
+                className="sync-btn pull-btn"
+                onClick={handleShowRestore}
+                disabled={anyBusy || !syncStatus?.drive_access_verified}
+              >
+                {restoring ? 'Restoring...' : 'Restore'}
+              </button>
+              <p className="button-description">Restore from a backup file</p>
+              {actionJobLinks.db_restore && onNavigateToJobs && (
+                <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); onNavigateToJobs(actionJobLinks.db_restore); }}>
+                  View in Jobs &rarr;
+                </a>
+              )}
+            </div>
+          </div>
 
-              <div className="sync-status-row">
-                <div className="sync-status-item">
-                  <label>Last Backup</label>
-                  <span>{formatDate(syncStatus.last_backup)}</span>
-                </div>
-              </div>
-
-              <div className="sync-buttons-grid">
-                <div className="sync-button-card">
-                  <button
-                    className="sync-btn push-btn"
-                    onClick={handleBackup}
-                    disabled={anyBusy}
-                  >
-                    {backingUp ? 'Backing up...' : 'Backup'}
-                  </button>
-                  <p className="button-description">pg_dump to Database folder</p>
-                </div>
-                <div className="sync-button-card">
-                  <button
-                    className="sync-btn pull-btn"
-                    onClick={handleShowRestore}
-                    disabled={anyBusy}
-                  >
-                    {restoring ? 'Restoring...' : 'Restore'}
-                  </button>
-                  <p className="button-description">Restore from a backup file</p>
-                </div>
-              </div>
-
-              {showRestoreList && backupsList && (
-                <div className="restore-list">
-                  {backupsList.length === 0 ? (
-                    <p className="restore-empty">No backups found in Database folder.</p>
-                  ) : (
-                    backupsList.map(backup => (
-                      <div key={backup.id} className="restore-item">
-                        <span className="restore-name">{backup.name}</span>
-                        <span className="restore-size">{formatSize(backup.size)}</span>
-                        <span className="restore-date">{formatDate(backup.createdTime)}</span>
-                        <button
-                          className="sync-btn-small"
-                          onClick={() => handleRestore(backup.id, backup.name)}
-                          disabled={restoring}
-                        >
-                          Restore
-                        </button>
-                      </div>
-                    ))
-                  )}
-                </div>
+          {showRestoreList && backupsList && (
+            <div className="restore-list">
+              {backupsList.length === 0 ? (
+                <p className="restore-empty">No backups found in Database folder.</p>
+              ) : (
+                backupsList.map(backup => (
+                  <div key={backup.id} className="restore-item">
+                    <span className="restore-name">{backup.name}</span>
+                    <span className="restore-size">{formatSize(backup.size)}</span>
+                    <span className="restore-date">{formatDate(backup.createdTime)}</span>
+                    <button
+                      className="sync-btn-small"
+                      onClick={() => handleRestore(backup.id, backup.name)}
+                      disabled={restoring}
+                    >
+                      Restore
+                    </button>
+                  </div>
+                ))
               )}
             </div>
           )}
-
-          {/* Images Section */}
-          {syncStatus.drive_access_verified && (
-            <div className="backup-section">
-              <div className="backup-section-header">
-                {driveIdRow('images', 'Images', '\u{1F5BC}\uFE0F', syncStatus.drive.folders.images)}
-              </div>
-
-              <div className="sync-status-row">
-                <div className="sync-status-item">
-                  <label>Media Files</label>
-                  <span>{imageBackup?.mediaFileCount ?? '...'} files</span>
-                </div>
-                <div className="sync-status-item">
-                  <label>Drive Media</label>
-                  <span>{imageBackup?.driveMediaCount ?? '...'} files</span>
-                </div>
-                <div className="sync-status-item">
-                  <label>DB Dumps</label>
-                  <span>{imageBackup?.driveDbDumpCount ?? '...'}</span>
-                </div>
-                <div className="sync-status-item">
-                  <label>Last Backup</label>
-                  <span>{formatDate(imageBackup?.lastBackup)}</span>
-                </div>
-              </div>
-
-              <div className="sync-buttons-grid">
-                <div className="sync-button-card">
-                  <button
-                    className="sync-btn push-btn"
-                    onClick={handleImageBackup}
-                    disabled={anyBusy}
-                  >
-                    {backingUpImages ? 'Backing up...' : 'Backup'}
-                  </button>
-                  <p className="button-description">Sync DB + media files to Drive</p>
-                </div>
-                <div className="sync-button-card">
-                  <button
-                    className="sync-btn pull-btn"
-                    onClick={handleImageRestore}
-                    disabled={anyBusy}
-                  >
-                    {restoringImages ? 'Restoring...' : 'Restore'}
-                  </button>
-                  <p className="button-description">Pull images from Drive to image server</p>
-                </div>
-              </div>
-            </div>
-          )}
         </div>
-      )}
+
+        {/* Images Section */}
+        <div className="backup-section">
+          <div className="backup-section-header">
+            {driveIdRow('images', 'Images', '\u{1F5BC}\uFE0F', syncStatus?.drive?.folders?.images)}
+          </div>
+
+          <div className="sync-status-row">
+            <div className="sync-status-item">
+              <label>Media Files</label>
+              <span>{imageBackup?.mediaFileCount ?? '...'} files</span>
+            </div>
+            <div className="sync-status-item">
+              <label>Drive Media</label>
+              <span>{imageBackup?.driveMediaCount ?? '...'} files</span>
+            </div>
+            <div className="sync-status-item">
+              <label>DB Dumps</label>
+              <span>{imageBackup?.driveDbDumpCount ?? '...'}</span>
+            </div>
+            <div className="sync-status-item">
+              <label>Last Backup</label>
+              <span>
+                {backingUpImages || restoringImages ? (
+                  <a href="#" className="job-link-active" onClick={(e) => { e.preventDefault(); if (onNavigateToJobs) onNavigateToJobs('image_backup'); }}>Active</a>
+                ) : imageBackup?.lastBackup ? (
+                  <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); if (onNavigateToJobs) onNavigateToJobs('image_backup'); }}>{formatDate(imageBackup.lastBackup)}</a>
+                ) : 'Never'}
+              </span>
+            </div>
+          </div>
+
+          <div className="sync-buttons-grid">
+            <div className="sync-button-card">
+              <button
+                className="sync-btn push-btn"
+                onClick={handleImageBackup}
+                disabled={anyBusy || !syncStatus?.drive_access_verified}
+              >
+                {backingUpImages ? 'Backing up...' : 'Backup'}
+              </button>
+              <p className="button-description">Sync DB + media files to Drive</p>
+              {actionJobLinks.img_backup && onNavigateToJobs && (
+                <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); onNavigateToJobs(actionJobLinks.img_backup); }}>
+                  View in Jobs &rarr;
+                </a>
+              )}
+            </div>
+            <div className="sync-button-card">
+              <button
+                className="sync-btn pull-btn"
+                onClick={handleImageRestore}
+                disabled={anyBusy || !syncStatus?.drive_access_verified}
+              >
+                {restoringImages ? 'Restoring...' : 'Restore'}
+              </button>
+              <p className="button-description">Pull images from Drive to image server</p>
+              {actionJobLinks.img_restore && onNavigateToJobs && (
+                <a href="#" className="job-link-inline" onClick={(e) => { e.preventDefault(); onNavigateToJobs(actionJobLinks.img_restore); }}>
+                  View in Jobs &rarr;
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
 
       {/* Danger Zone */}
       <div className="danger-zone">

--- a/run.sh
+++ b/run.sh
@@ -5,21 +5,21 @@ BASE_IMAGE_NAME="quay.io/crunchtools/rotv-base"
 IMAGE_NAME="quay.io/crunchtools/rotv"
 CONTAINER_NAME="rotv"
 
-# Development uses ephemeral storage (tmpfs) - data is thrown away on restart
-# Production should set PERSISTENT_DATA=true and DATA_DIR=/path/to/storage
-USE_PERSISTENT="${PERSISTENT_DATA:-false}"
-DATA_DIR="${DATA_DIR:-$HOME/.rotv/pgdata}"
-SEED_DATA_FILE="$HOME/.rotv/seed-data.sql"
-PRODUCTION_HOST="${PRODUCTION_HOST:-lotor.dc3.crunchtools.com}"
-PRODUCTION_PORT="${PRODUCTION_PORT:-22422}"
-PRODUCTION_CONTAINER="${PRODUCTION_CONTAINER:-rootsofthevalley.org}"
-
 # Load environment variables from .env file if it exists
 if [ -f ".env" ]; then
     export $(grep -v '^#' .env | xargs)
 elif [ -f "backend/.env" ]; then
     export $(grep -v '^#' backend/.env | xargs)
 fi
+
+# Development uses ephemeral storage (tmpfs) - data is thrown away on restart
+# Set PERSISTENT_DATA=true in .env or environment to persist across restarts
+USE_PERSISTENT="${PERSISTENT_DATA:-false}"
+DATA_DIR="${DATA_DIR:-$HOME/.rotv/pgdata}"
+SEED_DATA_FILE="$HOME/.rotv/seed-data.sql"
+PRODUCTION_HOST="${PRODUCTION_HOST:-lotor.dc3.crunchtools.com}"
+PRODUCTION_PORT="${PRODUCTION_PORT:-22422}"
+PRODUCTION_CONTAINER="${PRODUCTION_CONTAINER:-rootsofthevalley.org}"
 
 # Build environment variable arguments for podman
 ENV_ARGS=""
@@ -33,6 +33,9 @@ ENV_ARGS=""
 [ -n "$FACEBOOK_APP_SECRET" ] && ENV_ARGS="$ENV_ARGS -e FACEBOOK_APP_SECRET=$FACEBOOK_APP_SECRET"
 [ -n "$ADMIN_EMAIL" ] && ENV_ARGS="$ENV_ARGS -e ADMIN_EMAIL=$ADMIN_EMAIL"
 [ -n "$MCP_ADMIN_TOKEN" ] && ENV_ARGS="$ENV_ARGS -e MCP_ADMIN_TOKEN=$MCP_ADMIN_TOKEN"
+[ -n "$PGUSER" ] && ENV_ARGS="$ENV_ARGS -e PGUSER=$PGUSER"
+[ -n "$PGPASSWORD" ] && ENV_ARGS="$ENV_ARGS -e PGPASSWORD=$PGPASSWORD"
+[ -n "$PGDATABASE" ] && ENV_ARGS="$ENV_ARGS -e PGDATABASE=$PGDATABASE"
 
 case "${1:-help}" in
     build-base)
@@ -153,6 +156,9 @@ TWITTER_USERNAME=$TWITTER_USERNAME
 TWITTER_PASSWORD=$TWITTER_PASSWORD
 IMAGE_SERVER_URL=$IMAGE_SERVER_URL
 MCP_ADMIN_TOKEN=$MCP_ADMIN_TOKEN
+PGUSER=${PGUSER:-rotv}
+PGPASSWORD=${PGPASSWORD:-rotv}
+PGDATABASE=${PGDATABASE:-rotv}
 ENVFILE
 
         # Build MCP port mapping if token is configured


### PR DESCRIPTION
## Summary

- **Jobs tab**: 9 job cards with live progress, cron editor, prompt templates, expandable log history — single pane for all job operations
- **Data Collection tab**: stripped to config-only (AI providers, credentials, moderation settings)
- **Google tab**: Last Backup dates link to Jobs tab; persistent dev storage via `PERSISTENT_DATA=true`
- **Moderation tab**: search bar for filtering by title/description; fixed edit/save crash; Fix Date extracts dates from HTML metadata before falling back to Gemini
- **Comprehensive job logging**: all data operations (backup, restore, moderation scoring, Fix Date/URL, research, cleanup, purge) log to `job_logs` with unique `runId` and `{completed: true}` markers
- **MCP server**: `job_list` covers all job types; `job_logs` includes research/cleanup types
- **run.sh**: `.env` loaded before `PERSISTENT_DATA` check; PG vars passed to dev container; test env uses container defaults

### Bug fixes
- `editAndPublish` unused `$1` parameter crash when saving without publishing
- Empty date strings → null for timestamp columns
- Job history status inference uses completion markers instead of time-based heuristic
- `pillActive` undefined reference in Moderation create form
- Test container `PGUSER` mismatch causing all UI tests to fail

Closes #101

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 216/216 tests pass, 16 test files
- [ ] Verify Jobs tab shows all 9 cards with correct schedules
- [ ] Run database backup from Google tab, verify logs appear in Jobs tab
- [ ] Fix Date on a moderation item, verify HTML metadata extraction works
- [ ] Edit and save a moderation item
- [ ] Search moderation queue by keyword
- [ ] Persistent login survives `./run.sh stop && ./run.sh start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)