### PR TITLE
feat: unify collection pipeline — Phase I/II symmetry

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "rotv-backend",
-  "version": "1.9.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotv-backend",
-      "version": "1.9.0",
+      "version": "0.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@mozilla/readability": "^0.6.0",
-        "@perplexity-ai/perplexity_ai": "^0.18.4",
+        "axios": "^1.6.0",
+        "chrono-node": "^2.9.0",
         "connect-pg-simple": "^9.0.1",
         "cors": "^2.8.5",
         "csv-parse": "^5.5.3",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.5.0",
         "express-session": "^1.17.3",
         "googleapis": "^144.0.0",
         "jsdom": "^29.0.1",
@@ -1159,6 +1161,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1195,6 +1198,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
@@ -1409,12 +1430,6 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
-    },
-    "node_modules/@perplexity-ai/perplexity_ai": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@perplexity-ai/perplexity_ai/-/perplexity_ai-0.18.4.tgz",
-      "integrity": "sha512-K12CbOIGkIRdxd0VwRdZhTBUuaKMmE9PEeNMGlvhsFyMCq/DNTaV+k/jlnOdvlbuoy0FoWOTapy4HLMe0yTh5w==",
-      "license": "Apache-2.0"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.55.3",
@@ -1998,8 +2013,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2170,6 +2195,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chrono-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.0.tgz",
+      "integrity": "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2215,7 +2249,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2463,7 +2496,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2687,7 +2719,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2842,13 +2873,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -2954,11 +2982,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3226,7 +3273,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4355,6 +4401,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@mozilla/readability": "^0.6.0",
     "axios": "^1.6.0",
+    "chrono-node": "^2.9.0",
     "connect-pg-simple": "^9.0.1",
     "cors": "^2.8.5",
     "csv-parse": "^5.5.3",

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -5135,5 +5135,20 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   // End of Newsletter Management
   // ============================================================
 
+  // Moderation Sweep
+  // ============================================================
+
+  router.post('/moderation/sweep', isAdmin, async (req, res) => {
+    try {
+      console.log(`Admin ${req.user.email} triggered manual moderation sweep`);
+      const { processPendingItems } = await import('../services/moderationService.js');
+      await processPendingItems(pool);
+      res.json({ message: 'Moderation sweep completed' });
+    } catch (error) {
+      console.error('Moderation sweep error:', error);
+      res.status(500).json({ error: 'Moderation sweep failed' });
+    }
+  });
+
   return router;
 }

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4278,7 +4278,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
                  CASE
                    WHEN bool_or(level = 'error') THEN 'failed'
                    WHEN bool_or((details->>'completed')::boolean) THEN 'completed'
