### PR TITLE
Fix broken POI images and add development proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Development image proxy**: Localhost now proxies images from production when IMAGE_SERVER_URL is not configured
   - Allows viewing actual POI images during local development
-  - Falls back to production ROTV thumbnail endpoint
+  - Falls back to production asset endpoint for thumbnails
   - Only active when NODE_ENV=test or NODE_ENV=development
 
 ### Fixed
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Images existed on image server but missing poi_media linking records
   - Created migration to sync East Rim, Hampton Hills, Ohio & Erie Canal, Reagan-Huffman, Bedford Reserve, Royalview, and West Creek trailheads
   - All MTB trail images now display correctly
+- **Orphaned gallery images**: Promoted 37 gallery images to primary when no primary existed
+  - Red Lock Trailhead, Stanford Trail, Hampton Hills locations, and 34 others were showing broken images
+  - These images were incorrectly marked as 'gallery' during Immich restore migration
+  - Created migration to promote sole gallery images to primary role
+  - Updated has_primary_image flags for all affected POIs
+  - All 37 POIs now display thumbnails correctly in Results, Map, and Sidebar
 
 ## [1.31.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken image icons**: Fixed POIs showing broken image icons when has_primary_image flag was stale
   - Added onError handler to hide broken images gracefully (Sidebar destinations and linear features)
   - Added onError handler to Results tab tile thumbnails (falls back to default SVG icons)
-  - Added onError handler to Map tooltip thumbnails (hides broken images in map popups)
+  - Added onError handler to Map tooltip thumbnails (JSX and HTML string tooltips)
+  - Fixed HTML string tooltips for linear features using inline onerror attribute
   - Created migration to clean up 400 stale has_primary_image flags
   - Database now consistent: 60 POIs with flag match 60 POIs with actual images (53 + 7 MTB trails)
   - Fixed missing showImage prop in EditView for linear features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken image icons**: Fixed POIs showing broken image icons when has_primary_image flag was stale
   - Added onError handler to hide broken images gracefully (Sidebar destinations and linear features)
   - Added onError handler to Results tab tile thumbnails (falls back to default SVG icons)
+  - Added onError handler to Map tooltip thumbnails (hides broken images in map popups)
   - Created migration to clean up 400 stale has_primary_image flags
   - Database now consistent: 60 POIs with flag match 60 POIs with actual images (53 + 7 MTB trails)
   - Fixed missing showImage prop in EditView for linear features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed image server upload endpoint constraint violations
   - Corrected poi_media schema usage (role vs is_primary)
   - Migration checks both ROTV and image server databases for existing primaries
+- **Broken image icons**: Fixed POIs showing broken image icons when has_primary_image flag was stale
+  - Added onError handler to hide broken images gracefully (destinations and linear features)
+  - Created migration to clean up 400 stale has_primary_image flags
+  - Database now consistent: 53 POIs with flag match 53 POIs with actual images
+  - Fixed missing showImage prop in EditView for linear features
 
 ## [1.31.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added onError handler to hide broken images gracefully (Sidebar destinations and linear features)
   - Added onError handler to Results tab tile thumbnails (falls back to default SVG icons)
   - Created migration to clean up 400 stale has_primary_image flags
-  - Database now consistent: 53 POIs with flag match 53 POIs with actual images
+  - Database now consistent: 60 POIs with flag match 60 POIs with actual images (53 + 7 MTB trails)
   - Fixed missing showImage prop in EditView for linear features
+- **MTB trail images**: Synced 7 MTB trail images from image server to ROTV database
+  - Images existed on image server but missing poi_media linking records
+  - Created migration to sync East Rim, Hampton Hills, Ohio & Erie Canal, Reagan-Huffman, Bedford Reserve, Royalview, and West Creek trailheads
+  - All MTB trail images now display correctly
 
 ## [1.31.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Development image proxy**: Localhost now proxies images from production when IMAGE_SERVER_URL is not configured
+  - Allows viewing actual POI images during local development
+  - Falls back to production ROTV thumbnail endpoint
+  - Only active when NODE_ENV=test or NODE_ENV=development
+
 ### Fixed
 - **Image restoration**: Successfully restored 91 POI images from Immich backup (closes #200)
   - Fixed image server upload endpoint constraint violations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Corrected poi_media schema usage (role vs is_primary)
   - Migration checks both ROTV and image server databases for existing primaries
 - **Broken image icons**: Fixed POIs showing broken image icons when has_primary_image flag was stale
-  - Added onError handler to hide broken images gracefully (destinations and linear features)
+  - Added onError handler to hide broken images gracefully (Sidebar destinations and linear features)
+  - Added onError handler to Results tab tile thumbnails (falls back to default SVG icons)
   - Created migration to clean up 400 stale has_primary_image flags
   - Database now consistent: 53 POIs with flag match 53 POIs with actual images
   - Fixed missing showImage prop in EditView for linear features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added onError handler to hide broken images gracefully (Sidebar destinations and linear features)
   - Added onError handler to Results tab tile thumbnails (falls back to default SVG icons)
   - Added onError handler to Map tooltip thumbnails (JSX and HTML string tooltips)
+  - Added onError handler to Sidebar association item thumbnails (related POIs list)
   - Fixed HTML string tooltips for linear features using inline onerror attribute
   - Created migration to clean up 400 stale has_primary_image flags
   - Database now consistent: 60 POIs with flag match 60 POIs with actual images (53 + 7 MTB trails)

--- a/backend/migrations/fix-has-primary-image-flags.js
+++ b/backend/migrations/fix-has-primary-image-flags.js
@@ -1,0 +1,75 @@
+/**
+ * Fix has_primary_image flags to match actual poi_media data
+ *
+ * Issue: 453 POIs have has_primary_image=true but only 53 actually have images
+ * This script clears the flag for POIs without actual primary images
+ */
+
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  port: parseInt(process.env.PGPORT || '5432'),
+  database: process.env.PGDATABASE || 'rotv',
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD
+});
+
+async function main() {
+  console.log('Fixing has_primary_image flags...\n');
+
+  // Count POIs with stale flags
+  const staleCount = await pool.query(`
+    SELECT COUNT(*)
+    FROM pois
+    WHERE has_primary_image = true
+      AND id NOT IN (
+        SELECT DISTINCT poi_id
+        FROM poi_media
+        WHERE role = 'primary'
+          AND moderation_status IN ('published', 'auto_approved')
+      )
+  `);
+
+  console.log(`Found ${staleCount.rows[0].count} POIs with stale has_primary_image flags`);
+
+  if (staleCount.rows[0].count > 0) {
+    // Clear stale flags
+    const result = await pool.query(`
+      UPDATE pois
+      SET has_primary_image = false
+      WHERE has_primary_image = true
+        AND id NOT IN (
+          SELECT DISTINCT poi_id
+          FROM poi_media
+          WHERE role = 'primary'
+            AND moderation_status IN ('published', 'auto_approved')
+        )
+    `);
+
+    console.log(`✓ Cleared ${result.rowCount} stale flags\n`);
+  }
+
+  // Verify counts match
+  const poisWithFlag = await pool.query('SELECT COUNT(*) FROM pois WHERE has_primary_image = true');
+  const poisWithImage = await pool.query(`
+    SELECT COUNT(DISTINCT poi_id)
+    FROM poi_media
+    WHERE role = 'primary'
+      AND moderation_status IN ('published', 'auto_approved')
+  `);
+
+  console.log('=== Verification ===');
+  console.log(`POIs with has_primary_image=true: ${poisWithFlag.rows[0].count}`);
+  console.log(`POIs with actual primary images: ${poisWithImage.rows[0].count}`);
+  console.log(`Match: ${poisWithFlag.rows[0].count === poisWithImage.rows[0].count ? '✓' : '✗'}`);
+
+  await pool.end();
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  pool.end();
+  process.exit(1);
+});

