### PR TITLE
fix: graceful PostGIS fallback when extension unavailable

### DIFF
--- a/backend/migrations/021_add_postgis_support.sql
+++ b/backend/migrations/021_add_postgis_support.sql
@@ -1,38 +1,38 @@
--- Migration 018: Add PostGIS support for geographic grounding
+-- Migration 021: Add PostGIS support for geographic grounding
 -- Required for Serper integration spatial queries
+-- Gracefully skips if PostGIS package is not installed
 
--- Enable PostGIS extension
-CREATE EXTENSION IF NOT EXISTS postgis;
-
--- Add PostGIS geometry column to pois table
--- This will store point locations for spatial queries
-ALTER TABLE pois ADD COLUMN IF NOT EXISTS geom geometry(Point, 4326);
-
--- Populate geometry column from existing latitude/longitude
--- SRID 4326 = WGS 84 (standard GPS coordinates)
-UPDATE pois
-SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-WHERE latitude IS NOT NULL
-  AND longitude IS NOT NULL
-  AND geom IS NULL;
-
--- Create spatial index for fast geographic queries
--- Used by getGeographicContext() in serperService.js
-CREATE INDEX IF NOT EXISTS idx_pois_geom ON pois USING GIST (geom);
-
--- Add geometry column for boundary polygons
--- This will store polygon data from the existing JSONB geometry field
-ALTER TABLE pois ADD COLUMN IF NOT EXISTS boundary_geom geometry(Polygon, 4326);
-
--- Note: Boundary polygon migration from JSONB will be handled separately
--- The JSONB geometry field contains GeoJSON that needs custom parsing
--- For now, boundaries can be re-imported from GeoJSON files
-
--- Verify PostGIS is working
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') THEN
-    RAISE EXCEPTION 'PostGIS extension not available';
+  -- Try to enable PostGIS extension
+  BEGIN
+    CREATE EXTENSION IF NOT EXISTS postgis;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'PostGIS not available (%), skipping spatial setup', SQLERRM;
+    RETURN;
+  END;
+
+  -- Add PostGIS geometry column to pois table
+  ALTER TABLE pois ADD COLUMN IF NOT EXISTS geom geometry(Point, 4326);
+
+  -- Populate geometry column from existing latitude/longitude
+  UPDATE pois
+  SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+  WHERE latitude IS NOT NULL
+    AND longitude IS NOT NULL
+    AND geom IS NULL;
+
+  -- Add geometry column for boundary polygons
+  ALTER TABLE pois ADD COLUMN IF NOT EXISTS boundary_geom geometry(Polygon, 4326);
+
+  RAISE NOTICE 'PostGIS support enabled successfully';
+END $$;
+
+-- Create spatial indexes (only if PostGIS columns exist)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'pois' AND column_name = 'geom') THEN
+    CREATE INDEX IF NOT EXISTS idx_pois_geom ON pois USING GIST (geom);
   END IF;
-  RAISE NOTICE 'PostGIS extension installed successfully';
 END $$;

--- a/backend/migrations/022_migrate_boundary_geometry.sql
+++ b/backend/migrations/022_migrate_boundary_geometry.sql
@@ -1,45 +1,32 @@
--- Migration 019: Migrate boundary polygons from JSONB to PostGIS geometry
--- This converts the existing GeoJSON data to proper PostGIS geometry
--- Handles both Polygon and MultiPolygon geometries
+-- Migration 022: Migrate boundary polygons from JSONB to PostGIS geometry
+-- Converts existing GeoJSON data to proper PostGIS geometry
+-- Gracefully skips if PostGIS is not available
 
--- First, change column type to accept both Polygon and MultiPolygon
-ALTER TABLE pois DROP COLUMN IF EXISTS boundary_geom;
-ALTER TABLE pois ADD COLUMN boundary_geom geometry(MultiPolygon, 4326);
-
--- Convert JSONB GeoJSON to PostGIS geometry for boundaries
--- Ensures all geometries are MultiPolygon (converts Polygon → MultiPolygon if needed)
-UPDATE pois
-SET boundary_geom = ST_SetSRID(
-  ST_Multi(ST_GeomFromGeoJSON(geometry::text))::geometry(MultiPolygon, 4326),
-  4326
-)
-WHERE poi_type = 'boundary'
-  AND geometry IS NOT NULL
-  AND boundary_geom IS NULL;
-
--- Verify all boundaries have PostGIS geometry
 DO $$
-DECLARE
-  boundary_count INTEGER;
-  migrated_count INTEGER;
 BEGIN
-  SELECT COUNT(*) INTO boundary_count
-  FROM pois
+  -- Skip if PostGIS is not installed
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') THEN
+    RAISE NOTICE 'PostGIS not installed, skipping boundary geometry migration';
+    RETURN;
+  END IF;
+
+  -- Change column type to accept both Polygon and MultiPolygon
+  ALTER TABLE pois DROP COLUMN IF EXISTS boundary_geom;
+  ALTER TABLE pois ADD COLUMN boundary_geom geometry(MultiPolygon, 4326);
+
+  -- Convert JSONB GeoJSON to PostGIS geometry for boundaries
+  UPDATE pois
+  SET boundary_geom = ST_SetSRID(
+    ST_Multi(ST_GeomFromGeoJSON(geometry::text))::geometry(MultiPolygon, 4326),
+    4326
+  )
+  WHERE poi_type = 'boundary'
+    AND geometry IS NOT NULL
+    AND boundary_geom IS NULL;
+
+  -- Create spatial index for boundary polygons
+  CREATE INDEX IF NOT EXISTS idx_pois_boundary_geom ON pois USING GIST (boundary_geom)
   WHERE poi_type = 'boundary';
 
