### PR TITLE
fix: Edit link fills search bar with title instead of hidden id filter

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -118,6 +118,7 @@ function AppContent() {
 
   // Focus a specific news item in the moderation queue (from Edit link in news tab)
   const [moderationFocusId, setModerationFocusId] = useState(null);
+  const [moderationFocusTitle, setModerationFocusTitle] = useState(null);
 
   // News refresh trigger - increments when news collection completes
   const [newsRefreshTrigger, setNewsRefreshTrigger] = useState(0);
@@ -1649,8 +1650,9 @@ function AppContent() {
               setActiveTab('view');
             }
           }}
-          onEditNewsItem={(newsId) => {
+          onEditNewsItem={(newsId, newsTitle) => {
             setModerationFocusId(newsId);
+            setModerationFocusTitle(newsTitle || null);
             setActiveTab('settings');
             setSettingsTab('moderation');
           }}
@@ -1788,7 +1790,7 @@ function AppContent() {
               {settingsTab === 'surfaces' && <SurfacesSettings />}
               {settingsTab === 'icons' && <IconsSettings />}
               {settingsTab === 'dataCollection' && <DataCollectionSettings />}
-              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} focusItemId={moderationFocusId} />}
+              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} focusItemId={moderationFocusId} focusItemTitle={moderationFocusTitle} />}
               {settingsTab === 'jobs' && <JobsDashboard expandTarget={jobsExpandTarget} onExpandTargetConsumed={() => setJobsExpandTarget(null)} />}
               {settingsTab === 'google' && (
                 <div className="google-integration-tab">

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -28,7 +28,7 @@ const FIELD_CONFIGS = {
   ]
 };
 
-function ModerationInbox({ onCountChange, focusItemId }) {
+function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
   console.log('[ModerationInbox] Mounted with onCountChange:', !!onCountChange);
   const [queue, setQueue] = useState([]);
   const [total, setTotal] = useState(0);
@@ -59,33 +59,31 @@ function ModerationInbox({ onCountChange, focusItemId }) {
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [lightboxPoiId, setLightboxPoiId] = useState(null);
   const [user, setUser] = useState(null);
-  const [idFilter, setIdFilter] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null); // "news:123" key
   const LIMIT = 20;
 
-  // When focusItemId is set (Edit link from news tab), switch to all-status view and filter by ID
+  // When focusItemId/focusItemTitle is set (Edit link from news tab):
+  // fill the search bar with the title (visible to user) and show all statuses
+  const startEditingRef = React.useRef(null);
   useEffect(() => {
-    if (!focusItemId) return;
+    if (!focusItemId || !focusItemTitle) return;
     setStatusFilter('all');
     setFilter(null);
     setSourceFilter(null);
-    setSearchQuery('');
-    setSearchInput('');
     setPage(1);
-    setIdFilter(focusItemId);
-  }, [focusItemId]);
+    setSearchInput(focusItemTitle);
+    setSearchQuery(focusItemTitle);
+  }, [focusItemId, focusItemTitle]);
 
-  // After queue loads with a focused item, auto-expand and open edit mode
-  // startEditing is defined below — captured via ref so this effect doesn't need it as a dep
-  const startEditingRef = React.useRef(null);
+  // After queue loads, auto-expand and open edit mode for the focused item
   useEffect(() => {
-    if (!idFilter || loading || queue.length === 0) return;
-    const item = queue.find(i => i.id === idFilter && i.content_type === 'news');
+    if (!focusItemId || loading || queue.length === 0) return;
+    const item = queue.find(i => i.id === focusItemId && i.content_type === 'news');
     if (!item) return;
     const itemKey = `news:${item.id}`;
     setExpandedItem(itemKey);
     if (startEditingRef.current) startEditingRef.current(item);
-  }, [idFilter, loading, queue]);
+  }, [focusItemId, loading, queue]);
 
   // Scroll focused item into view after it expands
   useEffect(() => {
@@ -101,7 +99,6 @@ function ModerationInbox({ onCountChange, focusItemId }) {
       if (filter) params.set('type', filter);
       if (sourceFilter) params.set('source', sourceFilter);
       if (searchQuery) params.set('search', searchQuery);
-      if (idFilter) params.set('id', idFilter);
       const response = await fetch(`/api/admin/moderation/queue?${params}`, {
         credentials: 'include'
       });

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -215,7 +215,7 @@ function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, 
               ) : null}
               {isAdmin && onEditNewsItem && (
                 <button
-                  onClick={() => onEditNewsItem(item.id)}
+                  onClick={() => onEditNewsItem(item.id, item.title)}
                   className="news-link"
                   style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit' }}
                 >


### PR DESCRIPTION
## Summary

- Previous approach used a hidden backend ID filter — invisible to the user, and had a race condition causing blank pages on first navigation
- Now passes the article title from ParkNews → App → ModerationInbox
- ModerationInbox fills the search bar with the title (visible, editable) and sets status=all
- Auto-expand/edit still targets the exact item by ID after the search results load

## Test plan

- [ ] Click Edit on a news item in the News tab
- [ ] Confirm the Moderation queue opens with the article title in the search bar
- [ ] Confirm the item is found, expanded, and in edit mode
- [ ] Confirm no blank page on first click (race condition fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)