### PR TITLE
feat: simplify single-POI news/events collection UX

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -2806,7 +2806,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         message: `News collection completed for ${poi.name}`,
         newsFound: news.length,
         newsSaved: savedNews,
-        newsDuplicate: news.length - savedNews
+        newsDuplicate: news.length - savedNews,
+        jobId: poi.id,  // Use poi_id as identifier for single-POI jobs
+        jobType: 'news_single'
       });
     } catch (error) {
       console.error('Error collecting news for POI:', error);
@@ -2878,7 +2880,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         message: `Events collection completed for ${poi.name}`,
         eventsFound: events.length,
         eventsSaved: savedEvents,
-        eventsDuplicate: events.length - savedEvents
+        eventsDuplicate: events.length - savedEvents,
+        jobId: poi.id,  // Use poi_id as identifier for single-POI jobs
+        jobType: 'events_single'
       });
     } catch (error) {
       console.error('Error collecting events for POI:', error);
@@ -4256,6 +4260,46 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     } catch (error) {
       console.error('Error fetching job history:', error);
       res.status(500).json({ error: 'Failed to fetch job history' });
+    }
+  });
+
+  // Single-POI job logs (query by poi_id instead of job_id)
+  router.get('/jobs/logs', isAdmin, async (req, res) => {
+    try {
+      const { jobType, poiId } = req.query;
+      const limit = Math.max(1, Math.min(parseInt(req.query.limit) || 100, 500));
+      const offset = Math.max(0, parseInt(req.query.offset) || 0);
+
+      if (!jobType || !poiId) {
+        return res.status(400).json({
+          error: 'jobType and poiId are required'
+        });
+      }
+
+      const query = `
+        SELECT id, level, message, details, created_at
+        FROM job_logs
+        WHERE job_type = $1 AND poi_id = $2
+        ORDER BY created_at DESC
+        LIMIT $3 OFFSET $4
+      `;
+
+      const result = await pool.query(query, [jobType, poiId, limit, offset]);
+
+      res.json({
+        success: true,
+        data: {
+          logs: result.rows,
+          pagination: {
+            returned: result.rowCount,
+            limit,
+            offset
+          }
+        }
+      });
+    } catch (error) {
+      console.error('Error fetching single-POI job logs:', error);
+      res.status(500).json({ error: 'Failed to fetch job logs' });
     }
   });
 

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
@@ -69,6 +70,10 @@ function formatCronHuman(cron) {
 }
 
 export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) {
+  const [searchParams] = useSearchParams();
+  const urlJobId = searchParams.get('job');
+  const urlJobType = searchParams.get('type');
+
   const [scheduledJobs, setScheduledJobs] = useState([]);
   const [scheduledLoading, setScheduledLoading] = useState(true);
   const [expandedScheduled, setExpandedScheduled] = useState(null);
@@ -134,10 +139,23 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
   const fetchRunLogs = useCallback(async (jobType, runId) => {
     try {
-      const params = new URLSearchParams({ limit: '200' });
-      if (logLevelFilter !== 'all') params.set('level', logLevelFilter);
-      const res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${runId}/logs?${params}`, { credentials: 'include' });
-      if (res.ok) setRunLogs(await res.json());
+      let res;
+      if (jobType === 'news_single' || jobType === 'events_single') {
+        // Single-POI jobs: query by poiId
+        const params = new URLSearchParams({ jobType, poiId: runId, limit: '200' });
+        if (logLevelFilter !== 'all') params.set('level', logLevelFilter);
+        res = await fetch(`${API_BASE}/api/admin/jobs/logs?${params}`, { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setRunLogs(data.data?.logs || []);
+        }
+      } else {
+        // Batch jobs: query by job_id
+        const params = new URLSearchParams({ limit: '200' });
+        if (logLevelFilter !== 'all') params.set('level', logLevelFilter);
+        res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${runId}/logs?${params}`, { credentials: 'include' });
+        if (res.ok) setRunLogs(await res.json());
+      }
     } catch (err) {
       console.error('Failed to fetch run logs:', err);
     }
@@ -250,7 +268,22 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
   useEffect(() => {
     if (!expandedRun) return;
 
-    // Find the job for this run
+    // For single-POI jobs, poll briefly to catch any late-arriving logs
+    if (expandedRun.jobType === 'news_single' || expandedRun.jobType === 'events_single') {
+      let pollCount = 0;
+      const interval = setInterval(() => {
+        fetchRunLogs(expandedRun.jobType, expandedRun.runId);
+        pollCount++;
+        // Stop polling after 15 attempts (30 seconds)
+        if (pollCount >= 15) {
+          clearInterval(interval);
+        }
+      }, 2000);
+
+      return () => clearInterval(interval);
+    }
+
+    // For batch jobs, find the job and check if running
     const job = scheduledJobs.find(j =>
       j.historyTypes && j.historyTypes.includes(expandedRun.jobType)
     );
@@ -281,6 +314,42 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
       }
     }
   }, [jobHistory, autoExpandNewestRun]);