--- a/backend/migrations/fix-has-primary-image-flags.js
+++ b/backend/migrations/fix-has-primary-image-flags.js
@@ -16,44 +16,34 @@ const pool = new Pool({
   password: process.env.PGPASSWORD
 });
 
-async function main() {
-  console.log('Fixing has_primary_image flags...\n');
+console.log('Fixing has_primary_image flags...\n');
 
-  // Clear stale flags (UPDATE returns row count, no need for separate COUNT query)
-  const result = await pool.query(`
-    UPDATE pois
-    SET has_primary_image = false
-    WHERE has_primary_image = true
-      AND id NOT IN (
-        SELECT DISTINCT poi_id
-        FROM poi_media
-        WHERE role = 'primary'
-          AND moderation_status IN ('published', 'auto_approved')
-      )
-  `);
+const clearedStaleFlags = await pool.query(`
+  UPDATE pois
+  SET has_primary_image = false
+  WHERE has_primary_image = true
+    AND id NOT IN (
+      SELECT DISTINCT poi_id
+      FROM poi_media
+      WHERE role = 'primary'
+        AND moderation_status IN ('published', 'auto_approved')
+    )
+`);
 
-  console.log(`Found ${result.rowCount} POIs with stale has_primary_image flags`);
-  console.log(`✓ Cleared ${result.rowCount} stale flags\n`);
+console.log(`Found ${clearedStaleFlags.rowCount} POIs with stale has_primary_image flags`);
+console.log(`✓ Cleared ${clearedStaleFlags.rowCount} stale flags\n`);
 
-  // Verify counts match
-  const poisWithFlag = await pool.query('SELECT COUNT(*) FROM pois WHERE has_primary_image = true');
-  const poisWithImage = await pool.query(`
-    SELECT COUNT(DISTINCT poi_id)
-    FROM poi_media
-    WHERE role = 'primary'
-      AND moderation_status IN ('published', 'auto_approved')
-  `);
+const poisWithFlag = await pool.query('SELECT COUNT(*) FROM pois WHERE has_primary_image = true');
+const poisWithImage = await pool.query(`
+  SELECT COUNT(DISTINCT poi_id)
+  FROM poi_media
+  WHERE role = 'primary'
+    AND moderation_status IN ('published', 'auto_approved')
+`);
 
-  console.log('=== Verification ===');
-  console.log(`POIs with has_primary_image=true: ${poisWithFlag.rows[0].count}`);
-  console.log(`POIs with actual primary images: ${poisWithImage.rows[0].count}`);
-  console.log(`Match: ${poisWithFlag.rows[0].count === poisWithImage.rows[0].count ? '✓' : '✗'}`);
+console.log('=== Verification ===');
+console.log(`POIs with has_primary_image=true: ${poisWithFlag.rows[0].count}`);
+console.log(`POIs with actual primary images: ${poisWithImage.rows[0].count}`);
+console.log(`Match: ${poisWithFlag.rows[0].count === poisWithImage.rows[0].count ? '✓' : '✗'}`);
 
-  await pool.end();
-}
-
-main().catch(error => {
-  console.error('Fatal error:', error);
-  pool.end();
-  process.exit(1);
-});
+await pool.end();