-                   WHEN MAX(created_at) > NOW() - INTERVAL '2 minutes' THEN 'running'
+                   WHEN MAX(created_at) > NOW() - INTERVAL '10 minutes' THEN 'running'
                    ELSE 'stale'
                  END AS status,
                  MIN(created_at) AS started_at,

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -5141,12 +5141,15 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   router.post('/moderation/sweep', isAdmin, async (req, res) => {
     try {
       console.log(`Admin ${req.user.email} triggered manual moderation sweep`);
+      // Fire-and-forget — sweep runs in background, response returns immediately
       const { processPendingItems } = await import('../services/moderationService.js');
-      await processPendingItems(pool);
-      res.json({ message: 'Moderation sweep completed' });
+      processPendingItems(pool).catch(err => {
+        console.error('Background moderation sweep error:', err.message);
+      });
+      res.json({ message: 'Moderation sweep started' });
     } catch (error) {
       console.error('Moderation sweep error:', error);
-      res.status(500).json({ error: 'Moderation sweep failed' });
+      res.status(500).json({ error: 'Moderation sweep failed to start' });
     }
   });
 

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -55,8 +55,8 @@ export const COLLECTION_TYPES = [
     schedule: '*/15 * * * *',
     statusTable: null,
     historyTypes: ['moderation'],
-    triggerEndpoint: null,
-    manualTriggerMethod: null,
+    triggerEndpoint: '/api/admin/moderation/sweep',
+    manualTriggerMethod: 'POST',
     hasPrompt: false
   },
   {

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -18,12 +18,17 @@ export function parseDate(raw, timezone = 'America/New_York') {
 
   if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
     const [y, m, d] = trimmed.split('-').map(Number);
-    if (y >= 1900 && y <= 2100 && m >= 1 && m <= 12 && d >= 1 && d <= 31) {
+    // Validate day-of-month using Date constructor (catches Feb 31 etc.)
+    const probe = new Date(y, m - 1, d);
+    if (probe.getFullYear() === y && probe.getMonth() === m - 1 && probe.getDate() === d) {
       return trimmed;
     }
   }
 
-  const results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  let results;
+  try {
+    results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  } catch { return null; }
   if (results.length === 0) return null;
 
   const d = results[0].start;
@@ -49,7 +54,10 @@ export function parseDateTime(raw, timezone = 'America/New_York') {
   const isoMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)$/);
   if (isoMatch) return `${isoMatch[1]}T${isoMatch[2].length === 5 ? isoMatch[2] + ':00' : isoMatch[2]}`;
 
-  const results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  let results;
+  try {
+    results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  } catch { return null; }
   if (results.length === 0) return null;
 
   const d = results[0].start;
@@ -74,7 +82,10 @@ export function parseDateTime(raw, timezone = 'America/New_York') {
 export function extractDatesFromText(text, timezone = 'America/New_York') {
   if (!text || typeof text !== 'string') return [];
 
-  const results = chrono.parse(text, { instant: new Date(), timezone });
+  let results;
+  try {
+    results = chrono.parse(text, { instant: new Date(), timezone });
+  } catch { return []; }
   return results.map(r => {
     const s = r.start;
     const startStr = `${s.get('year')}-${String(s.get('month')).padStart(2, '0')}-${String(s.get('day')).padStart(2, '0')}`;

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -1,0 +1,164 @@
+/**
+ * Date Extractor — chrono-node wrapper for deterministic date parsing.
+ * Universal post-processor for every date entering the system.
+ */
+
+import * as chrono from 'chrono-node';
+
+/**
+ * Normalize a single date string to YYYY-MM-DD.
+ * @param {string|null} raw - Raw date string
+ * @param {string} timezone - IANA timezone (default: America/New_York)
+ * @returns {string|null} 'YYYY-MM-DD' or null
+ */
+export function parseDate(raw, timezone = 'America/New_York') {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const [y, m, d] = trimmed.split('-').map(Number);
+    if (y >= 1900 && y <= 2100 && m >= 1 && m <= 12 && d >= 1 && d <= 31) {
+      return trimmed;
+    }
+  }
+
+  const results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  if (results.length === 0) return null;
+
+  const d = results[0].start;
+  const year = d.get('year');
+  const month = d.get('month');
+  const day = d.get('day');
+  if (!year || !month || !day) return null;
+
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/**
+ * Normalize a datetime string to YYYY-MM-DDTHH:MM:SS.
+ * @param {string|null} raw - Raw datetime string
+ * @param {string} timezone - IANA timezone
+ * @returns {string|null} 'YYYY-MM-DDTHH:MM:SS' or null
+ */
+export function parseDateTime(raw, timezone = 'America/New_York') {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const isoMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)$/);
+  if (isoMatch) return `${isoMatch[1]}T${isoMatch[2].length === 5 ? isoMatch[2] + ':00' : isoMatch[2]}`;
+
+  const results = chrono.parse(trimmed, { instant: new Date(), timezone });
+  if (results.length === 0) return null;
+
+  const d = results[0].start;
+  const year = d.get('year');
+  const month = d.get('month');
+  const day = d.get('day');
+  if (!year || !month || !day) return null;
+
+  const hour = d.get('hour') ?? 0;
+  const minute = d.get('minute') ?? 0;
+  const second = d.get('second') ?? 0;
+
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`;
+}
+
+/**
+ * Scan raw text and return all date references found by chrono-node.
+ * @param {string} text - Raw page text / rendered markdown
+ * @param {string} timezone - IANA timezone
+ * @returns {Array<{text: string, start: string, end: string|null, index: number}>}
+ */
+export function extractDatesFromText(text, timezone = 'America/New_York') {
+  if (!text || typeof text !== 'string') return [];
+
+  const results = chrono.parse(text, { instant: new Date(), timezone });
+  return results.map(r => {
+    const s = r.start;
+    const startStr = `${s.get('year')}-${String(s.get('month')).padStart(2, '0')}-${String(s.get('day')).padStart(2, '0')}`;
+    const hasTime = s.isCertain('hour');
+    const startFull = hasTime
+      ? `${startStr} ${String(s.get('hour') ?? 0).padStart(2, '0')}:${String(s.get('minute') ?? 0).padStart(2, '0')}`
+      : startStr;
+
+    let endFull = null;
+    if (r.end) {
+      const e = r.end;
+      const endStr = `${e.get('year')}-${String(e.get('month')).padStart(2, '0')}-${String(e.get('day')).padStart(2, '0')}`;
+      const endHasTime = e.isCertain('hour');
+      endFull = endHasTime
+        ? `${endStr} ${String(e.get('hour') ?? 0).padStart(2, '0')}:${String(e.get('minute') ?? 0).padStart(2, '0')}`
+        : endStr;
+    }
+
+    return { text: r.text, start: startFull, end: endFull, index: r.index };
+  });
+}
+
+/**
+ * Find the most likely publication date from rendered page text.
+ * Checks structured patterns (bylines, metadata), title, then full text scan.
+ * @param {string} text - Rendered page content
+ * @param {string} title - Item title
+ * @param {string} timezone - IANA timezone
+ * @returns {string|null} 'YYYY-MM-DD' or null
+ */
+export function findPublicationDate(text, title, timezone = 'America/New_York') {
+  if (!text) return null;
+
+  const patterns = [
+    /(?:published|posted|updated|written|date)\s*(?:on|:)?\s*(.+?)(?:\n|$)/i,
+    /(?:^|\n)\s*[Bb]y\s+.+?[\|–—-]\s*(.+?)(?:\n|$)/,
+    /(?:^|\n)\s*((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*\.?\s+\d{1,2},?\s+\d{4})/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) {
+      const parsed = parseDate(match[1], timezone);
+      if (parsed) return parsed;
+    }
+  }
+
+  if (title) {
+    const titleDate = parseDate(title, timezone);
+    if (titleDate) return titleDate;
+  }
+
+  const dates = extractDatesFromText(text, timezone);
+  if (dates.length > 0) return dates[0].start.slice(0, 10);
+
+  return null;
+}
+
+/**
+ * Find start/end dates and times for an event from rendered page text.
+ * @param {string} text - Rendered page content
+ * @param {string} title - Event title
+ * @param {string} timezone - IANA timezone
+ * @returns {{startDate: string|null, startTime: string|null, endDate: string|null, endTime: string|null}}
+ */
+export function findEventDates(text, title, timezone = 'America/New_York') {
+  const result = { startDate: null, startTime: null, endDate: null, endTime: null };
+  if (!text) return result;
+
+  const dates = extractDatesFromText(text, timezone);
+  if (dates.length === 0) return result;
+
+  const first = dates[0];
+  result.startDate = first.start.slice(0, 10);
+  if (first.start.length > 10) {
+    result.startTime = first.start.slice(11);
+  }
+
+  if (first.end) {
+    result.endDate = first.end.slice(0, 10);
+    if (first.end.length > 10) {
+      result.endTime = first.end.slice(11);
+    }
+  }
+
+  return result;
+}

--- a/backend/services/deepCrawler.js
+++ b/backend/services/deepCrawler.js
@@ -82,7 +82,7 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
       visited.add(url);
 
       pagesChecked++;
-      console.log(`[Deep Crawler] Rendering (depth=${depth}, page=${pagesChecked}/${maxPages}): ${url}`);
+      console.log(`[Render] Rendering (depth=${depth}, page=${pagesChecked}/${maxPages}): ${url}`);
 
       const extracted = await extractor(url, {
         timeout: 15000,
@@ -93,7 +93,7 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
       if (!extracted.reachable || !extracted.markdown) continue;
 
       if (contentMatchesItem(extracted.markdown, item)) {
-        console.log(`[Deep Crawler] Match found at depth ${depth}: ${url}`);
+        console.log(`[Render] Match found at depth ${depth}: ${url}`);
         return { foundUrl: url, foundContent: extracted.markdown };
       }
 
@@ -123,7 +123,7 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
   if (prefetched && prefetched.markdown) {
     visited.add(sourceUrl);
     if (contentMatchesItem(prefetched.markdown, item)) {
-      console.log(`[Deep Crawler] Match found at depth 0 (prefetched): ${sourceUrl}`);
+      console.log(`[Render] Match found at depth 0 (prefetched): ${sourceUrl}`);
       return { foundUrl: sourceUrl, foundContent: prefetched.markdown, pagesChecked: 0 };
     }
     const candidateLinks = [];
@@ -168,6 +168,6 @@ export async function deepCrawlForArticle(sourceUrl, item, options = {}) {
     currentCandidates = levelResult.candidateLinks || [];
   }
 
-  console.log(`[Deep Crawler] No match found after checking ${pagesChecked} pages`);
+  console.log(`[Render] No match found after checking ${pagesChecked} pages`);
   return { foundUrl: null, foundContent: null, pagesChecked };
 }

--- a/backend/services/geminiService.js
+++ b/backend/services/geminiService.js
@@ -797,20 +797,10 @@ Score 0.0-1.0 on these criteria:
    personal trip reports, engagement announcements, family reunion recaps. These are not
    park news — they are private moments. Add "private_content" to issues and score 0.0.
 
-PUBLICATION DATE EXTRACTION (does NOT affect scoring):
-Extract or estimate when this content was originally published or when the event occurred.
-- If the source page has a clear publication date, byline date, or article timestamp,
-  set publication_date to that date (YYYY-MM-DD) and date_confidence to "exact".
-- If no explicit date but you can estimate from context clues (seasonal references,
-  "this spring", references to known dated events, copyright years, URL date patterns),
-  set your best estimate and date_confidence to "estimated".
-- If you cannot determine any date at all, set publication_date to null and
-  date_confidence to "unknown".
 NOTE: Old content is NOT a reason to reject. ROTV is a living history journal.
-Publication date is for sorting/filtering only.
 
 Return ONLY valid JSON (no markdown, no code blocks):
-{"confidence_score": 0.0, "reasoning": "...", "issues": [], "publication_date": "YYYY-MM-DD", "date_confidence": "exact"}`;
+{"confidence_score": 0.0, "reasoning": "...", "issues": []}`;
 
   const geminiResponse = await model.generateContent(prompt);
   const text = geminiResponse.response.text().trim();

--- a/backend/services/jobLogger.js
+++ b/backend/services/jobLogger.js
@@ -71,20 +71,17 @@ export function log(entry) {
  * Convenience: log an info entry
  */
 export function logInfo(jobId, jobType, poiId, poiName, message, details = null) {
+  console.log(message);
   log({ jobId, jobType, poiId, poiName, level: 'info', message, details });
 }
 
-/**
- * Convenience: log a warning entry
- */
 export function logWarn(jobId, jobType, poiId, poiName, message, details = null) {
+  console.warn(message);
   log({ jobId, jobType, poiId, poiName, level: 'warn', message, details });
 }
 
-/**
- * Convenience: log an error entry
- */
 export function logError(jobId, jobType, poiId, poiName, message, details = null) {
+  console.error(message);
   log({ jobId, jobType, poiId, poiName, level: 'error', message, details });
 }
 

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -509,7 +509,7 @@ function registerTools(server, pool, boss) {
                  CASE
                    WHEN bool_or(level = 'error') THEN 'failed'
                    WHEN bool_or((details->>'completed')::boolean) THEN 'completed'
-                   WHEN MAX(created_at) > NOW() - INTERVAL '2 minutes' THEN 'running'
+                   WHEN MAX(created_at) > NOW() - INTERVAL '10 minutes' THEN 'running'
                    ELSE 'stale'
                  END AS status,
                  MIN(created_at) AS started_at,

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -8,6 +8,7 @@ import { moderateContent, moderatePhoto, createGeminiClient, GEMINI_MODEL } from
 import { extractPageContent } from './contentExtractor.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
+import { findPublicationDate, findEventDates, parseDate } from './dateExtractor.js';
 
 const TABLE_MAP = {
   news: 'poi_news',
@@ -73,14 +74,11 @@ function extractDateFields(scoring) {
   let dateConfidence = 'unknown';
 
   if (scoring.publication_date) {
-    // Validate YYYY-MM-DD format strictly — don't trust Date constructor parsing
-    const dateStr = String(scoring.publication_date);
-    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
-      const [y, m, d] = dateStr.split('-').map(Number);
-      if (m >= 1 && m <= 12 && d >= 1 && d <= 31 && y >= 1900 && y <= 2100) {
-        publicationDate = dateStr;
-        dateConfidence = scoring.date_confidence || 'estimated';
-      }
+    // Normalize through chrono-node first — handles natural language, European format, etc.
+    const normalized = parseDate(String(scoring.publication_date));
+    if (normalized) {
+      publicationDate = normalized;
+      dateConfidence = scoring.date_confidence || 'estimated';
     }
   } else if (scoring.date_confidence) {
     dateConfidence = scoring.date_confidence;
@@ -223,7 +221,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
 
   if (contentType === 'news') {
     const newsQuery = await pool.query(
-      `SELECT n.id, n.title, n.summary, n.source_url, p.name as poi_name
+      `SELECT n.id, n.title, n.summary, n.source_url, n.publication_date, n.date_confidence, p.name as poi_name
        FROM poi_news n
        LEFT JOIN pois p ON n.poi_id = p.id
        WHERE n.id = $1`, [contentId]
@@ -284,8 +282,9 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       ({ scoring, foundIssue } = await attemptDeepCrawl(pool, 'news', contentId, row, scoring));
     }
 
-    // Extract date fields before quality filters
-    const { publicationDate: newsPubDate, dateConfidence: newsDateConf } = extractDateFields(scoring);
+    // Use dates from collection (set by chrono-node), not from Gemini moderation
+    const newsPubDate = row.publication_date ? parseDate(String(row.publication_date).slice(0, 10)) : null;
+    const newsDateConf = newsPubDate ? (row.date_confidence || 'estimated') : 'unknown';
 
     // Apply quality filters to adjust confidence_score
     scoring = applyQualityFilters(scoring, row.source_url, { publicationDate: newsPubDate, dateConfidence: newsDateConf }, trustedSet, competitorSet);
@@ -331,7 +330,8 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
 
   } else if (contentType === 'event') {
     const eventQuery = await pool.query(
-      `SELECT e.id, e.title, e.description, e.source_url, e.start_date, e.content_source, p.name as poi_name
+      `SELECT e.id, e.title, e.description, e.source_url, e.start_date, e.content_source,
+              e.publication_date, e.date_confidence, p.name as poi_name
        FROM poi_events e
        LEFT JOIN pois p ON e.poi_id = p.id
        WHERE e.id = $1`, [contentId]
@@ -395,8 +395,18 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       ({ scoring, foundIssue: eventFoundIssue } = await attemptDeepCrawl(pool, 'event', contentId, row, scoring));
     }
 
-    // Extract date fields before quality filters
-    const { publicationDate: eventPubDate, dateConfidence: eventDateConf } = extractDateFields(scoring);
+    // Use dates from collection (set by chrono-node), not from Gemini moderation
+    let eventPubDate = row.publication_date ? parseDate(String(row.publication_date).slice(0, 10)) : null;
+    let eventDateConf = eventPubDate ? (row.date_confidence || 'estimated') : 'unknown';
+
+    // Fallback: events with start_date but no pub date shouldn't get stuck as 'unknown'
+    if (eventDateConf === 'unknown' && row.start_date) {
+      const startStr = String(row.start_date).slice(0, 10);
+      if (/^\d{4}-\d{2}-\d{2}$/.test(startStr)) {
+        eventPubDate = startStr;
+        eventDateConf = 'estimated';
+      }
+    }
 
     // Apply quality filters to adjust confidence_score
     scoring = applyQualityFilters(scoring, row.source_url, { publicationDate: eventPubDate, dateConfidence: eventDateConf }, trustedSet, competitorSet);
@@ -820,55 +830,9 @@ export async function fixDate(pool, contentType, contentId) {
   console.log(`[Moderation] Fixing date for ${contentType} #${contentId}: "${item.title}"`);
   logInfo(runId, 'moderation', null, item.title, `Fix Date: ${contentType} #${contentId}`);
 
-  // Fetch actual page content if source URL exists
+  // Render page content via Playwright + Readability for chrono-node and Gemini
   let pageContent = '';
-  let htmlDateHints = '';
   if (item.source_url && isSafePublicUrl(item.source_url)) {
-    try {
-      // Simple fetch to get raw HTML for date metadata extraction
-      const res = await fetch(item.source_url, {
-        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ROTV/1.0)' },
-        signal: AbortSignal.timeout(10000)
-      });
-      if (res.ok) {
-        const html = await res.text();
-        // Extract date hints from HTML metadata and structured elements
-        const datePatterns = [];
-        const metaMatch = html.match(/<meta[^>]+(?:property|name)=["'](?:article:published_time|og:article:published_time|datePublished|date|DC\.date)["'][^>]+content=["']([^"']+)["']/i);
-        if (metaMatch) datePatterns.push(metaMatch[1]);
-        const timeMatch = html.match(/<time[^>]+datetime=["']([^"']+)["']/i);
-        if (timeMatch) datePatterns.push(timeMatch[1]);
-        const ldMatch = html.match(/"datePublished"\s*:\s*"([^"]+)"/);
-        if (ldMatch) datePatterns.push(ldMatch[1]);
-
-        // If we found a machine-readable date, use it directly — skip Gemini
-        if (datePatterns.length > 0) {
-          for (const raw of datePatterns) {
-            const isoMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
-            if (isoMatch) {
-              const dateStr = `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
-              const [y, m, d] = [parseInt(isoMatch[1]), parseInt(isoMatch[2]), parseInt(isoMatch[3])];
-              if (m >= 1 && m <= 12 && d >= 1 && d <= 31 && y >= 1900 && y <= 2100) {
-                await pool.query(
-                  `UPDATE ${table} SET publication_date = $1, date_confidence = 'exact' WHERE id = $2`,
-                  [dateStr, contentId]
-                );
-                console.log(`[Moderation] Fix date from HTML metadata: ${contentType} #${contentId} → ${dateStr}`);
-                logInfo(runId, 'moderation', null, item.title, `Fix Date: ${dateStr} (from HTML metadata)`, { completed: true, publication_date: dateStr });
-                await flushJobLogs();
-                return { date_updated: true, publication_date: dateStr, date_confidence: 'exact', reasoning: 'Extracted from HTML metadata' };
-              }
-            }
-          }
-          // Have hints but couldn't parse — pass to Gemini
-          htmlDateHints = '\nDate metadata found in HTML:\n' + datePatterns.join('\n');
-        }
-      }
-    } catch (fetchErr) {
-      console.warn(`[Moderation] Could not fetch raw HTML for fix-date: ${fetchErr.message}`);
-    }
-
-    // Also get readable content via Playwright + Readability
     try {
       const extracted = await extractPageContent(item.source_url, { maxLength: 4000, timeout: 15000 });
       if (extracted.markdown) {
@@ -879,6 +843,48 @@ export async function fixDate(pool, contentType, contentId) {
     }
   }
 
+  // Try chrono-node first — deterministic, no API call needed
+  if (pageContent) {
+    const chronoPubDate = findPublicationDate(pageContent, item.title, 'America/New_York');
+    if (chronoPubDate) {
+      // Fast path: chrono-node found a date, skip Gemini
+      if (contentType === 'event') {
+        const eventDates = findEventDates(pageContent, item.title, 'America/New_York');
+        const setClauses = ['publication_date = $2', "date_confidence = 'exact'"];
+        const values = [contentId, chronoPubDate];
+        let idx = 3;
+        if (eventDates.startDate) {
+          const startTs = eventDates.startTime
+            ? `${eventDates.startDate}T${eventDates.startTime}:00`
+            : `${eventDates.startDate}T00:00:00`;
+          setClauses.push(`start_date = $${idx}`);
+          values.push(startTs);
+          idx++;
+        }
+        if (eventDates.endDate) {
+          const endTs = eventDates.endTime
+            ? `${eventDates.endDate}T${eventDates.endTime}:00`
+            : `${eventDates.endDate}T23:59:00`;
+          setClauses.push(`end_date = $${idx}`);
+          values.push(endTs);
+          idx++;
+        }
+        await pool.query(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $1`, values);
+        console.log(`[Moderation] Fix date via chrono-node: ${contentType} #${contentId} → pub=${chronoPubDate}, start=${eventDates.startDate}`);
+      } else {
+        await pool.query(
+          `UPDATE ${table} SET publication_date = $1, date_confidence = 'exact' WHERE id = $2`,
+          [chronoPubDate, contentId]
+        );
+        console.log(`[Moderation] Fix date via chrono-node: ${contentType} #${contentId} → ${chronoPubDate}`);
+      }
+      logInfo(runId, 'moderation', null, item.title, `Fix Date: ${chronoPubDate} (chrono-node)`, { completed: true, publication_date: chronoPubDate });
+      await flushJobLogs();
+      return { date_updated: true, publication_date: chronoPubDate, date_confidence: 'exact', reasoning: 'Extracted by chrono-node' };
+    }
+  }
+
+  // Chrono-node failed — fall through to Gemini
   const typeLabel = contentType === 'news' ? 'news article' : 'event';
   const eventDateInstructions = contentType === 'event' ? `
 - EVENT DATES: Find the event start date/time and end date/time. These are the dates the event actually occurs, NOT when the article was published.
@@ -895,7 +901,6 @@ Title: "${item.title}"
 ${item.description ? `Description: "${item.description}"` : ''}
 ${item.source_url ? `Source URL: ${item.source_url}` : ''}
 ${item.poi_name ? `Location/Organization: ${item.poi_name}` : ''}
-${htmlDateHints}
 ${pageContent ? `\nPage Content:\n${pageContent}` : ''}
 
 Look for:
@@ -944,6 +949,11 @@ If truly impossible to determine, use "unknown" and set publication_date to null
     await flushJobLogs();
     return { date_updated: false, reasoning: 'Failed to parse AI response' };
   }
+
+  // Post-process Gemini dates through chrono-node for normalization
+  if (result.publication_date) result.publication_date = parseDate(result.publication_date) || result.publication_date;
+  if (result.start_date) result.start_date = parseDate(result.start_date) || result.start_date;
+  if (result.end_date) result.end_date = parseDate(result.end_date) || result.end_date;
 
   const { publicationDate, dateConfidence } = extractDateFields(result);
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1,15 +1,16 @@
 /**
  * News Collection Service
  * Two-phase pipeline: Phase I crawls POI's own pages, Phase II searches via Serper.
- * Both phases use Gemini for extraction.
+ * Both phases use Gemini for summarization, chrono-node for dates.
  *
  * Job execution is managed by pg-boss for crash recovery and resumability.
  * Progress is checkpointed after each batch so jobs can resume after container restarts.
  */
 
 import { generateTextWithCustomPrompt as geminiGenerateText } from './geminiService.js';
+import { parseDate, parseDateTime, extractDatesFromText } from './dateExtractor.js';
 
-// Simple Gemini call counter (replaces aiSearchFactory usage tracking)
+// Gemini call counter for job usage stats
 let geminiCallCount = 0;
 
 export function resetJobUsage() {
@@ -37,8 +38,6 @@ async function generateTextWithCustomPrompt(pool, prompt) {
   return { response: text, provider: 'gemini' };
 }
 import { extractPageContent } from './contentExtractor.js';
-import { calculateSimilarity } from './textUtils.js';
-import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logWarn, logError, flush as flushJobLogs } from './jobLogger.js';
 import { CollectionTracker, runBatch } from './collection/index.js';
 import { searchNewsUrls } from './serperService.js';
@@ -75,95 +74,11 @@ export const requestCancellation = (poiId) => tracker.requestCancellation(poiId)
 export const isCancellationRequested = (poiId) => tracker.isCancellationRequested(poiId);
 
 /**
- * Match an event or news item to extracted links from the page
- * @param {Object} item - Event or news item with title, description, start_date/published_date
- * @param {Array} links - Array of link objects from contentExtractor
- * @param {string} type - 'event' or 'news'
- * @returns {string|null} - Matched URL or null
- */
-function matchItemToLink(item, links, type = 'event') {
-  if (!links || links.length === 0) return null;
-  if (!item.title) return null;
-
-  let bestMatch = null;
-  let bestScore = 0;
-  const THRESHOLD = 2.0; // Minimum similarity to consider a match (increased to filter poor matches)
-
-  // Debug: log first attempt for this item
-  let isFirstLog = true;
-
-  for (const link of links) {
-    let score = 0;
-
-    // 1. Check title similarity to link text
-    const titleToLinkText = calculateSimilarity(item.title, link.text);
-    score += titleToLinkText * 3; // Title match is most important
-
-    // 2. Check if title appears in link context
-    const titleInContext = calculateSimilarity(item.title, link.context);
-    score += titleInContext * 2;
-
-    // 3. Check description similarity to context (if available)
-    if (item.description) {
-      const descInContext = calculateSimilarity(item.description, link.context);
-      score += descInContext;
-    }
-
-    if (item.summary) {
-      const summaryInContext = calculateSimilarity(item.summary, link.context);
-      score += summaryInContext;
-    }
-
-    // 4. Check for date in link text/context (for events)
-    if (type === 'event' && item.start_date) {
-      const dateStr = item.start_date;
-      const dateFormats = [
-        dateStr, // YYYY-MM-DD
-        new Date(dateStr).toLocaleDateString('en-US'), // M/D/YYYY
-        new Date(dateStr).toLocaleDateString('en-US', { month: 'long', day: 'numeric' }) // Month Day
-      ];
-
-      if (dateFormats.some(df => link.text.includes(df) || link.context.includes(df))) {
-        score += 1;
-      }
-    }
-
-    // 5. Bonus for event/news keywords in className
-    if (type === 'event' && (link.className.includes('event') || link.parentClassName.includes('event'))) {
-      score += 0.5;
-    }
-    if (type === 'news' && (link.className.includes('news') || link.className.includes('article') ||
-                             link.parentClassName.includes('news') || link.parentClassName.includes('article'))) {
-      score += 0.5;
-    }
-
-    // Debug: log the best scoring link for first item
-    if (isFirstLog && score > 0.5) {
-      console.log(`[Link Matcher DEBUG] Item: "${item.title.substring(0, 50)}..."`);
-      console.log(`[Link Matcher DEBUG] Link text: "${link.text.substring(0, 50)}..." | Score: ${score.toFixed(2)} (threshold: ${THRESHOLD})`);
-      isFirstLog = false;
-    }
-
-    if (score > bestScore) {
-      bestScore = score;
-      bestMatch = link.url;
-    }
-  }
-
-  if (bestMatch && bestScore >= THRESHOLD) {
-    console.log(`[Link Matcher] ✓ Matched "${item.title}" to ${bestMatch} (score: ${bestScore.toFixed(2)})`);
-    return bestMatch;
-  } else {
-    console.log(`[Link Matcher] ✗ No match for "${item.title}" (best score: ${bestScore.toFixed(2)}, threshold: ${THRESHOLD})`);
-    return null;
-  }
-}
-
-/**
  * Ensure the news_job_status table has checkpoint columns for resumability
  * Call this during server startup
  */
 export async function ensureNewsJobCheckpointColumns(pool) {
+  const runId = Math.floor(Date.now() / 1000);
   try {
     // Add poi_ids column if it doesn't exist
     await pool.query(`
@@ -183,9 +98,9 @@ export async function ensureNewsJobCheckpointColumns(pool) {
       ADD COLUMN IF NOT EXISTS pg_boss_job_id VARCHAR(100)
     `);
 
-    console.log('News job checkpoint columns verified');
+    logInfo(runId, 'news', null, null, 'News job checkpoint columns verified');
   } catch (error) {
-    console.error('Error ensuring checkpoint columns:', error.message);
+    logError(runId, 'news', null, null, `Error ensuring checkpoint columns: ${error.message}`);
   }
 }
 
@@ -208,14 +123,6 @@ export async function findIncompleteJobs(pool) {
 
 // Prompt template for news collection (exported for registry.js default prompt access)
 export const NEWS_COLLECTION_PROMPT = `You are a precise news researcher for Cuyahoga Valley National Park and surrounding areas in Northeast Ohio.
-
-TIMEZONE CONTEXT:
-- The current timezone is: {{timezone}}
-- When you see dates in articles, news, or events, interpret them as being in {{timezone}}
-- Return ALL dates in ISO 8601 format: YYYY-MM-DD
-- CRITICAL: Copy dates EXACTLY as they appear on the source. Do NOT add or subtract days.
-- Example: If you see "October 9, 2024" in an article, return "2024-10-09" (not 2024-10-08 or 2024-10-10)
-- Example: If you see "January 30" in 2026, return "2026-01-30" (not 2026-01-29 or 2026-01-31)
 
 Search for recent news and upcoming events SPECIFICALLY about: "{{name}}"
 Location type: {{poi_type}}
@@ -339,7 +246,7 @@ Return a JSON object with this exact structure:
       "summary": "2-3 sentence summary - must explain how this relates to {{name}} specifically",
       "source_name": "Source name (e.g., NPS.gov, Cleveland.com)",
       "source_url": "URL if available, or null",
-      "published_date": "YYYY-MM-DD in ISO 8601 format, or null if unknown",
+      "published_date": "date if visible on page, or null",
       "news_type": "general|alert|wildlife|infrastructure|community"
     }
   ],
@@ -347,8 +254,8 @@ Return a JSON object with this exact structure:
     {
       "title": "Event name",
       "description": "Brief description - must specify this event is at {{name}}",
-      "start_date": "YYYY-MM-DD in ISO 8601 format",
-      "end_date": "YYYY-MM-DD in ISO 8601 format, or null if single day",
+      "start_date": "event date if visible on page",
+      "end_date": "end date or null if single day",
       "event_type": "hike|race|concert|festival|program|volunteer|arts|community|alert",
       "location_details": "Must be at or near {{name}} specifically",
       "source_url": "Registration or info URL if available"
@@ -361,85 +268,8 @@ IMPORTANT:
 - It is better to return empty arrays than to include false positives
 - If no news or events found specifically for "{{name}}", return: {"news": [], "events": []}
 - Include the exact JSON structure above, no additional text
-- All dates must be in ISO 8601 format (YYYY-MM-DD), interpreted in {{timezone}}
 - NEWS should be from the last 365 days only - do NOT include older news
 - EVENTS must be upcoming (future dates) or currently happening - do NOT include past events`;
-
-/**
- * Crawl same-origin sub-pages beneath a dedicated events/news URL to build richer content.
- * When a POI has a dedicated URL (e.g. /excursions), sites often organize content into
- * sub-pages (e.g. /excursions/themed-events, /excursions/fun-games). This function
- * renders those sub-pages and combines their markdown + links for Gemini.
- *
- * @param {string} pageUrl - The dedicated page URL (events_url or news_url)
- * @param {Array} pageLinks - Links extracted from the dedicated page
- * @param {number} poiId - POI ID for logging
- * @param {Function} checkCancellation - Cancellation checker function
- * @param {Object} options - Optional overrides
- * @param {Function} options.extractor - Page extraction function (for testing)
- * @param {number} options.maxPages - Max sub-pages to render (default 10)
- * @returns {Object|null} - { markdown, links, pagesRendered } or null if insufficient content
- */
-async function crawlSubPages(pageUrl, pageLinks, poiId, checkCancellation, options = {}) {
-  const { extractor = extractPageContent, maxPages = 10 } = options;
-
-  // Parse page URL to get origin and path prefix
-  let pageOrigin, pagePath;
-  try {
-    const parsed = new URL(pageUrl);
-    pageOrigin = parsed.origin;
-    pagePath = parsed.pathname.replace(/\/+$/, '');
-  } catch { return null; }
-
-  // Filter to unique same-origin sub-page links
-  const seen = new Set();
-  const subPageLinks = pageLinks.filter(link => {
-    try {
-      const parsed = new URL(link.url);
-      if (parsed.origin !== pageOrigin) return false;
-      const linkPath = parsed.pathname.replace(/\/+$/, '');
-      if (linkPath === pagePath || !linkPath.startsWith(pagePath + '/')) return false;
-      if (seen.has(link.url)) return false;
-      seen.add(link.url);
-      return true;
-    } catch { return false; }
-  });
-
-  if (subPageLinks.length < 2) return null;
-
-  console.log(`[AI Research] Sub-page crawl: found ${subPageLinks.length} sub-pages under ${pagePath}`);
-
-  let combinedMarkdown = '';
-  let combinedLinks = [...pageLinks];
-  let pagesRendered = 0;
-
-  for (const subLink of subPageLinks.slice(0, maxPages)) {
-    checkCancellation();
-    pagesRendered++;
-    const sectionName = subLink.text?.trim() || subLink.url.split('/').pop().replace(/-/g, ' ');
-    console.log(`[AI Research]   Crawling sub-page ${pagesRendered}/${Math.min(subPageLinks.length, maxPages)}: ${subLink.url}`);
-
-    try {
-      const extracted = await extractor(subLink.url, {
-        timeout: 30000, hardTimeout: 60000, extractLinks: true
-      });
-
-      if (extracted.reachable && extracted.markdown?.length > 50) {
-        combinedMarkdown += `## ${sectionName}\n\n${extracted.markdown}\n\n`;
-        if (extracted.links) combinedLinks.push(...extracted.links);
-        console.log(`[AI Research]   ✓ ${extracted.markdown.length} chars, ${(extracted.links || []).length} links`);
-      } else {
-        console.log(`[AI Research]   ✗ Insufficient content (${extracted.markdown?.length || 0} chars)`);
-      }
-    } catch (err) {
-      console.log(`[AI Research]   ✗ Error: ${err.message}`);
-    }
-  }
-
-  return combinedMarkdown.length >= 200
-    ? { markdown: combinedMarkdown, links: combinedLinks, pagesRendered }
-    : null;
-}
 
 /**
  * Classify a web page as LISTING, DETAIL, or HYBRID using Gemini.
@@ -525,7 +355,7 @@ function filterDetailLinks(detailLinks, sourceUrl) {
  * @returns {Object} - { pages: [{url, markdown, title}], totalPagesRendered, totalDetailPages }
  */
 async function crawlWithClassification(pool, startUrl, contentType, poi, sheets, checkCancellation, options = {}) {
-  const { maxDepth = 2, maxPages = 50, maxDetailPages = 30, renderDelayMs = 1500, extractor = extractPageContent } = options;
+  const { maxDepth = 2, maxPages = 50, maxDetailPages = 30, renderDelayMs = 1500, extractor = extractPageContent, phase = 'Phase I', jobId = 0 } = options;
   const visited = new Set();
   let totalPagesRendered = 0;
   const collectedPages = []; // { url, markdown, title }
@@ -544,25 +374,29 @@ async function crawlWithClassification(pool, startUrl, contentType, poi, sheets,
         await new Promise(resolve => setTimeout(resolve, renderDelayMs));
       }
 
-      console.log(`[Classifier] Rendering (depth=${depth}, page=${totalPagesRendered}): ${url}`);
+      logInfo(jobId, 'news', poi.id, poi.name, `${phase}: [Render] ${url} (depth=${depth}, page=${totalPagesRendered})`);
       const extracted = await extractor(url, { timeout: 30000, hardTimeout: 60000, extractLinks: true });
       if (!extracted.reachable || !extracted.markdown) {
-        console.log(`[Classifier] ✗ Failed to render: ${extracted.reason || 'no content'}`);
+        logInfo(jobId, 'news', poi.id, poi.name, `${phase}: [Render] Skip — ${extracted.reason || 'no content'}`);
         continue;
       }
 
       const classification = await classifyPage(pool, extracted.markdown, extracted.links || [], url, contentType, sheets);
-      console.log(`[Classifier] ${url} → ${classification.pageType} (${classification.reasoning})`);
+      logInfo(jobId, 'news', poi.id, poi.name, `${phase}: [Classify] ${url} → ${classification.pageType} (${classification.reasoning})`);
 
       if (classification.pageType === 'detail') {
         collectedPages.push({ url, markdown: extracted.markdown, title: extracted.title });
       } else if (classification.pageType === 'listing') {
         const validLinks = filterDetailLinks(classification.detailLinks, url);
+        logInfo(jobId, 'news', poi.id, poi.name, `${phase}: [Crawl] Following ${validLinks.length} detail links from ${url}`);
         await processLevel(validLinks, depth + 1);
       } else if (classification.pageType === 'hybrid') {
         collectedPages.push({ url, markdown: extracted.markdown, title: extracted.title });
         const validLinks = filterDetailLinks(classification.detailLinks, url);
-        if (validLinks.length > 0) await processLevel(validLinks, depth + 1);
+        if (validLinks.length > 0) {
+          logInfo(jobId, 'news', poi.id, poi.name, `${phase}: [Crawl] Following ${validLinks.length} detail links from hybrid page ${url}`);
+          await processLevel(validLinks, depth + 1);
+        }
       }
     }
   }
@@ -581,7 +415,6 @@ async function crawlWithClassification(pool, startUrl, contentType, poi, sheets,
  * @returns {Object} - { news: [], events: [] }
  */
 export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'America/New_York', collectionType = 'both', onProgress = null) {
-  console.log(`[AI Research] Collection type: ${collectionType}`);
   const activities = poi.primary_activities || 'None specified';
   const website = poi.more_info_link || 'No website available';
   const eventsUrl = poi.events_url || 'No dedicated events page';
@@ -591,6 +424,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
   const existingProgress = tracker.getCollectionProgress(poi.id);
   const slotId = existingProgress?.slotId;
   const jobId = existingProgress?.jobId;
+
+  logInfo(jobId, 'news', poi.id, poi.name, `Collection type: ${collectionType}`);
 
   // Clear any old progress data for this POI before starting
   tracker.clearProgress(poi.id);
@@ -622,16 +457,12 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
     if (onProgress) onProgress(message);
   };
 
-  console.log(`[AI Research] Starting search for: ${poi.name}`);
-  console.log(`[AI Research]   - Website: ${website}`);
-  console.log(`[AI Research]   - Events URL: ${eventsUrl}`);
-  console.log(`[AI Research]   - News URL: ${newsUrl}`);
-  console.log(`[AI Research]   - Activities: ${activities}`);
+  logInfo(jobId, 'news', poi.id, poi.name, 'Starting search', { website, eventsUrl, newsUrl, activities });
 
   // Helper to check for cancellation and throw if requested
   const checkCancellation = () => {
     if (isCancellationRequested(poi.id)) {
-      console.log(`[AI Research] Cancellation detected for ${poi.name}`);
+      logInfo(jobId, 'news', poi.id, poi.name, 'Cancellation detected');
       updateProgress(poi.id, {
         phase: 'error',
         message: 'Collection cancelled by user',
@@ -641,199 +472,98 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
     }
   };
 
-  // Extract content from dedicated pages using Playwright + Readability + Turndown
-  // This renders ALL pages (not just JS-heavy ones) for clean markdown extraction
-  let renderedEventsContent = '';
-  let renderedNewsContent = '';
-  let usedDedicatedNewsUrl = false;
-  let eventsLinks = [];
-  let newsLinks = [];
-
-  // Classifier flags — when true, URLs come from actual page visits (no fabrication)
-  let usedClassifier = false;
+  // Classified content from Phase I (Render → Classify → Crawl pipeline)
   let classifiedEventsContent = null;
-  let usedNewsClassifier = false;
   let classifiedNewsContent = null;
+  let usedClassifier = false;
+  let usedNewsClassifier = false;
 
-  // CLASSIFIER PATH: When POI has a dedicated events URL, use AI page classification
+  // PHASE I EVENTS: Render → Classify → Crawl for dedicated events URL
   if (collectionType !== 'news' && eventsUrl !== 'No dedicated events page') {
     try {
       checkCancellation();
-      reportProgress(`Crawling events page: ${eventsUrl}`);
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Crawling events page', { url: eventsUrl });
+      reportProgress(`Rendering events page: ${eventsUrl}`);
+      logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Render] Starting events pipeline`, { url: eventsUrl });
       updateProgress(poi.id, {
         phase: 'classifying_events',
         message: 'Analyzing events pages...',
         steps: ['Initialized', 'Classifying events pages']
       });
-      const crawlResult = await crawlWithClassification(pool, eventsUrl, 'event', poi, sheets, checkCancellation);
+      const crawlResult = await crawlWithClassification(pool, eventsUrl, 'event', poi, sheets, checkCancellation, { phase: 'Phase I', jobId });
 
       if (crawlResult.pages.length > 0) {
         classifiedEventsContent = crawlResult.pages.map(p => `### Event Page: ${p.url}\n\n${p.markdown}`).join('\n\n---\n\n');
         usedClassifier = true;
         reportProgress(`Found ${crawlResult.pages.length} event pages (crawled ${crawlResult.totalPagesRendered} pages)`);
-        console.log(`[AI Research] Classifier found ${crawlResult.pages.length} event pages (${crawlResult.totalPagesRendered} rendered)`);
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Classifier found ${crawlResult.pages.length} event pages (${crawlResult.totalPagesRendered} rendered)`);
       } else {
-        reportProgress('No event pages found on dedicated URL, trying legacy crawl');
-        console.log(`[AI Research] Classifier found no event detail pages, falling back to legacy crawl`);
+        // Classifier found nothing — use the listing page itself as content
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] No detail pages found, using listing page content`);
+        const extracted = await extractPageContent(eventsUrl, { timeout: 30000, hardTimeout: 60000 });
+        if (extracted.reachable && extracted.markdown?.length >= 200) {
+          classifiedEventsContent = `### Event Page: ${eventsUrl}\n\n${extracted.markdown}`;
+          usedClassifier = true;
+          reportProgress('Using events listing page content directly');
+          logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Using listing page content (${extracted.markdown.length} chars)`);
+        } else {
+          reportProgress('Events page had insufficient content');
+          logWarn(jobId, 'news', poi.id, poi.name, `Phase I: Events page insufficient content (${extracted.markdown?.length || 0} chars)`);
+        }
       }
     } catch (err) {
       reportProgress(`Events page crawl failed: ${err.message}`);
-      console.log(`[Classifier] ⚠️ Classification failed: ${err.message}, falling back to legacy crawl`);
+      logWarn(jobId, 'news', poi.id, poi.name, `Phase I: Events classification failed: ${err.message}`);
     }
   }
 
-  // LEGACY EVENTS PATH: Only runs if classifier didn't produce results
-  if (!usedClassifier) {
-    // Only extract events page if we're collecting events
-    const eventsPageToRender = eventsUrl !== 'No dedicated events page' ? eventsUrl : website;
-    checkCancellation(); // Check before rendering events
-    if (collectionType !== 'news' && eventsPageToRender !== 'No website available') {
-      console.log(`[AI Research] Extracting events page content (collectionType: ${collectionType})`);
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Rendering events page', { url: eventsPageToRender });
-      updateProgress(poi.id, {
-        phase: 'rendering_events',
-        message: 'Extracting events page content...',
-        steps: ['Initialized', 'Extracting events page']
-      });
-
-      reportProgress(`Rendering events page: ${eventsPageToRender}`);
-      console.log(`[AI Research] Rendering events page with Readability pipeline: ${eventsPageToRender}`);
-      const extracted = await extractPageContent(eventsPageToRender, {
-        timeout: 30000,
-        hardTimeout: 60000,
-        extractLinks: true
-      });
-
-      if (extracted.reachable && extracted.markdown) {
-        const MIN_CONTENT_LENGTH = 200;
-        if (extracted.markdown.length >= MIN_CONTENT_LENGTH) {
-          renderedEventsContent = extracted.markdown;
-          eventsLinks = extracted.links || [];
-          console.log(`[AI Research] ✓ Extracted events page: ${renderedEventsContent.length} chars markdown, ${eventsLinks.length} links`);
-
-          updateProgress(poi.id, {
-            message: `Extracted events page (${eventsLinks.length} links found)`,
-            steps: ['Initialized', 'Extracted events page']
-          });
-        } else {
-          eventsLinks = extracted.links || [];
-          console.log(`[AI Research] ⚠️ Events page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+), kept ${eventsLinks.length} links`);
-        }
-      } else {
-        console.log(`[AI Research] ❌ Failed to extract events page: ${extracted.reason || 'no content'}`);
-      }
-    }
-
-    // SUB-PAGE CRAWL: When POI has a dedicated events URL, crawl sub-pages for richer content
-    if (collectionType !== 'news' && eventsUrl !== 'No dedicated events page' && eventsLinks.length > 0) {
-      const subPageResult = await crawlSubPages(eventsPageToRender, eventsLinks, poi.id, checkCancellation);
-      if (subPageResult) {
-        if (renderedEventsContent) {
-          renderedEventsContent += '\n\n' + subPageResult.markdown;
-        } else {
-          renderedEventsContent = subPageResult.markdown;
-        }
-        eventsLinks = subPageResult.links;
-        console.log(`[AI Research] ✓ Sub-page crawl: ${subPageResult.markdown.length} chars from ${subPageResult.pagesRendered} sub-pages, ${eventsLinks.length} total links`);
-        updateProgress(poi.id, {
-          message: `Enriched events from ${subPageResult.pagesRendered} sub-pages`,
-          steps: ['Initialized', 'Sub-pages crawled']
-        });
-      }
-    }
-  }
-
-  // CLASSIFIER PATH: When POI has a dedicated news URL, use AI page classification
+  // PHASE I NEWS: Render → Classify → Crawl for dedicated news URL
   if (collectionType !== 'events' && newsUrl !== 'No dedicated news page') {
     try {
       checkCancellation();
-      reportProgress(`Crawling news page: ${newsUrl}`);
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Crawling news page', { url: newsUrl });
+      reportProgress(`Rendering news page: ${newsUrl}`);
+      logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Render] Starting news pipeline`, { url: newsUrl });
       updateProgress(poi.id, {
         phase: 'classifying_news',
         message: 'Analyzing news pages...',
         steps: ['Initialized', 'Classifying news pages']
       });
-      const crawlResult = await crawlWithClassification(pool, newsUrl, 'news', poi, sheets, checkCancellation);
+      const crawlResult = await crawlWithClassification(pool, newsUrl, 'news', poi, sheets, checkCancellation, { phase: 'Phase I', jobId });
 
       if (crawlResult.pages.length > 0) {
         classifiedNewsContent = crawlResult.pages.map(p => `### News Page: ${p.url}\n\n${p.markdown}`).join('\n\n---\n\n');
         usedNewsClassifier = true;
         reportProgress(`Found ${crawlResult.pages.length} news pages (crawled ${crawlResult.totalPagesRendered} pages)`);
-        console.log(`[AI Research] Classifier found ${crawlResult.pages.length} news pages (${crawlResult.totalPagesRendered} rendered)`);
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Classifier found ${crawlResult.pages.length} news pages (${crawlResult.totalPagesRendered} rendered)`);
       } else {
-        reportProgress('No news pages found on dedicated URL, trying legacy crawl');
-        console.log(`[AI Research] Classifier found no news detail pages, falling back to legacy crawl`);
+        // Classifier found nothing — use the listing page itself as content
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] No detail pages found, using listing page content`);
+        const extracted = await extractPageContent(newsUrl, { timeout: 30000, hardTimeout: 60000 });
+        if (extracted.reachable && extracted.markdown?.length >= 200) {
+          classifiedNewsContent = `### News Page: ${newsUrl}\n\n${extracted.markdown}`;
+          usedNewsClassifier = true;
+          reportProgress('Using news listing page content directly');
+          logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Using listing page content (${extracted.markdown.length} chars)`);
+        } else {
+          reportProgress('News page had insufficient content');
+          logWarn(jobId, 'news', poi.id, poi.name, `Phase I: News page insufficient content (${extracted.markdown?.length || 0} chars)`);
+        }
       }
     } catch (err) {
       reportProgress(`News page crawl failed: ${err.message}`);
-      console.log(`[Classifier] ⚠️ News classification failed: ${err.message}, falling back to legacy crawl`);
+      logWarn(jobId, 'news', poi.id, poi.name, `Phase I: News classification failed: ${err.message}`);
     }
   }
 
-  // LEGACY NEWS PATH: Only runs if classifier didn't produce results
-  if (!usedNewsClassifier) {
-    // Only extract news page if we're collecting news
-    const newsPageToRender = newsUrl !== 'No dedicated news page' ? newsUrl : website;
-    checkCancellation(); // Check before rendering news
-    if (collectionType !== 'events' && newsPageToRender !== 'No website available') {
-      console.log(`[AI Research] Extracting news page content (collectionType: ${collectionType})`);
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Rendering news page', { url: newsPageToRender });
-      updateProgress(poi.id, {
-        phase: 'rendering_news',
-        message: 'Extracting news page content...',
-        steps: ['Initialized', 'Extracting news page']
-      });
-
-      reportProgress(`Rendering news page: ${newsPageToRender}`);
-      console.log(`[AI Research] Rendering news page with Readability pipeline: ${newsPageToRender}`);
-      const extracted = await extractPageContent(newsPageToRender, {
-        timeout: 30000,
-        hardTimeout: 60000,
-        extractLinks: true
-      });
-
-      if (extracted.reachable && extracted.markdown) {
-        const MIN_CONTENT_LENGTH = 200;
-        if (extracted.markdown.length >= MIN_CONTENT_LENGTH) {
-          renderedNewsContent = extracted.markdown;
-          newsLinks = extracted.links || [];
-          usedDedicatedNewsUrl = true;
-          console.log(`[AI Research] ✓ Extracted news page: ${renderedNewsContent.length} chars markdown, ${newsLinks.length} links`);
-
-          updateProgress(poi.id, {
-            message: `Extracted news page (${newsLinks.length} links found)`,
-            steps: ['Initialized', 'Extracted news page']
-          });
-        } else {
-          newsLinks = extracted.links || [];
-          console.log(`[AI Research] ⚠️ News page has insufficient content (${extracted.markdown.length} chars, need ${MIN_CONTENT_LENGTH}+), kept ${newsLinks.length} links`);
-        }
-      } else {
-        console.log(`[AI Research] ❌ Failed to extract news page: ${extracted.reason || 'no content'}`);
-      }
-    }
-
-    // SUB-PAGE CRAWL: When POI has a dedicated news URL, crawl sub-pages for richer content
-    if (collectionType !== 'events' && newsUrl !== 'No dedicated news page' && newsLinks.length > 0) {
-      const subPageResult = await crawlSubPages(newsPageToRender, newsLinks, poi.id, checkCancellation);
-      if (subPageResult) {
-        if (renderedNewsContent) {
-          renderedNewsContent += '\n\n' + subPageResult.markdown;
-          usedDedicatedNewsUrl = true;
-        } else {
-          renderedNewsContent = subPageResult.markdown;
-          usedDedicatedNewsUrl = true;
-        }
-        newsLinks = subPageResult.links;
-        console.log(`[AI Research] ✓ Sub-page crawl (news): ${subPageResult.markdown.length} chars from ${subPageResult.pagesRendered} sub-pages, ${newsLinks.length} total links`);
-        updateProgress(poi.id, {
-          message: `Enriched news from ${subPageResult.pagesRendered} sub-pages`,
-          steps: ['Initialized', 'Sub-pages crawled']
-        });
-      }
-    }
+  // Phase I: [Dates] Pre-extract dates from classified content using chrono-node
+  const pageDateHints = [];
+  if (classifiedEventsContent) {
+    pageDateHints.push(...extractDatesFromText(classifiedEventsContent, timezone));
+  }
+  if (classifiedNewsContent) {
+    pageDateHints.push(...extractDatesFromText(classifiedNewsContent, timezone));
+  }
+  if (pageDateHints.length > 0) {
+    logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Dates] ${pageDateHints.length} dates extracted from classified content`);
   }
 
   // Build prompt with extracted content if available
@@ -850,8 +580,17 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
     .replace('{{eventsUrl}}', eventsUrl)
     .replace('{{newsUrl}}', newsUrl);
 
-  // Add extracted markdown content to prompt if we have it
-  if (usedClassifier && classifiedEventsContent) {
+  // Append pre-extracted date hints to prompt
+  if (pageDateHints.length > 0) {
+    const uniqueHints = [...new Map(pageDateHints.map(h => [h.text, h])).values()].slice(0, 30);
+    const hintLines = uniqueHints.map(h =>
+      `- "${h.text}" → ${h.start}${h.end ? ` to ${h.end}` : ''}`
+    );
+    prompt += `\n\nDATES FOUND IN PAGE TEXT (use these exact dates, do not re-interpret):\n${hintLines.join('\n')}`;
+  }
+
+  // Add classified content to prompt
+  if (classifiedEventsContent) {
     prompt += `\n\nCLASSIFIED EVENT PAGES:
 We visited the organization's events pages and identified individual event detail pages.
 Each section below is from a REAL page we visited — the URL is verified.
@@ -863,7 +602,6 @@ ${classifiedEventsContent}
 - Do NOT invent, modify, or guess URLs — use ONLY the URLs provided above
 - Use RELAXED filtering (75% confidence) since these are from the organization's own site
 - Still exclude past events - only include upcoming/current events
-- Still require proper date formatting (YYYY-MM-DD) - interpret all dates in ${timezone} timezone
 
 **MULTIPLE DATES ON ONE PAGE**
 - If a single page lists multiple dates for the same event (e.g., "March 21" and "May 31"), create a SEPARATE event entry for each date
@@ -871,19 +609,9 @@ ${classifiedEventsContent}
 - This is common for recurring excursions — treat each date as its own event
 
 Extract ALL events from this content using these relaxed criteria.`;
-  } else if (renderedEventsContent) {
-    prompt += `\n\nEXTRACTED EVENTS PAGE CONTENT (markdown):\nWe rendered the events page and extracted this content:\n\n${renderedEventsContent}\n\n**SPECIAL INSTRUCTIONS FOR EXTRACTED EVENTS PAGE:**
-Since this content comes directly from the organization's dedicated events page, use RELAXED requirements:
-- You only need 75% confidence (not 95%) that an event is relevant
-- Events listed on this official page can be assumed to be associated with "${poi.name}" even if the name isn't explicitly mentioned in every listing
-- Include ALL events that appear to be listed on this page, as long as they're reasonably related to the organization
-- Still exclude past events - only include upcoming/current events
-- Still require proper date formatting (YYYY-MM-DD) - interpret all dates in ${timezone} timezone
-
-Extract ALL events from this content using these relaxed criteria.`;
   }
 
-  if (usedNewsClassifier && classifiedNewsContent) {
+  if (classifiedNewsContent) {
     prompt += `\n\nCLASSIFIED NEWS PAGES:
 We visited the organization's news pages and identified individual news detail pages.
 Each section below is from a REAL page we visited — the URL is verified.
@@ -895,27 +623,6 @@ ${classifiedNewsContent}
 - Do NOT invent, modify, or guess URLs — use ONLY the URLs provided above
 - Use RELAXED filtering (75% confidence) since these are from the organization's own site
 - Include ALL news items regardless of age
-- **IMPORTANT FOR DATES**: Try hard to extract dates from news titles and content:
-  - Look for month names, dates, or year references in the title (e.g., "April 2025 Newsletter", "July Newsletter", "May 9", "October 9")
-  - If the title has a month name, try to infer the year (use current year 2026 if recent, or 2025 if it seems past)
-  - If you find a partial date like "May 9" or "October Newsletter", estimate the full date in ISO 8601 format (YYYY-MM-DD)
-  - Remember: interpret all dates in ${timezone} timezone
-  - Only use "published_date": null if absolutely no date information can be extracted
-
-Extract ALL news from this content using these relaxed criteria.`;
-  } else if (renderedNewsContent) {
-    prompt += `\n\nEXTRACTED NEWS PAGE CONTENT (markdown):\nWe rendered the news page and extracted this content:\n\n${renderedNewsContent}\n\n**SPECIAL INSTRUCTIONS FOR EXTRACTED NEWS PAGE:**
-Since this content comes directly from the organization's dedicated news page, use RELAXED requirements:
-- You only need 75% confidence (not 95%) that a news item is relevant
-- News items on this official page can be assumed to be associated with "${poi.name}" even if not explicitly mentioned
-- Include ALL news items from this page, regardless of age (don't apply the 365-day filter)
-- **IMPORTANT FOR DATES**: Try hard to extract dates from news titles and content:
-  - Look for month names, dates, or year references in the title (e.g., "April 2025 Newsletter", "July Newsletter", "May 9", "October 9")
-  - If the title has a month name, try to infer the year (use current year 2026 if recent, or 2025 if it seems past)
-  - If you find a partial date like "May 9" or "October Newsletter", estimate the full date in ISO 8601 format (YYYY-MM-DD)
-  - Remember: interpret all dates in ${timezone} timezone
-  - Only use "published_date": null if absolutely no date information can be extracted
-- Prefer to include items even if dates are uncertain
 
 Extract ALL news from this content using these relaxed criteria.`;
   }
@@ -923,43 +630,41 @@ Extract ALL news from this content using these relaxed criteria.`;
   checkCancellation(); // Check before AI search
 
   try {
-    const hasCrawledContent = renderedEventsContent || renderedNewsContent || usedClassifier || usedNewsClassifier;
+    const hasCrawledContent = usedClassifier || usedNewsClassifier;
 
-    // Phase I: Gemini extraction — only runs when we have crawled content
+    // Phase I: [Summarize] — only runs when we have classified content
     // URL-less POIs skip straight to Phase II (Serper)
     let result = { news: [], events: [] };
     let response = '';
     const usedProvider = 'gemini';
 
     if (hasCrawledContent) {
-      reportProgress('Sending crawled content to Gemini for extraction');
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Gemini extraction', { has_events: !!(renderedEventsContent || usedClassifier), has_news: !!(renderedNewsContent || usedNewsClassifier) });
+      reportProgress('Sending classified content to Gemini for summarization');
+      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: [Summarize] Sending classified content to Gemini', { has_events: !!usedClassifier, has_news: !!usedNewsClassifier });
 
       updateProgress(poi.id, {
         phase: 'ai_search',
-        message: 'Extracting events/news from crawled content...',
-        steps: ['Initialized', 'Rendered pages', 'AI extraction']
+        message: 'Summarizing rendered content via Gemini...',
+        steps: ['Initialized', 'Rendered pages', 'AI summarization']
       });
 
       const aiResult = await generateTextWithCustomPrompt(pool, prompt);
       response = aiResult.response;
       reportProgress(`Gemini responded (${response.length} chars)`);
-      console.log(`[AI Research] Received response (${response.length} chars) from gemini`);
+      logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Summarize] Received response (${response.length} chars)`);
 
       // Parse JSON response
       const jsonMatch = response.match(/\{[\s\S]*\}/);
       if (!jsonMatch) {
-        console.log(`[AI Research] No JSON found in response for ${poi.name}`);
-        console.log(`[AI Research] Raw response preview: ${response.substring(0, 500)}...`);
+        logWarn(jobId, 'news', poi.id, poi.name, `No JSON found in response, preview: ${response.substring(0, 500)}...`);
       } else {
         result = JSON.parse(jsonMatch[0]);
-        reportProgress(`Extracted ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
-        console.log(`[AI Research] Found ${result.news?.length || 0} news, ${result.events?.length || 0} events for ${poi.name}`);
+        reportProgress(`Summarized ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
       }
     } else {
-      // No crawled content — skip Phase I, go straight to Phase II (Serper)
-      console.log(`[AI Research] No crawled content for ${poi.name}, skipping Phase I`);
-      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Skipped (no dedicated URLs)', {});
+      // No classified content — skip Phase I, go straight to Phase II (Serper)
+      logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: Skipped (no dedicated URLs)');
     }
 
     // Update progress with counts based on collection type
@@ -987,213 +692,42 @@ Extract ALL news from this content using these relaxed criteria.`;
     updateProgress(poi.id, processingUpdate);
 
     if (result.events && result.events.length > 0) {
-      console.log(`[AI Research] Events found:`);
-      result.events.forEach((event, idx) => {
-        console.log(`[AI Research]   ${idx + 1}. ${event.title} (${event.start_date})`);
-        console.log(`[AI Research]      Source: ${event.source_url || 'N/A'}`);
-      });
+      const eventsList = result.events.map((event, idx) =>
+        `${idx + 1}. ${event.title} (${event.start_date}) - ${event.source_url || 'N/A'}`
+      ).join('\n  ');
+      logInfo(jobId, 'news', poi.id, poi.name, `Events found:\n  ${eventsList}`);
     }
 
     if (result.news && result.news.length > 0) {
-      console.log(`[AI Research] News found:`);
-      result.news.forEach((item, idx) => {
-        console.log(`[AI Research]   ${idx + 1}. ${item.title} (${item.published_date})`);
-      });
-    }
-
-    checkCancellation(); // Check before link matching
-
-    // Match events/news to extracted links for deep linking
-    // Skip when classifier was used — URLs come from actual page visits, no matching needed
-    // When search grounding is off, always override — Gemini fabricates URLs from patterns
-    // When search grounding is on, only override missing/generic URLs (AI has real search results)
-    if (!usedClassifier) {
-      console.log(`[Link Matcher] Checking conditions - events: ${result.events?.length || 0}, eventsLinks: ${eventsLinks.length}`);
-      if (result.events && result.events.length > 0 && eventsLinks.length > 0) {
-        updateProgress(poi.id, {
-          phase: 'matching_links',
-          message: `Matching ${result.events.length} events to deep links...`,
-          steps: ['Initialized', 'Rendered pages', 'AI extraction complete', 'Matching deep links']
-        });
-
-        console.log(`[Link Matcher] Attempting to match ${result.events.length} events to ${eventsLinks.length} links...`);
-        let matchCount = 0;
-        result.events.forEach(event => {
-          // Always override AI-generated URLs with matched crawled links
-          const matchedUrl = matchItemToLink(event, eventsLinks, 'event');
-          if (matchedUrl) {
-            event.source_url = matchedUrl;
-            matchCount++;
-          }
-        });
-        console.log(`[Link Matcher] Matched ${matchCount} events to deep links`);
-      } else {
-        console.log(`[Link Matcher] Skipping event link matching - conditions not met`);
-      }
-    } else {
-      console.log(`[Link Matcher] Skipping event link matching — classifier provided real URLs`);
-    }
-
-    if (!usedNewsClassifier) {
-      console.log(`[Link Matcher] Checking conditions - news: ${result.news?.length || 0}, newsLinks: ${newsLinks.length}`);
-      if (result.news && result.news.length > 0 && newsLinks.length > 0) {
-        updateProgress(poi.id, {
-          phase: 'matching_links',
-          message: `Matching ${result.news.length} news items to deep links...`,
-          steps: ['Initialized', 'Rendered pages', 'AI extraction complete', 'Matching deep links']
-        });
-
-        console.log(`[Link Matcher] Attempting to match ${result.news.length} news items to ${newsLinks.length} links...`);
-        let matchCount = 0;
-        result.news.forEach(newsItem => {
-          // Always override AI-generated URLs with matched crawled links
-          const matchedUrl = matchItemToLink(newsItem, newsLinks, 'news');
-          if (matchedUrl) {
-            newsItem.source_url = matchedUrl;
-            matchCount++;
-          }
-        });
-        console.log(`[Link Matcher] Matched ${matchCount} news items to deep links`);
-      } else {
-        console.log(`[Link Matcher] Skipping news link matching - conditions not met`);
-      }
-    } else {
-      console.log(`[Link Matcher] Skipping news link matching — classifier provided real URLs`);
-    }
-
-    // BACKFILL: Items with no source_url get the POI's events/news listing page as a starting point
-    const hasEventsUrl = poi.events_url && poi.events_url.trim();
-    const hasNewsUrl = poi.news_url && poi.news_url.trim();
-    if (result.events && hasEventsUrl) {
-      let backfilled = 0;
-      for (const event of result.events) {
-        if (!event.source_url || event.source_url === 'N/A') {
-          event.source_url = poi.events_url;
-          backfilled++;
-        }
-      }
-      if (backfilled > 0) console.log(`[Deep Crawl] Backfilled ${backfilled} events with events_url: ${poi.events_url}`);
-    }
-    if (result.news && hasNewsUrl) {
-      let backfilled = 0;
-      for (const newsItem of result.news) {
-        if (!newsItem.source_url || newsItem.source_url === 'N/A') {
-          newsItem.source_url = poi.news_url;
-          backfilled++;
-        }
-      }
-      if (backfilled > 0) console.log(`[Deep Crawl] Backfilled ${backfilled} news with news_url: ${poi.news_url}`);
-    }
-
-    // DEEP CRAWL PHASE: Skip when classifier was used — URLs are from actual page visits
-    if (usedClassifier || usedNewsClassifier) {
-      console.log(`[Deep Crawl] Skipping — classifier provided verified URLs`);
-    }
-
-    const allItems = [
-      ...(result.events || []).map(e => ({ ...e, _type: 'event' })),
-      ...(result.news || []).map(n => ({ ...n, _type: 'news' }))
-    ];
-    const deepCrawlCandidates = allItems.filter(item =>
-      item.source_url && item.source_url !== 'N/A'
-    );
-
-    if (!usedClassifier && !usedNewsClassifier && deepCrawlCandidates.length > 0) {
-      updateProgress(poi.id, {
-        phase: 'deep_crawling',
-        message: `Verifying ${deepCrawlCandidates.length} source URLs...`,
-        steps: ['Initialized', 'Rendered pages', 'AI search complete', 'Matching deep links', 'Verifying sources']
-      });
-
-      console.log(`[Deep Crawl] Verifying ${deepCrawlCandidates.length} items have content on their source URLs...`);
-      let deepCrawlFixed = 0;
-      let alreadyCorrect = 0;
-
-      const bySourceUrl = new Map();
-      for (const item of deepCrawlCandidates) {
-        const group = bySourceUrl.get(item.source_url) || [];
-        group.push(item);
-        bySourceUrl.set(item.source_url, group);
-      }
-
-      for (const [sourceUrl, items] of bySourceUrl) {
-        checkCancellation();
-        console.log(`[Deep Crawl] Rendering ${sourceUrl} for ${items.length} items...`);
-
-        let prefetched = null;
-        try {
-          const page = await extractPageContent(sourceUrl, {
-            timeout: 30000,
-            hardTimeout: 60000,
-            extractLinks: true
-          });
-          if (page.reachable) {
-            prefetched = { markdown: page.markdown, links: page.links || [] };
-            console.log(`[Deep Crawl] Rendered ${sourceUrl}: ${prefetched.links.length} links`);
-          } else {
-            console.log(`[Deep Crawl] Could not render ${sourceUrl}: ${page.reason || 'no content'}`);
-            continue;
-          }
-        } catch (error) {
-          console.error(`[Deep Crawl] Error rendering ${sourceUrl}: ${error.message}`);
-          continue;
-        }
-
-        for (const item of items) {
-          checkCancellation();
-          try {
-            const crawlResult = await deepCrawlForArticle(sourceUrl, item, {
-              maxDepth: 2,
-              maxPages: 5,
-              timeoutMs: 45000,
-              prefetched
-            });
-            if (crawlResult.foundUrl && crawlResult.foundUrl !== sourceUrl) {
-              console.log(`[Deep Crawl] ✓ "${item.title.substring(0, 50)}..." → ${crawlResult.foundUrl}`);
-              const sourceArray = item._type === 'event' ? result.events : result.news;
-              const original = sourceArray.find(i => i.title === item.title && i.source_url === item.source_url);
-              if (original) {
-                original.source_url = crawlResult.foundUrl;
-                deepCrawlFixed++;
-              }
-            } else if (crawlResult.foundUrl === sourceUrl) {
-              alreadyCorrect++;
-            } else {
-              console.log(`[Deep Crawl] ✗ No match for "${item.title.substring(0, 50)}..." (checked ${crawlResult.pagesChecked} pages)`);
-            }
-          } catch (error) {
-            console.error(`[Deep Crawl] Error crawling for "${item.title.substring(0, 50)}...": ${error.message}`);
-          }
-        }
-      }
-
-      console.log(`[Deep Crawl] Results: ${alreadyCorrect} already correct, ${deepCrawlFixed} fixed, ${deepCrawlCandidates.length - alreadyCorrect - deepCrawlFixed} unresolved`);
+      const newsList = result.news.map((item, idx) =>
+        `${idx + 1}. ${item.title} (${item.published_date})`
+      ).join('\n  ');
+      logInfo(jobId, 'news', poi.id, poi.name, `News found:\n  ${newsList}`);
     }
 
     let allNews = result.news || [];
 
     checkCancellation(); // Check before Serper search
 
-    // PHASE II: External news via Serper (runs for EVERY POI when collecting news)
+    // PHASE II: External news via Serper — Search → Render → Classify → Crawl → Dates → Summarize
     if (collectionType !== 'events') {
       try {
         updateProgress(poi.id, {
           phase: 'serper_search',
           message: 'Searching for external news coverage...',
-          steps: ['Initialized', 'Rendered pages', 'AI search complete', 'Matching deep links', 'Searching external news']
+          steps: ['Initialized', 'Phase I complete', 'Searching external news']
         });
 
         reportProgress('Searching Serper for external news coverage...');
-        console.log(`[Serper] Phase II: Searching for external news coverage...`);
+        logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: [Search] Querying Serper for external coverage');
 
-        // Get Serper URLs with geographic grounding
+        // Phase II: [Search] — Serper API returns URLs
         const serperResult = await searchNewsUrls(pool, poi);
-        logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: Serper search', { query: serperResult.query, urls_found: serperResult.urls.length });
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Search] ${serperResult.urls.length} URLs (grounded: ${serperResult.grounded})`, { query: serperResult.query, urls_found: serperResult.urls.length });
         reportProgress(`Serper returned ${serperResult.urls.length} URLs (query: "${serperResult.query}")`);
-        console.log(`[Serper] Found ${serperResult.urls.length} URLs (grounded: ${serperResult.grounded}, query: "${serperResult.query}")`);
 
         if (serperResult.urls.length > 0) {
-          // Render each Serper URL with Playwright (same pipeline as official URLs)
+          // Phase II: Render → Classify → Crawl each Serper URL
           const renderedSerperContent = [];
           let renderedCount = 0;
 
@@ -1201,72 +735,88 @@ Extract ALL news from this content using these relaxed criteria.`;
             try {
               checkCancellation();
 
-              // 1.5 second delay between renders (matching Events system)
+              // 1.5 second delay between renders
               if (renderedCount > 0) {
                 await new Promise(resolve => setTimeout(resolve, 1500));
               }
 
-              reportProgress(`Crawling external: ${urlData.url}`);
-              console.log(`[Serper] Rendering ${urlData.url}...`);
+              // Phase II: [Render]
+              logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Render] ${urlData.url}`);
+              reportProgress(`Rendering external: ${urlData.url}`);
 
               const extracted = await extractPageContent(urlData.url, {
                 timeout: 30000,
                 hardTimeout: 60000,
-                extractLinks: false
+                extractLinks: true
               });
 
-              if (extracted.reachable && extracted.markdown) {
-                const MIN_CONTENT_LENGTH = 200;
-                if (extracted.markdown.length >= MIN_CONTENT_LENGTH) {
+              if (!extracted.reachable || !extracted.markdown || extracted.markdown.length < 200) {
+                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Render] Skip — ${extracted.reason || 'too short'} (${extracted.markdown?.length || 0} chars)`);
+                continue;
+              }
+
+              // Phase II: [Classify]
+              const classification = await classifyPage(pool, extracted.markdown, extracted.links || [], urlData.url, 'news', sheets);
+              logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Classify] ${urlData.url} → ${classification.pageType}`);
+
+              if (classification.pageType === 'detail') {
+                // Detail page — use content directly
+                renderedSerperContent.push({
+                  url: urlData.url, title: urlData.title, snippet: urlData.snippet,
+                  date: urlData.date, markdown: extracted.markdown
+                });
+                renderedCount++;
+              } else {
+                // Listing or hybrid — crawl detail pages
+                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Crawl] Following links from ${urlData.url}`);
+                const crawlResult = await crawlWithClassification(pool, urlData.url, 'news', poi, sheets, checkCancellation, {
+                  maxPages: 5, maxDetailPages: 3, phase: 'Phase II', jobId
+                });
+                for (const page of crawlResult.pages) {
                   renderedSerperContent.push({
-                    url: urlData.url,
-                    title: urlData.title,
-                    snippet: urlData.snippet,
-                    date: urlData.date,
-                    markdown: extracted.markdown
+                    url: page.url, title: page.title || urlData.title, snippet: urlData.snippet,
+                    date: urlData.date, markdown: page.markdown
                   });
                   renderedCount++;
-                  console.log(`[Serper] ✓ Rendered ${urlData.url} (${extracted.markdown.length} chars)`);
-                } else {
-                  console.log(`[Serper] ⚠️ Insufficient content from ${urlData.url} (${extracted.markdown.length} chars)`);
                 }
-              } else {
-                console.log(`[Serper] ❌ Failed to render ${urlData.url}: ${extracted.reason || 'no content'}`);
+                // If crawl found nothing, use the page itself
+                if (crawlResult.pages.length === 0) {
+                  renderedSerperContent.push({
+                    url: urlData.url, title: urlData.title, snippet: urlData.snippet,
+                    date: urlData.date, markdown: extracted.markdown
+                  });
+                  renderedCount++;
+                }
               }
             } catch (renderError) {
-              console.error(`[Serper] Error rendering ${urlData.url}: ${renderError.message}`);
+              logError(jobId, 'news', poi.id, poi.name, `Phase II: [Render] Error: ${urlData.url} — ${renderError.message}`);
             }
           }
 
-          reportProgress(`Crawled ${renderedCount} of ${serperResult.urls.length} external URLs`);
-          console.log(`[Serper] Rendered ${renderedCount} of ${serperResult.urls.length} URLs`);
+          reportProgress(`Rendered ${renderedCount} pages from ${serperResult.urls.length} external URLs`);
+          logInfo(jobId, 'news', poi.id, poi.name, `Phase II: Rendered ${renderedCount} pages from ${serperResult.urls.length} URLs`);
 
-          // If we have rendered content, use Gemini to extract structured news
+          // Phase II: [Summarize] — send all rendered content to Gemini
           if (renderedSerperContent.length > 0) {
-            logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: Extracting articles', { article_count: renderedSerperContent.length });
+            logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Summarize] Sending ${renderedSerperContent.length} pages to Gemini`);
             updateProgress(poi.id, {
-              phase: 'extracting_external_news',
-              message: `Extracting news from ${renderedSerperContent.length} external sources...`,
-              steps: ['Initialized', 'Rendered pages', 'AI search complete', 'Matching deep links', 'Extracting external news']
+              phase: 'summarizing_external_news',
+              message: `Summarizing ${renderedSerperContent.length} external pages via Gemini...`,
+              steps: ['Initialized', 'Phase I complete', 'Rendering external news', 'Summarizing']
             });
 
-            // Build markdown content for Gemini
-            const serperMarkdown = renderedSerperContent.map(page =>
-              `### External News Page: ${page.url}
+            // Build markdown content for Gemini — normalize Serper dates via chrono-node
+            const serperMarkdown = renderedSerperContent.map(page => {
+              const normalizedDate = parseDate(page.date) || page.date;
+              return `### External News Page: ${page.url}
 Title: ${page.title}
 Snippet: ${page.snippet}
-${page.date ? `Date: ${page.date}` : ''}
+${normalizedDate ? `Date: ${normalizedDate}` : ''}
 
-${page.markdown}`
-            ).join('\n\n---\n\n');
+${page.markdown}`;
+            }).join('\n\n---\n\n');
 
-            const serperPrompt = `Extract news items from these external news sources about "${poi.name}".
-
-TIMEZONE CONTEXT:
-- The current timezone is: ${timezone}
-- When you see dates in articles, interpret them as being in ${timezone}
-- Return ALL dates in ISO 8601 format: YYYY-MM-DD
-- CRITICAL: Copy dates EXACTLY as they appear. Do NOT add or subtract days.
+            let serperPrompt = `Summarize news items from these external news sources about "${poi.name}".
 
 MISSION SCOPE — Roots of The Valley:
 Only include news that connects to Cuyahoga Valley National Park themes: nature, trails,
@@ -1286,7 +836,6 @@ ${serperMarkdown}
 - Do NOT invent, modify, or guess URLs — use ONLY the URLs provided above
 - Use 95% confidence filtering since these are external sources
 - Only include news from the last 365 days
-- Extract dates from the content or use the "Date:" field if provided
 
 Return your results in this exact JSON structure:
 {
@@ -1296,7 +845,7 @@ Return your results in this exact JSON structure:
       "summary": "2-3 sentence summary",
       "source_name": "Source name (extracted from URL or content)",
       "source_url": "EXACT URL from header above",
-      "published_date": "YYYY-MM-DD in ISO 8601 format or null",
+      "published_date": "date if visible on page, or null",
       "news_type": "general|alert|wildlife|infrastructure|community"
     }
   ]
