### PR TITLE
fix: shared Chromium browser pool to prevent OOM kills

### DIFF
--- a/backend/services/browserPool.js
+++ b/backend/services/browserPool.js
@@ -24,6 +24,7 @@ import { chromium } from 'playwright';
 let sharedBrowser = null;
 let browserRefCount = 0;
 let browserCloseTimer = null;
+let launchPromise = null; // Prevents concurrent launches (race condition fix)
 
 const LAUNCH_OPTIONS = {
   headless: true,
@@ -48,11 +49,16 @@ export async function acquireBrowser() {
     browserCloseTimer = null;
   }
   if (!sharedBrowser || !sharedBrowser.isConnected()) {
-    const opts = { ...LAUNCH_OPTIONS };
-    if (process.env.PLAYWRIGHT_PROXY) {
-      opts.proxy = { server: process.env.PLAYWRIGHT_PROXY };
+    if (!launchPromise) {
+      launchPromise = (async () => {
+        const opts = { ...LAUNCH_OPTIONS };
+        if (process.env.PLAYWRIGHT_PROXY) {
+          opts.proxy = { server: process.env.PLAYWRIGHT_PROXY };
+        }
+        sharedBrowser = await chromium.launch(opts);
+      })().finally(() => { launchPromise = null; });
     }
-    sharedBrowser = await chromium.launch(opts);
+    await launchPromise;
   }
   browserRefCount++;
   return sharedBrowser;
@@ -64,8 +70,11 @@ export async function acquireBrowser() {
  */
 export function releaseBrowser() {
   browserRefCount--;
-  if (browserRefCount <= 0) {
+  if (browserRefCount < 0) {
+    console.error('[BrowserPool] BUG: releaseBrowser() called more times than acquireBrowser() — resetting to 0');
     browserRefCount = 0;
+  }
+  if (browserRefCount === 0) {
     browserCloseTimer = setTimeout(async () => {
       if (browserRefCount === 0 && sharedBrowser) {
         await sharedBrowser.close().catch(() => {});

--- a/backend/services/browserPool.js
+++ b/backend/services/browserPool.js
@@ -1,0 +1,76 @@
+/**
+ * Shared Chromium browser pool.
+ *
+ * One long-lived Chromium process is reused across all render calls in both
+ * jsRenderer and contentExtractor. Each render gets its own BrowserContext
+ * for full cookie/session isolation — only the expensive OS-level browser
+ * process is shared.
+ *
+ * Memory profile:
+ *   - 1 shared Chromium process  ≈ 200-300 MB base
+ *   - Each concurrent context    ≈ 50-100 MB
+ *   vs. previous model:
+ *   - Each render spawned its own Chromium ≈ 300-400 MB
+ *
+ * With MAX_CONCURRENCY=10 the old model peaked at ~4 GB; the new model
+ * peaks at ~1.2 GB under the same load.
+ *
+ * Idle behaviour: the browser closes 30 s after the last context is
+ * released, freeing memory between collection runs.
+ */
+
+import { chromium } from 'playwright';
+
+let sharedBrowser = null;
+let browserRefCount = 0;
+let browserCloseTimer = null;
+
+const LAUNCH_OPTIONS = {
+  headless: true,
+  args: [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-accelerated-2d-canvas',
+    '--disable-gpu',
+    '--disable-blink-features=AutomationControlled'
+  ]
+};
+
+/**
+ * Acquire the shared browser, launching it if not running.
+ * Every call must be paired with releaseBrowser().
+ * @returns {Promise<import('playwright').Browser>}
+ */
+export async function acquireBrowser() {
+  if (browserCloseTimer) {
+    clearTimeout(browserCloseTimer);
+    browserCloseTimer = null;
+  }
+  if (!sharedBrowser || !sharedBrowser.isConnected()) {
+    const opts = { ...LAUNCH_OPTIONS };
+    if (process.env.PLAYWRIGHT_PROXY) {
+      opts.proxy = { server: process.env.PLAYWRIGHT_PROXY };
+    }
+    sharedBrowser = await chromium.launch(opts);
+  }
+  browserRefCount++;
+  return sharedBrowser;
+}
+
+/**
+ * Release a browser reference acquired with acquireBrowser().
+ * Schedules the browser to close after 30 s of full idle.
+ */
+export function releaseBrowser() {
+  browserRefCount--;
+  if (browserRefCount <= 0) {
+    browserRefCount = 0;
+    browserCloseTimer = setTimeout(async () => {
+      if (browserRefCount === 0 && sharedBrowser) {
+        await sharedBrowser.close().catch(() => {});
+        sharedBrowser = null;
+      }
+    }, 30000);
+  }
+}

--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -4,10 +4,10 @@
  * Shared utility for both the news scraper and moderation pipeline.
  */
 
-import { chromium } from 'playwright';
 import { Readability } from '@mozilla/readability';
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
+import { acquireBrowser, releaseBrowser } from './browserPool.js';
 
 const turndown = new TurndownService({
   headingStyle: 'atx',
@@ -16,25 +16,6 @@ const turndown = new TurndownService({
 });
 
 turndown.remove(['img', 'iframe', 'video', 'audio', 'svg', 'canvas', 'figure']);
-
-// Shared browser pool — one Chromium process reused across renders.
-// Each render gets a fresh BrowserContext (cookie/session isolation) but
-// avoids the ~2s cold-start of launching a new Chromium per URL.
-let sharedBrowser = null;
-let browserRefCount = 0;
-let browserCloseTimer = null;
-
-const LAUNCH_OPTIONS = {
-  headless: true,
-  args: [
-    '--no-sandbox',
-    '--disable-setuid-sandbox',
-    '--disable-dev-shm-usage',
-    '--disable-accelerated-2d-canvas',
-    '--disable-gpu',
-    '--disable-blink-features=AutomationControlled'
-  ]
-};
 
 // Realistic browser context defaults to avoid bot detection.
 // Cloudflare checks navigator.webdriver, user-agent, and plugin lists.
@@ -55,37 +36,6 @@ const STEALTH_INIT_SCRIPT = `
   });
   window.chrome = { runtime: {} };
 `;
-
-
-async function acquireBrowser() {
-  if (browserCloseTimer) {
-    clearTimeout(browserCloseTimer);
-    browserCloseTimer = null;
-  }
-  if (!sharedBrowser || !sharedBrowser.isConnected()) {
-    const opts = { ...LAUNCH_OPTIONS };
-    if (process.env.PLAYWRIGHT_PROXY) {
-      opts.proxy = { server: process.env.PLAYWRIGHT_PROXY };
-    }
-    sharedBrowser = await chromium.launch(opts);
-  }
-  browserRefCount++;
-  return sharedBrowser;
-}
-
-function releaseBrowser() {
-  browserRefCount--;
-  if (browserRefCount <= 0) {
-    browserRefCount = 0;
-    // Close after 30s idle to free memory between POIs
-    browserCloseTimer = setTimeout(async () => {
-      if (browserRefCount === 0 && sharedBrowser) {
-        await sharedBrowser.close().catch(() => {});
-        sharedBrowser = null;
-      }
-    }, 30000);
-  }
-}
 
 /**
  * Extract page content as markdown using Playwright + Readability + Turndown.

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -103,7 +103,7 @@ export async function registerPoiNewsHandler(handler) {
   const scheduler = getJobScheduler();
 
   await scheduler.work(JOB_NAMES.NEWS_COLLECTION_POI, {
-    teamSize: 5, // Process 5 POIs concurrently
+    teamSize: 3, // Process 3 POIs concurrently
     teamConcurrency: 1
   }, async (job) => {
     try {

--- a/backend/services/jsRenderer.js
+++ b/backend/services/jsRenderer.js
@@ -1,4 +1,4 @@
-import { chromium } from 'playwright';
+import { acquireBrowser, releaseBrowser } from './browserPool.js';
 
 /**
  * Hard timeout wrapper - ensures a promise resolves within a time limit
@@ -198,26 +198,26 @@ export async function renderJavaScriptPage(url, options = {}) {
     twitterCredentials = null // Twitter credentials { username, password }
   } = options;
 
-  console.log(`[JS Renderer] Starting browser for: ${url}`);
+  console.log(`[JS Renderer] Acquiring browser context for: ${url}`);
 
-  // Track browser instance for cleanup on hard timeout
-  let browserRef = { browser: null };
+  // Track the BrowserContext for cleanup on hard timeout.
+  // We close only the context, never the shared browser process.
+  let contextRef = { context: null };
   let hardTimeoutId;
   let isTimedOut = false;
 
-  // Create a promise that will be rejected on hard timeout and clean up browser
   const hardTimeoutPromise = new Promise((_, reject) => {
     hardTimeoutId = setTimeout(async () => {
       isTimedOut = true;
       console.error(`[JS Renderer] ⏰ Hard timeout (${hardTimeout}ms) reached for ${url}, forcing cleanup...`);
 
-      // Force close the browser if it exists
-      if (browserRef.browser) {
+      if (contextRef.context) {
         try {
-          await browserRef.browser.close();
-          console.log(`[JS Renderer] ✓ Browser force-closed after hard timeout`);
+          await contextRef.context.close();
+          releaseBrowser();
+          console.log(`[JS Renderer] ✓ Context force-closed after hard timeout`);
         } catch (closeError) {
-          console.error(`[JS Renderer] Failed to force-close browser: ${closeError.message}`);
+          console.error(`[JS Renderer] Failed to force-close context: ${closeError.message}`);
         }
       }
 
@@ -226,15 +226,13 @@ export async function renderJavaScriptPage(url, options = {}) {
   });
 
   try {
-    // Auto-detect Twitter login requirement
     const needsTwitterLogin = requireTwitterLogin !== null
       ? requireTwitterLogin
       : (url.includes('twitter.com') || url.includes('x.com'));
 
-    // Race between the rendering operation and the hard timeout
     const result = await Promise.race([
       renderJavaScriptPageInternal(url, {
-        timeout, waitForSelector, waitTime, extractSelectors, browserLaunchTimeout, browserRef, needsTwitterLogin, twitterCredentials
+        timeout, waitForSelector, waitTime, extractSelectors, contextRef, needsTwitterLogin, twitterCredentials
       }),
       hardTimeoutPromise
     ]);
@@ -253,12 +251,13 @@ export async function renderJavaScriptPage(url, options = {}) {
   } finally {
     clearTimeout(hardTimeoutId);
 
-    // Extra safety: close browser if it's still open after hard timeout
-    if (isTimedOut && browserRef.browser) {
+    // Extra safety: release context if still open after hard timeout
+    if (isTimedOut && contextRef.context) {
       try {
-        await browserRef.browser.close();
+        await contextRef.context.close();
+        releaseBrowser();
       } catch (e) {
-        // Ignore - browser may already be closed
+        // Ignore - context may already be closed
       }
     }
   }
@@ -268,36 +267,21 @@ export async function renderJavaScriptPage(url, options = {}) {
  * Internal implementation of page rendering (wrapped by hard timeout)
  */
 async function renderJavaScriptPageInternal(url, options) {
-  const { timeout, waitForSelector, waitTime, extractSelectors, browserLaunchTimeout, browserRef, needsTwitterLogin, twitterCredentials } = options;
+  const { timeout, waitForSelector, waitTime, extractSelectors, contextRef, needsTwitterLogin, twitterCredentials } = options;
 
-  let browser = null;
+  let context = null;
   try {
-    // Launch browser with its own timeout to catch hangs during launch
-    console.log(`[JS Renderer] Launching browser (timeout: ${browserLaunchTimeout}ms)...`);
-    browser = await withHardTimeout(
-      chromium.launch({
-        headless: true,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-accelerated-2d-canvas',
-          '--disable-gpu'
-        ]
-      }),
-      browserLaunchTimeout,
-      'Browser launch'
-    );
+    const browser = await acquireBrowser();
 
-    // Store browser reference for hard timeout cleanup
-    if (browserRef) {
-      browserRef.browser = browser;
-    }
-
-    const context = await browser.newContext({
+    context = await browser.newContext({
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-      ignoreHTTPSErrors: true // Ignore SSL certificate errors for sites with invalid certs
+      ignoreHTTPSErrors: true
     });
+
+    // Store context reference so the hard timeout can close it if needed
+    if (contextRef) {
+      contextRef.context = context;
+    }
 
     // Load Twitter cookies if this is a Twitter URL
     if (needsTwitterLogin) {
@@ -525,7 +509,8 @@ async function renderJavaScriptPageInternal(url, options) {
     console.log(`[JS Renderer]   Title: ${content.title}`);
     console.log(`[JS Renderer]   Found ${content.links.length} links on page`);
 
-    await browser.close();
+    await context.close();
+    releaseBrowser();
 
     return {
       ...content,
@@ -535,8 +520,9 @@ async function renderJavaScriptPageInternal(url, options) {
   } catch (error) {
     console.error(`[JS Renderer] ❌ Error rendering ${url}:`, error.message);
 
-    if (browser) {
-      await browser.close().catch(() => {});
+    if (context) {
+      await context.close().catch(() => {});
+      releaseBrowser();
     }
 
     return {

--- a/run.sh
+++ b/run.sh
@@ -170,7 +170,7 @@ ENVFILE
         podman run -d \
             --name "$CONTAINER_NAME" \
             --privileged \
-            --network=pasta:--dns-forward,8.8.8.8 \
+            --network=host \
             -p 8080:8080 \
             -p 2525:25 \
             $MCP_PORT_MAP \
@@ -246,7 +246,7 @@ ENVFILE
         podman run -d \
             --name "$CONTAINER_NAME" \
             --privileged \
-            --network=pasta:--dns-forward,8.8.8.8 \
+            --network=host \
             -p 8080:8080 \
             -p 2525:25 \
             --tmpfs /run \


### PR DESCRIPTION
## Summary

- Extract shared Chromium browser pool into `browserPool.js` — one long-lived process reused across all renders
- Both `contentExtractor.js` and `jsRenderer.js` import `acquireBrowser`/`releaseBrowser` from the shared pool
- Hard-timeout in `jsRenderer` now closes the `BrowserContext` rather than killing the entire browser
- Reduce `teamSize` 5→3 for the per-POI pg-boss worker queue
- Fix local dev `run.sh` to use `--network=host` (resolves IPv6 `localhost` breakage)

**Memory before:** 10 concurrent renders × ~400MB (new Chromium per call) = ~4GB → OOM kill  
**Memory after:** 1 shared Chromium (~250MB) + 10 contexts (~80MB each) = ~1GB

Root cause of today's production incident: news collection job 168 crashed and restarted ~15 times between 10AM–1PM due to OOM kills. Memory limit was also raised from 4g→8g on lotor as an immediate mitigation.

## Test plan

- [x] Container build passes
- [x] Full test suite passes (21/21 files)
- [ ] Verify 6AM collection run completes without OOM kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)