--- a/backend/migrations/fix-has-primary-image-flags.js
+++ b/backend/migrations/fix-has-primary-image-flags.js
@@ -19,10 +19,10 @@ const pool = new Pool({
 async function main() {
   console.log('Fixing has_primary_image flags...\n');
 
-  // Count POIs with stale flags
-  const staleCount = await pool.query(`
-    SELECT COUNT(*)
-    FROM pois
+  // Clear stale flags (UPDATE returns row count, no need for separate COUNT query)
+  const result = await pool.query(`
+    UPDATE pois
+    SET has_primary_image = false
     WHERE has_primary_image = true
       AND id NOT IN (
         SELECT DISTINCT poi_id
@@ -32,24 +32,8 @@ async function main() {
       )
   `);
 
-  console.log(`Found ${staleCount.rows[0].count} POIs with stale has_primary_image flags`);
-
-  if (staleCount.rows[0].count > 0) {
-    // Clear stale flags
-    const result = await pool.query(`
-      UPDATE pois
-      SET has_primary_image = false
-      WHERE has_primary_image = true
-        AND id NOT IN (
-          SELECT DISTINCT poi_id
-          FROM poi_media
-          WHERE role = 'primary'
-            AND moderation_status IN ('published', 'auto_approved')
-        )
-    `);
-
-    console.log(`✓ Cleared ${result.rowCount} stale flags\n`);
-  }
+  console.log(`Found ${result.rowCount} POIs with stale has_primary_image flags`);
+  console.log(`✓ Cleared ${result.rowCount} stale flags\n`);
 
   // Verify counts match
   const poisWithFlag = await pool.query('SELECT COUNT(*) FROM pois WHERE has_primary_image = true');

--- a/backend/migrations/promote-orphaned-gallery-images.js
+++ b/backend/migrations/promote-orphaned-gallery-images.js
@@ -1,0 +1,95 @@
+/**
+ * Promote orphaned gallery images to primary
+ *
+ * Issue: 37 POIs have gallery images but no primary images (from Immich restore)
+ * These POIs have has_primary_image=false but have a gallery image
+ * Since there's only one image, promote it to primary
+ */
+
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  port: parseInt(process.env.PGPORT || '5432'),
+  database: process.env.PGDATABASE || 'rotv',
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD
+});
+
+async function main() {
+  console.log('Promoting orphaned gallery images to primary...\n');
+
+  // Find POIs with gallery images but no primary images
+  const orphanedGallery = await pool.query(`
+    SELECT p.id, p.name, pm.id as media_id, pm.image_server_asset_id
+    FROM pois p
+    JOIN poi_media pm ON p.id = pm.poi_id
+    WHERE p.has_primary_image = false
+      AND pm.role = 'gallery'
+      AND pm.moderation_status IN ('published', 'auto_approved')
+      AND NOT EXISTS (
+        SELECT 1 FROM poi_media pm2
+        WHERE pm2.poi_id = p.id
+          AND pm2.role = 'primary'
+          AND pm2.moderation_status IN ('published', 'auto_approved')
+      )
+    ORDER BY p.id
+  `);
+
+  console.log(`Found ${orphanedGallery.rows.length} POIs with orphaned gallery images\n`);
+
+  let promoted = 0;
+  let flagged = 0;
+
+  for (const row of orphanedGallery.rows) {
+    // Promote gallery to primary
+    await pool.query(`
+      UPDATE poi_media
+      SET role = 'primary'
+      WHERE id = $1
+    `, [row.media_id]);
+
+    console.log(`[PROMOTE] ${row.name} (POI ${row.id}) - asset ${row.image_server_asset_id} promoted to primary`);
+    promoted++;
+
+    // Set has_primary_image flag
+    await pool.query(`
+      UPDATE pois
+      SET has_primary_image = true
+      WHERE id = $1 AND has_primary_image = false
+    `, [row.id]);
+
+    flagged++;
+  }
+
+  console.log('\n=== Summary ===');
+  console.log(`Promoted: ${promoted} gallery images to primary`);
+  console.log(`Updated: ${flagged} has_primary_image flags`);
+
+  // Verification
+  const verification = await pool.query(`
+    SELECT COUNT(*) as orphaned_count
+    FROM pois p
+    JOIN poi_media pm ON p.id = pm.poi_id
+    WHERE p.has_primary_image = false
+      AND pm.role = 'gallery'
+      AND pm.moderation_status IN ('published', 'auto_approved')
+      AND NOT EXISTS (
+        SELECT 1 FROM poi_media pm2
+        WHERE pm2.poi_id = p.id
+          AND pm2.role = 'primary'
+          AND pm2.moderation_status IN ('published', 'auto_approved')
+      )
+  `);
+
+  console.log(`\nRemaining orphaned gallery images: ${verification.rows[0].orphaned_count} (should be 0)`);
+
+  await pool.end();
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  pool.end();
+  process.exit(1);
+});

--- a/backend/migrations/promote-orphaned-gallery-images.js
+++ b/backend/migrations/promote-orphaned-gallery-images.js
@@ -17,95 +17,81 @@ const pool = new Pool({
   password: process.env.PGPASSWORD
 });
 
-async function main() {
-  console.log('Promoting orphaned gallery images to primary...\n');
+console.log('Promoting orphaned gallery images to primary...\n');
 
-  // Find POIs with gallery images but no primary images
-  // Use DISTINCT ON to select only the first gallery image per POI (by created_at)
-  const orphanedGallery = await pool.query(`
-    SELECT DISTINCT ON (p.id)
-           p.id, p.name, pm.id as media_id, pm.image_server_asset_id
-    FROM pois p
-    JOIN poi_media pm ON p.id = pm.poi_id
-    WHERE p.has_primary_image = false
-      AND pm.role = 'gallery'
-      AND pm.moderation_status IN ('published', 'auto_approved')
-      AND NOT EXISTS (
-        SELECT 1 FROM poi_media pm2
-        WHERE pm2.poi_id = p.id
-          AND pm2.role = 'primary'
-          AND pm2.moderation_status IN ('published', 'auto_approved')
-      )
-    ORDER BY p.id, pm.created_at ASC
-  `);
+const orphanedGallery = await pool.query(`
+  SELECT DISTINCT ON (p.id)
+         p.id, p.name, pm.id as media_id, pm.image_server_asset_id
+  FROM pois p
+  JOIN poi_media pm ON p.id = pm.poi_id
+  WHERE p.has_primary_image = false
+    AND pm.role = 'gallery'
+    AND pm.moderation_status IN ('published', 'auto_approved')
+    AND NOT EXISTS (
+      SELECT 1 FROM poi_media pm2
+      WHERE pm2.poi_id = p.id
+        AND pm2.role = 'primary'
+        AND pm2.moderation_status IN ('published', 'auto_approved')
+    )
+  ORDER BY p.id, pm.created_at ASC
+`);
 
-  console.log(`Found ${orphanedGallery.rows.length} POIs with orphaned gallery images\n`);
+console.log(`Found ${orphanedGallery.rows.length} POIs with orphaned gallery images\n`);
 
-  let promoted = 0;
-  let flagged = 0;
+let promoted = 0;
+let flagged = 0;
 
-  // Use transactions to ensure data consistency
-  const client = await pool.connect();
-  try {
-    for (const row of orphanedGallery.rows) {
-      await client.query('BEGIN');
+const client = await pool.connect();
+try {
+  for (const row of orphanedGallery.rows) {
+    await client.query('BEGIN');
 
-      try {
-        // Promote gallery to primary
-        await client.query(`
-          UPDATE poi_media
-          SET role = 'primary'
-          WHERE id = $1
-        `, [row.media_id]);
+    try {
+      await client.query(`
+        UPDATE poi_media
+        SET role = 'primary'
+        WHERE id = $1
+      `, [row.media_id]);
 
-        // Set has_primary_image flag
-        await client.query(`
-          UPDATE pois
-          SET has_primary_image = true
-          WHERE id = $1 AND has_primary_image = false
-        `, [row.id]);
+      await client.query(`
+        UPDATE pois
+        SET has_primary_image = true
+        WHERE id = $1 AND has_primary_image = false
+      `, [row.id]);
 
-        await client.query('COMMIT');
+      await client.query('COMMIT');
 
-        console.log(`[PROMOTE] ${row.name} (POI ${row.id}) - asset ${row.image_server_asset_id} promoted to primary`);
-        promoted++;
-        flagged++;
-      } catch (error) {
-        await client.query('ROLLBACK');
-        console.error(`[ERROR] Failed to promote ${row.name} (POI ${row.id}):`, error.message);
-      }
+      console.log(`[PROMOTE] ${row.name} (POI ${row.id}) - asset ${row.image_server_asset_id} promoted to primary`);
+      promoted++;
+      flagged++;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      console.error(`[ERROR] Failed to promote ${row.name} (POI ${row.id}):`, error.message);
     }
-  } finally {
-    client.release();
   }
-
-  console.log('\n=== Summary ===');
-  console.log(`Promoted: ${promoted} gallery images to primary`);
-  console.log(`Updated: ${flagged} has_primary_image flags`);
-
-  // Verification
-  const verification = await pool.query(`
-    SELECT COUNT(*) as orphaned_count
-    FROM pois p
-    JOIN poi_media pm ON p.id = pm.poi_id
-    WHERE p.has_primary_image = false
-      AND pm.role = 'gallery'
-      AND pm.moderation_status IN ('published', 'auto_approved')
-      AND NOT EXISTS (
-        SELECT 1 FROM poi_media pm2
-        WHERE pm2.poi_id = p.id
-          AND pm2.role = 'primary'
-          AND pm2.moderation_status IN ('published', 'auto_approved')
-      )
-  `);
-
-  console.log(`\nRemaining orphaned gallery images: ${verification.rows[0].orphaned_count} (should be 0)`);
-
-  await pool.end();
+} finally {
+  client.release();
 }
 
-main().catch(error => {
-  console.error('Fatal error:', error);
-  pool.end();
-  process.exit(1);
-});
+console.log('\n=== Summary ===');
+console.log(`Promoted: ${promoted} gallery images to primary`);
+console.log(`Updated: ${flagged} has_primary_image flags`);
+
+const verification = await pool.query(`
+  SELECT COUNT(*) as orphaned_count
+  FROM pois p
+  JOIN poi_media pm ON p.id = pm.poi_id
+  WHERE p.has_primary_image = false
+    AND pm.role = 'gallery'
+    AND pm.moderation_status IN ('published', 'auto_approved')
+    AND NOT EXISTS (
+      SELECT 1 FROM poi_media pm2
+      WHERE pm2.poi_id = p.id
+        AND pm2.role = 'primary'
+        AND pm2.moderation_status IN ('published', 'auto_approved')
+    )
+`);
+
+console.log(`\nRemaining orphaned gallery images: ${verification.rows[0].orphaned_count} (should be 0)`);
+
+await pool.end();

--- a/backend/migrations/promote-orphaned-gallery-images.js
+++ b/backend/migrations/promote-orphaned-gallery-images.js
@@ -21,8 +21,10 @@ async function main() {
   console.log('Promoting orphaned gallery images to primary...\n');
 
   // Find POIs with gallery images but no primary images
+  // Use DISTINCT ON to select only the first gallery image per POI (by created_at)
   const orphanedGallery = await pool.query(`
-    SELECT p.id, p.name, pm.id as media_id, pm.image_server_asset_id
+    SELECT DISTINCT ON (p.id)
+           p.id, p.name, pm.id as media_id, pm.image_server_asset_id
     FROM pois p
     JOIN poi_media pm ON p.id = pm.poi_id
     WHERE p.has_primary_image = false
@@ -34,7 +36,7 @@ async function main() {
           AND pm2.role = 'primary'
           AND pm2.moderation_status IN ('published', 'auto_approved')
       )
-    ORDER BY p.id
+    ORDER BY p.id, pm.created_at ASC
   `);
 
   console.log(`Found ${orphanedGallery.rows.length} POIs with orphaned gallery images\n`);
@@ -42,25 +44,39 @@ async function main() {
   let promoted = 0;
   let flagged = 0;
 
-  for (const row of orphanedGallery.rows) {
-    // Promote gallery to primary
-    await pool.query(`
-      UPDATE poi_media
-      SET role = 'primary'
-      WHERE id = $1
-    `, [row.media_id]);
+  // Use transactions to ensure data consistency
+  const client = await pool.connect();
+  try {
+    for (const row of orphanedGallery.rows) {
+      await client.query('BEGIN');
 
-    console.log(`[PROMOTE] ${row.name} (POI ${row.id}) - asset ${row.image_server_asset_id} promoted to primary`);
-    promoted++;
+      try {
+        // Promote gallery to primary
+        await client.query(`
+          UPDATE poi_media
+          SET role = 'primary'
+          WHERE id = $1
+        `, [row.media_id]);
 
-    // Set has_primary_image flag
-    await pool.query(`
-      UPDATE pois
-      SET has_primary_image = true
-      WHERE id = $1 AND has_primary_image = false
-    `, [row.id]);
+        // Set has_primary_image flag
+        await client.query(`
+          UPDATE pois
+          SET has_primary_image = true
+          WHERE id = $1 AND has_primary_image = false
+        `, [row.id]);
 
-    flagged++;
+        await client.query('COMMIT');
+
+        console.log(`[PROMOTE] ${row.name} (POI ${row.id}) - asset ${row.image_server_asset_id} promoted to primary`);
+        promoted++;
+        flagged++;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        console.error(`[ERROR] Failed to promote ${row.name} (POI ${row.id}):`, error.message);
+      }
+    }
+  } finally {
+    client.release();
   }
 
   console.log('\n=== Summary ===');

--- a/backend/migrations/restore-from-immich.js
+++ b/backend/migrations/restore-from-immich.js
@@ -20,135 +20,112 @@ const pool = new Pool({
   password: process.env.PGPASSWORD
 });
 
-// Initialize image server client
 imageServerClient.initialize();
 
-function extractPoiId(filename) {
-  const match = filename.match(/^poi-(\d+)-/);
-  return match ? parseInt(match[1]) : null;
-}
+console.log('Starting POI image restoration from Immich backup...\n');
 
-function convertToBackupPath(immichPath) {
+const csvContent = fs.readFileSync(CSV_FILE, 'utf-8');
+const lines = csvContent.trim().split('\n');
+
+console.log(`Found ${lines.length} images to restore\n`);
+
+const existingPrimaries = await pool.query(`
+  SELECT DISTINCT poi_id
+  FROM poi_media
+  WHERE role = 'primary'
+    AND moderation_status IN ('published', 'auto_approved')
+`);
+const poisWithPrimary = new Set(existingPrimaries.rows.map(r => r.poi_id));
+console.log(`${poisWithPrimary.size} POIs have primary images in ROTV database`);
+
+const imageServerPrimaries = await imageServerClient.listAllAssets();
+for (const asset of imageServerPrimaries) {
+  if (asset.role === 'primary' && asset.poi_id) {
+    poisWithPrimary.add(asset.poi_id);
+  }
+}
+console.log(`${poisWithPrimary.size} POIs have primary images (ROTV + image server combined)\n`);
+
+const poiFirstImage = new Map();
+let successCount = 0;
+let skipCount = 0;
+let errorCount = 0;
+
+for (let i = 0; i < lines.length; i++) {
+  const [immichId, filename, immichPath] = lines[i].split(',');
+
+  const poiIdMatch = filename.match(/^poi-(\d+)-/);
+  const poiId = poiIdMatch ? parseInt(poiIdMatch[1]) : null;
+
+  if (!poiId) {
+    console.log(`[${i + 1}/${lines.length}] SKIP: Cannot extract POI ID from ${filename}`);
+    skipCount++;
+    continue;
+  }
+
   const relativePath = immichPath.replace('/usr/src/app/', '');
-  return `${BACKUP_BASE}/${relativePath}`;
-}
+  const backupPath = `${BACKUP_BASE}/${relativePath}`;
 
-async function main() {
-  console.log('Starting POI image restoration from Immich backup...\n');
-
-  const csvContent = fs.readFileSync(CSV_FILE, 'utf-8');
-  const lines = csvContent.trim().split('\n');
-
-  console.log(`Found ${lines.length} images to restore\n`);
-
-  // Check which POIs already have primary images in the ROTV database
-  const existingPrimaries = await pool.query(`
-    SELECT DISTINCT poi_id
-    FROM poi_media
-    WHERE role = 'primary'
-      AND moderation_status IN ('published', 'auto_approved')
-  `);
-  const poisWithPrimary = new Set(existingPrimaries.rows.map(r => r.poi_id));
-  console.log(`${poisWithPrimary.size} POIs have primary images in ROTV database`);
-
-  // Also check which POIs have primary images in the image server database
-  const imageServerPrimaries = await imageServerClient.listAllAssets();
-  for (const asset of imageServerPrimaries) {
-    if (asset.role === 'primary' && asset.poi_id) {
-      poisWithPrimary.add(asset.poi_id);
-    }
+  if (!fs.existsSync(backupPath)) {
+    console.log(`[${i + 1}/${lines.length}] ERROR: File not found: ${backupPath}`);
+    errorCount++;
+    continue;
   }
-  console.log(`${poisWithPrimary.size} POIs have primary images (ROTV + image server combined)\n`);
 
-  const poiFirstImage = new Map();
-  let successCount = 0;
-  let skipCount = 0;
-  let errorCount = 0;
+  console.log(`[${i + 1}/${lines.length}] Processing POI ${poiId}: ${filename}`);
 
-  for (let i = 0; i < lines.length; i++) {
-    const [immichId, filename, immichPath] = lines[i].split(',');
-    const poiId = extractPoiId(filename);
+  try {
+    const imageBuffer = fs.readFileSync(backupPath);
+    const mimeType = filename.endsWith('.png') ? 'image/png' : 'image/jpeg';
 
-    if (!poiId) {
-      console.log(`[${i + 1}/${lines.length}] SKIP: Cannot extract POI ID from ${filename}`);
-      skipCount++;
-      continue;
+    const role = (!poisWithPrimary.has(poiId) && !poiFirstImage.has(poiId)) ? 'primary' : 'gallery';
+
+    const uploadResult = await imageServerClient.uploadImage(
+      imageBuffer,
+      poiId,
+      role,
+      filename,
+      mimeType
+    );
+
+    if (!uploadResult.success) {
+      throw new Error(uploadResult.error);
     }
 
-    const backupPath = convertToBackupPath(immichPath);
+    console.log(`  ✓ Uploaded to image server: ${uploadResult.assetId} (role: ${role})`);
 
-    if (!fs.existsSync(backupPath)) {
-      console.log(`[${i + 1}/${lines.length}] ERROR: File not found: ${backupPath}`);
-      errorCount++;
-      continue;
-    }
+    await pool.query(`
+      INSERT INTO poi_media (poi_id, image_server_asset_id, media_type, role, moderation_status)
+      VALUES ($1, $2, 'image', $3, 'auto_approved')
+    `, [poiId, uploadResult.assetId, role]);
 
-    console.log(`[${i + 1}/${lines.length}] Processing POI ${poiId}: ${filename}`);
+    console.log(`  ✓ Created poi_media record (role: ${role})`);
 
-    try {
-      // Read the image file
-      const imageBuffer = fs.readFileSync(backupPath);
-      const mimeType = filename.endsWith('.png') ? 'image/png' : 'image/jpeg';
-
-      // Only set as primary if POI doesn't have one AND this is the first from Immich
-      const role = (!poisWithPrimary.has(poiId) && !poiFirstImage.has(poiId)) ? 'primary' : 'gallery';
-
-      // Upload to image server
-      const result = await imageServerClient.uploadImage(
-        imageBuffer,
-        poiId,
-        role,
-        filename,
-        mimeType
-      );
-
-      if (!result.success) {
-        throw new Error(result.error);
-      }
-
-      console.log(`  ✓ Uploaded to image server: ${result.assetId} (role: ${role})`);
-
-      // Create poi_media record
+    if (role === 'primary') {
       await pool.query(`
-        INSERT INTO poi_media (poi_id, image_server_asset_id, media_type, role, moderation_status)
-        VALUES ($1, $2, 'image', $3, 'auto_approved')
-      `, [poiId, result.assetId, role]);
-
-      console.log(`  ✓ Created poi_media record (role: ${role})`);
-
-      // Update POI has_primary_image flag if this is the first image
-      if (role === 'primary') {
-        await pool.query(`
-          UPDATE pois
-          SET has_primary_image = true
-          WHERE id = $1
-        `, [poiId]);
-        console.log(`  ✓ Updated POI ${poiId} has_primary_image=true`);
-        poiFirstImage.set(poiId, result.assetId);
-        poisWithPrimary.add(poiId);
-      }
-
-      successCount++;
-    } catch (error) {
-      console.error(`  ✗ Error: ${error.message}`);
-      errorCount++;
+        UPDATE pois
+        SET has_primary_image = true
+        WHERE id = $1
+      `, [poiId]);
+      console.log(`  ✓ Updated POI ${poiId} has_primary_image=true`);
+      poiFirstImage.set(poiId, uploadResult.assetId);
+      poisWithPrimary.add(poiId);
     }
 
-    console.log('');
+    successCount++;
+  } catch (error) {
+    console.error(`  ✗ Error: ${error.message}`);
+    errorCount++;
   }
 
-  console.log('\n=== Restoration Summary ===');
-  console.log(`Total images: ${lines.length}`);
-  console.log(`✓ Success: ${successCount}`);
-  console.log(`⊘ Skipped: ${skipCount}`);
-  console.log(`✗ Errors: ${errorCount}`);
-  console.log(`POIs updated: ${poiFirstImage.size}`);
-
-  await pool.end();
+  console.log('');
 }
 
-main().catch(error => {
-  console.error('Fatal error:', error);
-  pool.end();
-  process.exit(1);
-});
+console.log('\n=== Restoration Summary ===');
+console.log(`Total images: ${lines.length}`);
+console.log(`✓ Success: ${successCount}`);
+console.log(`⊘ Skipped: ${skipCount}`);
+console.log(`✗ Errors: ${errorCount}`);
+console.log(`POIs updated: ${poiFirstImage.size}`);
+
+await pool.end();

--- a/backend/migrations/sync-mtb-images.js
+++ b/backend/migrations/sync-mtb-images.js
@@ -1,0 +1,85 @@
+/**
+ * Sync MTB trail images from image server to ROTV database
+ *
+ * Issue: MTB trail images exist on image server but missing poi_media records in ROTV db
+ * This creates the linking records so images can be displayed.
+ */
+
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  port: parseInt(process.env.PGPORT || '5432'),
+  database: process.env.PGDATABASE || 'rotv',
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD
+});
+
+// MTB trail POI IDs and their corresponding image server asset IDs
+const mtbImages = [
+  { poi_id: 5527, asset_id: 21, name: 'East Rim Trailhead' },
+  { poi_id: 5544, asset_id: 29, name: 'Hampton Hills Mountain Bike Trailhead' },
+  { poi_id: 5591, asset_id: 43, name: 'Ohio & Erie Canal Mountain Bike Trailhead' },
+  { poi_id: 5680, asset_id: 68, name: 'Reagan-Huffman Mountain Bike Trailhead' },
+  { poi_id: 5681, asset_id: 69, name: 'Bedford Reserve Mountain Bike Trailhead' },
+  { poi_id: 5682, asset_id: 70, name: 'Royalview Mountain Bike Trailhead' },
+  { poi_id: 5683, asset_id: 71, name: 'West Creek Mountain Bike Trailhead' }
+];
+
+async function main() {
+  console.log('Syncing MTB trail images from image server...\n');
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const { poi_id, asset_id, name } of mtbImages) {
+    // Check if poi_media record already exists
+    const existing = await pool.query(
+      'SELECT id FROM poi_media WHERE poi_id = $1 AND image_server_asset_id = $2',
+      [poi_id, asset_id]
+    );
+
+    if (existing.rows.length > 0) {
+      console.log(`[SKIP] ${name} - poi_media record already exists`);
+      skipped++;
+      continue;
+    }
+
+    // Create poi_media record
+    await pool.query(`
+      INSERT INTO poi_media (poi_id, image_server_asset_id, media_type, role, moderation_status)
+      VALUES ($1, $2, 'image', 'primary', 'auto_approved')
+    `, [poi_id, asset_id]);
+
+    console.log(`[CREATE] ${name} - created poi_media record (asset ${asset_id})`);
+    created++;
+
+    // Update has_primary_image flag
+    const result = await pool.query(`
+      UPDATE pois
+      SET has_primary_image = true
+      WHERE id = $1 AND has_primary_image = false
+      RETURNING id
+    `, [poi_id]);
+
+    if (result.rows.length > 0) {
+      console.log(`[UPDATE] ${name} - set has_primary_image=true`);
+      updated++;
+    }
+  }
+
+  console.log('\n=== Summary ===');
+  console.log(`Created: ${created} poi_media records`);
+  console.log(`Updated: ${updated} has_primary_image flags`);
+  console.log(`Skipped: ${skipped} (already synced)`);
+
+  await pool.end();
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  pool.end();
+  process.exit(1);
+});