@@ -1304,11 +853,24 @@ Return your results in this exact JSON structure:
 
 Return {"news": []} if no relevant news found.`;
 
-            reportProgress(`Sending ${renderedSerperContent.length} external articles to Gemini for extraction`);
+            // Phase II: [Dates] — chrono-node date hints for Serper content
+            const serperDateHints = [];
+            for (const page of renderedSerperContent) {
+              serperDateHints.push(...extractDatesFromText(page.markdown, timezone));
+            }
+            if (serperDateHints.length > 0) {
+              const hintBlock = serperDateHints.slice(0, 30).map(h =>
+                `- "${h.text}" → ${h.start}${h.end ? ' to ' + h.end : ''}`
+              ).join('\n');
+              serperPrompt += `\n\nDATES FOUND IN PAGE TEXT (use these, do not re-interpret):\n${hintBlock}`;
+            }
+            logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Dates] ${serperDateHints.length} dates extracted from ${renderedSerperContent.length} pages`);
+
+            reportProgress(`Sending ${renderedSerperContent.length} external pages to Gemini for summarization`);
             const serperAiResult = await generateTextWithCustomPrompt(pool, serperPrompt);
 
             const serperAiResponse = serperAiResult.response;
-            console.log(`[Serper] Received extraction response (${serperAiResponse.length} chars) from ${serperAiResult.provider}`);
+            logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Summarize] Received response (${serperAiResponse.length} chars)`);
 
             const serperJsonMatch = serperAiResponse.match(/\{[\s\S]*\}/);
             if (serperJsonMatch) {
@@ -1316,10 +878,10 @@ Return {"news": []} if no relevant news found.`;
               const serperNews = serperExtracted.news || [];
 
               if (serperNews.length > 0) {
-                console.log(`[Serper] ✓ Extracted ${serperNews.length} news items from external sources`);
-                serperNews.forEach((item, idx) => {
-                  console.log(`[Serper]   ${idx + 1}. ${item.title} (${item.published_date || 'no date'}) - ${item.source_name || 'unknown source'}`);
-                });
+                const serperList = serperNews.map((item, idx) =>
+                  `${idx + 1}. ${item.title} (${item.published_date || 'no date'}) - ${item.source_name || 'unknown source'}`
+                ).join('\n  ');
+                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Summarize] ${serperNews.length} news items:\n  ${serperList}`);
 
                 // Merge with existing news, avoiding duplicates by title
                 const existingTitles = new Set(allNews.map(n => n.title.toLowerCase().trim()));
@@ -1330,25 +892,24 @@ Return {"news": []} if no relevant news found.`;
 
                 if (newItems.length > 0) {
                   reportProgress(`Found ${newItems.length} new articles from external sources`);
-                  console.log(`[Serper] Adding ${newItems.length} unique items from external sources`);
+                  logInfo(jobId, 'news', poi.id, poi.name, `Phase II: Adding ${newItems.length} unique items`);
                   allNews = [...allNews, ...newItems];
                 } else {
                   reportProgress('External articles were duplicates, skipped');
-                  console.log(`[Serper] All external news items were duplicates, skipped`);
+                  logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: All external news items were duplicates, skipped');
                 }
               } else {
                 reportProgress('No relevant news in external articles');
-                console.log(`[Serper] No relevant news extracted from external sources`);
+                logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: No relevant news extracted from external sources');
               }
             }
           }
         } else {
-          console.log(`[Serper] No external news URLs found`);
+          logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: [Search] No external news URLs found');
         }
       } catch (serperError) {
-        console.error(`[Serper] ⚠️ External news search failed: ${serperError.message}`);
-        logWarn(jobId, 'news', poi.id, poi.name, `External news search failed: ${serperError.message}`);
-        // Continue with Layer 1 results even if Layer 2 fails
+        logWarn(jobId, 'news', poi.id, poi.name, `Phase II: Search failed: ${serperError.message}`);
+        // Continue with Phase I results even if Phase II fails
       }
     }
 
