### PR TITLE
fix: run moderation sweep daily at 7 AM

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2615,8 +2615,8 @@ async function start() {
       }
     }, 'moderation-sweep'));
 
-    // Schedule moderation sweep every hour — avoids resource contention with news collection
-    await scheduleModerationSweep('0 * * * *');
+    // Schedule moderation sweep daily at 7 AM — runs after 6 AM news collection completes
+    await scheduleModerationSweep('0 7 * * *');
 
     // Register newsletter email processing handler
     await registerNewsletterHandler(async (emailId) => {


### PR DESCRIPTION
## Summary

News collection runs at 6 AM daily. Moderation sweep now runs at 7 AM so it processes the freshly collected items once the news run is complete, rather than running every hour and contending for resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)