### PR TITLE
fix: use TCP connections in rotv-init.sh, consolidate migration runner

### DIFF
--- a/rootfs/usr/local/bin/rotv-init.sh
+++ b/rootfs/usr/local/bin/rotv-init.sh
@@ -16,27 +16,35 @@ done
 
 echo "Creating database..."
 cd /app
-psql -U postgres -d postgres -c "CREATE DATABASE rotv;" 2>/dev/null || echo "Database already exists"
+psql -h localhost -U postgres -d postgres -c "CREATE DATABASE rotv;" 2>/dev/null || echo "Database already exists"
 
 if [ -f /tmp/seed-data.sql ]; then
   echo "Importing seed data (schema + data)..."
-  psql -U postgres -d rotv -f /tmp/seed-data.sql
+  psql -h localhost -U postgres -d rotv -f /tmp/seed-data.sql
   echo "Seed data imported"
 fi
 
-echo "Running schema migrations..."
-for migration in /app/migrations/*.sql; do
-  if [ -f "$migration" ]; then
-    echo "Running migration: $(basename $migration)"
-    psql -U postgres -d rotv -f "$migration"
+# Run all numbered SQL migrations in sorted order
+# Migrations are idempotent (IF NOT EXISTS, etc.) so safe to re-run
+echo "Running database migrations..."
+MIGRATION_COUNT=0
+for migration in /app/migrations/[0-9]*.sql; do
+  [ -f "$migration" ] || continue
+  MIGRATION_NAME=$(basename "$migration")
+  if psql -h localhost -U postgres -d rotv -f "$migration" > /tmp/migration_output.txt 2>&1; then
+    MIGRATION_COUNT=$((MIGRATION_COUNT + 1))
+  else
+    echo "ERROR: Migration $MIGRATION_NAME failed:"
+    cat /tmp/migration_output.txt
+    exit 1
   fi
 done
-echo "Migrations complete"
+echo "$MIGRATION_COUNT migrations applied"
 
 # Post-migration setup for auth bypass (test mode)
 if [ "$BYPASS_AUTH" = "true" ] || [ "$NODE_ENV" = "test" ]; then
   echo "Setting up auth bypass for test mode..."
-  psql -U postgres -d rotv <<'EOF'
+  psql -h localhost -U postgres -d rotv <<'EOF'
 -- Create test admin user for auth bypass
 INSERT INTO users (id, email, name, oauth_provider, oauth_provider_id, is_admin, role)
 VALUES (999, 'test-admin@rotv.local', 'Test Admin', 'test', '999', true, 'admin')
@@ -48,36 +56,5 @@ ON CONFLICT (id) DO UPDATE SET
 EOF
   echo "Auth bypass test user created (ID 999)"
 fi
-
-# Fix boundary geometry if needed (migration 019 workaround)
-echo "Verifying boundary geometry..."
-psql -U postgres -d rotv <<'EOF'
--- Ensure boundary_geom column exists and is MultiPolygon type
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'pois' AND column_name = 'boundary_geom'
-  ) THEN
-    ALTER TABLE pois ADD COLUMN boundary_geom geometry(MultiPolygon, 4326);
-  END IF;
-END $$;
-
--- Populate boundary geometry from GeoJSON if empty
-UPDATE pois
-SET boundary_geom = ST_SetSRID(
-  ST_Multi(ST_GeomFromGeoJSON(geometry::text))::geometry(MultiPolygon, 4326),
-  4326
-)
-WHERE poi_type = 'boundary'
-  AND geometry IS NOT NULL
-  AND boundary_geom IS NULL;
-
--- Create spatial index if it doesn't exist
-CREATE INDEX IF NOT EXISTS idx_pois_boundary_geom
-ON pois USING GIST (boundary_geom)
-WHERE poi_type = 'boundary';
-EOF
-echo "Boundary geometry verified"
 
 echo "Database initialization complete"


### PR DESCRIPTION
## Summary
- `rotv-init.sh` psql calls defaulted to Unix socket `/run/postgresql/.s.PGSQL.5432` which doesn't exist — PostgreSQL listens on `localhost:5432` TCP
- Added `-h localhost` to all psql calls so they use TCP
- Consolidated migration runner to use `[0-9]*.sql` glob pattern (matches entrypoint.sh from PR #205)
- Removed hardcoded boundary geometry workaround (now handled by migration 022)

## Test plan
- [x] All 263 tests pass
- [x] Gourmand clean
- [ ] Deploy and verify `rotv-init.service` succeeds (was failing before)
- [ ] Verify `geom` column exists and news collection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)