@@ -1356,7 +917,7 @@ Return {"news": []} if no relevant news found.`;
     let completionMessage;
     let progressUpdate = {
       phase: 'complete',
-      steps: ['Initialized', 'Rendered pages', 'AI search complete', 'Deep links matched', 'Complete'],
+      steps: ['Initialized', 'Phase I: Classify & Crawl', 'Phase I: Summarize', 'Phase II: Search & Classify', 'Phase II: Summarize', 'Complete'],
       completed: true
     };
 
@@ -1384,13 +945,13 @@ Return {"news": []} if no relevant news found.`;
       news: allNews,
       events: result.events || [],
       metadata: {
-        usedDedicatedNewsUrl,
+        usedDedicatedNewsUrl: usedNewsClassifier,
         provider: 'gemini',
         ai_response: response
       }
     };
   } catch (error) {
-    console.error(`[AI Research] ❌ Error collecting news for ${poi.name}:`, error.message);
+    logError(jobId, 'news', poi.id, poi.name, `Error collecting news: ${error.message}`);
 
     updateProgress(poi.id, {
       phase: 'error',
@@ -1402,7 +963,7 @@ Return {"news": []} if no relevant news found.`;
 
     // Keep error visible - frontend will clear it when appropriate
 
-    return { news: [], events: [], metadata: { usedDedicatedNewsUrl: false } };
+    return { news: [], events: [], metadata: { usedDedicatedNewsUrl: false, provider: 'gemini' } };
   }
 }
 
@@ -1435,15 +996,15 @@ async function resolveRedirectUrl(url) {
     const finalUrl = response.url;
 
     if (finalUrl && finalUrl !== url) {
-      console.log(`[URL Resolver] ✓ Resolved: ${url.substring(0, 50)}... → ${finalUrl}`);
+      console.log(`[Search] ✓ Resolved: ${url.substring(0, 50)}... → ${finalUrl}`);
       return finalUrl;
     }
 
     // If we got back the same URL, it's not redirecting properly
-    console.log(`[URL Resolver] ✗ No redirect found for: ${url.substring(0, 60)}...`);
+    console.log(`[Search] ✗ No redirect found for: ${url.substring(0, 60)}...`);
     return null; // Don't save broken redirects
   } catch (error) {
-    console.log(`[URL Resolver] ✗ Failed to resolve: ${url.substring(0, 50)}... (${error.message})`);
+    console.log(`[Search] ✗ Failed to resolve: ${url.substring(0, 50)}... (${error.message})`);
     return null; // Don't save broken redirects
   }
 }
@@ -1491,7 +1052,7 @@ function normalizeUrl(url) {
  * Save news items to database
  * @param {Pool} pool - Database connection pool
  * @param {number} poiId - POI ID
- * @param {Array} newsItems - Array of news items from AI extraction
+ * @param {Array} newsItems - Array of news items from AI summarization
  * @param {Object} options - Optional settings
  * @param {boolean} options.skipDateFilter - If true, allow news items older than 365 days
  */
@@ -1507,11 +1068,14 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 
   for (const item of newsItems) {
     try {
+      // Normalize dates via chrono-node — handles natural language, European format, partial dates
+      item.published_date = parseDate(item.published_date) || null;
+
       // Skip news older than 365 days (unless skipDateFilter is true)
       // Use string comparison to avoid timezone conversion issues
       if (!skipDateFilter && item.published_date && /^\d{4}-\d{2}-\d{2}$/.test(item.published_date)) {
         if (item.published_date < oneYearAgoStr) {
-          console.log(`Skipping old news item: ${item.title} (${item.published_date})`);
+          console.log(`[Save] Skipping old news: ${item.title} (${item.published_date})`);
           continue;
         }
       }
@@ -1527,7 +1091,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
       );
 
       if (isRedirectUrl && !resolvedUrl) {
-        console.log(`Skipping news item with failed URL resolution: "${item.title}"`);
+        console.log(`[Save] Skipping news (failed URL resolution): "${item.title}"`);
         continue;
       }
 
@@ -1555,7 +1119,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         if (matchedUrl === normalizedUrl) {
           // Exact same URL — truly skip
           duplicateCount++;
-          console.log(`Skipping duplicate (same URL): "${item.title}"`);
+          console.log(`[Save] Skipping duplicate (same URL): "${item.title}"`);
           continue;
         }
         // Different URL, similar title — merge URL into existing item
@@ -1569,7 +1133,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
           [existingId, resolvedUrl, item.source_name || null]
         );
         duplicateCount++;
-        console.log(`Merged URL into news #${existingId}: "${item.title}"`);
+        console.log(`[Save] Merged URL into news #${existingId}: "${item.title}"`);
         continue;
       }
 
@@ -1600,7 +1164,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
  * Save events to database
  * @param {Pool} pool - Database connection pool
  * @param {number} poiId - POI ID
- * @param {Array} eventItems - Array of events from AI extraction
+ * @param {Array} eventItems - Array of events from AI summarization
  */
 export async function saveEventItems(pool, poiId, eventItems) {
   let savedCount = 0;
@@ -1612,11 +1176,15 @@ export async function saveEventItems(pool, poiId, eventItems) {
 
   for (const item of eventItems) {
     try {
+      // Normalize event dates via chrono-node — handles natural language, European format, etc.
+      item.start_date = parseDate(item.start_date) || item.start_date;
+      item.end_date = parseDate(item.end_date) || null;
+
       // Skip past events using string comparison to avoid timezone issues
       if (item.start_date && /^\d{4}-\d{2}-\d{2}$/.test(item.start_date)) {
         const endDateStr = item.end_date || item.start_date;
         if (endDateStr < todayStr) {
-          console.log(`Skipping past event: ${item.title} (${item.start_date})`);
+          console.log(`[Save] Skipping past event: ${item.title} (${item.start_date})`);
           continue;
         }
       }
@@ -1631,7 +1199,7 @@ export async function saveEventItems(pool, poiId, eventItems) {
       );
 
       if (isRedirectUrl && !resolvedUrl) {
-        console.log(`Skipping event with failed URL resolution: "${item.title}"`);
+        console.log(`[Save] Skipping event (failed URL resolution): "${item.title}"`);
         continue;
       }
 
@@ -1654,7 +1222,7 @@ export async function saveEventItems(pool, poiId, eventItems) {
         if (matchedEventUrl === normalizedEventUrl) {
           // Exact same URL — truly skip
           duplicateCount++;
-          console.log(`Skipping duplicate event (same URL): "${item.title}"`);
+          console.log(`[Save] Skipping duplicate event (same URL): "${item.title}"`);
           continue;
         }
         // Different URL, similar title+date — merge URL into existing item
@@ -1668,7 +1236,7 @@ export async function saveEventItems(pool, poiId, eventItems) {
           [existingId, resolvedUrl, item.source_name || null]
         );
         duplicateCount++;
-        console.log(`Merged URL into event #${existingId}: "${item.title}"`);
+        console.log(`[Save] Merged URL into event #${existingId}: "${item.title}"`);
         continue;
       }
 
@@ -1806,7 +1374,7 @@ export async function createNewsCollectionJob(pool, poiIds, source = 'batch') {
   ]);
   const jobId = jobResult.rows[0].id;
 
-  console.log(`[Job ${jobId}] Created news collection job for ${totalPois} POIs`);
+  logInfo(jobId, 'news', null, null, `Created news collection job for ${totalPois} POIs`);
 
   return { jobId, totalPois, poiIds: validPoiIds };
 }
@@ -1848,7 +1416,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
   const remainingPoiIds = allPoiIds.filter(id => !processedSet.has(id));
 
   if (remainingPoiIds.length === 0) {
-    console.log(`[Job ${jobId}] All POIs already processed, marking complete`);
+    logInfo(jobId, 'news', null, null, 'All POIs already processed, marking complete');
     await pool.query(`
       UPDATE news_job_status
       SET status = 'completed', completed_at = $1, pg_boss_job_id = $2
@@ -1870,7 +1438,6 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
   // Initialize display slots for this job
   initializeSlots(jobId);
 
-  console.log(`[Job ${jobId}] Starting/resuming news collection: ${remainingPoiIds.length} POIs remaining (${processedPoiIds.length} already done)`);
   logInfo(jobId, 'news', null, null, `Job started: ${remainingPoiIds.length} POIs remaining`, { total: allPoiIds.length, already_done: processedPoiIds.length });
 
   // Get POI details for remaining POIs
@@ -1922,8 +1489,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
         const { news, events, metadata } = await collectNewsForPoi(pool, poi, sheets, 'America/New_York');
         const savedNews = await saveNewsItems(pool, poi.id, news, { skipDateFilter: metadata.usedDedicatedNewsUrl });
         const savedEvents = await saveEventItems(pool, poi.id, events);
-        console.log(`[News Job ${jobId}] [${index + 1}/${total}] ${poi.name}: ${savedNews} news, ${savedEvents} events`);
-        logInfo(jobId, 'news', poi.id, poi.name, `${savedNews} news, ${savedEvents} events saved`, { news_found: news.length, events_found: events.length, news_saved: savedNews, events_saved: savedEvents, provider: metadata?.provider, ai_response: metadata?.ai_response });
+        logInfo(jobId, 'news', poi.id, poi.name, `[${index + 1}/${total}] ${savedNews} news, ${savedEvents} events saved`, { news_found: news.length, events_found: events.length, news_saved: savedNews, events_saved: savedEvents });
 
         // Update last_news_collection timestamp
         await pool.query(`
@@ -1956,7 +1522,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
 
     // Log AI provider usage for this job
     const usage = getJobUsage();
-    console.log(`[Job ${jobId}] AI provider usage: Gemini=${usage.gemini}`);
+    logInfo(jobId, 'news', null, null, `AI provider usage: Gemini=${usage.gemini}`, { gemini_calls: usage.gemini });
 
     // Only mark complete if not cancelled (cancel endpoint already set status)
     if (!jobCancelled) {
@@ -1966,14 +1532,12 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
         WHERE id = $2
       `, [new Date(), jobId, JSON.stringify(usage)]);
     } else {
-      console.log(`[Job ${jobId}] Job was cancelled, not marking as completed`);
+      logInfo(jobId, 'news', null, null, 'Job was cancelled, not marking as completed');
     }
 
     if (jobCancelled) {
-      console.log(`[Job ${jobId}] Cancelled after processing ${processed} POIs, ${newsFound} news, ${eventsFound} events`);
       logInfo(jobId, 'news', null, null, `Job cancelled: ${processed} POIs, ${newsFound} news, ${eventsFound} events`, { pois_processed: processed, news_found: newsFound, events_found: eventsFound });
     } else {
-      console.log(`[Job ${jobId}] Completed: ${processed} POIs, ${newsFound} news, ${eventsFound} events`);
       logInfo(jobId, 'news', null, null, `Job completed: ${processed} POIs, ${newsFound} news, ${eventsFound} events`, { pois_processed: processed, news_found: newsFound, events_found: eventsFound, ai_usage: usage });
     }
     await flushJobLogs();
@@ -1985,21 +1549,18 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
     const poisWithoutResults = batchResults.filter(r => !r.success || !r.result || (r.result.savedNews === 0 && r.result.savedEvents === 0));
 
     if (poisWithResults.length > 0) {
-      console.log(`[Job ${jobId}] POIs with results (${poisWithResults.length}):`);
-      poisWithResults.forEach(r => {
-        console.log(`[Job ${jobId}]   - ${r.item.name}: ${r.result.savedNews} news, ${r.result.savedEvents} events`);
-      });
+      const resultsList = poisWithResults.map(r =>
+        `- ${r.item.name}: ${r.result.savedNews} news, ${r.result.savedEvents} events`
+      ).join('\n');
+      logInfo(jobId, 'news', null, null, `POIs with results (${poisWithResults.length}):\n${resultsList}`);
     }
 
     if (poisWithoutResults.length > 0) {
-      console.log(`[Job ${jobId}] POIs with no results (${poisWithoutResults.length}):`);
-      poisWithoutResults.forEach(r => {
-        console.log(`[Job ${jobId}]   - ${r.item.name}`);
-      });
+      const noResultsList = poisWithoutResults.map(r => `- ${r.item.name}`).join('\n');
+      logInfo(jobId, 'news', null, null, `POIs with no results (${poisWithoutResults.length}):\n${noResultsList}`);
     }
 
   } catch (error) {
-    console.error(`[Job ${jobId}] Failed:`, error);
     logError(jobId, 'news', null, null, `Job failed: ${error.message}`, { error_stack: error.stack?.split('\n').slice(0, 5).join('\n') });
     await flushJobLogs();
     await pool.query(`
@@ -2024,7 +1585,7 @@ export async function runBatchNewsCollection(pool, poiIds, sheets = null, source
     try {
       await processNewsCollectionJob(pool, sheets, `legacy-${jobId}`, { jobId });
     } catch (error) {
-      console.error(`[Job ${jobId}] Background processing failed:`, error);
+      logError(jobId, 'news', null, null, `Background processing failed: ${error.message}`);
     }
   });
 
@@ -2061,7 +1622,8 @@ export async function runNewsCollection(pool, sheets = null) {
   const poiIds = await getAllPoisForCollection(pool);
 
   if (poiIds.length === 0) {
-    console.log('No POIs to collect');
+    const runId = Math.floor(Date.now() / 1000);
+    logInfo(runId, 'news', null, null, 'No POIs to collect');
     return {
       jobId: null,
       totalPois: 0,
@@ -2069,7 +1631,8 @@ export async function runNewsCollection(pool, sheets = null) {
     };
   }
 
-  console.log(`Starting news collection for ${poiIds.length} POIs`);
+  const runId = Math.floor(Date.now() / 1000);
+  logInfo(runId, 'news', null, null, `Starting news collection for ${poiIds.length} POIs`);
   return runBatchNewsCollection(pool, poiIds, sheets, 'scheduled');
 }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -482,7 +482,7 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
   if (collectionType !== 'news' && eventsUrl !== 'No dedicated events page') {
     try {
       checkCancellation();
-      reportProgress(`Rendering events page: ${eventsUrl}`);
+      reportProgress(`Phase I: [Render] Rendering events page: ${eventsUrl}`);
       logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Render] Starting events pipeline`, { url: eventsUrl });
       updateProgress(poi.id, {
         phase: 'classifying_events',
@@ -494,8 +494,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
       if (crawlResult.pages.length > 0) {
         classifiedEventsContent = crawlResult.pages.map(p => `### Event Page: ${p.url}\n\n${p.markdown}`).join('\n\n---\n\n');
         usedClassifier = true;
-        reportProgress(`Found ${crawlResult.pages.length} event pages (crawled ${crawlResult.totalPagesRendered} pages)`);
-        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Classifier found ${crawlResult.pages.length} event pages (${crawlResult.totalPagesRendered} rendered)`);
+        reportProgress(`Phase I: [Classify] Found ${crawlResult.pages.length} event pages (crawled ${crawlResult.totalPagesRendered} pages)`);
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] Found ${crawlResult.pages.length} event pages (${crawlResult.totalPagesRendered} rendered)`);
       } else {
         // Classifier found nothing — use the listing page itself as content
         logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] No detail pages found, using listing page content`);
@@ -503,15 +503,15 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
         if (extracted.reachable && extracted.markdown?.length >= 200) {
           classifiedEventsContent = `### Event Page: ${eventsUrl}\n\n${extracted.markdown}`;
           usedClassifier = true;
-          reportProgress('Using events listing page content directly');
+          reportProgress('Phase I: [Classify] No detail pages, using listing page directly');
           logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Using listing page content (${extracted.markdown.length} chars)`);
         } else {
-          reportProgress('Events page had insufficient content');
+          reportProgress('Phase I: [Render] Events page had insufficient content');
           logWarn(jobId, 'news', poi.id, poi.name, `Phase I: Events page insufficient content (${extracted.markdown?.length || 0} chars)`);
         }
       }
     } catch (err) {
-      reportProgress(`Events page crawl failed: ${err.message}`);
+      reportProgress(`Phase I: Events crawl failed: ${err.message}`);
       logWarn(jobId, 'news', poi.id, poi.name, `Phase I: Events classification failed: ${err.message}`);
     }
   }
@@ -520,7 +520,7 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
   if (collectionType !== 'events' && newsUrl !== 'No dedicated news page') {
     try {
       checkCancellation();
-      reportProgress(`Rendering news page: ${newsUrl}`);
+      reportProgress(`Phase I: [Render] Rendering news page: ${newsUrl}`);
       logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Render] Starting news pipeline`, { url: newsUrl });
       updateProgress(poi.id, {
         phase: 'classifying_news',
@@ -532,8 +532,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
       if (crawlResult.pages.length > 0) {
         classifiedNewsContent = crawlResult.pages.map(p => `### News Page: ${p.url}\n\n${p.markdown}`).join('\n\n---\n\n');
         usedNewsClassifier = true;
-        reportProgress(`Found ${crawlResult.pages.length} news pages (crawled ${crawlResult.totalPagesRendered} pages)`);
-        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Classifier found ${crawlResult.pages.length} news pages (${crawlResult.totalPagesRendered} rendered)`);
+        reportProgress(`Phase I: [Classify] Found ${crawlResult.pages.length} news pages (crawled ${crawlResult.totalPagesRendered} pages)`);
+        logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] Found ${crawlResult.pages.length} news pages (${crawlResult.totalPagesRendered} rendered)`);
       } else {
         // Classifier found nothing — use the listing page itself as content
         logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Classify] No detail pages found, using listing page content`);
@@ -541,15 +541,15 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
         if (extracted.reachable && extracted.markdown?.length >= 200) {
           classifiedNewsContent = `### News Page: ${newsUrl}\n\n${extracted.markdown}`;
           usedNewsClassifier = true;
-          reportProgress('Using news listing page content directly');
+          reportProgress('Phase I: [Classify] No detail pages, using listing page directly');
           logInfo(jobId, 'news', poi.id, poi.name, `Phase I: Using listing page content (${extracted.markdown.length} chars)`);
         } else {
-          reportProgress('News page had insufficient content');
+          reportProgress('Phase I: [Render] News page had insufficient content');
           logWarn(jobId, 'news', poi.id, poi.name, `Phase I: News page insufficient content (${extracted.markdown?.length || 0} chars)`);
         }
       }
     } catch (err) {
-      reportProgress(`News page crawl failed: ${err.message}`);
+      reportProgress(`Phase I: News crawl failed: ${err.message}`);
       logWarn(jobId, 'news', poi.id, poi.name, `Phase I: News classification failed: ${err.message}`);
     }
   }
@@ -639,7 +639,7 @@ Extract ALL news from this content using these relaxed criteria.`;
     const usedProvider = 'gemini';
 
     if (hasCrawledContent) {
-      reportProgress('Sending classified content to Gemini for summarization');
+      reportProgress('Phase I: [Summarize] Sending classified content to Gemini');
       logInfo(jobId, 'news', poi.id, poi.name, 'Phase I: [Summarize] Sending classified content to Gemini', { has_events: !!usedClassifier, has_news: !!usedNewsClassifier });
 
       updateProgress(poi.id, {
@@ -650,7 +650,7 @@ Extract ALL news from this content using these relaxed criteria.`;
 
       const aiResult = await generateTextWithCustomPrompt(pool, prompt);
       response = aiResult.response;
-      reportProgress(`Gemini responded (${response.length} chars)`);
+      reportProgress(`Phase I: [Summarize] Gemini responded (${response.length} chars)`);
       logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Summarize] Received response (${response.length} chars)`);
 
       // Parse JSON response
@@ -659,7 +659,7 @@ Extract ALL news from this content using these relaxed criteria.`;
         logWarn(jobId, 'news', poi.id, poi.name, `No JSON found in response, preview: ${response.substring(0, 500)}...`);
       } else {
         result = JSON.parse(jsonMatch[0]);
-        reportProgress(`Summarized ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
+        reportProgress(`Phase I: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
         logInfo(jobId, 'news', poi.id, poi.name, `Phase I: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events`);
       }
     } else {
@@ -718,18 +718,22 @@ Extract ALL news from this content using these relaxed criteria.`;
           steps: ['Initialized', 'Phase I complete', 'Searching external news']
         });
 
-        reportProgress('Searching Serper for external news coverage...');
+        reportProgress('Phase II: [Search] Querying Serper for external coverage');
         logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: [Search] Querying Serper for external coverage');
 
         // Phase II: [Search] — Serper API returns URLs
         const serperResult = await searchNewsUrls(pool, poi);
         logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Search] ${serperResult.urls.length} URLs (grounded: ${serperResult.grounded})`, { query: serperResult.query, urls_found: serperResult.urls.length });
