### PR TITLE
fix: cap future news dates, moderation date locale, admin Edit link

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -3921,14 +3921,15 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   // Get paginated moderation queue
   router.get('/moderation/queue', isAdmin, async (req, res) => {
     try {
-      const { page = 1, limit = 20, type, status = 'pending', source, search } = req.query;
+      const { page = 1, limit = 20, type, status = 'pending', source, search, id } = req.query;
       const result = await getModerationQueue(pool, {
         page: parseInt(page),
         limit: parseInt(limit),
         contentType: type || null,
         status,
         contentSource: source || null,
-        search: search || null
+        search: search || null,
+        id: id || null
       });
       res.json(result);
     } catch (error) {

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -1044,7 +1044,7 @@ If truly impossible to determine, use "unknown" and set publication_date to null
   };
 }
 
-export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null, search = null } = {}) {
+export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null, search = null, id = null } = {}) {
   const offset = (page - 1) * limit;
   const statusList = status === 'all'
     ? ['pending', 'published', 'auto_approved', 'rejected']
@@ -1108,6 +1108,11 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
   if (search) {
     filters.push(`(title ILIKE $${paramIdx} OR description ILIKE $${paramIdx})`);
     params.push(`%${search}%`);
+    paramIdx++;
+  }
+  if (id) {
+    filters.push(`id = $${paramIdx}`);
+    params.push(parseInt(id));
     paramIdx++;
   }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -345,11 +345,22 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
 
   // [Dates] — OG metadata first (structured, reliable), chrono-node as fallback
   // These are applied directly to items AFTER Gemini returns — Gemini never touches dates
-  const ogPublished = extracted.ogDates?.publishedTime
+  const today = new Date().toISOString().substring(0, 10);
+  const ogRaw = extracted.ogDates?.publishedTime
     ? parseDate(extracted.ogDates.publishedTime, timezone)
     : null;
+  // Discard OG date if it's in the future — likely an event date or bad metadata, not the publish date
+  const ogPublished = (ogRaw && ogRaw <= today) ? ogRaw : null;
+  if (ogRaw && ogRaw > today) {
+    logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Discarding future OG date ${ogRaw}, falling back to chrono-node`);
+  }
   const dateHints = extractDatesFromText(extracted.markdown, timezone);
-  const primaryDate = ogPublished || (dateHints.length > 0 ? dateHints[0].start?.substring(0, 10) : null);
+  const rawPrimaryDate = ogPublished || (dateHints.length > 0 ? dateHints[0].start?.substring(0, 10) : null);
+  // For news, cap publication date at today — future dates are issue/cover dates, not publish dates
+  const primaryDate = (contentType === 'news' && rawPrimaryDate && rawPrimaryDate > today) ? today : rawPrimaryDate;
+  if (contentType === 'news' && rawPrimaryDate && rawPrimaryDate > today) {
+    logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Capping future news date ${rawPrimaryDate} to today ${today}`);
+  }
   const secondDate = dateHints.length > 1 ? dateHints[1].start?.substring(0, 10) : null;
   const dateSource = ogPublished ? 'og' : (dateHints.length > 0 ? 'chrono' : 'none');
   logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] ${primaryDate || 'none'} (${dateSource}), ${dateHints.length} chrono hints from ${url}`);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -116,6 +116,9 @@ function AppContent() {
   // Moderation queue pending count for badge
   const [moderationCount, setModerationCount] = useState(0);
 
+  // Focus a specific news item in the moderation queue (from Edit link in news tab)
+  const [moderationFocusId, setModerationFocusId] = useState(null);
+
   // News refresh trigger - increments when news collection completes
   const [newsRefreshTrigger, setNewsRefreshTrigger] = useState(0);
 
@@ -1646,6 +1649,11 @@ function AppContent() {
               setActiveTab('view');
             }
           }}
+          onEditNewsItem={(newsId) => {
+            setModerationFocusId(newsId);
+            setActiveTab('settings');
+            setSettingsTab('moderation');
+          }}
         />
         </main>
       )}
@@ -1780,7 +1788,7 @@ function AppContent() {
               {settingsTab === 'surfaces' && <SurfacesSettings />}
               {settingsTab === 'icons' && <IconsSettings />}
               {settingsTab === 'dataCollection' && <DataCollectionSettings />}
-              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} />}
+              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} focusItemId={moderationFocusId} />}
               {settingsTab === 'jobs' && <JobsDashboard expandTarget={jobsExpandTarget} onExpandTargetConsumed={() => setJobsExpandTarget(null)} />}
               {settingsTab === 'google' && (
                 <div className="google-integration-tab">

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -28,7 +28,7 @@ const FIELD_CONFIGS = {
   ]
 };
 
-function ModerationInbox({ onCountChange }) {
+function ModerationInbox({ onCountChange, focusItemId }) {
   console.log('[ModerationInbox] Mounted with onCountChange:', !!onCountChange);
   const [queue, setQueue] = useState([]);
   const [total, setTotal] = useState(0);
@@ -59,7 +59,31 @@ function ModerationInbox({ onCountChange }) {
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [lightboxPoiId, setLightboxPoiId] = useState(null);
   const [user, setUser] = useState(null);
+  const [idFilter, setIdFilter] = useState(null);
   const LIMIT = 20;
+
+  // When focusItemId is set (Edit link from news tab), switch to all-status view and filter by ID
+  useEffect(() => {
+    if (!focusItemId) return;
+    setStatusFilter('all');
+    setFilter(null);
+    setSourceFilter(null);
+    setSearchQuery('');
+    setSearchInput('');
+    setPage(1);
+    setIdFilter(focusItemId);
+  }, [focusItemId]);
+
+  // After queue loads with a focused item, auto-expand and open edit mode
+  // startEditing is defined below — captured via ref so this effect doesn't need it as a dep
+  const startEditingRef = React.useRef(null);
+  useEffect(() => {
+    if (!idFilter || loading || queue.length === 0) return;
+    const item = queue.find(i => i.id === idFilter && i.content_type === 'news');
+    if (!item) return;
+    setExpandedItem(`news:${item.id}`);
+    if (startEditingRef.current) startEditingRef.current(item);
+  }, [idFilter, loading, queue]);
 
   const fetchQueue = useCallback(async () => {
     setLoading(true);
@@ -68,6 +92,7 @@ function ModerationInbox({ onCountChange }) {
       if (filter) params.set('type', filter);
       if (sourceFilter) params.set('source', sourceFilter);
       if (searchQuery) params.set('search', searchQuery);
+      if (idFilter) params.set('id', idFilter);
       const response = await fetch(`/api/admin/moderation/queue?${params}`, {
         credentials: 'include'
       });
@@ -81,7 +106,7 @@ function ModerationInbox({ onCountChange }) {
     } finally {
       setLoading(false);
     }
-  }, [page, filter, statusFilter, sourceFilter, searchQuery]);
+  }, [page, filter, statusFilter, sourceFilter, searchQuery, idFilter]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
 
@@ -433,6 +458,9 @@ function ModerationInbox({ onCountChange }) {
     }
   };
 
+  // Keep ref current so the auto-focus effect can call startEditing without it as a dep
+  useEffect(() => { startEditingRef.current = startEditing; });
+
   const handleSave = async (type, id) => {
     console.log('[Moderation] Saving:', { type, id, edits: editFields });
     const item = queue.find(q => q.content_type === type && q.id === id);
@@ -612,9 +640,12 @@ function ModerationInbox({ onCountChange }) {
         </select>
       );
     }
+    // Use text input for date fields — browser <input type="date"> renders in OS locale (e.g. European DD/MM/YYYY)
+    const inputType = (fc.type === 'date') ? 'text' : (fc.type || 'text');
+    const placeholder = (fc.type === 'date') ? 'YYYY-MM-DD' : fc.label;
     return (
-      <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
-        style={inputStyle} placeholder={fc.label} required={fc.required} />
+      <input type={inputType} value={val} onChange={e => onChange(e.target.value)}
+        style={inputStyle} placeholder={placeholder} required={fc.required} />
     );
   };
 

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -8,7 +8,7 @@ const DEFAULT_PARK_BOUNDS = [
   [41.45, -81.50]   // Northeast corner
 ];
 
-function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
+function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
   const [news, setNews] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -213,6 +213,15 @@ function ParkNews({ _isAdmin, onSelectPoi, filteredDestinations, filteredLinearF
                   Read more
                 </a>
               ) : null}
+              {isAdmin && onEditNewsItem && (
+                <button
+                  onClick={() => onEditNewsItem(item.id)}
+                  className="news-link"
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit' }}
+                >
+                  Edit
+                </button>
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- **Future date capping**: OG dates in the future are now discarded (likely event/cover dates, not publish dates). Chrono-node dates for news items are also capped at today — so a magazine issue titled "May-June 2026" won't produce a future `publication_date`
- **Moderation date input**: `<input type="date">` rendered in OS locale (European DD/MM/YYYY on some systems); switched to text input with `YYYY-MM-DD` placeholder
- **Admin Edit link**: Admins now see an "Edit" link next to "Read more" in the News tab; clicking it navigates directly to the item in the Moderation queue with edit mode open
- **Moderation queue id filter**: Backend now supports filtering queue by specific item `id` to support the Edit link deep-link

## Test plan

- [ ] Collect news for a POI that sources from a magazine or publication with a future cover date — confirm `publication_date` is capped at today
- [ ] Open Settings → Moderation, click edit on a news item — confirm date field shows `YYYY-MM-DD` format regardless of OS locale
- [ ] Log in as admin, go to News tab, confirm "Edit" link appears next to "Read more"
- [ ] Click "Edit" on a news item — confirm it jumps to Settings → Moderation with that item expanded in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)