--- a/backend/migrations/sync-mtb-images.js
+++ b/backend/migrations/sync-mtb-images.js
@@ -16,7 +16,6 @@ const pool = new Pool({
   password: process.env.PGPASSWORD
 });
 
-// MTB trail POI IDs and their corresponding image server asset IDs
 const mtbImages = [
   { poi_id: 5527, asset_id: 21, name: 'East Rim Trailhead' },
   { poi_id: 5544, asset_id: 29, name: 'Hampton Hills Mountain Bike Trailhead' },
@@ -27,59 +26,48 @@ const mtbImages = [
   { poi_id: 5683, asset_id: 71, name: 'West Creek Mountain Bike Trailhead' }
 ];
 
-async function main() {
-  console.log('Syncing MTB trail images from image server...\n');
+console.log('Syncing MTB trail images from image server...\n');
 
-  let created = 0;
-  let updated = 0;
-  let skipped = 0;
+let created = 0;
+let updated = 0;
+let skipped = 0;
 
-  for (const { poi_id, asset_id, name } of mtbImages) {
-    // Check if poi_media record already exists
-    const existing = await pool.query(
-      'SELECT id FROM poi_media WHERE poi_id = $1 AND image_server_asset_id = $2',
-      [poi_id, asset_id]
-    );
+for (const { poi_id, asset_id, name } of mtbImages) {
+  const existing = await pool.query(
+    'SELECT id FROM poi_media WHERE poi_id = $1 AND image_server_asset_id = $2',
+    [poi_id, asset_id]
+  );
 
-    if (existing.rows.length > 0) {
-      console.log(`[SKIP] ${name} - poi_media record already exists`);
-      skipped++;
-      continue;
-    }
-
-    // Create poi_media record
-    await pool.query(`
-      INSERT INTO poi_media (poi_id, image_server_asset_id, media_type, role, moderation_status)
-      VALUES ($1, $2, 'image', 'primary', 'auto_approved')
-    `, [poi_id, asset_id]);
-
-    console.log(`[CREATE] ${name} - created poi_media record (asset ${asset_id})`);
-    created++;
-
-    // Update has_primary_image flag
-    const result = await pool.query(`
-      UPDATE pois
-      SET has_primary_image = true
-      WHERE id = $1 AND has_primary_image = false
-      RETURNING id
-    `, [poi_id]);
-
-    if (result.rows.length > 0) {
-      console.log(`[UPDATE] ${name} - set has_primary_image=true`);
-      updated++;
-    }
+  if (existing.rows.length > 0) {
+    console.log(`[SKIP] ${name} - poi_media record already exists`);
+    skipped++;
+    continue;
   }
 
-  console.log('\n=== Summary ===');
-  console.log(`Created: ${created} poi_media records`);
-  console.log(`Updated: ${updated} has_primary_image flags`);
-  console.log(`Skipped: ${skipped} (already synced)`);
+  await pool.query(`
+    INSERT INTO poi_media (poi_id, image_server_asset_id, media_type, role, moderation_status)
+    VALUES ($1, $2, 'image', 'primary', 'auto_approved')
+  `, [poi_id, asset_id]);
 
-  await pool.end();
+  console.log(`[CREATE] ${name} - created poi_media record (asset ${asset_id})`);
+  created++;
+
+  const flagUpdate = await pool.query(`
+    UPDATE pois
+    SET has_primary_image = true
+    WHERE id = $1 AND has_primary_image = false
+    RETURNING id
+  `, [poi_id]);
+
+  if (flagUpdate.rows.length > 0) {
+    console.log(`[UPDATE] ${name} - set has_primary_image=true`);
+    updated++;
+  }
 }
 
-main().catch(error => {
-  console.error('Fatal error:', error);
-  pool.end();
-  process.exit(1);
-});
+console.log('\n=== Summary ===');
+console.log(`Created: ${created} poi_media records`);
+console.log(`Updated: ${updated} has_primary_image flags`);
+console.log(`Skipped: ${skipped} (already synced)`);
+
+await pool.end();

--- a/backend/server.js
+++ b/backend/server.js
@@ -995,15 +995,17 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
             return res.status(404).json({ error: 'Image not found' });
           }
 
-          const buffer = await productionResponse.arrayBuffer();
-          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
-
-          res.setHeader('Content-Type', contentType);
+          const contentType = productionResponse.headers.get('content-type');
+          if (contentType) {
+            res.setHeader('Content-Type', contentType);
+          }
           res.setHeader('Cache-Control', 'public, max-age=604800');
           res.setHeader('Access-Control-Allow-Origin', '*');
-          return res.send(Buffer.from(buffer));
+
+          // Stream response to avoid memory exhaustion (DoS prevention)
+          return productionResponse.body.pipe(res);
         } catch (fallbackError) {
-          console.error(`[Thumbnail] Production fallback failed for POI ${id}, asset ${assetId}:`, fallbackError);
+          console.error(`[Thumbnail] Production fallback failed for POI ${id}, asset ${assetId}:`, fallbackError.message);
           return res.status(404).json({ error: 'Image not found' });
         }
       }