-        reportProgress(`Serper returned ${serperResult.urls.length} URLs (query: "${serperResult.query}")`);
+        reportProgress(`Phase II: [Search] ${serperResult.urls.length} URLs (query: "${serperResult.query}")`);
 
         if (serperResult.urls.length > 0) {
           // Phase II: Render → Classify → Crawl each Serper URL
+          // Fast path: Serper returns news articles which are nearly always detail pages.
+          // Only classify pages that look like listings (high link density, low content).
           const renderedSerperContent = [];
           let renderedCount = 0;
+          const LISTING_HEURISTIC_LINK_THRESHOLD = 15;
+          const LISTING_HEURISTIC_RATIO = 100; // chars per link — low ratio = listing page
 
           for (const urlData of serperResult.urls) {
             try {
@@ -742,7 +746,7 @@ Extract ALL news from this content using these relaxed criteria.`;
 
               // Phase II: [Render]
               logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Render] ${urlData.url}`);
-              reportProgress(`Rendering external: ${urlData.url}`);
+              reportProgress(`Phase II: [Render] ${urlData.url}`);
 
               const extracted = await extractPageContent(urlData.url, {
                 timeout: 30000,
@@ -755,45 +759,62 @@ Extract ALL news from this content using these relaxed criteria.`;
                 continue;
               }
 
-              // Phase II: [Classify]
-              const classification = await classifyPage(pool, extracted.markdown, extracted.links || [], urlData.url, 'news', sheets);
-              logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Classify] ${urlData.url} → ${classification.pageType}`);
+              // Fast-path: most Serper results are detail pages (news articles).
+              // Only call Gemini Classify if the page looks like a listing:
+              // high link count + low chars-per-link ratio.
+              const linkCount = (extracted.links || []).length;
+              const charsPerLink = linkCount > 0 ? extracted.markdown.length / linkCount : Infinity;
+              const looksLikeListing = linkCount >= LISTING_HEURISTIC_LINK_THRESHOLD && charsPerLink < LISTING_HEURISTIC_RATIO;
 
-              if (classification.pageType === 'detail') {
-                // Detail page — use content directly
-                renderedSerperContent.push({
-                  url: urlData.url, title: urlData.title, snippet: urlData.snippet,
-                  date: urlData.date, markdown: extracted.markdown
-                });
-                renderedCount++;
-              } else {
-                // Listing or hybrid — crawl detail pages
-                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Crawl] Following links from ${urlData.url}`);
-                const crawlResult = await crawlWithClassification(pool, urlData.url, 'news', poi, sheets, checkCancellation, {
-                  maxPages: 5, maxDetailPages: 3, phase: 'Phase II', jobId
-                });
-                for (const page of crawlResult.pages) {
-                  renderedSerperContent.push({
-                    url: page.url, title: page.title || urlData.title, snippet: urlData.snippet,
-                    date: urlData.date, markdown: page.markdown
-                  });
-                  renderedCount++;
-                }
-                // If crawl found nothing, use the page itself
-                if (crawlResult.pages.length === 0) {
+              if (looksLikeListing) {
+                // Phase II: [Classify] — only for suspected listing pages
+                const classification = await classifyPage(pool, extracted.markdown, extracted.links || [], urlData.url, 'news', sheets);
+                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Classify] ${urlData.url} → ${classification.pageType}`);
+                reportProgress(`Phase II: [Classify] ${urlData.url} → ${classification.pageType}`);
+
+                if (classification.pageType === 'detail') {
                   renderedSerperContent.push({
                     url: urlData.url, title: urlData.title, snippet: urlData.snippet,
                     date: urlData.date, markdown: extracted.markdown
                   });
                   renderedCount++;
+                } else {
+                  // Listing or hybrid — crawl detail pages
+                  logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Crawl] Following links from ${urlData.url}`);
+                  const crawlResult = await crawlWithClassification(pool, urlData.url, 'news', poi, sheets, checkCancellation, {
+                    maxPages: 5, maxDetailPages: 3, phase: 'Phase II', jobId
+                  });
+                  for (const page of crawlResult.pages) {
+                    renderedSerperContent.push({
+                      url: page.url, title: page.title || urlData.title, snippet: urlData.snippet,
+                      date: urlData.date, markdown: page.markdown
+                    });
+                    renderedCount++;
+                  }
+                  // If crawl found nothing, use the page itself
+                  if (crawlResult.pages.length === 0) {
+                    renderedSerperContent.push({
+                      url: urlData.url, title: urlData.title, snippet: urlData.snippet,
+                      date: urlData.date, markdown: extracted.markdown
+                    });
+                    renderedCount++;
+                  }
                 }
+              } else {
+                // Fast path — treat as detail page, no Gemini classify call
+                logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Classify] ${urlData.url} → detail (fast path: ${linkCount} links, ${Math.round(charsPerLink)} chars/link)`);
+                renderedSerperContent.push({
+                  url: urlData.url, title: urlData.title, snippet: urlData.snippet,
+                  date: urlData.date, markdown: extracted.markdown
+                });
+                renderedCount++;
               }
             } catch (renderError) {
               logError(jobId, 'news', poi.id, poi.name, `Phase II: [Render] Error: ${urlData.url} — ${renderError.message}`);
             }
           }
 
