### PR TITLE
fix: set image_drive_file_id when accepting hero image

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -708,6 +708,12 @@ export function createAdminRouter(pool) {
         console.log(`[Hero Image] Deleted old primary asset ${existingPrimary.id} for POI ${sanitizedPoiId}`);
       }
 
+      // Set image_drive_file_id so frontend knows a primary image exists
+      await pool.query(
+        "UPDATE pois SET image_drive_file_id = 'image-server', updated_at = NOW() WHERE id = $1",
+        [sanitizedPoiId]
+      );
+
       console.log(`Admin ${req.user.email} accepted hero image for POI ${sanitizedPoiId}: asset ${uploadResult.assetId}`);
       res.json({ success: true, assetId: uploadResult.assetId });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Accept-hero-image endpoint now sets `image_drive_file_id = 'image-server'` on the POI after successful upload
- Without this, generated hero images were invisible — the frontend checks this field as the "has image" flag across Sidebar, Map tooltips, ResultsTile, and ThumbnailCarousel

Closes #99

## Test plan
- [ ] Generate hero image for a POI with no existing image
- [ ] Accept the image
- [ ] Verify image appears in sidebar, map tooltip, and results tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)