### PR TITLE
fix: correct column names in migration 001 admin_settings insert

### DIFF
--- a/backend/migrations/001_add_trail_status_support.sql
+++ b/backend/migrations/001_add_trail_status_support.sql
@@ -65,12 +65,12 @@ DO $$
 BEGIN
   IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'admin_settings') THEN
     -- Insert settings if they don't exist
-    INSERT INTO admin_settings (setting_key, setting_value, description)
+    INSERT INTO admin_settings (key, value)
     VALUES
-      ('trail_status_collection_enabled', 'true', 'Enable/disable trail status collection'),
-      ('trail_status_collection_interval_hours', '2', 'Hours between status collection runs'),
-      ('trail_status_ai_provider', 'gemini', 'AI provider for status extraction (gemini or perplexity)')
-    ON CONFLICT (setting_key) DO NOTHING;
+      ('trail_status_collection_enabled', 'true'),
+      ('trail_status_collection_interval_hours', '2'),
+      ('trail_status_ai_provider', 'gemini')
+    ON CONFLICT (key) DO NOTHING;
   END IF;
 END$$;
 


### PR DESCRIPTION
## Summary
- Migration 001 used `setting_key`/`setting_value` but actual table columns are `key`/`value`
- Previously silent because psql didn't use `ON_ERROR_STOP` — now caught by PR #207's fix
- Also removed `description` column reference (doesn't exist in the table)

## Test plan
- [x] All tests pass
- [x] Gourmand clean
- [ ] Deploy and verify all 22 migrations succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)