### PR TITLE
fix: add expand chevrons to jobs log entries

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12606,6 +12606,31 @@ svg.leaflet-zoom-animated {
   background: #fffaf0;
 }
 
+.job-log-entry.has-details:hover {
+  background: #edf2f7;
+}
+
+.job-log-entry.has-details.error:hover {
+  background: #fee2e2;
+}
+
+.job-log-entry.has-details.warn:hover {
+  background: #fef3c7;
+}
+
+.log-expand-icon {
+  display: inline-block;
+  width: 12px;
+  font-size: 0.7rem;
+  color: #718096;
+  margin-top: 2px;
+  text-align: center;
+}
+
+.job-log-entry.has-details:hover .log-expand-icon {
+  color: #2d3748;
+}
+
 .log-level-dot {
   display: inline-block;
   width: 8px;

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -648,10 +648,13 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
                                     ) : (
                                       <div className="job-logs-scroll">
                                         {runLogs.map(entry => (
-                                          <div key={entry.id} className={`job-log-entry ${entry.level}`}
+                                          <div key={entry.id} className={`job-log-entry ${entry.level}${entry.details ? ' has-details' : ''}${logDetailsExpanded.has(entry.id) ? ' expanded' : ''}`}
                                             onClick={(e) => { e.stopPropagation(); if (entry.details) toggleLogDetails(entry.id); }}
                                             style={{ cursor: entry.details ? 'pointer' : 'default' }}>
-                                            <span className={`log-level-dot ${entry.level}`}></span>
+                                            {entry.details
+                                              ? <span className="log-expand-icon">{logDetailsExpanded.has(entry.id) ? '▾' : '▸'}</span>
+                                              : <span className={`log-level-dot ${entry.level}`}></span>
+                                            }
                                             <span className="log-poi">{entry.poi_name || '--'}</span>
                                             <span className="log-message">{entry.message}</span>
                                             <span className="log-time">{formatTime(entry.created_at)}</span>


### PR DESCRIPTION
## Summary
- Log entries with details now show **▸/▾ chevrons** instead of the colored level dot, making it immediately obvious which rows are expandable
- Entries without details keep the plain colored dot (info/warn/error)
- Hover highlight added for expandable rows (subtle background shift)

## Test plan
- [x] Build succeeds
- [x] Visual verification in browser — chevrons appear on expandable entries, dots on non-expandable
- [ ] Verify hover state works on expandable entries
- [ ] Verify chevron toggles between ▸ and ▾ on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)