### PR TITLE
fix: pg date type parser — stop moderation scoring from corrupting dates to wrong year

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -110,6 +110,15 @@ function invalidateMosaicCache(poiId) {
 // Trust reverse proxy (for secure cookies behind CloudFlare/Apache)
 app.set('trust proxy', 1);
 
+// Return date/timestamp columns as ISO strings, not JavaScript Date objects.
+// Date objects lose the year when passed through String().slice(0,10) because
+// their .toString() format is locale-dependent ("Sat May 31 2025 ...").
+// OID 1082 = date, 1114 = timestamp without tz, 1184 = timestamp with tz
+const { types } = pg;
+types.setTypeParser(1082, (val) => val);   // date → 'YYYY-MM-DD' string
+types.setTypeParser(1114, (val) => val);   // timestamp → string
+types.setTypeParser(1184, (val) => val);   // timestamptz → string
+
 const pool = new Pool({
   host: process.env.PGHOST || 'localhost',
   port: process.env.PGPORT || 5432,

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -283,7 +283,10 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     }
 
     // Use dates from collection (set by chrono-node), not from Gemini moderation
-    const newsPubDate = row.publication_date ? parseDate(String(row.publication_date).slice(0, 10)) : null;
+    // Use toISOString() for Date objects to avoid losing the year in .toString() output
+    const newsPubDate = row.publication_date ? parseDate(
+      row.publication_date instanceof Date ? row.publication_date.toISOString().slice(0, 10) : String(row.publication_date).slice(0, 10)
+    ) : null;
     const newsDateConf = newsPubDate ? (row.date_confidence || 'estimated') : 'unknown';
 
     // Apply quality filters to adjust confidence_score
@@ -396,12 +399,15 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     }
 
     // Use dates from collection (set by chrono-node), not from Gemini moderation
-    let eventPubDate = row.publication_date ? parseDate(String(row.publication_date).slice(0, 10)) : null;
+    // Use toISOString() for Date objects to avoid losing the year in .toString() output
+    let eventPubDate = row.publication_date ? parseDate(
+      row.publication_date instanceof Date ? row.publication_date.toISOString().slice(0, 10) : String(row.publication_date).slice(0, 10)
+    ) : null;
     let eventDateConf = eventPubDate ? (row.date_confidence || 'estimated') : 'unknown';
 
     // Fallback: events with start_date but no pub date shouldn't get stuck as 'unknown'
     if (eventDateConf === 'unknown' && row.start_date) {
-      const startStr = String(row.start_date).slice(0, 10);
+      const startStr = row.start_date instanceof Date ? row.start_date.toISOString().slice(0, 10) : String(row.start_date).slice(0, 10);
       if (/^\d{4}-\d{2}-\d{2}$/.test(startStr)) {
         eventPubDate = startStr;
         eventDateConf = 'estimated';


### PR DESCRIPTION
## Summary

- **Root cause found**: pg library returns PostgreSQL `date` columns as JavaScript Date objects. `moderationService.js` called `String(row.publication_date).slice(0,10)` which produces locale-format output like `"Sat May 31 2025 00:00:00 GMT+0000"`. `.slice(0,10)` gives `"Sat May 31"` — no year. chrono-node then re-parsed this as the NEXT occurrence of that date from today (April 2026), turning `2025-05-31` → `2026-05-31` and `2025-09-30` → `2026-09-30` on every moderation scoring pass.
- **Global fix**: Set pg type parsers for date/timestamp OIDs (1082, 1114, 1184) to return raw strings in `server.js`. This is the correct approach — the codebase uses dates as strings everywhere.
- **Defense-in-depth**: Also added `instanceof Date` guards in `moderationService.js` for the explicit `.slice()` calls.
- **DB corrected**: 3 affected rows fixed directly (Terra Vista #8616, Highbridge/Scriptype #8653, Akron Documenters #8568).

## Test plan

- [ ] Run moderation scoring on a news item with a 2025 date — verify it stays 2025 after scoring
- [ ] Verify Park News tab shows correct dates for Terra Vista and Highbridge articles
- [ ] Verify no new future dates appear after the next news collection job

🤖 Generated with [Claude Code](https://claude.com/claude-code)