-          reportProgress(`Rendered ${renderedCount} pages from ${serperResult.urls.length} external URLs`);
+          reportProgress(`Phase II: [Render] ${renderedCount} pages from ${serperResult.urls.length} URLs`);
           logInfo(jobId, 'news', poi.id, poi.name, `Phase II: Rendered ${renderedCount} pages from ${serperResult.urls.length} URLs`);
 
           // Phase II: [Summarize] — send all rendered content to Gemini
@@ -866,7 +887,7 @@ Return {"news": []} if no relevant news found.`;
             }
             logInfo(jobId, 'news', poi.id, poi.name, `Phase II: [Dates] ${serperDateHints.length} dates extracted from ${renderedSerperContent.length} pages`);
 
-            reportProgress(`Sending ${renderedSerperContent.length} external pages to Gemini for summarization`);
+            reportProgress(`Phase II: [Summarize] Sending ${renderedSerperContent.length} pages to Gemini`);
             const serperAiResult = await generateTextWithCustomPrompt(pool, serperPrompt);
 
             const serperAiResponse = serperAiResult.response;
@@ -891,15 +912,15 @@ Return {"news": []} if no relevant news found.`;
                 });
 
                 if (newItems.length > 0) {
-                  reportProgress(`Found ${newItems.length} new articles from external sources`);
+                  reportProgress(`Phase II: [Summarize] ${newItems.length} new articles from external sources`);
                   logInfo(jobId, 'news', poi.id, poi.name, `Phase II: Adding ${newItems.length} unique items`);
                   allNews = [...allNews, ...newItems];
                 } else {
-                  reportProgress('External articles were duplicates, skipped');
+                  reportProgress('Phase II: [Summarize] All duplicates, skipped');
                   logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: All external news items were duplicates, skipped');
                 }
               } else {
-                reportProgress('No relevant news in external articles');
+                reportProgress('Phase II: [Summarize] No relevant news found');
                 logInfo(jobId, 'news', poi.id, poi.name, 'Phase II: No relevant news extracted from external sources');
               }
             }

--- a/docs/NEWS_EVENTS_ARCHITECTURE.md
+++ b/docs/NEWS_EVENTS_ARCHITECTURE.md
@@ -1,909 +1,180 @@
 # News & Events Collection Architecture
 
-## Introduction: How It Works
+## The Problem
 
-The News & Events collection system automatically discovers, extracts, and organizes relevant news articles and upcoming events for every destination in the Roots of The Valley application. This system combines Playwright browser rendering, Gemini AI content extraction, and PostgreSQL deduplication to deliver accurate, up-to-date information.
+Roots of The Valley tracks hundreds of Points of Interest (POIs) across the Cuyahoga Valley region. Each POI may have news articles, upcoming events, trail alerts, and community announcements spread across dozens of websites. These websites use every framework imaginable — Wix, Squarespace, WordPress, React SPAs, plain HTML — making traditional scraping unreliable. Manually maintaining content for hundreds of destinations is impractical.
 
-### The Problem We're Solving
+The system solves this with an automated pipeline that discovers, renders, classifies, crawls, date-stamps, summarizes, moderates, and saves content — with clear separation of responsibilities between tools.
 
-Traditional web scraping struggles with modern websites that rely heavily on JavaScript frameworks (like Wix, Squarespace, and WordPress). Simply fetching HTML often returns empty pages or loading spinners because the content is generated client-side after page load. Additionally, manually maintaining news and events for hundreds of destinations is impractical and error-prone.
+## Pipeline Architecture
 