-  SELECT COUNT(*) INTO migrated_count
-  FROM pois
-  WHERE poi_type = 'boundary'
-    AND boundary_geom IS NOT NULL;
-
-  RAISE NOTICE 'Boundary migration: % of % boundaries have PostGIS geometry',
-    migrated_count, boundary_count;
-
-  IF migrated_count < boundary_count THEN
-    RAISE WARNING 'Some boundaries missing PostGIS geometry - check GeoJSON format';
-  END IF;
+  RAISE NOTICE 'Boundary geometry migration complete';
 END $$;
-
--- Create spatial index for boundary polygons (if not exists)
-CREATE INDEX IF NOT EXISTS idx_pois_boundary_geom ON pois USING GIST (boundary_geom)
-WHERE poi_type = 'boundary';

--- a/backend/services/serperService.js
+++ b/backend/services/serperService.js
@@ -46,31 +46,35 @@ export async function searchNewsUrls(pool, poi) {
 
   const apiKey = apiKeyResult.rows[0].value;
 
-  const contextResult = await pool.query(`
-    WITH poi_point AS (
-      SELECT
-        id,
-        CASE
-          WHEN poi_type = 'point' AND geom IS NOT NULL THEN geom
-          WHEN poi_type IN ('trail', 'boundary', 'river') AND geometry IS NOT NULL THEN
-            ST_StartPoint(ST_GeometryN(ST_GeomFromGeoJSON(geometry::text), 1))
-          ELSE NULL
-        END as point_geom
-      FROM pois
-      WHERE id = $1
-    )
-    SELECT boundary.name
-    FROM poi_point
-    LEFT JOIN pois AS boundary
-      ON boundary.poi_type = 'boundary'
-      AND boundary.boundary_geom IS NOT NULL
-      AND ST_Contains(boundary.boundary_geom, poi_point.point_geom)
-    WHERE poi_point.point_geom IS NOT NULL
-    ORDER BY ST_Area(boundary.boundary_geom) ASC
-    LIMIT 1
-  `, [poi.id]);
-
-  const context = contextResult.rows[0]?.name || '';
+  let context = '';
+  try {
+    const contextResult = await pool.query(`
+      WITH poi_point AS (
+        SELECT
+          id,
+          CASE
+            WHEN poi_type = 'point' AND geom IS NOT NULL THEN geom
+            WHEN poi_type IN ('trail', 'boundary', 'river') AND geometry IS NOT NULL THEN
+              ST_StartPoint(ST_GeometryN(ST_GeomFromGeoJSON(geometry::text), 1))
+            ELSE NULL
+          END as point_geom
+        FROM pois
+        WHERE id = $1
+      )
+      SELECT boundary.name
+      FROM poi_point
+      LEFT JOIN pois AS boundary
+        ON boundary.poi_type = 'boundary'
+        AND boundary.boundary_geom IS NOT NULL
+        AND ST_Contains(boundary.boundary_geom, poi_point.point_geom)
+      WHERE poi_point.point_geom IS NOT NULL
+      ORDER BY ST_Area(boundary.boundary_geom) ASC
+      LIMIT 1
+    `, [poi.id]);
+    context = contextResult.rows[0]?.name || '';
+  } catch (err) {
+    console.warn(`[Serper] PostGIS grounding unavailable, using ungrounded search: ${err.message}`);
+  }
 
   const query = context
     ? `${poi.name} ${context} news`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,7 +88,7 @@ MIGRATION_COUNT=0
 for migration in /app/migrations/[0-9]*.sql; do
     [ -f "$migration" ] || continue
     MIGRATION_NAME=$(basename "$migration")
-    if psql -h "$PGRUNDIR" -U postgres -d rotv -f "$migration" > /tmp/migration_output.txt 2>&1; then
+    if psql -h "$PGRUNDIR" -U postgres -d rotv -v ON_ERROR_STOP=1 -f "$migration" > /tmp/migration_output.txt 2>&1; then
         MIGRATION_COUNT=$((MIGRATION_COUNT + 1))
     else
         echo "ERROR: Migration $MIGRATION_NAME failed:"

--- a/rootfs/usr/local/bin/rotv-init.sh
+++ b/rootfs/usr/local/bin/rotv-init.sh
@@ -31,7 +31,7 @@ MIGRATION_COUNT=0
 for migration in /app/migrations/[0-9]*.sql; do
   [ -f "$migration" ] || continue
   MIGRATION_NAME=$(basename "$migration")
-  if psql -h localhost -U postgres -d rotv -f "$migration" > /tmp/migration_output.txt 2>&1; then
+  if psql -h localhost -U postgres -d rotv -v ON_ERROR_STOP=1 -f "$migration" > /tmp/migration_output.txt 2>&1; then
     MIGRATION_COUNT=$((MIGRATION_COUNT + 1))
   else
     echo "ERROR: Migration $MIGRATION_NAME failed:"


### PR DESCRIPTION
## Summary
- PostGIS package can't install on RHEL 10 (missing `libboost_serialization.so.1.83.0`)
- Migrations 021/022 now skip gracefully with a NOTICE instead of failing
- `serperService.js` wraps PostGIS grounding query in try/catch, falls back to ungrounded search
- Migration runner now uses `ON_ERROR_STOP=1` so real SQL errors are caught (previously psql returned 0 on errors)

## Test plan
- [x] All 263 tests pass
- [x] Gourmand clean (0 violations)
- [ ] Deploy and verify rotv-init succeeds with all 22 migrations
- [ ] Verify news collection runs without errors (ungrounded search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)