### PR TITLE
fix: run moderation sweep hourly instead of every 15 minutes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2615,8 +2615,8 @@ async function start() {
       }
     }, 'moderation-sweep'));
 
-    // Schedule moderation sweep every 15 minutes
-    await scheduleModerationSweep('*/15 * * * *');
+    // Schedule moderation sweep every hour — avoids resource contention with news collection
+    await scheduleModerationSweep('0 * * * *');
 
     // Register newsletter email processing handler
     await registerNewsletterHandler(async (emailId) => {


### PR DESCRIPTION
## Summary

Reduces moderation sweep frequency from `*/15 * * * *` to `0 * * * *` to avoid resource contention with the news & events collection run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)