### PR TITLE
fix: blank Edit screen and date cap defense-in-depth

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -867,8 +867,9 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   let duplicateCount = 0;
   const { skipDateFilter = false, log = null } = options;
 
-  // Calculate 365 days ago as a date string (YYYY-MM-DD) to avoid timezone issues
+  // Calculate date strings (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
   const oneYearAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 365);
   const oneYearAgoStr = `${oneYearAgo.getFullYear()}-${String(oneYearAgo.getMonth() + 1).padStart(2, '0')}-${String(oneYearAgo.getDate()).padStart(2, '0')}`;
 
@@ -876,6 +877,13 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
     try {
       // Normalize dates via chrono-node — handles natural language, European format, partial dates
       item.published_date = parseDate(item.published_date) || null;
+
+      // Defense-in-depth: cap future news dates at today (primary cap is in processOneUrl,
+      // but this catches any case where a future date slips through to saveNewsItems)
+      if (item.published_date && item.published_date > todayStr) {
+        if (log) log(`[Save] Capping future date ${item.published_date} → ${todayStr} for "${item.title}"`);
+        item.published_date = todayStr;
+      }
 
       // Skip news older than 365 days (unless skipDateFilter is true)
       if (!skipDateFilter && item.published_date && /^\d{4}-\d{2}-\d{2}$/.test(item.published_date)) {

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -112,7 +112,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
     } finally {
       setLoading(false);
     }
-  }, [page, filter, statusFilter, sourceFilter, searchQuery, idFilter]);
+  }, [page, filter, statusFilter, sourceFilter, searchQuery]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
 


### PR DESCRIPTION
## Summary

- **Blank screen on Edit**: `idFilter` was left in `useCallback`'s dependency array in `ModerationInbox` after the ID-filter approach was replaced by title search in PR #226. This caused a ReferenceError on every component mount, showing a blank screen when navigating via the Edit link from the News tab.
- **Future date defense-in-depth**: Added a second future-date cap in `saveNewsItems` to catch any news items whose `publication_date` is still in the future after the primary cap in `processOneUrl`. This explains why the Terra Vista article got stored as `2026-09-30` despite the primary cap — the date was corrected in production DB directly.

## Test plan

- [ ] Click Edit on a news item from the Park News tab — should navigate to Moderation and open the item in edit mode (no blank screen)
- [ ] Verify the Moderation inbox loads normally when accessed directly
- [ ] Confirm Terra Vista article now shows 2025-09-30 in Park News

🤖 Generated with [Claude Code](https://claude.com/claude-code)