### PR TITLE
fix: discard chrono-node today-dates as page noise; restore date picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **News date year corruption**: Fixed systematic 2025→2026 year shift in publication dates (#228)
+  - Root cause: pg library returns `date` columns as JavaScript Date objects; `String(dateObj).slice(0,10)` produces `"Sat May 31"` (no year), which chrono-node re-parses as the next future occurrence
+  - Fix: global pg type parsers (`types.setTypeParser`) for OID 1082/1114/1184 now return raw ISO strings
+  - Defense-in-depth: `moderationService.js` guards with `instanceof Date` checks before slicing
+  - Corrected 3 existing corrupted rows in DB (ids 8568, 8616, 8653)
+- **Moderation inbox blank screen on Edit deep-link**: Fixed `ReferenceError: idFilter is not defined` crashing ModerationInbox (#227)
+  - Stale `idFilter` reference left in `useCallback` dependency array after PR #226 rewrote the approach
+- **Edit deep-link showing multiple results**: Fixed Edit button in Park News opening 5 related articles instead of exactly the targeted one (#229)
+  - Switched from title `ILIKE` search (could match multiple) to `?id=N` exact fetch
+  - Lazy state initialization (`useState(() => focusItemId)`) eliminates race condition where first fetch fired before useEffect set the filter
+
 ### Added
 - **Development image proxy**: Localhost now proxies images from production when IMAGE_SERVER_URL is not configured
   - Allows viewing actual POI images during local development

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -355,14 +355,21 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Discarding future OG date ${ogRaw}, falling back to chrono-node`);
   }
   const dateHints = extractDatesFromText(extracted.markdown, timezone);
-  const rawPrimaryDate = ogPublished || (dateHints.length > 0 ? dateHints[0].start?.substring(0, 10) : null);
+  const chronoPrimary = dateHints.length > 0 ? dateHints[0].start?.substring(0, 10) : null;
+  // Discard chrono-node date when it equals today and there's no OG metadata — live pages
+  // often show today's date in navigation/footers, which is page noise not a publication date.
+  const chronoUsable = (chronoPrimary && chronoPrimary !== today) ? chronoPrimary : null;
+  if (chronoPrimary && chronoPrimary === today && !ogPublished) {
+    logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Discarding today-date from chrono-node (likely page noise), no OG fallback`);
+  }
+  const rawPrimaryDate = ogPublished || chronoUsable;
   // For news, cap publication date at today — future dates are issue/cover dates, not publish dates
   const primaryDate = (contentType === 'news' && rawPrimaryDate && rawPrimaryDate > today) ? today : rawPrimaryDate;
   if (contentType === 'news' && rawPrimaryDate && rawPrimaryDate > today) {
     logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Capping future news date ${rawPrimaryDate} to today ${today}`);
   }
   const secondDate = dateHints.length > 1 ? dateHints[1].start?.substring(0, 10) : null;
-  const dateSource = ogPublished ? 'og' : (dateHints.length > 0 ? 'chrono' : 'none');
+  const dateSource = ogPublished ? 'og' : (chronoUsable ? 'chrono' : 'none');
   logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] ${primaryDate || 'none'} (${dateSource}), ${dateHints.length} chrono hints from ${url}`);
 
   // [Summarize] — Gemini identifies items and writes summaries (no date fields)

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -670,12 +670,9 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
         </select>
       );
     }
-    // Use text input for date fields — browser <input type="date"> renders in OS locale (e.g. European DD/MM/YYYY)
-    const inputType = (fc.type === 'date') ? 'text' : (fc.type || 'text');
-    const placeholder = (fc.type === 'date') ? 'YYYY-MM-DD' : fc.label;
     return (
-      <input type={inputType} value={val} onChange={e => onChange(e.target.value)}
-        style={inputStyle} placeholder={placeholder} required={fc.required} />
+      <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
+        style={inputStyle} placeholder={fc.label} required={fc.required} />
     );
   };
 


### PR DESCRIPTION
## Summary
- **newsService**: discard chrono-node dates that equal today when no OG metadata is present. Live venue pages (e.g. clevelandamphitheater.com) show today's date in nav/footers; chrono-node was treating it as the publication date with `date_confidence='exact'`, letting stale year-in-review and Black Friday articles pass auto-approval with a fake today-date.
- **ModerationInbox**: restore `<input type="date">` for the Publication Date edit field. A previous PR switched it to `<input type="text">` to avoid European locale display (DD/MM/YYYY), but `<input type="date">` always submits YYYY-MM-DD regardless of display locale, so the workaround was unnecessary overhead.

## Test plan
- [ ] Run Blossom Music Center news collection — articles without OG dates should now save with `publication_date = NULL` and `date_confidence = 'unknown'` instead of today's date
- [ ] Edit a news item in the Moderation queue — Publication Date field should show a calendar picker again