### PR TITLE
fix: bulk-load all log entries on initial expand, incremental on polls

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4385,7 +4385,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         return res.status(400).json({ error: 'Invalid job ID' });
       }
       const level = req.query.level || null;
-      const limit = Math.max(1, Math.min(parseInt(req.query.limit) || 200, 500));
+      const limit = Math.max(1, Math.min(parseInt(req.query.limit) || 200, 10000));
       const offset = Math.max(0, parseInt(req.query.offset) || 0);
 
       let query = 'SELECT * FROM job_logs WHERE job_type = $1 AND job_id = $2';

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -149,7 +149,13 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
 
   const fetchRunLogs = useCallback(async (jobType, runId, poiId) => {
     try {
-      const params = new URLSearchParams({ limit: '200', offset: String(runLogsOffsetRef.current) });
+      // Initial load (offset=0): fetch up to 10000 entries to get everything at once.
+      // Subsequent polls: fetch only new entries since last offset.
+      const isInitial = runLogsOffsetRef.current === 0;
+      const params = new URLSearchParams({
+        limit: isInitial ? '10000' : '200',
+        offset: String(runLogsOffsetRef.current)
+      });
       const res = await fetch(`${API_BASE}/api/admin/jobs/${jobType}/${runId}/logs?${params}`, { credentials: 'include' });
       if (res.ok) {
         const newLogs = await res.json();


### PR DESCRIPTION
## Summary

Fixes two log display regressions from the offset-based fetch:

- **Completed jobs** only showed first 200 entries (no polling for finished jobs)
- **Running jobs** trickled in 200 entries at a time causing "no logs → slow appearance"

Fix: initial expand fetches up to 10,000 entries at once; subsequent polls fetch only new entries since last offset.

## Test plan
- [ ] Expand a completed job — all log entries appear immediately
- [ ] Expand a running job — all existing entries appear immediately, new ones append as they arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)