@@ -1458,15 +1460,17 @@ app.get('/api/assets/:assetId/thumbnail', assetProxyLimiter, async (req, res) =>
             return res.status(statusCode).json({ error: message });
           }
 
-          const buffer = await productionResponse.arrayBuffer();
-          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
-
-          res.setHeader('Content-Type', contentType);
+          const contentType = productionResponse.headers.get('content-type');
+          if (contentType) {
+            res.setHeader('Content-Type', contentType);
+          }
           res.setHeader('Cache-Control', 'public, max-age=604800');
           res.setHeader('Access-Control-Allow-Origin', '*');
-          return res.send(Buffer.from(buffer));
+
+          // Stream response to avoid memory exhaustion (DoS prevention)
+          return productionResponse.body.pipe(res);
         } catch (fallbackError) {
-          console.error(`[Asset Thumbnail] Production fallback failed for asset ${assetId}:`, fallbackError);
+          console.error(`[Asset Thumbnail] Production fallback failed for asset ${assetId}:`, fallbackError.message);
           return res.status(503).json({ error: 'Image service unavailable' });
         }
       }
@@ -1522,15 +1526,17 @@ app.get('/api/assets/:assetId/original', assetProxyLimiter, async (req, res) => 
             return res.status(statusCode).json({ error: message });
           }
 
