### PR TITLE
fix: force en-US locale on date inputs

### DIFF
--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -670,9 +670,11 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
         </select>
       );
     }
+    // lang="en-US" forces MM/DD/YYYY display regardless of browser language locale
+    const lang = fc.type === 'date' ? 'en-US' : undefined;
     return (
       <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
-        style={inputStyle} placeholder={fc.label} required={fc.required} />
+        style={inputStyle} placeholder={fc.label} required={fc.required} lang={lang} />
     );
   };
 


### PR DESCRIPTION
## Summary
- Adds `lang="en-US"` to `<input type="date">` fields in the moderation edit form
- Forces MM/DD/YYYY display regardless of browser language locale setting
- Timezone (America/New_York) and language locale are separate browser settings; this decouples date format from whatever language the browser happens to have set

## Test plan
- [ ] Edit a news item in Moderation — Publication Date picker should show MM/DD/YYYY