-### Our Multi-Layered Solution
-
-**1. Intelligent JavaScript Rendering**
-When the system encounters a website that uses JavaScript frameworks, it automatically launches a headless Chromium browser using Playwright. This real browser renders the page exactly as users see it, waits for all JavaScript to execute, and extracts the fully-rendered content. This works seamlessly with Wix, Squarespace, and other dynamic platforms that would otherwise be invisible to traditional scrapers.
-
-**2. AI-Powered Content Discovery**
-The system uses Google Gemini AI with Google Search grounding to intelligently search for and extract relevant content. For news collection, it employs a two-pass strategy:
-- **First pass**: Analyzes the organization's dedicated news page (if available) using relaxed filtering criteria (75% confidence threshold)
-- **Second pass**: Searches Google News, PR Newswire, and news outlets for external coverage using strict filtering (95% confidence threshold)
-
-This dual approach ensures comprehensive coverage - catching both the organization's own announcements and third-party media coverage.
-
-**3. Smart URL Resolution**
-Google Search results initially return redirect URLs (like `vertexaisearch.cloud.google.com/grounding-api-redirect/...`) rather than direct links. Our system automatically resolves these redirects to extract the real destination URLs. This provides two major benefits:
-- **Faster user experience**: Users click directly to articles without intermediate redirects
-- **Better deduplication**: The same article found through different search queries resolves to the same final URL, making it easy to detect duplicates
-
-**4. Dual-Check Deduplication**
-The system prevents duplicates using two complementary strategies:
-- **URL matching**: Same resolved URL = same article (catches articles found via different search queries)
-- **Normalized title matching**: Strips date suffixes like "| January 30" or "| 2026-01-30" before comparing (catches same content with different title formatting)
-
-This robust deduplication allows admins to refresh news multiple times without creating duplicates, even when the AI finds the same articles through different search paths.
-
-**5. Multi-Provider AI Strategy**
-The system supports multiple AI providers with automatic fallback. Administrators can configure:
-- **Primary Provider**: First choice for searches (Gemini or Perplexity)
-- **Secondary Provider**: Fallback when primary reaches rate limits
-- **Usage Limits**: Configure per-job request limits for each provider (0 = unlimited)
-
-When the primary provider hits its configured limit or returns rate-limiting errors (HTTP 429), the system automatically switches to the secondary provider. This ensures uninterrupted collection even under heavy load.
-
-**6. Timezone-Aware Date Parsing**
-All dates are interpreted in the user's configured timezone (defaults to Eastern Time for Cuyahoga Valley). The AI extracts dates in ISO 8601 format (YYYY-MM-DD), ensuring consistency across all sources and preventing timezone-related bugs. This is especially important for event start dates and news publication dates.
-
-**7. Real-Time Progress Tracking**
-The UI displays a scrollable status widget that moves through distinct phases:
-- Rendering JavaScript-heavy pages
-- AI search with Google Search grounding
-- Matching deep links to extracted items
-- Searching Google News for external coverage
-- Saving items to database
-
-The progress widget also displays real-time AI provider statistics:
-- Current primary/secondary provider being used
-- Number of requests made to each provider
-- Total usage across the job session
-
-Admins can scroll down to see newly added items while the collection is still running, providing immediate feedback and transparency into what the system is finding.
-
-**8. Batch Job Cancellation**
-Long-running batch jobs can be cancelled at any time via the Cancel button. When cancelled:
-- The system stops starting new POI collections
-- In-flight POIs complete naturally (no data loss)
-- Job status updates to "cancelled" with a distinctive UI badge
-- Progress shows how many POIs were processed before cancellation
-
-**9. Quality Filters and Validation**
-- **Date filtering**: News older than 365 days is automatically excluded (unless from a dedicated news page)
-- **Past event filtering**: Events with end dates in the past are skipped
-- **Failed URL resolution**: Items with unresolvable redirect URLs are discarded to maintain data quality
-- **Confidence thresholds**: Dedicated pages use relaxed filtering (75%), while general searches use strict filtering (95%)
-
-### Key Benefits
-
-**For End Users:**
-- **Fresh, relevant content**: Automatic updates ensure news and events stay current
-- **Fast navigation**: Direct URLs mean instant access to articles (no redirect delays)
-- **Comprehensive coverage**: Captures both organizational announcements and media coverage
-- **Accurate dates**: Timezone-aware parsing ensures event times are correct
-
-**For Administrators:**
-- **Zero maintenance**: No manual updates required - just click "Refresh News" or "Refresh Events"
-- **No duplicates**: Multiple refreshes don't create duplicate entries thanks to dual-check deduplication
-- **Transparent process**: Real-time progress tracking shows exactly what the system is finding
-- **Scalable**: Works for hundreds of destinations without performance degradation
-- **Flexible**: Handles any website type - static HTML, Wix, Squarespace, WordPress, etc.
-
-**For Developers:**
-- **Modular architecture**: Clear separation between rendering, AI search, and data persistence
-- **Crash-recoverable**: Uses pg-boss job queue for batch processing that survives container restarts
-- **Comprehensive logging**: Detailed logs show URL resolution, duplicate detection, and filtering decisions
-- **Extensible**: Easy to add new event types, news categories, or content sources
-
-### Technology Stack
-
-- **Playwright**: Headless browser automation for JavaScript rendering
-- **AI Providers** (configurable primary/secondary):
-  - **Google Gemini 2.0 Flash**: AI-powered content extraction with search grounding
-  - **Perplexity Sonar Pro**: Alternative AI with built-in web search capability
-- **PostgreSQL**: Structured storage for news, events, and deduplication
-- **pg-boss**: Job queue for reliable background processing
-- **Node.js/Express**: Backend API and orchestration
-- **React**: Real-time progress tracking UI
-
-## Overview
-
-The News & Events collection system uses AI-powered research combined with headless browser rendering to automatically discover and extract relevant news articles and upcoming events for Points of Interest (POIs) in the Cuyahoga Valley National Park region.
-
-**Key Features:**
-- Automatic detection and rendering of JavaScript-heavy websites (Wix, Squarespace, etc.)
-- Playwright-based headless browser for dynamic content extraction
-- Google Gemini AI with Google Search grounding for intelligent content discovery
-- Relaxed filtering for dedicated events/news URLs vs. strict filtering for general web searches
-- Per-POI refresh capability with progress tracking
-- Batch processing for multiple POIs
-
-## System Architecture
+Every piece of content flows through seven stages. Both Phase I and Phase II follow the same pipeline — Phase II simply adds a Search step at the front.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                         Frontend UI                             │
-│  - Refresh News/Events buttons (per-POI, edit mode)             │
-│  - "Update News & Events" batch button (map, edit mode)         │
-│  - Event/News counters and scrollable lists                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Backend API Routes                         │
-│  POST /api/admin/pois/:id/news/collect  - Single POI            │
-│  POST /api/admin/pois/:id/events/collect - Single POI (alias)   │
-│  POST /api/admin/news/batch-collect - Batch multiple POIs       │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    News Service Layer                           │
-│  (backend/services/newsService.js)                              │
-│                                                                 │
-│  1. collectNewsForPoi(poi) - Main collection logic              │
-│     ├─ Check events_url & news_url for JS-heavy sites          │
-│     ├─ Render with Playwright if needed                        │
-│     ├─ Build AI prompt with rendered content                   │
-│     └─ Parse and return {news[], events[]}                     │
-│                                                                 │
-│  2. saveNewsItems(poiId, news[]) - Dedupe & save               │
-│  3. saveEventItems(poiId, events[]) - Dedupe & save            │
-│  4. batchCollectNews(poiIds[], jobId) - Parallel processing    │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                 JavaScript Renderer Service                     │
-│  (backend/services/jsRenderer.js)                               │
-│                                                                 │
-│  1. isJavaScriptHeavySite(url)                                  │
-│     ├─ Check domain patterns (wix.com, squarespace.com, etc.)  │
-│     ├─ Check HTTP headers (x-wix-request-id, server: Pepyaka)  │
-│     └─ Check HTML signatures (wixstatic, parastorage, etc.)    │
-│                                                                 │
-│  2. renderJavaScriptPage(url, options)                          │
-│     ├─ Launch headless Chromium via Playwright                 │
-│     ├─ Navigate to URL, wait for networkidle                   │
-│     ├─ Wait additional time for JS execution (default 3s)      │
-│     ├─ Extract: document.body.innerText, innerHTML, title      │
-│     └─ Return {text, html, title, success}                     │
-│                                                                 │
-│  3. extractEventContent(text) - [DEPRECATED]                    │
-│     └─ Originally filtered content, now using full text        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Playwright / Chromium                        │
-│  - Headless browser execution                                   │
-│  - JavaScript rendering engine                                  │
-│  - DOM manipulation and content extraction                      │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│                   AI Search Factory                             │
-│  (backend/services/aiSearchFactory.js)                          │
-│                                                                 │
-│  - Selects AI provider based on configuration                   │
-│  - Tracks usage per job session                                 │
-│  - Auto-fallback on rate limits (429 errors)                    │
-│  - Provides unified interface for news/events collection        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-              ┌───────────────┴───────────────┐
-              ▼                               ▼
-┌─────────────────────────────┐ ┌─────────────────────────────────┐
-│   Google Gemini 2.0 Flash   │ │     Perplexity Sonar Pro        │
-│  (geminiService.js)         │ │    (perplexityService.js)       │
-│                             │ │                                 │
-│  - Google Search grounding  │ │  - Built-in web search          │
-│  - Custom prompts           │ │  - Citations included           │
-│  - Structured JSON output   │ │  - Structured JSON output       │
-│  - Temperature: 0.1         │ │  - Temperature: 0.1             │
-└─────────────────────────────┘ └─────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    PostgreSQL Database                          │
-│                                                                 │
-│  pois table:                                                    │
-│    - events_url: Dedicated events page URL                      │
-│    - news_url: Dedicated news page URL                          │
-│                                                                 │
-│  poi_news table:                                                │
-│    - poi_id, title, summary, source_url, published_at          │
-│    - news_type: general|closure|seasonal|maintenance|wildlife   │
-│                                                                 │
-│  poi_events table:                                              │
-│    - poi_id, title, description, start_date, end_date          │
-│    - event_type: guided-tour|program|festival|volunteer|etc    │
-│    - location_details, source_url                               │
-│                                                                 │
-│  news_job_status table:                                         │
-│    - job_id, status, progress tracking, resumability            │
-└─────────────────────────────────────────────────────────────────┘
+ [Search]  →  [Render]  →  [Classify]  →  [Crawl]  →  [Dates]  →  [Summarize]  →  [Save]
+  Serper      Playwright     Gemini       Playwright   chrono-node    Gemini        PostgreSQL
 ```
 
-## JavaScript Rendering System
+### The Seven Stages
 
-### Detection Logic
+| Stage | Log Prefix | Tool | Responsibility |
+|-------|-----------|------|----------------|
+| **Search** | `[Search]` | Serper API | Find URLs for external coverage (Phase II only) |
+| **Render** | `[Render]` | Playwright + Readability | Convert URLs to clean markdown |
+| **Classify** | `[Classify]` | Google Gemini | Determine if a page is a listing, detail, or hybrid |
+| **Crawl** | `[Crawl]` | Playwright + Readability | Follow links from listing/hybrid pages to detail pages |
+| **Dates** | `[Dates]` | chrono-node | Extract and normalize all dates deterministically |
+| **Summarize** | `[Summarize]` | Google Gemini | Identify distinct items, write summaries, classify types |
+| **Save** | `[Save]` | PostgreSQL | Deduplicate, normalize, persist |
 
-The system automatically detects JavaScript-heavy websites using multiple strategies:
+### Key Design Principle: Tools Stay in Their Lane
 
-**1. Domain Pattern Matching**
-```javascript
-const jsHeavyDomains = [
-  'wix.com', 'wixsite.com', 'wixstatic.com',
-  'squarespace.com', 'webflow.io', 'webflow.com',
-  'carrd.co', 'weebly.com', 'wordpress.com',
-  'sites.google.com'
-];
-```
+- **Gemini never extracts dates.** Dates are chrono-node's job. Gemini may pass through dates it sees in content, but chrono-node normalizes everything at the save chokepoint.
+- **Gemini classifies pages, not content.** Classification asks "Is this page a listing or a detail page?" — it does not summarize or extract data.
+- **chrono-node never summarizes.** It only finds and normalizes date references in text.
+- **Serper never renders.** It returns URLs. Playwright renders them.
+- **Moderation never overwrites collection dates.** Dates are set during collection and preserved through moderation. The only exception is the manual "Fix Date" button, which uses chrono-node first and Gemini as a fallback.
 
-**2. HTTP Header Detection**
-- `server: Pepyaka` (Wix platform)
-- `x-wix-request-id` (Wix-specific header)
+### Gemini's Three Roles
 
-**3. HTML Content Signatures**
-```javascript
-const signatures = [
-  'wix.com', 'wixstatic.com', 'parastorage.com',
-  'thunderbolt', 'window.wixSite', '__NEXT_DATA__'
-];
-```
+Gemini is used for three distinct tasks, each with a clear boundary:
 
-### Rendering Process
-
-When a JavaScript-heavy site is detected:
-
-1. **Launch Browser**: Chromium headless instance via Playwright
-2. **Navigate**: Load URL with `waitUntil: 'networkidle'` (network quiet for 500ms)
-3. **Wait**: Additional configurable wait (default 3-4 seconds) for lazy-loaded content
-4. **Extract**: Capture `document.body.innerText` and `innerHTML`
-5. **Cleanup**: Close browser gracefully
-6. **Limits**: Extract up to 15,000 characters for AI processing
-
-**Configuration Options:**
-```javascript
-renderJavaScriptPage(url, {
-  timeout: 20000,        // Max page load time (20s)
-  waitTime: 4000,        // Additional JS execution wait (4s)
-  waitForSelector: null  // Optional specific element to wait for
-})
-```
-
-## AI Provider System
-
-### Provider Configuration
-
-The system supports two AI providers that can be configured as primary or secondary:
-
-| Provider | Model | Key Features |
-|----------|-------|--------------|
-| **Gemini** | gemini-2.0-flash | Google Search grounding, high accuracy |
-| **Perplexity** | sonar-pro | Built-in web search, includes citations |
-
-**Configuration is stored in the database (`ai_config` table) and can be changed via the Admin Settings UI.**
-
-### AI Search Factory
-
-The `aiSearchFactory.js` module provides a unified interface for AI searches:
-
-```javascript
-// Factory exports
-import {
-  performAiSearch,    // Main search function - auto-selects provider
-  getJobStats,        // Get current usage stats for display
-  resetJobUsage,      // Reset counters for new job session
-  forceProviderSwitch // Manually switch providers (for testing)
-} from '../services/aiSearchFactory.js';
-
-// Usage tracking per job session
-const stats = getJobStats();
-// Returns: { gemini: 15, perplexity: 5, rateLimitHits: 2 }
-```
-
-### Fallback Behavior
-
-1. **Usage Limit Fallback**: When primary provider reaches configured limit, switches to secondary
-2. **Rate Limit Fallback**: On HTTP 429 errors, automatically retries with secondary provider
-3. **Error Tracking**: Rate limit hits are counted and displayed in the UI
-
-### Admin Settings UI
-
-Administrators can configure AI providers via the Settings page:
-
-- **Primary Provider**: Select Gemini or Perplexity as default
-- **Primary Limit**: Maximum requests before switching (0 = unlimited)
-- **Secondary Provider**: Fallback provider
-- **Secondary Limit**: Maximum secondary requests (0 = unlimited)
-
-The UI displays real-time statistics during collection:
-```
-AI Stats: Gemini: 10 | Perplexity: 5 | Rate Limits: 0
-```
-
-## AI Collection Prompt System
-
-### Dual-Tier Filtering Strategy
-
-**Tier 1: Strict Filtering (General Web Search)**
-- **Confidence**: 95% that content is specifically about the POI
-- **Name Matching**: Must explicitly mention POI by name
-- **Context**: "It is better to return empty arrays than false positives"
-
-**Tier 2: Relaxed Filtering (Dedicated URLs Only)**
-- **Confidence**: 75% that content is relevant
-- **Assumption**: Content on official events/news pages is inherently relevant
-- **Directive**: "Include ALL events that appear to be listed on this page"
-
-### Prompt Components
-
-**1. POI Context**
-```
-Search for recent news and upcoming events SPECIFICALLY about: "{{name}}"
-Location type: {{poi_type}}
-Activities: {{activities}}
-
-Official website: {{website}}
-Dedicated events page: {{eventsUrl}}
-Dedicated news page: {{newsUrl}}
-```
-
-**2. Priority Sources**
-- National Park Service (NPS)
-- Ohio Department of Transportation (ODOT)
-- Summit Metro Parks
-- Cleveland Metroparks
-- Local news outlets
-
-**3. Alternative Search Strategies** (for JS-heavy sites)
-- Facebook Events (most reliable for organizations)
-- Eventbrite, Meetup
-- Instagram announcements
-- Google Business Profile
-- Local event aggregators
-
-**4. Rendered Content Injection**
-```
-RENDERED EVENTS PAGE CONTENT:
-We rendered the JavaScript-heavy events page and extracted this content:
-
-[15,000 chars of rendered text]
-
-**SPECIAL INSTRUCTIONS FOR RENDERED EVENTS PAGE:**
-Since this content comes directly from the organization's dedicated events page,
-use RELAXED requirements:
-- You only need 75% confidence (not 95%) that an event is relevant
-- Events listed on this official page can be assumed to be associated with
-  "Open Trail Collective" even if the name isn't explicitly mentioned
-- Include ALL events that appear to be listed on this page
-```
-
-### Response Format
-
-The AI returns structured JSON:
-
-```json
-{
-  "news": [
-    {
-      "title": "Trail Closure on Blue Hen Falls Path",
-      "summary": "Blue Hen Falls trail temporarily closed for bridge repair...",
-      "source_name": "NPS.gov",
-      "source_url": "https://www.nps.gov/cuva/...",
-      "published_date": "2026-01-15",
-      "news_type": "closure"
-    }
-  ],
-  "events": [
-    {
-      "title": "Guided Hike: Winter Bird Watching",
-      "description": "Join naturalists for a winter bird watching hike...",
-      "start_date": "2026-02-10",
-      "end_date": null,
-      "event_type": "guided-tour",
-      "location_details": "Meets at Blue Hen Falls Trailhead",
-      "source_url": "https://example.org/events/winter-birds"
-    }
-  ]
-}
-```
-
-## Database Schema
-
-### POI Extensions
-
-```sql
-ALTER TABLE pois ADD COLUMN events_url VARCHAR(500);
-ALTER TABLE pois ADD COLUMN news_url VARCHAR(500);
-```
-
-### News Table
-
-```sql
-CREATE TABLE poi_news (
-  id SERIAL PRIMARY KEY,
-  poi_id INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
-  title VARCHAR(500) NOT NULL,
-  summary TEXT,
-  source_name VARCHAR(200),
-  source_url VARCHAR(1000),
-  published_at TIMESTAMP,
-  news_type VARCHAR(50), -- general|closure|seasonal|maintenance|wildlife
-  created_at TIMESTAMP DEFAULT NOW()
-);
-
-CREATE INDEX idx_poi_news_poi_id ON poi_news(poi_id);
-CREATE INDEX idx_poi_news_published ON poi_news(published_at DESC);
-```
-
-### Events Table
-
-```sql
-CREATE TABLE poi_events (
-  id SERIAL PRIMARY KEY,
-  poi_id INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
-  title VARCHAR(500) NOT NULL,
-  description TEXT,
-  start_date DATE NOT NULL,
-  end_date DATE,
-  event_type VARCHAR(50), -- guided-tour|program|festival|volunteer|educational|concert
-  location_details VARCHAR(500),
-  source_url VARCHAR(1000),
-  created_at TIMESTAMP DEFAULT NOW()
-);
-
-CREATE INDEX idx_poi_events_poi_id ON poi_events(poi_id);
-CREATE INDEX idx_poi_events_start_date ON poi_events(start_date);
-```
-
-### Deduplication Logic
-
-**News Items:**
-```sql
-SELECT id FROM poi_news
-WHERE poi_id = $1
-  AND title = $2
-  AND published_at = $3
-LIMIT 1
-```
-
-**Events:**
-```sql
-SELECT id FROM poi_events
-WHERE poi_id = $1
-  AND title = $2
-  AND start_date = $3
-LIMIT 1
-```
-
-## API Endpoints
-
-### Single POI Collection
-
-**POST /api/admin/pois/:id/news/collect**
-
-Collects news and events for a single POI.
-
-**Request:**
-```bash
-curl -X POST http://localhost:3001/api/admin/pois/123/news/collect \
-  -H "Cookie: session=..." \
-  --cookie-jar cookies.txt
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "News collection completed for Open Trail Collective",
-  "newsFound": 5,
-  "newsSaved": 3,
-  "eventsFound": 8,
-  "eventsSaved": 6
-}
-```
-
-**Process:**
-1. Fetch POI from database (id, name, events_url, news_url, etc.)
-2. Call `collectNewsForPoi(pool, poi)`
-3. Save results with deduplication
-4. Return counts
-
-### Batch Collection
-
-**POST /api/admin/news/batch-collect**
-
-Collects news/events for multiple POIs in parallel.
-
-**Request:**
-```json
-{
-  "poiIds": [1, 2, 3, 4, 5]
-}
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "News collection started for 5 POIs",
-  "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-**Process:**
-1. Create job record in `news_job_status` table
-2. Launch pg-boss background job
-3. Process POIs in parallel (concurrency: 15)
-4. Update job progress as POIs complete
-5. Mark job complete when done
-
-**Job Status Tracking:**
-```sql
-SELECT status, processed_count, total_count, error_message
-FROM news_job_status
-WHERE job_id = $1
-```
-
-### Cancel Batch Job
-
-**PUT /api/admin/news/batch-collect/:jobId/cancel**
-
-Cancels a running batch job.
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "Job 550e8400-e29b-41d4-a716-446655440000 cancelled"
-}
-```
-
-### Read Endpoints
-
-**GET /api/pois/:id/news?limit=20**
-
-Returns news items for a POI, newest first.
-
-**GET /api/pois/:id/events**
-
-Returns upcoming events for a POI, sorted by start_date.
-
-**GET /api/admin/news/job-status/:jobId**
-
-Returns batch job status and progress.
-
-**GET /api/admin/news/ai-stats**
-
-Returns current AI provider usage statistics.
-
-```json
-{
-  "gemini": 15,
-  "perplexity": 5,
-  "rateLimitHits": 2
-}
-```
-
-## Job Scheduling
-
-### Daily Scheduled Collection
-
-The system uses pg-boss for reliable job scheduling with PostgreSQL as the backing store.
-
-**Schedule:** Daily at 6:00 AM Eastern Time
-
-```javascript
-// Cron expression: 0 6 * * * (6 AM daily)
-await scheduleNewsCollection('0 6 * * *');
-```
-
-**Job Types:**
-
-| Job Name | Purpose |
-|----------|---------|
-| `news-collection` | Scheduled daily collection for all POIs |
-| `news-collection-poi` | Individual POI processing (internal) |
-| `news-batch-collection` | Admin-triggered batch collection |
-
-### Batch Job Lifecycle
-
-1. **Submit**: Admin clicks "Update News & Events" → creates job in `news_job_status` table
-2. **Queue**: Job submitted to pg-boss queue for background processing
-3. **Process**: Worker picks up job, processes POIs with configurable concurrency
-4. **Progress**: Real-time updates written to database, polled by frontend
-5. **Complete/Cancel**: Job finishes normally or is cancelled by admin
-
-### Cancellation Flow
-
-```
-Admin clicks Cancel → PUT /api/admin/news/batch-collect/:id/cancel
-                    → Database status set to 'cancelled'
-                    → Worker checks status before each new POI
-                    → In-flight POIs complete naturally
-                    → No new POIs started
-                    → Final status remains 'cancelled'
-```
-
-## Frontend Components
-
-### Sidebar News/Events Tabs
-
-**File:** `frontend/src/components/Sidebar.jsx`
-
-**Components:**
-- `PoiNews({ poiId, isAdmin, editMode, onCountChange })`
-- `PoiEvents({ poiId, isAdmin, editMode, onCountChange })`
-
-**Features:**
-- Scrollable lists with hidden scrollbars
-- Sticky refresh buttons (edit mode only)
-- Event/News counters on buttons
-- Delete functionality (edit mode only)
-- Real-time collection feedback
-
-**UI States:**
-- **View Mode**: Tab shows count (e.g., "News (6)"), no refresh button
-- **Edit Mode**: Refresh button shows count (e.g., "🔍 Refresh News (6)")
-
-**Refresh Button (Edit Mode):**
-```javascript
-<button className="refresh-content-btn" onClick={handleCollectNews}>
-  {collecting ? '🔄 Searching...' : `🔍 Refresh News${news.length > 0 ? ` (${news.length})` : ''}`}
-</button>
-```
-
-**CSS Styling:**
-```css
-.poi-tab-actions {
-  position: sticky;
-  top: 0;
-  padding: 1rem;
-  background: #f8f9fa;
-  border-bottom: 1px solid #dee2e6;
-  z-index: 10;
-}
-
-.poi-news-list, .poi-events-list {
-  max-height: calc(100vh - 300px);
-  overflow-y: auto;
-  scrollbar-width: none; /* Firefox */
-}
-```
-
-### Map Batch Collection Button
-
-**File:** `frontend/src/App.jsx`
-
-**Feature:** "Update News & Events" button on map (edit mode only)
-
-**Process:**
-1. Collect visible POI IDs from current map viewport
-2. POST to `/api/admin/news/batch-collect` with poiIds
-3. Display progress notification
-4. Poll job status until complete
-
-## Configuration
-
-### Environment Variables
-
-```bash
-# AI Provider API Keys
-GEMINI_API_KEY=your_gemini_api_key_here
-PERPLEXITY_API_KEY=your_perplexity_api_key_here
-
-# Database
-POSTGRES_USER=rotv
-POSTGRES_PASSWORD=rotv
-POSTGRES_DB=rotv
-```
-
-### AI Configuration Table
-
-The `ai_config` table stores provider settings:
-
-```sql
-CREATE TABLE ai_config (
-  key VARCHAR(100) PRIMARY KEY,
-  value VARCHAR(500) NOT NULL,
-  updated_at TIMESTAMP DEFAULT NOW()
-);
-
--- Default values
-INSERT INTO ai_config (key, value) VALUES
-  ('primary_provider', 'gemini'),
-  ('secondary_provider', 'perplexity'),
-  ('primary_limit', '0'),      -- 0 = unlimited
-  ('secondary_limit', '0');
-```
-
-### Dependencies
-
-**Backend:**
-```json
-{
-  "@google/generative-ai": "^0.2.0",
-  "pg-boss": "^10.0.0"
-}
-```
-
-**Note:** Perplexity API uses standard HTTP requests, no additional package required.
-
-**Playwright Infrastructure:**
-
-Playwright and Chromium browsers are installed in the **base container image** (`Containerfile.base`):
-- Base image installs Playwright globally and downloads Chromium browsers
-- Base image records the version in `/etc/playwright-version`
-- App image installs the matching Playwright npm package version
-
-This ensures browser binaries match the npm package and avoids large downloads on every build.
-
-## Performance Considerations
-
-### Rendering Timeouts
-
-- **Page Load**: 20 seconds max (configurable)
-- **JS Execution Wait**: 3-4 seconds (configurable)
-- **Network Idle**: 500ms of no network activity
-
-### Parallel Processing
-
-- **Batch Jobs**: 15 concurrent POIs
-- **Character Limits**: 15,000 chars per rendered page
-- **AI Request Rate**: Controlled by Gemini API limits
-
-### Caching Strategy
-
-**No caching currently implemented.** Future considerations:
-- Cache rendered pages for 1 hour
-- Cache AI responses for 24 hours
-- Invalidate on manual refresh
-
-## Error Handling
-
-### Playwright Failures
-
-```javascript
-if (rendered.success) {
-  // Use rendered content
-} else {
-  console.log(`Failed to render: ${rendered.error}`);
-  // Fall back to standard web search without rendered content
-}
-```
-
-### AI Parsing Failures
-
-```javascript
-const jsonMatch = response.match(/\{[\s\S]*\}/);
-if (!jsonMatch) {
-  console.log('No JSON found in AI response');
-  return { news: [], events: [] };
-}
-```
-
-### Database Errors
-
-- Duplicate insertions are silently skipped (deduplication)
-- Foreign key violations logged but don't fail batch jobs
-- Transaction rollbacks on critical errors
-
-## Testing
-
-### Test Script
-
-**File:** `backend/test-playwright.js`
-
-```bash
-cd backend
-node test-playwright.js
-```
-
-**What it tests:**
-1. `isJavaScriptHeavySite()` - Detection accuracy
-2. `renderJavaScriptPage()` - Full rendering pipeline
-3. `extractEventContent()` - Content extraction (deprecated)
-4. Output preview - First 1000 chars of rendered content
-
-### Manual Testing
-
-1. **Single POI**: Navigate to POI in edit mode, click "🔍 Refresh Events"
-2. **Batch Collection**: Click "Update News & Events" on map
-3. **Verify Results**: Check News/Events tabs for new content
-
-### Expected Results
-
-**Open Trail Collective (Wix site):**
-- Should detect as JS-heavy: ✓
-- Should render with Playwright: ✓
-- Should extract 8 events: ✓
-- Should save deduplicated events: ✓
-
-## Future Enhancements
-
-### Planned Improvements
-
-1. **Incremental Updates**: Only fetch new content since last collection
-2. **Event Expiration**: Auto-delete past events after 30 days
-3. **News Archival**: Move old news to archive table
-4. **Image Extraction**: Pull event images from rendered pages
-5. **Calendar Export**: iCal/Google Calendar integration
-6. **Webhooks**: Notify on new events/news
-7. **RSS Feeds**: Generate feeds per POI
-
-### Optimization Opportunities
-
-1. **Browser Pooling**: Reuse Playwright browser instances
-2. **Selective Rendering**: Only render if content changed (ETag/Last-Modified)
-3. **Smart Scheduling**: Auto-refresh high-traffic POIs more frequently
-4. **AI Model Tuning**: Fine-tune prompts based on success rates
-5. **Response Caching**: Cache AI responses with TTL
-
-## Troubleshooting
-
-### Common Issues
-
-**1. "No events found" despite visible events on page**
-- Check if character limit (15,000) is truncating content
-- Verify AI confidence threshold (should be 75% for dedicated URLs)
-- Increase `waitTime` if lazy-loaded content not appearing
-
-**2. Playwright browser fails to launch**
-- Verify base image was built with Playwright: check `/etc/playwright-version` exists
-- Ensure app image installed matching Playwright npm version
-- Check Settings > Data Collection for Playwright status indicator
-- System dependencies (libx11, libgbm, etc.) are pre-installed in base image
-
-**3. Events duplicating on refresh**
-- Check deduplication query (title + start_date match)
-- Verify event titles are consistent across refreshes
-
-**4. Slow collection times**
-- Reduce `waitTime` from 4s to 2s if acceptable
-- Lower concurrency from 15 to 10
-- Check Gemini API rate limits
-
-### Debug Logging
-
-Enable verbose logging:
-```javascript
-console.log(`[AI Research] Starting search for: ${poi.name}`);
-console.log(`[AI Research] Events URL: ${eventsUrl}`);
-console.log(`[JS Renderer] Detected JS-heavy site: ${url}`);
-console.log(`[JS Renderer] Rendered ${content.text.length} chars`);
-```
-
-## Changelog
-
-**Version 1.4.1 (2026-02-03)**
-- 📝 Updated docs to reflect Playwright/Chromium installation in base container image
-- 📝 Added Playwright status indicator reference in troubleshooting
-
-**Version 1.4.0 (2026-01-22)**
-- ✨ Added multi-provider AI support (Gemini + Perplexity with automatic fallback)
-- ✨ Added AI provider configuration UI in Admin Settings
-- ✨ Added real-time AI usage statistics display during collection
-- ✨ Added batch job cancellation feature with Cancel button
-- ✨ Added cancelled status badge for stopped jobs
-- 🔧 Simplified scheduling to single daily job at 6 AM Eastern (removed tier system)
-- 🐛 Fixed single-POI collection not respecting provider fallback limits
-- 🐛 Fixed Primary Limit input UX (step by 100, empty field shows 0)
-- 📝 Updated architecture documentation
-
-**Version 1.3.0 (2026-01-20)**
-- ✨ Added Playwright JavaScript rendering for Wix/Squarespace sites
-- ✨ Implemented dual-tier filtering (strict vs. relaxed)
-- ✨ Added sticky refresh buttons in sidebar
-- ✨ Added event/news counters on UI buttons
-- 🐛 Fixed missing events from JS-heavy pages (6→8 events)
-- 📝 Created comprehensive architecture documentation
-
-**Version 1.2.0 (2025-12)**
-- Added `events_url` and `news_url` fields to POI schema
-- Created dedicated refresh buttons per POI
-- Separated batch collection from individual POI refresh
-
-**Version 1.0.0 (2025-11)**
-- Initial News & Events collection system
-- Google Gemini integration with search grounding
-- Basic web search without JS rendering
+1. **Classification** — "Is this page a listing, detail, or hybrid?" Called per-page during the Classify stage. Returns a page type and links to follow.
+2. **Summarization** — "What news/events are on these pages?" Called once per phase with all rendered content batched together. Returns structured JSON.
+3. **Moderation** — "Is this item relevant and high-quality?" Called per-item during the separate moderation sweep. Returns a quality score.
+
+## Two-Phase Collection
+
+Content collection happens in two phases per POI. Both phases follow the same Render → Classify → Crawl → Dates → Summarize pipeline. Logs always show `Phase I:` or `Phase II:` prefix so you can tell which phase a URL is in.
+
+### Phase I: POI's Own Pages
+
+If a POI has dedicated `events_url` or `news_url` configured:
+
+1. **Render** the dedicated page via Playwright
+2. **Classify** the page as listing, detail, or hybrid via Gemini
+3. **Crawl** — if listing/hybrid, follow links to detail pages and render each one
+4. If classifier finds no detail pages, use the listing page content directly (fallback)
+5. **Dates** — extract dates from all rendered content via chrono-node (passed as hints to Gemini)
+6. **Summarize** all rendered content in a single Gemini call with relaxed filtering (75% confidence)
+
+Phase I uses relaxed confidence thresholds because content on an organization's own events/news page is inherently relevant to that POI.
+
+POIs without dedicated URLs skip Phase I entirely and go straight to Phase II.
+
+### Phase II: External Coverage (Serper)
+
+After Phase I, the system searches for external news coverage:
+
+1. **Search** via Serper API for news about the POI
+2. **Render** each returned URL via Playwright (with `extractLinks: true`)
+3. **Classify** each page as listing, detail, or hybrid via Gemini
+4. **Crawl** — if listing/hybrid, follow links to detail pages (capped at 5 pages, 3 detail pages per URL)
+5. If crawl finds nothing, use the page content directly (same fallback as Phase I)
+6. **Dates** — extract dates from all rendered content via chrono-node
+7. **Summarize** all rendered content in a single Gemini call with strict filtering (95% confidence)
+8. **Merge** with Phase I results, deduplicating by URL and normalized title
+
+Phase II uses strict confidence thresholds because external sources may mention a POI tangentially without being truly relevant. Per-URL crawl limits are tight to prevent 10 Serper URLs x 5 crawled pages = 50 renders.
+
+### Single Gemini Call per Phase
+
+Both phases batch all rendered content into a single Gemini API call rather than one-per-URL. This is a deliberate design choice: one call with 9 articles is faster and cheaper than 9 separate calls, and gives Gemini context to deduplicate across articles.
+
+## AI Moderation Pipeline
+
+After collection saves items to the database, a separate moderation sweep scores each item for quality and relevance. The sweep can be triggered manually from the Jobs dashboard or runs automatically on a schedule.
+
+### What Moderation Does
+
+- Renders the item's source URL via Playwright
+- Sends the title, summary, and rendered content to Gemini for **quality scoring only** (not date extraction)
+- Checks for issues: content not on source page, wrong POI, wrong geography, misclassified type, private content
+- Applies domain reputation filters (trusted vs. competitor domains)
+- Auto-approves items above the confidence threshold, rejects items below the floor, holds everything else for human review
+
+### What Moderation Does NOT Do
+
+- **Does not extract or overwrite dates.** Publication dates and event dates are set during collection by chrono-node and preserved through moderation.
+- Does not re-summarize content. The summary from collection is kept.
+
+### The "Unknown Date" Hold Rule
+
+- **News items** with no publication date (unknown confidence) are held for human review regardless of quality score.
+- **Events** with a `start_date` but no `publication_date` use `start_date` as a fallback — they are NOT held just because the publication date is missing.
+
+### Fix Date (Manual Admin Action)
+
+When an admin clicks "Fix Date" on a held item:
+
+1. **Render** the source URL via Playwright
+2. **chrono-node** scans the rendered content for dates (fast path, no API call)
+3. If chrono-node finds a date, it's saved immediately as `exact` confidence
+4. If chrono-node fails, **Gemini** is called as a fallback (the only place Gemini is used for date work)
+
+## Job Execution
+
+### Scheduling
+
+- **Daily batch**: Runs at 6:00 AM Eastern via pg-boss cron, processing all POIs
+- **Manual single-POI**: Admin triggers from the sidebar in edit mode
+- **Manual batch**: Admin triggers from the Jobs dashboard for all POIs
+- **Moderation sweep**: Runs every 15 minutes via pg-boss, or manually from the Jobs dashboard
+
+### Batch Processing
+
+- POIs are processed with staggered dispatch and limited concurrency
+- pg-boss provides crash recovery — jobs survive container restarts
+- Progress is checkpointed after each POI so interrupted jobs can resume
+- Batch jobs can be cancelled at any time; in-flight POIs complete naturally
+
+### Real-Time Progress
+
+The admin UI shows a per-POI log tree during collection. Each POI entry expands to show the pipeline stages as they execute, with the most recent POI auto-expanded. Logs are stored in the `job_logs` table and polled by the frontend.
+
+## Deduplication Strategy
+
+Content is deduplicated at the Save stage using two complementary strategies:
+
+- **URL matching**: Same resolved URL across any POI = same article. Catches the same content found through different search paths or different POIs.
+- **Normalized title matching**: Strips date suffixes and compares titles within the same POI. Catches the same content with slightly different formatting.
+
+When a duplicate is detected with a different URL, the new URL is merged into the existing item's URL list rather than creating a new entry.
+
+## Content Filtering
+
+| Filter | Applied At | Rule |
+|--------|-----------|------|
+| Staleness | Save | News older than 365 days is excluded (unless from a dedicated news page) |
+| Past events | Save | Events whose end date has passed are skipped |
+| Confidence | Summarize | Dedicated pages: 75% threshold. External sources: 95% threshold |
+| URL resolution | Save | Items with unresolvable redirect URLs are discarded |
+| Domain reputation | Moderation | Trusted domains get a score boost; competitor/scam domains get penalized |
+
+## Technology Stack
+
+| Component | Technology | Purpose |
+|-----------|-----------|---------|
+| Search | Serper API | Web search and URL discovery |
+| Rendering | Playwright + Chromium + Readability | JavaScript rendering and content extraction |
+| Classification | Google Gemini | Page type classification (listing/detail/hybrid) |
+| Dates | chrono-node | Deterministic date parsing and normalization |
+| Summarization | Google Gemini | Content identification, summarization, type classification |
+| Quality scoring | Google Gemini | AI-powered moderation with issue detection |
+| Job queue | pg-boss | Crash-recoverable background job processing |
+| Database | PostgreSQL | Content storage, deduplication, moderation state |
+| Frontend | React | Real-time progress tracking, moderation inbox |
+
+## Key Files
+
+| File | Stage | Purpose |
+|------|-------|---------|
+| `backend/services/newsService.js` | Render, Classify, Crawl, Dates, Summarize, Save | Main collection orchestrator |
+| `backend/services/dateExtractor.js` | Dates | chrono-node wrapper utilities |
+| `backend/services/geminiService.js` | Summarize, Moderation | Gemini API integration and prompts |
+| `backend/services/moderationService.js` | Moderation | Quality scoring, Fix Date, auto-approval |
+| `backend/services/contentExtractor.js` | Render | Playwright + Readability pipeline |
+| `backend/services/serperService.js` | Search | Serper API integration |
+| `backend/services/collection/registry.js` | — | Collection type registry (schedules, triggers) |
+| `frontend/src/components/JobsDashboard.jsx` | — | Job monitoring and log viewer |
+| `frontend/src/components/ModerationInbox.jsx` | — | Moderation review interface |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,16 @@ if [ -f /tmp/seed-data.sql ]; then
     echo "✓ Seed data imported"
 fi
 
+# Create test admin user for auth bypass (after seed data which may overwrite users table)
+if [ "$BYPASS_AUTH" = "true" ] || [ "$NODE_ENV" = "test" ]; then
+    psql -h "$PGRUNDIR" -U postgres -d rotv -c "
+      INSERT INTO users (id, email, name, oauth_provider, oauth_provider_id, is_admin, role)
+      VALUES (999, 'test-admin@rotv.local', 'Test Admin', 'test', '999', true, 'admin')
+      ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email, is_admin = true, role = 'admin';
+    " > /dev/null 2>&1
+    echo "✓ Test admin user created (ID 999)"
+fi
+
 # Run all numbered SQL migrations (after seed data import)
 # Migrations are idempotent (IF NOT EXISTS, etc.) so safe to re-run
 echo "Running database migrations..."

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12864,27 +12864,6 @@ svg.leaflet-zoom-animated {
   background: #fafafa;
 }
 
-.log-level-filters {
-  display: flex;
-  gap: 6px;
-  margin-bottom: 8px;
-}
-
-.log-filter-btn {
-  padding: 4px 12px;
-  border: 1px solid #cbd5e0;
-  border-radius: 4px;
-  background: white;
-  font-size: 0.8rem;
-  cursor: pointer;
-}
-
-.log-filter-btn.active {
-  background: #4a7c23;
-  color: white;
-  border-color: #4a7c23;
-}
-
 .job-error-banner {
   background: #fed7d7;
   color: #742a2a;

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
@@ -92,9 +92,9 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
   const [expandedRun, setExpandedRun] = useState(null);
   const [runLogs, setRunLogs] = useState([]);
-  const [logLevelFilter, setLogLevelFilter] = useState('all');
   const [logDetailsExpanded, setLogDetailsExpanded] = useState(new Set());
   const [expandedPoiGroups, setExpandedPoiGroups] = useState(new Set());
+  const autoExpandedPoisRef = useRef(new Set());
 
   const [runningJobs, setRunningJobs] = useState({});
   const [activeSlots, setActiveSlots] = useState({});
@@ -142,7 +142,6 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
   const fetchRunLogs = useCallback(async (jobType, runId, poiId) => {
     try {
       const params = new URLSearchParams({ limit: '200' });
-      if (logLevelFilter !== 'all') params.set('level', logLevelFilter);
       const res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${runId}/logs?${params}`, { credentials: 'include' });
       if (res.ok) {
         const newLogs = await res.json();
@@ -161,7 +160,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
     } catch (err) {
       console.error('Failed to fetch run logs:', err);
     }