-          const buffer = await productionResponse.arrayBuffer();
-          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
-
-          res.setHeader('Content-Type', contentType);
+          const contentType = productionResponse.headers.get('content-type');
+          if (contentType) {
+            res.setHeader('Content-Type', contentType);
+          }
           res.setHeader('Cache-Control', 'public, max-age=86400');
           res.setHeader('Access-Control-Allow-Origin', '*');
-          return res.send(Buffer.from(buffer));
+
+          // Stream response to avoid memory exhaustion (DoS prevention)
+          return productionResponse.body.pipe(res);
         } catch (fallbackError) {
-          console.error(`[Asset Original] Production fallback failed for asset ${assetId}:`, fallbackError);
+          console.error(`[Asset Original] Production fallback failed for asset ${assetId}:`, fallbackError.message);
           return res.status(503).json({ error: 'Image service unavailable' });
         }
       }

--- a/backend/server.js
+++ b/backend/server.js
@@ -985,10 +985,10 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
     const assetId = result.rows[0].image_server_asset_id;
 
     if (!imageServerClient.initialized) {
-      // Development fallback: proxy from production when IMAGE_SERVER_URL not configured
+      // Development fallback: proxy from production asset endpoint when IMAGE_SERVER_URL not configured
       if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
         try {
-          const productionUrl = `https://rootsofthevalley.org/api/pois/${id}/thumbnail`;
+          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail`;
           const productionResponse = await fetch(productionUrl);
 
           if (!productionResponse.ok) {
@@ -1003,7 +1003,7 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
           res.setHeader('Access-Control-Allow-Origin', '*');
           return res.send(Buffer.from(buffer));
         } catch (fallbackError) {
-          console.error(`[Thumbnail] Production fallback failed for POI ${id}:`, fallbackError);
+          console.error(`[Thumbnail] Production fallback failed for POI ${id}, asset ${assetId}:`, fallbackError);
           return res.status(404).json({ error: 'Image not found' });
         }
       }
@@ -1444,6 +1444,32 @@ app.get('/api/assets/:assetId/thumbnail', assetProxyLimiter, async (req, res) =>
     }
 
     if (!imageServerClient.initialized) {
+      // Development fallback: proxy from production when IMAGE_SERVER_URL not configured
+      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+        try {
+          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail`;
+          const productionResponse = await fetch(productionUrl);
+
+          if (!productionResponse.ok) {
+            const statusCode = productionResponse.status;
+            const message = statusCode === 404 ? 'Asset not found' :
+                            statusCode >= 500 ? 'Image service error' :
+                            'Failed to fetch asset';
+            return res.status(statusCode).json({ error: message });
+          }
+
+          const buffer = await productionResponse.arrayBuffer();
+          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
+
+          res.setHeader('Content-Type', contentType);
+          res.setHeader('Cache-Control', 'public, max-age=604800');
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          return res.send(Buffer.from(buffer));
+        } catch (fallbackError) {
+          console.error(`[Asset Thumbnail] Production fallback failed for asset ${assetId}:`, fallbackError);
+          return res.status(503).json({ error: 'Image service unavailable' });
+        }
+      }
       return res.status(503).json({ error: 'Image service unavailable' });
     }
 
