### PR TITLE
fix: update newsletter digest schedule display strings to 8 AM

### DIFF
--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -76,11 +76,11 @@ export const COLLECTION_TYPES = [
   {
     id: 'newsletter_digest',
     label: 'Newsletter Digest',
-    description: 'Weekly email digest sent every Friday at 6 AM',
+    description: 'Weekly email digest sent every Friday at 8 AM',
     icon: '\u{1F4E7}',
     promptKeys: [],
     scheduleJobName: 'newsletter-digest',
-    schedule: '0 6 * * 5',
+    schedule: '0 8 * * 5',
     statusTable: null,
     historyTypes: ['newsletter-digest'],
     triggerEndpoint: '/api/newsletter/send-digest',

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -594,7 +594,7 @@ export async function registerDigestHandler(handler) {
 export async function scheduleDigest(cronExpression = '0 8 * * 5') {
   const scheduler = getJobScheduler();
 
-  // Every Friday at 6 AM EST
+  // Every Friday at 8 AM EST
   await scheduler.schedule(JOB_NAMES.NEWSLETTER_DIGEST, cronExpression, {}, {
     tz: 'America/New_York'
   });

--- a/frontend/src/components/NewsletterSettings.jsx
+++ b/frontend/src/components/NewsletterSettings.jsx
@@ -338,7 +338,7 @@ function NewsletterSettings({ user }) {
           <li><strong>Buttondown Setup:</strong> Sign up at <a href="https://buttondown.com" target="_blank" rel="noopener noreferrer">buttondown.com</a> (free for up to 100 subscribers)</li>
           <li><strong>Verify Email:</strong> Verify your sender email in Buttondown before sending</li>
           <li><strong>Get API Key:</strong> Generate an API key from Buttondown Settings → API</li>
-          <li><strong>Schedule:</strong> Digest sends automatically every Friday at 6 AM EST</li>
+          <li><strong>Schedule:</strong> Digest sends automatically every Friday at 8 AM EST</li>
           <li><strong>Content:</strong> Includes events (Fri-Sun) and recent news (last 7 days)</li>
           <li><strong>Testing:</strong> Use Settings → Jobs → Newsletter Digest → "Run Now" to test</li>
         </ul>

--- a/frontend/src/components/UserSettings.jsx
+++ b/frontend/src/components/UserSettings.jsx
@@ -154,7 +154,7 @@ function UserSettings({ user }) {
             <li>Events happening this weekend (Friday-Sunday)</li>
             <li>Recent news from the past week</li>
             <li>Trail status updates (when available)</li>
-            <li>Sent every Friday at 6 AM EST</li>
+            <li>Sent every Friday at 8 AM EST</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Hardcoded '6 AM' strings missed when the cron was changed from 6 AM to 8 AM in PR #245
- Fixed in: `registry.js`, `jobScheduler.js`, `NewsletterSettings.jsx`, `UserSettings.jsx`

## Test plan
- [ ] Jobs dashboard shows "Friday at 8 AM" and cron `0 8 * * 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)