-  }, [logLevelFilter]);
+  }, []);
 
   const checkRunningJobs = useCallback(async () => {
     const running = {};
@@ -264,7 +263,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
   useEffect(() => {
     if (expandedRun) fetchRunLogs(expandedRun.jobType, expandedRun.runId, expandedRun.poiId);
-  }, [expandedRun, logLevelFilter, fetchRunLogs]);
+  }, [expandedRun, fetchRunLogs]);
 
   // Poll logs when a run is expanded and its job is running or recently finished
   useEffect(() => {
@@ -325,6 +324,19 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
     }
   }, [expandedRun, runLogs]);
 
+  // Auto-expand the most recent POI in the log tree (so user sees live progress),
+  // but only once per POI — user can collapse it and it stays collapsed
+  useEffect(() => {
+    if (!runLogs || runLogs.length === 0) return;
+    const poiLogs = runLogs.filter(l => l.poi_id);
+    if (poiLogs.length === 0) return;
+    const lastPoiId = poiLogs[poiLogs.length - 1].poi_id;
+    if (lastPoiId && !autoExpandedPoisRef.current.has(lastPoiId)) {
+      autoExpandedPoisRef.current.add(lastPoiId);
+      setExpandedPoiGroups(prev => new Set([...prev, lastPoiId]));
+    }
+  }, [runLogs]);
+
   // Auto-expand newest run after clicking "Run Now"
   useEffect(() => {
     if (autoExpandNewestRun && jobHistory[autoExpandNewestRun]) {
@@ -380,12 +392,12 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
   const handleExpandRun = (jobType, run) => {
     const key = `${jobType}-${String(run.id)}`;
     if (expandedRun && `${expandedRun.jobType}-${String(expandedRun.runId)}` === key) {
-      setExpandedRun(null); setRunLogs([]); setLogLevelFilter('all');
+      setExpandedRun(null); setRunLogs([]);
     } else {
       // For single-POI jobs, the run's id in history is the runId (timestamp), but logs are queried by poi_id
       // The history query returns poi_id count as items_total, so we can't get poi_id from there
       // Instead, query logs by job_id (which is the runId) using the batch endpoint
-      setExpandedRun({ jobType, runId: run.id }); setLogLevelFilter('all'); setLogDetailsExpanded(new Set()); setExpandedPoiGroups(new Set());
+      setExpandedRun({ jobType, runId: run.id }); setLogDetailsExpanded(new Set()); setExpandedPoiGroups(new Set()); autoExpandedPoisRef.current = new Set();
     }
   };
 
@@ -795,18 +807,10 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
                                 {isExpanded && (
                                   <div className="job-logs-panel">
-                                    <div className="log-level-filters">
-                                      {['all', 'error', 'warn'].map(level => (
-                                        <button key={level} className={`log-filter-btn ${logLevelFilter === level ? 'active' : ''}`}
-                                          onClick={(e) => { e.stopPropagation(); setLogLevelFilter(level); }}>
-                                          {level === 'all' ? 'All' : level === 'error' ? 'Errors' : 'Warnings'}
-                                        </button>
-                                      ))}
-                                    </div>
                                     {run.error_message && <div className="job-error-banner">{run.error_message}</div>}
                                     {runLogs.length === 0 ? (
                                       <p style={{ color: '#999', padding: '8px 0', margin: 0, fontSize: '0.82rem' }}>
-                                        No log entries{logLevelFilter !== 'all' ? ` with level "${logLevelFilter}"` : ''}.
+                                        No log entries.
                                       </p>
                                     ) : (
                                       <PoiLogTree
@@ -842,7 +846,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
 function formatLogLine(entry) {
   const time = entry.created_at ? new Date(entry.created_at).toLocaleTimeString() : '--';
-  const level = entry.level === 'error' ? 'ERR' : entry.level === 'warn' ? 'WRN' : 'INF';
+  const level = entry.level === 'error' ? 'Error' : entry.level === 'warn' ? 'Warning' : 'Info';
   let line = `${time}  ${level}  ${entry.message}`;
   if (entry.details) {
     const detailParts = Object.entries(entry.details)
@@ -876,22 +880,18 @@ function PoiLogTree({ logs, expandedPoiGroups, onToggleGroup }) {
     }
   }
 
-  // Auto-expand the most recent POI group
   const poiGroups = [...groups.values()];
-  const lastPoiId = poiGroups.length > 0 ? poiGroups[poiGroups.length - 1].poiId : null;
 
   return (
     <div className="poi-log-tree">
-      {/* Job-level logs at the top */}
       {jobLevelLogs.length > 0 && (
         <pre className="job-logs-text" style={{ marginBottom: '4px' }}>
           {jobLevelLogs.map(e => formatLogLine(e)).join('\n')}
         </pre>
       )}
 
-      {/* Per-POI groups */}
       {poiGroups.map(group => {
-        const isOpen = expandedPoiGroups.has(group.poiId) || group.poiId === lastPoiId;
+        const isOpen = expandedPoiGroups.has(group.poiId);
         const hasErrors = group.logs.some(l => l.level === 'error');
 
         return (

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -410,9 +410,13 @@ function ModerationInbox({ onCountChange }) {
         const fieldConfigs = FIELD_CONFIGS[item.content_type] || [];
         for (const fc of fieldConfigs) {
           if (fc.type === 'datetime-local' && detail[fc.key]) {
-            fields[fc.key] = new Date(detail[fc.key]).toISOString().slice(0, 16);
+            const raw = String(detail[fc.key]);
+            const match = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
+            fields[fc.key] = match ? `${match[1]}T${match[2]}` : raw.slice(0, 16);
           } else if (fc.type === 'date' && detail[fc.key]) {
-            fields[fc.key] = new Date(detail[fc.key]).toISOString().slice(0, 10);
+            const raw = String(detail[fc.key]);
+            const match = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+            fields[fc.key] = match ? match[1] : raw.slice(0, 10);
           } else {
             fields[fc.key] = detail[fc.key] || '';
           }
@@ -988,7 +992,9 @@ function ModerationInbox({ onCountChange }) {
                       {item.content_type !== 'photo' && (() => {
                         const issues = item.ai_issues ? (() => { try { return JSON.parse(item.ai_issues); } catch { return []; } })() : [];
                         const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
-                        const hasNoDate = !item.publication_date || item.date_confidence === 'unknown';
+                        const hasNoDate = item.content_type === 'event'
+                          ? !item.publication_date && !item.start_date
+                          : !item.publication_date || item.date_confidence === 'unknown';
                         const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
                         const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
                         const hasOther = issues.some(i => !urlIssueCodes.includes(i));

--- a/rootfs/etc/systemd/system/rotv-init.service
+++ b/rootfs/etc/systemd/system/rotv-init.service
@@ -6,6 +6,7 @@ Requires=postgresql.service
 
 [Service]
 Type=oneshot
+EnvironmentFile=-/etc/rotv/environment
 ExecStart=/usr/local/bin/rotv-init.sh
 RemainAfterExit=yes
 


### PR DESCRIPTION
## Summary

- **Unified pipeline**: Both Phase I and Phase II now follow the same Render → Classify → Crawl → Dates → Summarize pipeline. Phase II adds Search (Serper) at the front.
- **Classification in Phase II**: Serper URLs now get classified as listing/detail/hybrid. Listing pages get crawled for detail links instead of being used as opaque blobs.
- **Removed legacy paths**: `crawlSubPages()`, `matchItemToLink()`, deep crawl verification, and URL backfill are all gone. Net -938 lines.
- **Phase-prefixed logging**: All log messages now show `Phase I:` or `Phase II:` prefix with pipeline stage tags (`[Render]`, `[Classify]`, `[Crawl]`, `[Dates]`, `[Summarize]`).
- **Moderation sweep trigger**: New `POST /api/admin/moderation/sweep` endpoint. "Run Now" button works from Jobs dashboard.
- **chrono-node date hints**: Phase II now gets the same chrono-node date extraction that Phase I has.
- **Architecture doc rewritten**: Updated to reflect the 7-stage unified pipeline, Gemini's three roles, and symmetric phase descriptions.

Also includes prior session changes: chrono-node dependency, unified job logger, ModerationInbox fixes, JobsDashboard fixes, entrypoint admin user creation.

## Test plan
- [x] `./run.sh build` — passes
- [x] `./run.sh test` — 263 tests pass (1 skipped, pre-existing)
- [x] Gourmand — 1 pre-existing violation only
- [ ] Start on localhost:8080, run single-POI collection
- [ ] Logs show `Phase I:` and `Phase II:` prefixes
- [ ] Each URL shows pipeline stages: `[Render]`, `[Classify]`, `[Crawl]`, `[Dates]`, `[Summarize]`
- [ ] Moderation Sweep "Run Now" button works from Jobs dashboard
- [ ] No "legacy crawl" or "sub-page crawl" messages in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)