@@ -1482,6 +1508,32 @@ app.get('/api/assets/:assetId/original', assetProxyLimiter, async (req, res) => 
     }
 
     if (!imageServerClient.initialized) {
+      // Development fallback: proxy from production when IMAGE_SERVER_URL not configured
+      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+        try {
+          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/original`;
+          const productionResponse = await fetch(productionUrl);
+
+          if (!productionResponse.ok) {
+            const statusCode = productionResponse.status;
+            const message = statusCode === 404 ? 'Asset not found' :
+                            statusCode >= 500 ? 'Image service error' :
+                            'Failed to fetch asset';
+            return res.status(statusCode).json({ error: message });
+          }
+
+          const buffer = await productionResponse.arrayBuffer();
+          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
+
+          res.setHeader('Content-Type', contentType);
+          res.setHeader('Cache-Control', 'public, max-age=86400');
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          return res.send(Buffer.from(buffer));
+        } catch (fallbackError) {
+          console.error(`[Asset Original] Production fallback failed for asset ${assetId}:`, fallbackError);
+          return res.status(503).json({ error: 'Image service unavailable' });
+        }
+      }
       return res.status(503).json({ error: 'Image service unavailable' });
     }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -985,6 +985,28 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
     const assetId = result.rows[0].image_server_asset_id;
 
     if (!imageServerClient.initialized) {
+      // Development fallback: proxy from production when IMAGE_SERVER_URL not configured
+      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+        try {
+          const productionUrl = `https://rootsofthevalley.org/api/pois/${id}/thumbnail`;
+          const productionResponse = await fetch(productionUrl);
+
+          if (!productionResponse.ok) {
+            return res.status(404).json({ error: 'Image not found' });
+          }
+
+          const buffer = await productionResponse.arrayBuffer();
+          const contentType = productionResponse.headers.get('content-type') || 'image/jpeg';
+
+          res.setHeader('Content-Type', contentType);
+          res.setHeader('Cache-Control', 'public, max-age=604800');
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          return res.send(Buffer.from(buffer));
+        } catch (fallbackError) {
+          console.error(`[Thumbnail] Production fallback failed for POI ${id}:`, fallbackError);
+          return res.status(404).json({ error: 'Image not found' });
+        }
+      }
       return res.status(404).json({ error: 'Image not found' });
     }
 

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -877,7 +877,14 @@ function DestinationMarker({ dest, icon, isSelected, isEditMode, onSelect, onDra
           <div className="tooltip-content">
             {dest.has_primary_image && (
               <div className="tooltip-thumbnail">
-                <img src={`/api/pois/${dest.id}/thumbnail?size=medium`} alt="" />
+                <img
+                  src={`/api/pois/${dest.id}/thumbnail?size=medium`}
+                  alt=""
+                  onError={(e) => {
+                    e.target.style.display = 'none';
+                    e.target.parentElement.style.display = 'none';
+                  }}
+                />
               </div>
             )}
             <strong>{dest.name}</strong>

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1294,7 +1294,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
 
                       let tooltipHtml = '<div class="tooltip-content">';
                       if (hasImage) {
-                        tooltipHtml += `<div class="tooltip-thumbnail"><img src="${imageUrl}" alt="" /></div>`;
+                        tooltipHtml += `<div class="tooltip-thumbnail"><img src="${imageUrl}" alt="" onerror="this.style.display='none';this.parentElement.style.display='none'" /></div>`;
                       }
                       tooltipHtml += `<strong>${feature.name}</strong>`;
                       if (feature.brief_description) {
@@ -1358,7 +1358,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
 
                     let tooltipHtml = '<div class="tooltip-content">';
                     if (hasImage) {
-                      tooltipHtml += `<div class="tooltip-thumbnail"><img src="${imageUrl}" alt="" /></div>`;
+                      tooltipHtml += `<div class="tooltip-thumbnail"><img src="${imageUrl}" alt="" onerror="this.style.display='none';this.parentElement.style.display='none'" /></div>`;
                     }
                     tooltipHtml += `<strong>${feature.name}</strong>`;
                     if (feature.brief_description) {

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -48,7 +48,16 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual
       {/* Thumbnail */}
       <div className={`results-tile-image ${isVirtual ? 'virtual-thumbnail' : ''}`}>
         {imageUrl ? (
-          <img src={imageUrl} alt={poi.name} loading="lazy" className={isVirtual ? 'logo-image' : ''} />
+          <img
+            src={imageUrl}
+            alt={poi.name}
+            loading="lazy"
+            className={isVirtual ? 'logo-image' : ''}
+            onError={(e) => {
+              e.target.src = getDefaultThumbnail();
+              e.target.className = 'default-thumbnail';
+            }}
+          />
         ) : (
           <img src={getDefaultThumbnail()} alt={poi.name} className="default-thumbnail" loading="lazy" />
         )}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3385,6 +3385,10 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
               <img
                 src={`/api/pois/${linearFeature.id}/thumbnail?size=medium&v=${linearFeature.updated_at || Date.now()}`}
                 alt={linearFeature?.name}
+                onError={(e) => {
+                  e.target.style.display = 'none';
+                  e.target.parentElement.style.display = 'none';
+                }}
               />
             </div>
           ) : user && linearFeature?.id && !mediaLoading ? (
@@ -3488,6 +3492,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
                 deleting={deleting}
                 isNewPOI={false}
                 isLinearFeature={true}
+                showImage={false}
                 onImageUpdate={(hasImage, driveFileId) => {
                   if (onLinearFeatureUpdate) {
                     onLinearFeatureUpdate({
@@ -3720,6 +3725,10 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
               src={`/api/pois/${destination.id}/thumbnail?size=medium&v=${destination.updated_at || Date.now()}`}
               alt={destination?.name}
               className={destination?.poi_type === 'virtual' ? 'logo-image' : ''}
+              onError={(e) => {
+                e.target.style.display = 'none';
+                e.target.parentElement.style.display = 'none';
+              }}
             />
           </div>
         ) : user && destination?.id && !mediaLoading ? (

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2084,7 +2084,16 @@ function AssociationsModal({ isOpen, onClose, poi, associations, allDestinations
                     >
                       <div className={`association-item-thumbnail ${associatedPoi._isVirtual ? 'virtual-thumbnail' : ''}`}>
                         {imageUrl ? (
-                          <img src={imageUrl} alt={associatedPoi.name} loading="lazy" className={associatedPoi._isVirtual ? 'logo-image' : ''} />
+                          <img
+                            src={imageUrl}
+                            alt={associatedPoi.name}
+                            loading="lazy"
+                            className={associatedPoi._isVirtual ? 'logo-image' : ''}
+                            onError={(e) => {
+                              e.target.src = getDefaultThumbnail();
+                              e.target.className = 'default-thumbnail';
+                            }}
+                          />
                         ) : (
                           <img src={getDefaultThumbnail()} alt={associatedPoi.name} className="default-thumbnail" loading="lazy" />
                         )}
@@ -2410,7 +2419,16 @@ function AssociationsTabContent({ poi, associations, allDestinations, allLinearF
                   >
                     <div className={`association-item-thumbnail ${associatedPoi._isVirtual ? 'virtual-thumbnail' : ''}`}>
                       {imageUrl ? (
-                        <img src={imageUrl} alt={associatedPoi.name} loading="lazy" className={associatedPoi._isVirtual ? 'logo-image' : ''} />
+                        <img
+                          src={imageUrl}
+                          alt={associatedPoi.name}
+                          loading="lazy"
+                          className={associatedPoi._isVirtual ? 'logo-image' : ''}
+                          onError={(e) => {
+                            e.target.src = getDefaultThumbnail();
+                            e.target.className = 'default-thumbnail';
+                          }}
+                        />
                       ) : (
                         <img src={getDefaultThumbnail()} alt={associatedPoi.name} className="default-thumbnail" loading="lazy" />
                       )}


### PR DESCRIPTION
## Summary
- Fixed 400+ stale `has_primary_image` flags from before Immich migration
- Restored 91 POI images from Immich backup to image server
- Synced 7 MTB trail images from image server to ROTV database
- Promoted 37 orphaned gallery images to primary role (Red Lock Trailhead, Stanford Trail, etc.)
- Added onError handlers to all 6 POI thumbnail rendering locations:
  - Results tab tiles
  - Sidebar main images (destinations, linear features)
  - Sidebar association item thumbnails
  - Map JSX tooltips
  - Map HTML string tooltips (linear features)
- Added production image proxy fallback for localhost development
  - POI thumbnail endpoint proxies from production asset endpoint
  - Asset thumbnail/original endpoints proxy from production
  - Only active when IMAGE_SERVER_URL not configured in dev/test

## Database Changes
- Migration: `fix-has-primary-image-flags.js` - cleans up stale flags
- Migration: `restore-from-immich.js` - restores 91 images from backup
- Migration: `sync-mtb-images.js` - creates poi_media records for 7 MTB trails
- Migration: `promote-orphaned-gallery-images.js` - promotes 37 gallery images to primary

## Test plan
- [x] Localhost displays all POI images correctly (via production proxy)
- [x] Results tab shows default SVG for POIs without images
- [x] Sidebar shows images or "Add Photo" button appropriately
- [x] Map tooltips handle missing images gracefully
- [x] Database migrations run successfully
- [ ] Production deployment runs all 4 migrations
- [ ] Production images display after migrations complete
- [ ] All onError handlers prevent broken image icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)