+
+  // Auto-expand job from URL parameters (for single-POI redirects)
+  useEffect(() => {
+    if (urlJobId && urlJobType && !scheduledLoading) {
+      // For single-POI jobs, directly expand using URL parameters
+      if (urlJobType === 'news_single' || urlJobType === 'events_single') {
+        setExpandedRun({ jobType: urlJobType, runId: urlJobId });
+
+        // Scroll to logs panel if it exists (will exist after logs load)
+        setTimeout(() => {
+          const element = document.querySelector('.job-logs-panel');
+          if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        }, 500);
+      } else {
+        // For batch jobs, find the matching run in history
+        const runs = Object.values(jobHistory).flat();
+        const targetRun = runs.find(r =>
+          String(r.id) === urlJobId && r.job_type === urlJobType
+        );
+
+        if (targetRun) {
+          setExpandedRun({ jobType: targetRun.job_type, runId: targetRun.id });
+
+          // Scroll to the job entry
+          setTimeout(() => {
+            const element = document.getElementById(`job-${targetRun.job_type}-${targetRun.id}`);
+            if (element) {
+              element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+          }, 100);
+        }
+      }
+    }
+  }, [urlJobId, urlJobType, scheduledLoading, jobHistory]);
 
   const handleExpandRun = (jobType, run) => {
     const key = `${jobType}-${run.id}`;
@@ -673,7 +742,10 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
                           {runs.map(run => {
                             const isExpanded = expandedRun && expandedRun.jobType === run.job_type && expandedRun.runId === run.id;
                             return (
-                              <div key={`${run.job_type}-${run.id}`} className="job-run-item">
+                              <div
+                                key={`${run.job_type}-${run.id}`}
+                                id={`job-${run.job_type}-${run.id}`}
+                                className="job-run-item">
                                 <div className={`job-run-row ${isExpanded ? 'expanded' : ''}`}
                                   onClick={(e) => { e.stopPropagation(); handleExpandRun(run.job_type, run); }}>
                                   <span className="status-badge" style={{ backgroundColor: STATUS_COLORS[run.status] || '#9e9e9e' }}>{run.status}</span>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ImageUploader from './ImageUploader';
-import CollectionStatus from './CollectionStatus';
 import ThumbnailCarousel from './ThumbnailCarousel';
 import { formatDateTime, formatPublicationDate } from './NewsEventsShared';
 import Mosaic from './Mosaic';
@@ -1374,17 +1374,11 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
 
 // POI-specific News component
 function PoiNews({ poiId, isAdmin, editMode, onCountChange }) {
+  const navigate = useNavigate();
   const [news, setNews] = useState([]);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(null);
-  const [collecting, setCollecting] = useState(() => {
-    // Check localStorage to see if collection was in progress
-    const stored = localStorage.getItem(`news-collecting-${poiId}`);
-    return stored === 'true';
-  });
-  const [collectionSession, setCollectionSession] = useState(0);
-  const [showCompletedStatus, setShowCompletedStatus] = useState(false);
-  const [, setCollectResult] = useState(null);
+  const [collecting, setCollecting] = useState(false);
 
   const fetchNews = async () => {
     if (!poiId) {
@@ -1409,103 +1403,35 @@ function PoiNews({ poiId, isAdmin, editMode, onCountChange }) {
 
   useEffect(() => {
     fetchNews();
-    // Clean up collecting state if we're loading fresh data
-    if (collecting) {
-      // If we were collecting but now mounting fresh, the collection likely completed
-      setTimeout(() => {
-        localStorage.removeItem(`news-collecting-${poiId}`);
-        setCollecting(false);
-      }, 2000);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [poiId]); // fetchNews and collecting intentionally excluded to avoid re-fetching on state changes
+  }, [poiId]);
 
-  // Clear completed status when editMode changes
-  useEffect(() => {
-    if (!editMode) {
-      setShowCompletedStatus(false);
-    }
-  }, [editMode]);
-
-  // Collect news for this POI and refresh
+  // Collect news for this POI and redirect to Jobs dashboard
   const handleCollectNews = async () => {
     if (!poiId) return;
     setCollecting(true);
-    setShowCompletedStatus(false); // Clear previous completed status
-    setCollectionSession(prev => prev + 1); // Increment session to force timer reset
-    localStorage.setItem(`news-collecting-${poiId}`, 'true');
-    setCollectResult(null);
-
-    let shouldStopCollecting = false;
 
     try {
-      // Read timezone from localStorage (defaults to America/New_York)
       const timezone = localStorage.getItem('app-timezone') || 'America/New_York';
-
       const response = await fetch(`/api/admin/pois/${poiId}/news/collect`, {
         method: 'POST',
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ timezone })
       });
+
       if (response.ok) {
         const result = await response.json();
-
-        // If collection is already running, just attach to it
-        if (result.alreadyRunning) {
-          // The status widget will poll and show the current progress
-          // Don't change collecting state - keep it true to show widget
-          return;
-        }
-
-        setCollectResult({
-          type: 'success',
-          newsFound: result.newsFound,
-          newsSaved: result.newsSaved,
-          newsDuplicate: result.newsDuplicate || 0
-        });
-        // Refresh the news list
-        await fetchNews();
-        shouldStopCollecting = true;
+        // Redirect to Jobs dashboard with job identifier
+        navigate(`/admin/jobs?job=${result.jobId}&type=${result.jobType}`);
       } else {
         const error = await response.json();
-        setCollectResult({ type: 'error', message: error.error || 'Collection failed' });
-        shouldStopCollecting = true;
+        alert(`Collection failed: ${error.error || 'Unknown error'}`);
+        setCollecting(false);
       }
     } catch (err) {
-      setCollectResult({ type: 'error', message: err.message });
-      shouldStopCollecting = true;
-    } finally {
-      if (shouldStopCollecting) {
-        // Give the CollectionStatus widget time to fetch final progress before stopping polling
-        setTimeout(() => {
-          setCollecting(false);
-          setShowCompletedStatus(true); // Keep status widget visible after completion
-          localStorage.removeItem(`news-collecting-${poiId}`);
-        }, 1500); // 1.5 second delay to ensure final progress is fetched
-      }
-    }
-  };
-
-  const handleCancelCollection = async () => {
-    if (!poiId) return;
-    try {
-      const response = await fetch(`/api/admin/pois/${poiId}/collection-cancel`, {
-        method: 'POST',
-        credentials: 'include'
-      });
-      if (response.ok) {
-        // The status widget will update to show cancelled state
-        setTimeout(() => {
-          setCollecting(false);
-          setShowCompletedStatus(true);
-          localStorage.removeItem(`news-collecting-${poiId}`);
-        }, 500);
-      }
-    } catch (err) {
-      console.error('[PoiNews] Error cancelling collection:', err);
+      alert(`Collection failed: ${err.message}`);
+      setCollecting(false);
     }
   };
 
@@ -1543,21 +1469,6 @@ function PoiNews({ poiId, isAdmin, editMode, onCountChange }) {
       )}
 
       <div className="poi-news-list-content">
-        {isAdmin && editMode && (collecting || showCompletedStatus) && (
-          <CollectionStatus
-            key={`news-${collectionSession}`}
-            poiId={poiId}
-            isCollecting={collecting}
-            onComplete={(_data) => {
-              // Keep showing status even after completion
-            }}
-            onClose={() => {
-              setShowCompletedStatus(false);
-            }}
-            onCancel={handleCancelCollection}
-          />
-        )}
-
         {news.length === 0 ? (
           <div className="sidebar-tab-empty">No news for this location.</div>
         ) : news.map(item => (
@@ -1597,17 +1508,11 @@ function PoiNews({ poiId, isAdmin, editMode, onCountChange }) {
 
 // POI-specific Events component
 function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange }) {
+  const navigate = useNavigate();
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(null);
-  const [collecting, setCollecting] = useState(() => {
-    // Check localStorage to see if collection was in progress
-    const stored = localStorage.getItem(`events-collecting-${poiId}`);
-    return stored === 'true';
-  });
-  const [collectionSession, setCollectionSession] = useState(0);
-  const [showCompletedStatus, setShowCompletedStatus] = useState(false);
-  const [, setCollectResult] = useState(null);
+  const [collecting, setCollecting] = useState(false);
 
   const fetchEvents = async () => {
     if (!poiId) return;
@@ -1628,103 +1533,35 @@ function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange }) {
 
   useEffect(() => {
     fetchEvents();
-    // Clean up collecting state if we're loading fresh data
-    if (collecting) {
-      // If we were collecting but now mounting fresh, the collection likely completed
-      setTimeout(() => {
-        localStorage.removeItem(`events-collecting-${poiId}`);
-        setCollecting(false);
-      }, 2000);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [poiId]); // fetchEvents and collecting intentionally excluded to avoid re-fetching on state changes
+  }, [poiId]);
 
-  // Clear completed status when editMode changes
-  useEffect(() => {
-    if (!editMode) {
-      setShowCompletedStatus(false);
-    }
-  }, [editMode]);
-
-  // Collect events for this POI and refresh
+  // Collect events for this POI and redirect to Jobs dashboard
   const handleCollectEvents = async () => {
     if (!poiId) return;
     setCollecting(true);
-    setShowCompletedStatus(false); // Clear previous completed status
-    setCollectionSession(prev => prev + 1); // Increment session to force timer reset
-    localStorage.setItem(`events-collecting-${poiId}`, 'true');
-    setCollectResult(null);
-
-    let shouldStopCollecting = false;
 
     try {
-      // Read timezone from localStorage (defaults to America/New_York)
       const timezone = localStorage.getItem('app-timezone') || 'America/New_York';
-
       const response = await fetch(`/api/admin/pois/${poiId}/events/collect`, {
         method: 'POST',
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ timezone })
       });
+
       if (response.ok) {
         const result = await response.json();
-
-        // If collection is already running, just attach to it
-        if (result.alreadyRunning) {
-          // The status widget will poll and show the current progress
-          // Don't change collecting state - keep it true to show widget
-          return;
-        }
-
-        setCollectResult({
-          type: 'success',
-          eventsFound: result.eventsFound,
-          eventsSaved: result.eventsSaved,
-          eventsDuplicate: result.eventsDuplicate || 0
-        });
-        // Refresh the events list
-        await fetchEvents();
-        shouldStopCollecting = true;
+        // Redirect to Jobs dashboard with job identifier
+        navigate(`/admin/jobs?job=${result.jobId}&type=${result.jobType}`);
       } else {
         const error = await response.json();
-        setCollectResult({ type: 'error', message: error.error || 'Collection failed' });
-        shouldStopCollecting = true;
+        alert(`Collection failed: ${error.error || 'Unknown error'}`);
+        setCollecting(false);
       }
     } catch (err) {
-      setCollectResult({ type: 'error', message: err.message });
-      shouldStopCollecting = true;
-    } finally {
-      if (shouldStopCollecting) {
-        // Give the CollectionStatus widget time to fetch final progress before stopping polling
-        setTimeout(() => {
-          setCollecting(false);
-          setShowCompletedStatus(true); // Keep status widget visible after completion
-          localStorage.removeItem(`events-collecting-${poiId}`);
-        }, 1500); // 1.5 second delay to ensure final progress is fetched
-      }
-    }
-  };
-
-  const handleCancelCollection = async () => {
-    if (!poiId) return;
-    try {
-      const response = await fetch(`/api/admin/pois/${poiId}/collection-cancel`, {
-        method: 'POST',
-        credentials: 'include'
-      });
-      if (response.ok) {
-        // The status widget will update to show cancelled state
-        setTimeout(() => {
-          setCollecting(false);
-          setShowCompletedStatus(true);
-          localStorage.removeItem(`events-collecting-${poiId}`);
-        }, 500);
-      }
-    } catch (err) {
-      console.error('[PoiEvents] Error cancelling collection:', err);
+      alert(`Collection failed: ${err.message}`);
+      setCollecting(false);
     }
   };
 
@@ -1780,21 +1617,6 @@ function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange }) {
       )}
 
       <div className="poi-events-list-content">
-        {isAdmin && editMode && (collecting || showCompletedStatus) && (
-          <CollectionStatus
-            key={`events-${collectionSession}`}
-            poiId={poiId}
-            isCollecting={collecting}
-            onComplete={(_data) => {
-              // Keep showing status even after completion
-            }}
-            onClose={() => {
-              setShowCompletedStatus(false);
-            }}
-            onCancel={handleCancelCollection}
-          />
-        )}
-
         {events.length === 0 ? (
           <div className="sidebar-tab-empty">No upcoming events for this location.</div>
         ) : events.map(item => (


### PR DESCRIPTION
## Summary

Replaces the inline CollectionStatus widget with a redirect to the Jobs dashboard for consistent job monitoring UX. After clicking "Collect News" or "Collect Events" on a POI detail page, admins are immediately redirected to `/admin/jobs?job=<poi_id>&type=<job_type>` where the job is auto-expanded and logs are displayed.

### Backend changes
- Add `jobId` and `jobType` to single-POI collection API responses
- Add new endpoint `GET /api/admin/jobs/logs` for querying single-POI job logs (queries by `poi_id` instead of `job_id`)

### Frontend changes
- **Sidebar.jsx**: Remove CollectionStatus widget, simplify state management, redirect to Jobs dashboard
- **JobsDashboard.jsx**: Parse URL parameters, auto-expand jobs, fetch logs for single-POI jobs, add polling (30s max)

### Benefits
- ✅ Simpler admin workflow (one place for all job monitoring)
- ✅ Reduced code complexity (net -64 lines: -211 deleted, +147 added)
- ✅ Consistent UX across batch and single-POI collections

## Test plan
- [x] Build passes: `./run.sh build`
- [x] Tests pass: `./run.sh test` (262/263 passed - 1 flaky carousel test unrelated to changes)
- [ ] Manual verification: trigger single-POI news collection and verify redirect + logs
- [ ] Manual verification: trigger single-POI events collection and verify redirect + logs
- [ ] Regression test: verify batch jobs still work correctly

## Quality gates
- ✅ Container build successful
- ✅ 262/263 tests passing (99.6%)
- ⚠️ 1 flaky test (carousel navigation timing, unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)