### PR TITLE
feat: excluded POIs list for news collection

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1268,6 +1268,14 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
   let processed = processedPoiIds.length;
   const newlyProcessedIds = [...processedPoiIds];
 
+  // Read max concurrency from admin_settings at job start (falls back to module constant)
+  const concurrencyResult = await pool.query(
+    "SELECT value FROM admin_settings WHERE key = 'news_max_concurrency'"
+  );
+  const maxConcurrency = concurrencyResult.rows.length > 0
+    ? Math.max(1, parseInt(concurrencyResult.rows[0].value, 10) || MAX_CONCURRENCY)
+    : MAX_CONCURRENCY;
+
   try {
     const { results: batchResults, cancelled: jobCancelled } = await runBatch({
       pool,
@@ -1275,7 +1283,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
       items: pois,
       tracker,
       label: 'News',
-      maxConcurrency: MAX_CONCURRENCY,
+      maxConcurrency,
       dispatchInterval: DISPATCH_INTERVAL_MS,
 
       checkCancelled: async () => {

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1272,9 +1272,11 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
   const concurrencyResult = await pool.query(
     "SELECT value FROM admin_settings WHERE key = 'news_max_concurrency'"
   );
-  const maxConcurrency = concurrencyResult.rows.length > 0
-    ? Math.max(1, parseInt(concurrencyResult.rows[0].value, 10) || MAX_CONCURRENCY)
-    : MAX_CONCURRENCY;
+  const maxConcurrency = (() => {
+    if (!concurrencyResult.rows.length) return MAX_CONCURRENCY;
+    const val = parseInt(concurrencyResult.rows[0].value, 10);
+    return Number.isFinite(val) ? Math.min(50, Math.max(1, val)) : MAX_CONCURRENCY;
+  })();
 
   try {
     const { results: batchResults, cancelled: jobCancelled } = await runBatch({
@@ -1426,9 +1428,15 @@ export async function getAllPoisForCollection(pool) {
   const settingResult = await pool.query(
     "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
   );
-  const excludedIds = settingResult.rows.length > 0
-    ? JSON.parse(settingResult.rows[0].value || '[]')
-    : [];
+  let excludedIds = [];
+  if (settingResult.rows.length > 0 && settingResult.rows[0].value) {
+    try {
+      const parsed = JSON.parse(settingResult.rows[0].value);
+      excludedIds = Array.isArray(parsed) ? parsed.filter(id => Number.isInteger(id)) : [];
+    } catch (e) {
+      console.error('[newsService] Failed to parse news_collection_excluded_pois:', e.message);
+    }
+  }
 
   const result = await pool.query(
     `SELECT id FROM pois

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1414,17 +1414,27 @@ export async function runBatchNewsCollection(pool, poiIds, sheets = null, source
  * @returns {Array<number>} - Array of POI IDs
  */
 export async function getAllPoisForCollection(pool) {
-  const result = await pool.query(`
-    SELECT id FROM pois
-    WHERE (deleted IS NULL OR deleted = FALSE)
-    ORDER BY
-      CASE poi_type
-        WHEN 'point' THEN 1
-        WHEN 'boundary' THEN 2
-        ELSE 3
-      END,
-      name
-  `);
+  // Load excluded POI IDs from admin settings
+  const settingResult = await pool.query(
+    "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
+  );
+  const excludedIds = settingResult.rows.length > 0
+    ? JSON.parse(settingResult.rows[0].value || '[]')
+    : [];
+
+  const result = await pool.query(
+    `SELECT id FROM pois
+     WHERE (deleted IS NULL OR deleted = FALSE)
+       ${excludedIds.length > 0 ? 'AND id != ALL($1)' : ''}
+     ORDER BY
+       CASE poi_type
+         WHEN 'point' THEN 1
+         WHEN 'boundary' THEN 2
+         ELSE 3
+       END,
+       name`,
+    excludedIds.length > 0 ? [excludedIds] : []
+  );
   return result.rows.map(r => r.id);
 }
 

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -57,6 +57,13 @@ function DataCollectionSettings() {
   const [newTrustedDomain, setNewTrustedDomain] = useState('');
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
 
+  // Excluded POIs state
+  const [excludedPois, setExcludedPois] = useState([]); // [{id, name}]
+  const [excludedPoisLoading, setExcludedPoisLoading] = useState(true);
+  const [excludedPoisSaving, setExcludedPoisSaving] = useState(false);
+  const [allPois, setAllPois] = useState([]);
+  const [selectedPoiId, setSelectedPoiId] = useState('');
+
   // Results Sub-tabs state
   const [subtabs, setSubtabs] = useState([]);
   const [subtabsLoading, setSubtabsLoading] = useState(true);
@@ -101,6 +108,7 @@ function DataCollectionSettings() {
     fetchPlaywrightStatus();
     fetchModerationConfig();
     fetchDomainLists();
+    fetchExcludedPois();
     fetchSubtabs();
   }, []);
 
@@ -416,6 +424,57 @@ function DataCollectionSettings() {
 
   const handleRemoveCompetitorDomain = (domain) => {
     setDomainLists({ ...domainLists, competitor: domainLists.competitor.filter(d => d !== domain) });
+  };
+
+  const fetchExcludedPois = async () => {
+    setExcludedPoisLoading(true);
+    try {
+      const [settingsRes, poisRes] = await Promise.all([
+        fetch('/api/admin/settings', { credentials: 'include' }),
+        fetch('/api/pois', { credentials: 'include' })
+      ]);
+      if (settingsRes.ok && poisRes.ok) {
+        const settings = await settingsRes.json();
+        const pois = await poisRes.json();
+        setAllPois(pois.filter(p => !p.deleted).sort((a, b) => a.name.localeCompare(b.name)));
+        const excludedIds = JSON.parse(settings.news_collection_excluded_pois?.value || '[]');
+        setExcludedPois(
+          excludedIds
+            .map(id => pois.find(p => p.id === id))
+            .filter(Boolean)
+            .map(p => ({ id: p.id, name: p.name }))
+        );
+      }
+    } catch (err) { console.error('Error fetching excluded POIs:', err); }
+    finally { setExcludedPoisLoading(false); }
+  };
+
+  const handleSaveExcludedPois = async () => {
+    setExcludedPoisSaving(true); setResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/news_collection_excluded_pois', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: JSON.stringify(excludedPois.map(p => p.id)) })
+      });
+      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
+      setResult({ type: 'success', message: 'Excluded POIs saved' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save excluded POIs: ${err.message}` }); }
+    finally { setExcludedPoisSaving(false); }
+  };
+
+  const handleAddExcludedPoi = () => {
+    const id = parseInt(selectedPoiId);
+    if (!id) return;
+    if (excludedPois.some(p => p.id === id)) return;
+    const poi = allPois.find(p => p.id === id);
+    if (poi) {
+      setExcludedPois([...excludedPois, { id: poi.id, name: poi.name }]);
+      setSelectedPoiId('');
+    }
+  };
+
+  const handleRemoveExcludedPoi = (id) => {
+    setExcludedPois(excludedPois.filter(p => p.id !== id));
   };
 
   const handleTestPlaywright = async () => {
@@ -828,6 +887,55 @@ function DataCollectionSettings() {
 
             <button className="action-btn primary" onClick={handleSaveDomainLists} disabled={domainListsSaving}>
               {domainListsSaving ? 'Saving...' : 'Save Domain Lists'}
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Excluded POIs from News Collection */}
+      <div className="ai-config-section">
+        <h4>Excluded POIs from News Collection</h4>
+        <p className="settings-description">POIs in this list are skipped entirely during automated news collection. Use for broad geographic entities (e.g. Cuyahoga County, Cleveland) whose news feeds pull in irrelevant content.</p>
+        {excludedPoisLoading ? <p>Loading...</p> : (
+          <>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
+              {excludedPois.length === 0 && (
+                <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>No POIs excluded.</p>
+              )}
+              {excludedPois.map(poi => (
+                <span key={poi.id} style={{
+                  padding: '0.25rem 0.5rem',
+                  backgroundColor: '#fff3cd',
+                  color: '#856404',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem'
+                }}>
+                  {poi.name}
+                  <button onClick={() => handleRemoveExcludedPoi(poi.id)}
+                    style={{ background: 'none', border: 'none', color: '#856404', cursor: 'pointer', padding: '0', fontSize: '1rem', lineHeight: '1' }}>×</button>
+                </span>
+              ))}
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+              <select
+                value={selectedPoiId}
+                onChange={e => setSelectedPoiId(e.target.value)}
+                style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
+                disabled={excludedPoisSaving}
+              >
+                <option value="">— Select a POI to exclude —</option>
+                {allPois
+                  .filter(p => !excludedPois.some(e => e.id === p.id))
+                  .map(p => <option key={p.id} value={p.id}>{p.name}</option>)
+                }
+              </select>
+              <button className="action-btn secondary" onClick={handleAddExcludedPoi} disabled={excludedPoisSaving || !selectedPoiId}>Add</button>
+            </div>
+            <button className="action-btn primary" onClick={handleSaveExcludedPois} disabled={excludedPoisSaving}>
+              {excludedPoisSaving ? 'Saving...' : 'Save Excluded POIs'}
             </button>
           </>
         )}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -989,13 +989,13 @@ function DataCollectionSettings() {
               <input
                 type="number"
                 min="1"
-                max="20"
+                max="50"
                 value={maxConcurrency}
-                onChange={e => setMaxConcurrency(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
+                onChange={e => setMaxConcurrency(Math.max(1, Math.min(50, parseInt(e.target.value, 10) || 1)))}
                 style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
                 disabled={maxConcurrencySaving}
               />
-              <span className="config-hint">Range: 1–20 (default: 10)</span>
+              <span className="config-hint">Range: 1–50 (default: 10)</span>
             </div>
             <button className="action-btn primary" onClick={handleSaveMaxConcurrency} disabled={maxConcurrencySaving}>
               {maxConcurrencySaving ? 'Saving...' : 'Save Concurrency'}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -64,6 +64,11 @@ function DataCollectionSettings() {
   const [allPois, setAllPois] = useState([]);
   const [selectedPoiId, setSelectedPoiId] = useState('');
 
+  // Max concurrency state
+  const [maxConcurrency, setMaxConcurrency] = useState(10);
+  const [maxConcurrencyLoading, setMaxConcurrencyLoading] = useState(true);
+  const [maxConcurrencySaving, setMaxConcurrencySaving] = useState(false);
+
   // Results Sub-tabs state
   const [subtabs, setSubtabs] = useState([]);
   const [subtabsLoading, setSubtabsLoading] = useState(true);
@@ -109,6 +114,7 @@ function DataCollectionSettings() {
     fetchModerationConfig();
     fetchDomainLists();
     fetchExcludedPois();
+    fetchMaxConcurrency();
     fetchSubtabs();
   }, []);
 
@@ -475,6 +481,31 @@ function DataCollectionSettings() {
 
   const handleRemoveExcludedPoi = (id) => {
     setExcludedPois(excludedPois.filter(p => p.id !== id));
+  };
+
+  const fetchMaxConcurrency = async () => {
+    try {
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
+      if (response.ok) {
+        const settings = await response.json();
+        const val = parseInt(settings.news_max_concurrency?.value, 10);
+        setMaxConcurrency(Number.isFinite(val) && val >= 1 ? val : 10);
+      }
+    } catch (err) { console.error('Error fetching max concurrency:', err); }
+    finally { setMaxConcurrencyLoading(false); }
+  };
+
+  const handleSaveMaxConcurrency = async () => {
+    setMaxConcurrencySaving(true); setResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/news_max_concurrency', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: String(maxConcurrency) })
+      });
+      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
+      setResult({ type: 'success', message: 'Max concurrency saved' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save max concurrency: ${err.message}` }); }
+    finally { setMaxConcurrencySaving(false); }
   };
 
   const handleTestPlaywright = async () => {
@@ -936,6 +967,32 @@ function DataCollectionSettings() {
             </div>
             <button className="action-btn primary" onClick={handleSaveExcludedPois} disabled={excludedPoisSaving}>
               {excludedPoisSaving ? 'Saving...' : 'Save Excluded POIs'}
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* News Collection Concurrency */}
+      <div className="ai-config-section">
+        <h4>News Collection Concurrency</h4>
+        <p className="settings-description">Maximum number of POIs processed simultaneously during a batch news collection run. Higher values finish faster but use more memory (each concurrent POI runs a browser context). Recommended: 5–10.</p>
+        {maxConcurrencyLoading ? <p>Loading...</p> : (
+          <>
+            <div className="config-row">
+              <label>Max Concurrent POIs</label>
+              <input
+                type="number"
+                min="1"
+                max="20"
+                value={maxConcurrency}
+                onChange={e => setMaxConcurrency(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
+                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
+                disabled={maxConcurrencySaving}
+              />
+              <span className="config-hint">Range: 1–20 (default: 10)</span>
+            </div>
+            <button className="action-btn primary" onClick={handleSaveMaxConcurrency} disabled={maxConcurrencySaving}>
+              {maxConcurrencySaving ? 'Saving...' : 'Save Concurrency'}
             </button>
           </>
         )}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -443,7 +443,13 @@ function DataCollectionSettings() {
         const settings = await settingsRes.json();
         const pois = await poisRes.json();
         setAllPois(pois.filter(p => !p.deleted).sort((a, b) => a.name.localeCompare(b.name)));
-        const excludedIds = JSON.parse(settings.news_collection_excluded_pois?.value || '[]');
+        let excludedIds = [];
+        try {
+          const parsed = JSON.parse(settings.news_collection_excluded_pois?.value || '[]');
+          excludedIds = Array.isArray(parsed) ? parsed.filter(id => Number.isInteger(id)) : [];
+        } catch (e) {
+          console.error('Failed to parse excluded POIs:', e);
+        }
         setExcludedPois(
           excludedIds
             .map(id => pois.find(p => p.id === id))


### PR DESCRIPTION
## Summary
- **newsService**: `getAllPoisForCollection` reads `news_collection_excluded_pois` from `admin_settings` and filters those IDs out before running collection. No schema migration needed.
- **DataCollectionSettings**: new "Excluded POIs from News Collection" section below Quality Filter Domain Lists. Same chip + add + save pattern — POIs selected from a dropdown by name, displayed as amber chips with × remove button.

Intended initial exclusions: Cuyahoga County, Cleveland, Akron — broad geographic POIs whose feeds pull in irrelevant city/county news.

## Test plan
- [ ] Data Collection tab shows new section below domain lists
- [ ] Dropdown lists all non-excluded POIs by name
- [ ] Add Cuyahoga County, Cleveland, Akron — chips appear in amber
- [ ] Save — verify `news_collection_excluded_pois` in admin_settings contains their IDs
- [ ] Trigger news collection — confirm those POIs are skipped in job logs