### PR TITLE
Skip auto hero image generation when POI already has one

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -605,8 +605,8 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       setDraftFieldStates(initialStates);
       setShowDraftModal(true);
 
-      // Auto-start hero image generation concurrently
-      if (destination?.id) {
+      // Auto-start hero image generation only if POI has no primary image
+      if (destination?.id && !editedData.has_primary_image) {
         setGeneratingHeroImage(true);
         fetch('/api/admin/ai/generate-hero-image', {
           method: 'POST',


### PR DESCRIPTION
## Summary
- AI research was auto-generating a hero image for every POI, even ones that already had a primary image
- Now only auto-generates when `has_primary_image` is false
- The manual "Regenerate" button in the draft modal still works for admins who want to replace an existing image

## Test plan
- [ ] Run AI research on a POI **with** a primary image — no hero image auto-generated
- [ ] Run AI research on a POI **without** a primary image — hero image auto-generates as before
- [ ] Click "Regenerate" in draft modal — still works regardless of existing image
- [ ] Accept regenerated image — edit page updates immediately with new thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)