### PR TITLE
feat: multi-boundary Serper grounding, events Phase II, and poi_type removal

### DIFF
--- a/backend/migrations/025_rename_virtual_to_organization.sql
+++ b/backend/migrations/025_rename_virtual_to_organization.sql
@@ -1,0 +1,9 @@
+-- Migration 025: Rename virtual POI type/role to organization
+-- 'virtual' was a placeholder name for organizations, agencies, and stewardship groups.
+-- Renaming to 'organization' for clarity.
+
+UPDATE pois
+SET
+  poi_type = 'organization',
+  poi_roles = array_replace(poi_roles, 'virtual', 'organization')
+WHERE 'virtual' = ANY(poi_roles);

--- a/backend/migrations/026_drop_poi_type.sql
+++ b/backend/migrations/026_drop_poi_type.sql
@@ -1,0 +1,8 @@
+-- Migration 026: Drop poi_type column
+-- All logic now uses poi_roles array. poi_type is fully replaced.
+
+-- Drop unique constraint that depended on poi_type
+ALTER TABLE pois DROP CONSTRAINT IF EXISTS pois_name_poi_type_active_key;
+
+-- Drop poi_type column
+ALTER TABLE pois DROP COLUMN IF EXISTS poi_type;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -166,7 +166,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   router.put('/pois/:id', isAdmin, async (req, res) => {
     const { id } = req.params;
     const allowedFields = [
-      'name', 'poi_type', 'poi_roles', 'latitude', 'longitude', 'geometry', 'geometry_drive_file_id',
+      'name', 'poi_roles', 'latitude', 'longitude', 'geometry', 'geometry_drive_file_id',
       'property_owner', 'owner_id', 'brief_description', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'research_context',
@@ -333,16 +333,17 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
   // Create POI
   router.post('/pois', isAdmin, async (req, res) => {
-    const { name, poi_type, poi_roles, latitude, longitude } = req.body;
+    const { name, poi_roles, latitude, longitude } = req.body;
 
     // Validate required fields
     if (!name || !name.trim()) {
       return res.status(400).json({ error: 'Name is required' });
     }
 
-    const validTypes = ['point', 'trail', 'river', 'boundary'];
-    if (!poi_type || !validTypes.includes(poi_type)) {
-      return res.status(400).json({ error: 'Invalid poi_type. Must be: point, trail, river, or boundary' });
+    const validRoles = ['point', 'trail', 'river', 'boundary', 'organization'];
+    const rolesArray = Array.isArray(poi_roles) ? poi_roles : (poi_roles ? [poi_roles] : []);
+    if (rolesArray.length === 0 || !rolesArray.every(r => validRoles.includes(r))) {
+      return res.status(400).json({ error: 'Invalid poi_roles. Must include at least one of: point, trail, river, boundary, organization' });
     }
 
     // Only validate coordinates when geometry is not provided and lat/lon are given
@@ -361,13 +362,13 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
 
     const allowedFields = [
-      'poi_type', 'poi_roles', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
+      'poi_roles', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
       'historical_description', 'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'has_primary_image'
     ];
 
-    const fields = ['name'];
-    const values = [name.trim()];
+    const fields = ['name', 'poi_roles'];
+    const values = [name.trim(), rolesArray];
 
     if (hasCoords) {
       fields.push('latitude', 'longitude');
@@ -375,16 +376,11 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
 
     for (const field of allowedFields) {
+      if (field === 'poi_roles') continue; // already added
       if (req.body[field] !== undefined && req.body[field] !== null && req.body[field] !== '') {
         fields.push(field);
         values.push(req.body[field]);
       }
-    }
-
-    // Seed poi_roles from poi_type if not provided
-    if (!fields.includes('poi_roles')) {
-      fields.push('poi_roles');
-      values.push([poi_type]);
     }
 
     const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
@@ -397,7 +393,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         values
       );
 
-      console.log(`Admin ${req.user.email} created new POI (${poi_type}): ${name}`);
+      console.log(`Admin ${req.user.email} created new POI (${rolesArray.join(', ')}): ${name}`);
       res.status(201).json(result.rows[0]);
     } catch (error) {
       console.error('Error creating POI:', error);
@@ -1433,7 +1429,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       const result = await pool.query(`
         SELECT id, name, boundary_type, boundary_color
         FROM pois
-        WHERE poi_type = 'boundary' AND (deleted IS NULL OR deleted = FALSE)
+        WHERE 'boundary' = ANY(poi_roles) AND (deleted IS NULL OR deleted = FALSE)
         ORDER BY name
       `);
       res.json(result.rows);
@@ -1479,7 +1475,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       const result = await pool.query(`
         UPDATE pois
         SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP
-        WHERE id = $${paramIndex} AND poi_type = 'boundary'
+        WHERE id = $${paramIndex} AND 'boundary' = ANY(poi_roles)
         RETURNING id, name, boundary_type, boundary_color
       `, values);
 
@@ -2105,13 +2101,13 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
       const result = await pool.query(`
         INSERT INTO pois (
-          name, poi_type, geometry, property_owner, owner_id, brief_description,
+          name, poi_roles, geometry, property_owner, owner_id, brief_description,
           era_id, historical_description, primary_activities, surface, pets,
           cell_signal, more_info_link, length_miles, difficulty
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         RETURNING *
       `, [
-        name, feature_type, JSON.stringify(geometry), property_owner, owner_id, brief_description,
+        name, [feature_type], JSON.stringify(geometry), property_owner, owner_id, brief_description,
         era_id, historical_description, primary_activities, surface, pets,
         cell_signal, more_info_link, length_miles, difficulty
       ]);
@@ -2133,16 +2129,11 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     try {
       const { id } = req.params;
       const allowedFields = [
-        'name', 'poi_type', 'geometry', 'property_owner', 'owner_id', 'brief_description',
+        'name', 'poi_roles', 'geometry', 'property_owner', 'owner_id', 'brief_description',
         'era_id', 'historical_description', 'primary_activities', 'surface', 'pets',
         'cell_signal', 'more_info_link', 'length_miles', 'difficulty',
         'boundary_type', 'boundary_color', 'status_url', 'news_url', 'events_url'
       ];
-
-      // Map feature_type to poi_type for backward compatibility
-      if (req.body.feature_type && !req.body.poi_type) {
-        req.body.poi_type = req.body.feature_type;
-      }
 
       const updates = [];
       const values = [];
@@ -2167,7 +2158,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       const result = await pool.query(`
         UPDATE pois SET ${updates.join(', ')}
         WHERE id = $${paramIndex}
-        RETURNING id, name, poi_type, latitude, longitude, property_owner,
+        RETURNING id, name, poi_roles, latitude, longitude, property_owner,
                   brief_description, era_id, historical_description, primary_activities,
                   surface, pets, cell_signal, more_info_link, length_miles, difficulty,
                   has_primary_image, geometry_drive_file_id,
@@ -2258,11 +2249,11 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
           for (const trail of consolidatedTrails) {
             try {
               await pool.query(`
-                INSERT INTO pois (name, poi_type, geometry)
-                VALUES ($1, 'trail', $2)
+                INSERT INTO pois (name, poi_roles, geometry)
+                VALUES ($1, '{trail}', $2)
                 ON CONFLICT (name) DO UPDATE SET
                   geometry = EXCLUDED.geometry,
-                  poi_type = EXCLUDED.poi_type,
+                  poi_roles = EXCLUDED.poi_roles,
                   updated_at = CURRENT_TIMESTAMP
               `, [trail.name, JSON.stringify(trail.geometry)]);
               results.trails++;
@@ -2285,11 +2276,11 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
           for (const river of consolidatedRivers) {
             try {
               await pool.query(`
-                INSERT INTO pois (name, poi_type, geometry)
-                VALUES ($1, 'river', $2)
+                INSERT INTO pois (name, poi_roles, geometry)
+                VALUES ($1, '{river}', $2)
                 ON CONFLICT (name) DO UPDATE SET
                   geometry = EXCLUDED.geometry,
-                  poi_type = EXCLUDED.poi_type,
+                  poi_roles = EXCLUDED.poi_roles,
                   updated_at = CURRENT_TIMESTAMP
               `, [river.name, JSON.stringify(river.geometry)]);
               results.rivers++;
@@ -2312,11 +2303,11 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
             const name = feature.properties?.name || 'Park Boundary';
             try {
               await pool.query(`
-                INSERT INTO pois (name, poi_type, geometry)
-                VALUES ($1, 'boundary', $2)
+                INSERT INTO pois (name, poi_roles, geometry)
+                VALUES ($1, '{boundary}', $2)
                 ON CONFLICT (name) DO UPDATE SET
                   geometry = EXCLUDED.geometry,
-                  poi_type = EXCLUDED.poi_type,
+                  poi_roles = EXCLUDED.poi_roles,
                   updated_at = CURRENT_TIMESTAMP
               `, [name, JSON.stringify(feature.geometry)]);
               results.boundaries++;
@@ -2439,13 +2430,14 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       for (const feature of consolidatedFeatures) {
         try {
           await pool.query(`
-            INSERT INTO pois (name, poi_type, geometry, deleted)
+            INSERT INTO pois (name, poi_roles, geometry, deleted)
             VALUES ($1, $2, $3, FALSE)
-            ON CONFLICT (name, poi_type) DO UPDATE SET
+            ON CONFLICT (name) DO UPDATE SET
               geometry = EXCLUDED.geometry,
+              poi_roles = EXCLUDED.poi_roles,
               deleted = FALSE,
               updated_at = CURRENT_TIMESTAMP
-          `, [feature.name, feature_type, JSON.stringify(feature.geometry)]);
+          `, [feature.name, [feature_type], JSON.stringify(feature.geometry)]);
           importedCount++;
         } catch (err) {
           errors.push(`"${feature.name}": ${err.message}`);
@@ -2530,13 +2522,14 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       for (const feature of consolidatedFeatures) {
         try {
           await pool.query(`
-            INSERT INTO pois (name, poi_type, geometry, deleted)
+            INSERT INTO pois (name, poi_roles, geometry, deleted)
             VALUES ($1, $2, $3, FALSE)
-            ON CONFLICT (name, poi_type) DO UPDATE SET
+            ON CONFLICT (name) DO UPDATE SET
               geometry = EXCLUDED.geometry,
+              poi_roles = EXCLUDED.poi_roles,
               deleted = FALSE,
               updated_at = CURRENT_TIMESTAMP
-          `, [feature.name, feature_type, JSON.stringify(feature.geometry)]);
+          `, [feature.name, [feature_type], JSON.stringify(feature.geometry)]);
           importedCount++;
         } catch (err) {
           errors.push(`"${feature.name}": ${err.message}`);
@@ -2620,9 +2613,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         SELECT id FROM pois
         WHERE (deleted IS NULL OR deleted = FALSE)
         ORDER BY
-          CASE poi_type
-            WHEN 'point' THEN 1
-            WHEN 'boundary' THEN 2
+          CASE
+            WHEN 'point' = ANY(poi_roles) THEN 1
+            WHEN 'boundary' = ANY(poi_roles) THEN 2
             ELSE 3
           END,
           name
@@ -2750,7 +2743,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
       // Get POI details
       const poiResult = await pool.query(
-        'SELECT id, name, poi_type, poi_roles, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = $1',
+        'SELECT id, name, poi_roles, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = $1',
         [id]
       );
 
@@ -2858,7 +2851,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
       // Get POI details
       const poiResult = await pool.query(
-        'SELECT id, name, poi_type, poi_roles, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = $1',
+        'SELECT id, name, poi_roles, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = $1',
         [id]
       );
 
@@ -3231,7 +3224,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
       // Get trail details
       const poiResult = await pool.query(
-        'SELECT id, name, poi_type, status_url, location FROM pois WHERE id = $1',
+        'SELECT id, name, poi_roles, status_url, location FROM pois WHERE id = $1',
         [id]
       );
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -214,9 +214,9 @@ async function importGeoJSONFeatures(client) {
 
     for (const trail of consolidatedTrails) {
       await client.query(
-        `INSERT INTO pois (name, poi_type, geometry)
-         VALUES ($1, 'trail', $2)
-         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry WHERE pois.poi_type = 'trail'`,
+        `INSERT INTO pois (name, poi_roles, geometry)
+         VALUES ($1, '{trail}', $2)
+         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry`,
         [trail.name, JSON.stringify(trail.geometry)]
       );
     }
@@ -229,9 +229,9 @@ async function importGeoJSONFeatures(client) {
 
     for (const river of consolidatedRivers) {
       await client.query(
-        `INSERT INTO pois (name, poi_type, geometry)
-         VALUES ($1, 'river', $2)
-         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry WHERE pois.poi_type = 'river'`,
+        `INSERT INTO pois (name, poi_roles, geometry)
+         VALUES ($1, '{river}', $2)
+         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry`,
         [river.name, JSON.stringify(river.geometry)]
       );
     }
@@ -244,9 +244,9 @@ async function importGeoJSONFeatures(client) {
     for (const feature of boundaryData.features) {
       const name = feature.properties?.name || 'Park Boundary';
       await client.query(
-        `INSERT INTO pois (name, poi_type, geometry)
-         VALUES ($1, 'boundary', $2)
-         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry WHERE pois.poi_type = 'boundary'`,
+        `INSERT INTO pois (name, poi_roles, geometry)
+         VALUES ($1, '{boundary}', $2)
+         ON CONFLICT (name) DO UPDATE SET geometry = EXCLUDED.geometry`,
         [name, JSON.stringify(feature.geometry)]
       );
     }
@@ -297,9 +297,6 @@ async function initDatabase() {
         id SERIAL PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
 
-        -- POI type: 'point', 'trail', 'river', or 'boundary'
-        poi_type VARCHAR(50) NOT NULL DEFAULT 'point',
-
         -- Point geometry (for point POIs)
         latitude DECIMAL(10, 8),
         longitude DECIMAL(11, 8),
@@ -334,9 +331,9 @@ async function initDatabase() {
       )
     `);
 
-    // Create index for faster lookups by type
+    // Create index for faster lookups by role (GIN index on array)
     await client.query(`
-      CREATE INDEX IF NOT EXISTS idx_pois_type ON pois(poi_type)
+      CREATE INDEX IF NOT EXISTS idx_pois_roles ON pois USING GIN(poi_roles)
     `);
 
     // Create index for owner lookups
@@ -344,21 +341,14 @@ async function initDatabase() {
       CREATE INDEX IF NOT EXISTS idx_pois_owner_id ON pois(owner_id)
     `);
 
-    // Create unique constraint on (name, poi_type) to allow same-named features of different types
-    // Only applies to non-deleted POIs (partial index) to allow reusing names after deletion
+    // Drop old poi_type-based constraints if they exist (cleanup only, no replacement)
     await client.query(`
       DO $$ BEGIN
-        -- Drop old constraint if it exists
         IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'pois_name_poi_type_key') THEN
           ALTER TABLE pois DROP CONSTRAINT pois_name_poi_type_key;
         END IF;
-        -- Drop old name-only constraint if it exists
+        ALTER TABLE pois DROP CONSTRAINT IF EXISTS pois_name_poi_type_active_key;
         ALTER TABLE pois DROP CONSTRAINT IF EXISTS pois_name_key;
-        -- Create partial unique index that excludes deleted POIs
-        IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'pois_name_poi_type_active_key') THEN
-          CREATE UNIQUE INDEX pois_name_poi_type_active_key ON pois(name, poi_type)
-          WHERE (deleted IS NULL OR deleted = FALSE);
-        END IF;
       END $$;
     `);
 
@@ -372,11 +362,11 @@ async function initDatabase() {
     if (destTableExists.rows[0].exists) {
       // Migrate destinations to pois table
       const migrated = await client.query(`
-        INSERT INTO pois (name, poi_type, latitude, longitude, property_owner, brief_description,
+        INSERT INTO pois (name, poi_roles, latitude, longitude, property_owner, brief_description,
                           era, historical_description, primary_activities, surface, pets,
                           cell_signal, more_info_link, has_primary_image,
                           deleted, created_at, updated_at)
-        SELECT name, 'point', latitude, longitude, property_owner, brief_description,
+        SELECT name, '{point}', latitude, longitude, property_owner, brief_description,
                era, historical_description, primary_activities, surface, pets,
                cell_signal, more_info_link, has_primary_image,
                COALESCE(deleted, FALSE),
@@ -400,12 +390,12 @@ async function initDatabase() {
     if (linearTableExists.rows[0].exists) {
       // Migrate linear_features to pois table
       const migrated = await client.query(`
-        INSERT INTO pois (name, poi_type, geometry, property_owner, brief_description,
+        INSERT INTO pois (name, poi_roles, geometry, property_owner, brief_description,
                           era, historical_description, primary_activities, surface, pets,
                           cell_signal, more_info_link, length_miles, difficulty,
                           has_primary_image,
                           deleted, created_at, updated_at)
-        SELECT name, feature_type, geometry, property_owner, brief_description,
+        SELECT name, ARRAY[feature_type]::text[], geometry, property_owner, brief_description,
                era, historical_description, primary_activities, surface, pets,
                cell_signal, more_info_link, length_miles, difficulty,
                has_primary_image,
@@ -414,8 +404,7 @@ async function initDatabase() {
         FROM linear_features
         ON CONFLICT (name) DO UPDATE SET
           geometry = EXCLUDED.geometry,
-          poi_type = EXCLUDED.poi_type
-        WHERE pois.poi_type IN ('trail', 'river', 'boundary')
+          poi_roles = EXCLUDED.poi_roles
         RETURNING id
       `);
       if (migrated.rowCount > 0) {
@@ -644,7 +633,7 @@ async function initDatabase() {
     `);
     // Set default boundary_type for existing boundaries
     await client.query(`
-      UPDATE pois SET boundary_type = 'cvnp' WHERE poi_type = 'boundary' AND boundary_type IS NULL
+      UPDATE pois SET boundary_type = 'cvnp' WHERE 'boundary' = ANY(poi_roles) AND boundary_type IS NULL
     `);
 
     // Add events_url and news_url columns for targeted AI Research
@@ -882,7 +871,7 @@ app.get('/api/pois', async (req, res) => {
     const { type, role } = req.query;
 
     let query = `
-      SELECT p.id, p.name, p.poi_type, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
+      SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -901,10 +890,10 @@ app.get('/api/pois', async (req, res) => {
       query += ` AND $${params.length} = ANY(p.poi_roles)`;
     } else if (type) {
       params.push(type);
-      query += ` AND p.poi_type = $${params.length}`;
+      query += ` AND $${params.length} = ANY(p.poi_roles)`;
     }
 
-    query += ` ORDER BY p.poi_type, p.name`;
+    query += ` ORDER BY p.poi_roles, p.name`;
 
     const poisQuery = await pool.query(query, params);
     res.json(poisQuery.rows);
@@ -917,7 +906,7 @@ app.get('/api/pois', async (req, res) => {
 app.get('/api/pois/:id', async (req, res) => {
   try {
     const poiQuery = await pool.query(`
-      SELECT p.id, p.name, p.poi_type, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
+      SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1602,7 +1591,7 @@ app.get('/api/filters', async (req, res) => {
     const owners = await pool.query(`
       SELECT DISTINCT o.id, o.name
       FROM pois o
-      WHERE o.poi_type = 'virtual'
+      WHERE 'organization' = ANY(o.poi_roles)
         AND (o.deleted IS NULL OR o.deleted = FALSE)
         AND EXISTS (SELECT 1 FROM pois p WHERE p.owner_id = o.id)
       ORDER BY o.name
@@ -1629,7 +1618,7 @@ app.get('/api/owner-organizations', async (req, res) => {
     const organizationsQuery = await pool.query(`
       SELECT id, name, brief_description
       FROM pois
-      WHERE poi_type = 'virtual'
+      WHERE 'organization' = ANY(poi_roles)
         AND (deleted IS NULL OR deleted = FALSE)
       ORDER BY name
     `);
@@ -1646,8 +1635,8 @@ app.get('/api/pois/:id/associations', async (req, res) => {
     const { id } = req.params;
     const associationsQuery = await pool.query(`
       SELECT a.id, a.virtual_poi_id, a.physical_poi_id, a.association_type,
-             vp.name as virtual_poi_name, vp.poi_type as virtual_poi_type,
-             pp.name as physical_poi_name, pp.poi_type as physical_poi_type,
+             vp.name as virtual_poi_name, vp.poi_roles as virtual_poi_roles,
+             pp.name as physical_poi_name, pp.poi_roles as physical_poi_roles,
              a.created_at, a.updated_at
       FROM poi_associations a
       LEFT JOIN pois vp ON a.virtual_poi_id = vp.id
@@ -1701,7 +1690,7 @@ app.get('/api/pois/virtual-in-viewport', async (req, res) => {
 
     // Find virtual POIs that have at least one associated physical POI within bounds
     const virtualPoisQuery = await pool.query(`
-      SELECT DISTINCT vp.id, vp.name, vp.poi_type, vp.property_owner,
+      SELECT DISTINCT vp.id, vp.name, vp.poi_roles, vp.property_owner,
              vp.brief_description, vp.era_id, e.name as era_name, vp.era, vp.historical_description,
              vp.primary_activities, vp.surface, vp.pets, vp.cell_signal,
              vp.more_info_link, vp.has_primary_image,
@@ -1711,7 +1700,7 @@ app.get('/api/pois/virtual-in-viewport', async (req, res) => {
       JOIN poi_associations a ON vp.id = a.virtual_poi_id
       JOIN pois pp ON a.physical_poi_id = pp.id
       LEFT JOIN eras e ON vp.era_id = e.id
-      WHERE vp.poi_type = 'virtual'
+      WHERE 'organization' = ANY(vp.poi_roles)
         AND (vp.deleted IS NULL OR vp.deleted = FALSE)
         AND (pp.deleted IS NULL OR pp.deleted = FALSE)
         AND pp.latitude IS NOT NULL
@@ -1732,16 +1721,16 @@ app.get('/api/pois/virtual-in-viewport', async (req, res) => {
 app.get('/api/destinations', async (req, res) => {
   try {
     const destinationsQuery = await pool.query(`
-      SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude,
+      SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.has_primary_image, p.news_url, p.events_url, p.research_context, p.status_url,
              p.deleted, p.created_at, p.updated_at
       FROM pois p
-      LEFT JOIN pois o ON p.owner_id = o.id AND o.poi_type = 'virtual'
+      LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
       LEFT JOIN eras e ON p.era_id = e.id
-      WHERE p.poi_type = 'point'
+      WHERE 'point' = ANY(p.poi_roles)
         AND p.latitude IS NOT NULL AND p.longitude IS NOT NULL
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       ORDER BY p.name
@@ -1756,14 +1745,14 @@ app.get('/api/destinations', async (req, res) => {
 app.get('/api/destinations/:id', async (req, res) => {
   try {
     const destinationQuery = await pool.query(`
-      SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude,
+      SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.has_primary_image, p.news_url, p.events_url, p.research_context, p.status_url,
              p.deleted, p.created_at, p.updated_at
       FROM pois p
-      LEFT JOIN pois o ON p.owner_id = o.id AND o.poi_type = 'virtual'
+      LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
       LEFT JOIN eras e ON p.era_id = e.id
       WHERE p.id = $1`,
       [req.params.id]
@@ -1782,7 +1771,7 @@ app.get('/api/destinations/:id', async (req, res) => {
 app.get('/api/linear-features', async (req, res) => {
   try {
     const linearFeaturesQuery = await pool.query(`
-      SELECT p.id, p.name, p.poi_type as feature_type, p.geometry,
+      SELECT p.id, p.name, p.poi_roles, p.geometry,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1790,11 +1779,11 @@ app.get('/api/linear-features', async (req, res) => {
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
              p.deleted, p.created_at, p.updated_at
       FROM pois p
-      LEFT JOIN pois o ON p.owner_id = o.id AND o.poi_type = 'virtual'
+      LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
       LEFT JOIN eras e ON p.era_id = e.id
-      WHERE p.poi_type IN ('trail', 'river', 'boundary')
+      WHERE p.poi_roles && ARRAY['trail','river','boundary']::text[]
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      ORDER BY p.poi_type, p.name
+      ORDER BY p.poi_roles, p.name
     `);
     res.json(linearFeaturesQuery.rows);
   } catch (error) {
@@ -1806,7 +1795,7 @@ app.get('/api/linear-features', async (req, res) => {
 app.get('/api/linear-features/:id', async (req, res) => {
   try {
     const linearFeatureQuery = await pool.query(`
-      SELECT p.id, p.name, p.poi_type as feature_type, p.geometry,
+      SELECT p.id, p.name, p.poi_roles, p.geometry,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1814,7 +1803,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
              p.deleted, p.created_at, p.updated_at
       FROM pois p
-      LEFT JOIN pois o ON p.owner_id = o.id AND o.poi_type = 'virtual'
+      LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
       LEFT JOIN eras e ON p.era_id = e.id
       WHERE p.id = $1`,
       [req.params.id]
@@ -1999,7 +1988,7 @@ app.get('/api/trails/mtb', async (req, res) => {
     const includeStatus = req.query.includeStatus === 'true';
 
     let query = `
-      SELECT id, name, brief_description, poi_type, status_url,
+      SELECT id, name, brief_description, poi_roles, status_url,
              latitude, longitude,
              length_miles, difficulty, surface, primary_activities,
              geometry
@@ -2065,7 +2054,7 @@ app.get('/api/trail-status/mtb-trails', async (req, res) => {
       SELECT
         p.id,
         p.name,
-        p.poi_type,
+        p.poi_roles,
         p.latitude,
         p.longitude,
         p.geometry,
@@ -2086,7 +2075,7 @@ app.get('/api/trail-status/mtb-trails', async (req, res) => {
       ) ts ON true
       WHERE p.status_url IS NOT NULL
         AND p.status_url != ''
-        AND p.poi_type = 'point'
+        AND 'point' = ANY(p.poi_roles)
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       ORDER BY p.name
     `);
@@ -2105,14 +2094,14 @@ app.get('/api/news/recent', async (req, res) => {
     const recentNewsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.publication_date, n.date_confidence, n.collection_date,
-             p.id as poi_id, p.name as poi_name, p.poi_type,
+             p.id as poi_id, p.name as poi_name, p.poi_roles,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
       LEFT JOIN poi_news_urls u ON u.news_id = n.id
       WHERE n.moderation_status IN ('published', 'auto_approved')
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      GROUP BY n.id, p.id, p.name, p.poi_type
+      GROUP BY n.id, p.id, p.name, p.poi_roles
       ORDER BY COALESCE(n.publication_date, n.collection_date::date) DESC, n.collection_date DESC
       LIMIT $1
     `, [limit]);
@@ -2130,7 +2119,7 @@ app.get('/api/events/upcoming', async (req, res) => {
     const tz = req.query.tz || 'America/New_York';
     const upcomingEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
@@ -2138,7 +2127,7 @@ app.get('/api/events/upcoming', async (req, res) => {
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND e.start_date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      GROUP BY e.id, p.id, p.name, p.poi_type
+      GROUP BY e.id, p.id, p.name, p.poi_roles
       ORDER BY e.start_date ASC
     `, [tz]);
     res.json(upcomingEventsQuery.rows);
@@ -2155,7 +2144,7 @@ app.get('/api/events/past', async (req, res) => {
     const tz = req.query.tz || 'America/New_York';
     const pastEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type,
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
@@ -2163,7 +2152,7 @@ app.get('/api/events/past', async (req, res) => {
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND e.start_date < (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      GROUP BY e.id, p.id, p.name, p.poi_type
+      GROUP BY e.id, p.id, p.name, p.poi_roles
       ORDER BY e.start_date DESC
       LIMIT $1
     `, [limit, tz]);
@@ -2268,7 +2257,7 @@ app.get('/share/linear-feature/:id', async (req, res) => {
   try {
     const { id } = req.params;
     const featureQuery = await pool.query(
-      `SELECT id, name, poi_type, brief_description FROM pois WHERE id = $1`,
+      `SELECT id, name, poi_roles, brief_description FROM pois WHERE id = $1`,
       [id]
     );
 
@@ -2353,7 +2342,7 @@ app.use(async (req, res, next) => {
     try {
       // Look up POI by matching slug against name
       const poisQuery = await pool.query(`
-        SELECT id, name, poi_type, brief_description
+        SELECT id, name, poi_roles, brief_description
         FROM pois
         WHERE (deleted IS NULL OR deleted = FALSE)
       `);

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -17,7 +17,7 @@ export const COLLECTION_TYPES = [
     promptKeys: [{
       key: 'news_collection_prompt',
       label: 'News Collection Prompt',
-      placeholders: ['{{name}}', '{{poi_type}}', '{{timezone}}', '{{website}}', '{{eventsUrl}}', '{{newsUrl}}']
+      placeholders: ['{{name}}', '{{poi_roles}}', '{{timezone}}', '{{website}}', '{{eventsUrl}}', '{{newsUrl}}']
     }],
     scheduleJobName: 'news-collection',
     schedule: '0 6 * * *',

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -63,11 +63,11 @@ function registerTools(server, pool, boss) {
 
   server.tool(
     'poi_list',
-    'List POIs with optional type filter',
-    { type: z.enum(['point', 'trail', 'river', 'boundary', 'virtual']).optional().describe('Filter by POI type') },
-    async ({ type }) => {
+    'List POIs with optional role filter',
+    { role: z.enum(['point', 'trail', 'river', 'boundary', 'organization']).optional().describe('Filter by POI role') },
+    async ({ role }) => {
       let query = `
-        SELECT p.id, p.name, p.poi_type, p.latitude, p.longitude,
+        SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude,
                p.brief_description, p.news_url, p.events_url, p.status_url,
                e.name as era_name
         FROM pois p
@@ -75,11 +75,11 @@ function registerTools(server, pool, boss) {
         WHERE (p.deleted IS NULL OR p.deleted = FALSE)
       `;
       const params = [];
-      if (type) {
-        params.push(type);
-        query += ` AND p.poi_type = $1`;
+      if (role) {
+        params.push(role);
+        query += ` AND $1 = ANY(p.poi_roles)`;
       }
-      query += ` ORDER BY p.poi_type, p.name`;
+      query += ` ORDER BY p.poi_roles, p.name`;
       const result = await pool.query(query, params);
       return { content: [{ type: 'text', text: JSON.stringify(result.rows, null, 2) }] };
     }
@@ -94,7 +94,7 @@ function registerTools(server, pool, boss) {
         SELECT p.*, e.name as era_name, o.name as owner_name
         FROM pois p
         LEFT JOIN eras e ON p.era_id = e.id
-        LEFT JOIN pois o ON p.owner_id = o.id AND o.poi_type = 'virtual'
+        LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
         WHERE p.id = $1
       `, [id]);
       if (result.rows.length === 0) {
@@ -174,7 +174,7 @@ function registerTools(server, pool, boss) {
     { query: z.string().describe('Name substring to search for') },
     async ({ query }) => {
       const result = await pool.query(`
-        SELECT id, name, poi_type, brief_description
+        SELECT id, name, poi_roles, brief_description
         FROM pois
         WHERE (deleted IS NULL OR deleted = FALSE)
           AND LOWER(name) LIKE $1
@@ -187,33 +187,33 @@ function registerTools(server, pool, boss) {
 
   server.tool(
     'poi_create',
-    'Create a new POI (point of interest or virtual organization)',
+    'Create a new POI (point of interest or organization)',
     {
       name: z.string().describe('POI name'),
-      poi_type: z.enum(['point', 'trail', 'river', 'boundary', 'virtual']).describe('POI type (use virtual for organizations)'),
+      poi_roles: z.array(z.enum(['point', 'trail', 'river', 'boundary', 'organization'])).describe('POI roles (use organization for organizations; a POI can have multiple roles)'),
       brief_description: z.string().optional().describe('Short description'),
-      latitude: z.number().optional().describe('Latitude (not needed for virtual POIs)'),
-      longitude: z.number().optional().describe('Longitude (not needed for virtual POIs)'),
+      latitude: z.number().optional().describe('Latitude (not needed for organization-only POIs)'),
+      longitude: z.number().optional().describe('Longitude (not needed for organization-only POIs)'),
       news_url: z.string().url().optional().describe('URL for news collection'),
       events_url: z.string().url().optional().describe('URL for events collection'),
       status_url: z.string().url().optional().describe('URL for trail status collection'),
       more_info_link: z.string().url().optional().describe('External link for more info'),
-      owner_id: z.number().optional().describe('ID of virtual POI that owns/manages this POI')
+      owner_id: z.number().optional().describe('ID of organization POI that owns/manages this POI')
     },
     async (args) => {
-      if (args.poi_type !== 'virtual' && (args.latitude === undefined || args.longitude === undefined)) {
-        return { content: [{ type: 'text', text: `POI type '${args.poi_type}' requires latitude and longitude.` }], isError: true };
+      if (!args.poi_roles?.includes('organization') && (args.latitude === undefined || args.longitude === undefined)) {
+        return { content: [{ type: 'text', text: `POI roles '${(args.poi_roles || []).join(', ')}' require latitude and longitude.` }], isError: true };
       }
 
       const fields = Object.keys(args).filter(key => args[key] !== undefined);
       const values = fields.map(key => args[key]);
       const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
       const result = await pool.query(
-        `INSERT INTO pois (${fields.join(', ')}) VALUES (${placeholders}) RETURNING id, name, poi_type`,
+        `INSERT INTO pois (${fields.join(', ')}) VALUES (${placeholders}) RETURNING id, name, poi_roles`,
         values
       );
       const row = result.rows[0];
-      return { content: [{ type: 'text', text: `Created POI #${row.id}: ${row.name} (${row.poi_type})` }] };
+      return { content: [{ type: 'text', text: `Created POI #${row.id}: ${row.name} (${(row.poi_roles || []).join(', ')})` }] };
     }
   );
 
@@ -730,7 +730,7 @@ function registerTools(server, pool, boss) {
       const result = await pool.query(`
         SELECT a.id, a.virtual_poi_id, a.physical_poi_id, a.association_type,
                vp.name as virtual_poi_name, pp.name as physical_poi_name,
-               pp.poi_type as physical_poi_type
+               pp.poi_roles as physical_poi_roles
         FROM poi_associations a
         LEFT JOIN pois vp ON a.virtual_poi_id = vp.id
         LEFT JOIN pois pp ON a.physical_poi_id = pp.id
@@ -839,9 +839,9 @@ function registerTools(server, pool, boss) {
             SELECT id FROM pois
             WHERE (deleted IS NULL OR deleted = FALSE)
             ORDER BY
-              CASE poi_type
-                WHEN 'point' THEN 1
-                WHEN 'boundary' THEN 2
+              CASE
+                WHEN 'point' = ANY(poi_roles) THEN 1
+                WHEN 'boundary' = ANY(poi_roles) THEN 2
                 ELSE 3
               END,
               name

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -236,7 +236,7 @@ function parseGeminiResponse(responseText) {
  * Build a Gemini prompt for a single rendered page.
  * No multi-page headers, no concatenation — one page per call.
  *
- * @param {Object} poi - POI object (name, poi_type, primary_activities)
+ * @param {Object} poi - POI object (name, poi_roles, primary_activities)
  * @param {string} url - The URL that was rendered
  * @param {string} markdown - Rendered page markdown
  * @param {Array} dateHints - chrono-node date hints from this page
@@ -252,7 +252,7 @@ function buildSinglePagePrompt(poi, url, markdown, contentType, confidence) {
 
   let prompt = `Extract ${contentType === 'event' ? 'events' : 'news'} from this single web page about "${poi.name}".
 
-POI: "${poi.name}" (${poi.poi_type})
+POI: "${poi.name}" (roles: ${(poi.poi_roles || []).join(', ') || 'unknown'})
 Activities: ${activities}
 Source URL: ${url}
 
@@ -497,13 +497,23 @@ async function crawlWithClassification(pool, startUrl, contentType, poi, sheets,
 /**
  * Collect news and events for a specific POI
  * @param {Pool} pool - Database connection pool
- * @param {Object} poi - POI object with id, name, poi_type, primary_activities, more_info_link, events_url, news_url
+ * @param {Object} poi - POI object with id, name, poi_roles, primary_activities, more_info_link, events_url, news_url
  * @param {Object} sheets - Optional sheets client for API key restore
  * @param {string} timezone - IANA timezone string (e.g., 'America/New_York')
  * @param {string} collectionType - 'news', 'events', or 'both' to indicate what's being collected
  * @returns {Object} - { news: [], events: [] }
  */
 export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'America/New_York', collectionType = 'both', onProgress = null) {
+  // Only collect news/events for POIs with roles: point, organization, or river
+  const collectibleRoles = ['point', 'organization', 'river'];
+  const poiRoles = poi.poi_roles || [];
+  if (!poiRoles.some(r => collectibleRoles.includes(r))) {
+    const jobId = tracker.getCollectionProgress(poi.id)?.jobId;
+    const jobType = tracker.getCollectionProgress(poi.id)?.jobType || 'news';
+    logInfo(jobId, jobType, poi.id, poi.name, `Skipping: no collectible role (roles: ${poiRoles.join(', ') || 'none'})`);
+    return { news: [], events: [], metadata: { skipped: true, reason: 'no collectible role' } };
+  }
+
   const activities = poi.primary_activities || 'None specified';
   const website = poi.more_info_link || 'No website available';
   const eventsUrl = poi.events_url || 'No dedicated events page';
@@ -679,7 +689,7 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
         reportProgress('Phase II: [Search] Querying Serper for external coverage');
         logInfo(jobId, jobType, poi.id, poi.name, 'Phase II: [Search] Querying Serper for external coverage');
 
-        const serperResult = await searchNewsUrls(pool, poi);
+        const serperResult = await searchNewsUrls(pool, poi, { contentType: 'news' });
         logInfo(jobId, jobType, poi.id, poi.name, `Phase II: [Search] "${serperResult.query}" → ${serperResult.urls.length} URLs (grounded: ${serperResult.grounded})`);
         reportProgress(`Phase II: [Search] ${serperResult.urls.length} URLs (query: "${serperResult.query}")`);
 
@@ -700,8 +710,8 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
             } catch { return false; }
           });
 
-          // Use all Serper results (up to 10 — Serper's default page size)
-          const MAX_PHASE2_URLS = 10;
+          // Serper is configured to return 3 results max
+          const MAX_PHASE2_URLS = 3;
           const urlsToProcess = externalUrls.slice(0, MAX_PHASE2_URLS);
           if (externalUrls.length > MAX_PHASE2_URLS) {
             logInfo(jobId, jobType, poi.id, poi.name, `Phase II: Capped at ${MAX_PHASE2_URLS} URLs (${externalUrls.length} external of ${serperResult.urls.length} total)`);
@@ -760,6 +770,93 @@ export async function collectNewsForPoi(pool, poi, sheets = null, timezone = 'Am
       } catch (serperError) {
         if (serperError.message === 'Collection cancelled by user') throw serperError;
         logWarn(jobId, jobType, poi.id, poi.name, `Phase II: Search failed: ${serperError.message}`);
+      }
+    }
+
+    // PHASE II: External events via Serper — per-URL pipeline
+    if (collectionType !== 'news') {
+      try {
+        updateProgress(poi.id, {
+          phase: 'search',
+          message: 'Searching for external events coverage...',
+          steps: ['Initialized', 'Phase I complete', 'Searching external events']
+        });
+
+        reportProgress('Phase II: [Search] Querying Serper for external events');
+        logInfo(jobId, jobType, poi.id, poi.name, 'Phase II: [Search] Querying Serper for external events');
+
+        const serperEventsResult = await searchNewsUrls(pool, poi, { contentType: 'events' });
+        logInfo(jobId, jobType, poi.id, poi.name, `Phase II: [Search] "${serperEventsResult.query}" → ${serperEventsResult.urls.length} URLs (grounded: ${serperEventsResult.grounded})`);
+        reportProgress(`Phase II: [Search] ${serperEventsResult.urls.length} event URLs (query: "${serperEventsResult.query}")`);
+
+        if (serperEventsResult.urls.length > 0) {
+          const poiOrigins = new Set();
+          for (const u of [website, eventsUrl, newsUrl]) {
+            try { poiOrigins.add(new URL(u).origin); } catch { /* skip invalid */ }
+          }
+          const externalEventUrls = serperEventsResult.urls.filter(urlData => {
+            try {
+              const origin = new URL(urlData.url).origin;
+              if (poiOrigins.has(origin)) {
+                logInfo(jobId, jobType, poi.id, poi.name, `Phase II Events: Skip same-origin URL: ${urlData.url}`);
+                return false;
+              }
+              return true;
+            } catch { return false; }
+          });
+
+          const MAX_PHASE2_EVENT_URLS = 3;
+          const eventUrlsToProcess = externalEventUrls.slice(0, MAX_PHASE2_EVENT_URLS);
+
+          let renderedEventCount = 0;
+          let phase2EventPagesCollected = 0;
+
+          const phase2EventResults = await runConcurrent(eventUrlsToProcess.map(urlData => async () => {
+            checkCancellation();
+            if (phase2EventPagesCollected >= MAX_PHASE2_PAGES) return [];
+
+            reportProgress(`Phase II Events: [Classify] ${urlData.url}`);
+            const crawlResult = await crawlWithClassification(pool, urlData.url, 'event', poi, sheets, checkCancellation, {
+              maxDepth: 1,
+              maxPages: 6,
+              maxDetailPages: Math.min(5, MAX_PHASE2_PAGES - phase2EventPagesCollected),
+              phase: 'Phase II Events',
+              jobId,
+              jobType
+            });
+
+            renderedEventCount++;
+            const pageItems = [];
+            for (const page of crawlResult.pages) {
+              checkCancellation();
+              if (phase2EventPagesCollected >= MAX_PHASE2_PAGES) break;
+              const items = await processOneUrl(pool, page.url, poi, 'event', { phase: 'Phase II Events', jobId, jobType, timezone, confidence: '95%' });
+              pageItems.push(...(items.events || []));
+              phase2EventPagesCollected++;
+            }
+            return pageItems;
+          }), 3);
+
+          for (const itemsOrError of phase2EventResults) {
+            if (!itemsOrError || itemsOrError instanceof Error) continue;
+            const newEvents = itemsOrError.filter(item => {
+              const titleLower = item.title.toLowerCase().trim();
+              return !allEvents.some(e => e.title.toLowerCase().trim() === titleLower);
+            });
+            if (newEvents.length > 0) {
+              logInfo(jobId, jobType, poi.id, poi.name, `Phase II Events: Adding ${newEvents.length} unique items`);
+              allEvents.push(...newEvents);
+            }
+          }
+
+          reportProgress(`Phase II Events: Processed ${renderedEventCount} Serper URLs, ${phase2EventPagesCollected} pages collected`);
+          logInfo(jobId, jobType, poi.id, poi.name, `Phase II Events: Processed ${renderedEventCount} of ${serperEventsResult.urls.length} Serper URLs, ${phase2EventPagesCollected} pages collected`);
+        } else {
+          logInfo(jobId, jobType, poi.id, poi.name, 'Phase II Events: [Search] No external event URLs found');
+        }
+      } catch (serperError) {
+        if (serperError.message === 'Collection cancelled by user') throw serperError;
+        logWarn(jobId, jobType, poi.id, poi.name, `Phase II Events: Search failed: ${serperError.message}`);
       }
     }
 
@@ -1288,7 +1385,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
 
   // Get POI details for remaining POIs
   const poisResult = await pool.query(
-    'SELECT id, name, poi_type, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = ANY($1)',
+    'SELECT id, name, poi_roles, primary_activities, more_info_link, events_url, news_url FROM pois WHERE id = ANY($1)',
     [remainingPoiIds]
   );
   const pois = poisResult.rows;
@@ -1475,9 +1572,9 @@ export async function getAllPoisForCollection(pool) {
      WHERE (deleted IS NULL OR deleted = FALSE)
        ${excludedIds.length > 0 ? 'AND id != ALL($1)' : ''}
      ORDER BY
-       CASE poi_type
-         WHEN 'point' THEN 1
-         WHEN 'boundary' THEN 2
+       CASE
+         WHEN 'point' = ANY(poi_roles) THEN 1
+         WHEN 'boundary' = ANY(poi_roles) THEN 2
          ELSE 3
        END,
        name`,
@@ -1574,7 +1671,7 @@ export async function getEventsForPoi(pool, poiId, upcomingOnly = true) {
 export async function getRecentNews(pool, limit = 20) {
   const result = await pool.query(`
     SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
-           n.publication_date, n.collection_date, p.id as poi_id, p.name as poi_name, p.poi_type
+           n.publication_date, n.collection_date, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_news n
     JOIN pois p ON n.poi_id = p.id
     WHERE n.moderation_status IN ('published', 'auto_approved')
@@ -1593,7 +1690,7 @@ export async function getRecentNews(pool, limit = 20) {
 export async function getUpcomingEvents(pool, daysAhead = 30) {
   const result = await pool.query(`
     SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-           e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type
+           e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_events e
     JOIN pois p ON e.poi_id = p.id
     WHERE e.start_date >= CURRENT_DATE

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -9,7 +9,7 @@ export async function generateDigest(pool) {
   // Get events happening Friday-Sunday (next 3 days from Friday)
   const eventsQuery = `
     SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-           e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_type
+           e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_events e
     JOIN pois p ON e.poi_id = p.id
     WHERE e.start_date >= CURRENT_DATE
@@ -22,7 +22,7 @@ export async function generateDigest(pool) {
   // Get news published in last 7 days
   const newsQuery = `
     SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
-           n.publication_date, n.collection_date, p.id as poi_id, p.name as poi_name, p.poi_type
+           n.publication_date, n.collection_date, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_news n
     JOIN pois p ON n.poi_id = p.id
     WHERE n.moderation_status IN ('published', 'auto_approved')

--- a/backend/services/serperService.js
+++ b/backend/services/serperService.js
@@ -1,13 +1,14 @@
 /**
- * Serper Service - External news search with geographic grounding
+ * Serper Service - External news/events search with geographic grounding
  *
  * Provides two-layer news collection:
  * - Layer 1: Official POI URLs (news_url, events_url) - already handled by newsService.js
  * - Layer 2: External news coverage via Serper.dev with PostGIS geographic grounding
  *
- * Geographic grounding uses PostGIS spatial queries to find the smallest boundary polygon
- * containing each POI, then adds that context to search queries to eliminate geographic
- * confusion (e.g., "Ledges Trail" → "Ledges Trail Cuyahoga Valley National Park").
+ * Geographic grounding uses PostGIS spatial queries to find ALL boundary polygons
+ * containing each POI (ordered smallest-first), then adds that context to search
+ * queries to eliminate geographic confusion
+ * (e.g., "Ledges Trail" → "Latest news for Ledges Trail in Cuyahoga Falls, Cuyahoga Valley National Park").
  *
  * Test results show 80-100% improvement in result relevance with geographic grounding.
  */
@@ -16,26 +17,28 @@ import fetch from 'node-fetch';
 
 
 /**
- * Search for news about a POI using Serper with geographic grounding
+ * Search for news or events about a POI using Serper with geographic grounding
  *
- * Returns direct URLs to external news coverage. These URLs should be rendered
+ * Returns direct URLs to external news/events coverage. These URLs should be rendered
  * with Playwright (same pipeline as official POI URLs) and processed by Gemini.
  *
- * Geographic grounding is applied automatically:
- * - POI in boundary: "${poi_name} ${boundary_name} news"
- * - POI outside boundaries: "${poi_name} news"
+ * Geographic grounding is applied automatically using ALL containing boundaries
+ * (ordered smallest area first):
+ * - POI in boundaries: "Latest news for ${poi_name} in ${b1}, ${b2}, ..."
+ * - POI outside boundaries: "Latest news for ${poi_name}"
  *
  * Test results:
  * - Without grounding: 0-20% relevant results (wrong cities/states)
  * - With grounding: 80-100% relevant results
- * - Average: 9.9 URLs per query, 52% include publication dates
  *
  * @param {Pool} pool - Database connection pool
- * @param {object} poi - POI object with id, name, latitude, longitude
+ * @param {object} poi - POI object with id, name, latitude, longitude, poi_roles
+ * @param {object} [options] - Options
+ * @param {string} [options.contentType='news'] - 'news' or 'events'
  * @returns {Promise<object>} - {query, grounded, groundingContext, urls[], credits}
  * @throws {Error} - If Serper API key not configured or API error
  */
-export async function searchNewsUrls(pool, poi) {
+export async function searchNewsUrls(pool, poi, { contentType = 'news' } = {}) {
   const apiKeyResult = await pool.query(
     "SELECT value FROM admin_settings WHERE key = 'serper_api_key'"
   );
@@ -45,16 +48,24 @@ export async function searchNewsUrls(pool, poi) {
   }
 
   const apiKey = apiKeyResult.rows[0].value;
+  const prefix = contentType === 'events' ? 'Upcoming events' : 'Latest news';
 
-  let context = '';
+  const maxResultsRow = await pool.query(
+    "SELECT value FROM admin_settings WHERE key = 'serper_max_results'"
+  );
+  const maxResults = maxResultsRow.rows.length
+    ? Math.min(10, Math.max(1, parseInt(maxResultsRow.rows[0].value, 10) || 3))
+    : 3;
+
+  let boundaries = [];
   try {
     const contextResult = await pool.query(`
       WITH poi_point AS (
         SELECT
           id,
           CASE
-            WHEN poi_type = 'point' AND geom IS NOT NULL THEN geom
-            WHEN poi_type IN ('trail', 'boundary', 'river') AND geometry IS NOT NULL THEN
+            WHEN 'point' = ANY(poi_roles) AND geom IS NOT NULL THEN geom
+            WHEN poi_roles && ARRAY['trail','boundary','river']::text[] AND geometry IS NOT NULL THEN
               ST_StartPoint(ST_GeometryN(ST_GeomFromGeoJSON(geometry::text), 1))
             ELSE NULL
           END as point_geom
@@ -64,21 +75,22 @@ export async function searchNewsUrls(pool, poi) {
       SELECT boundary.name
       FROM poi_point
       LEFT JOIN pois AS boundary
-        ON boundary.poi_type = 'boundary'
+        ON 'boundary' = ANY(boundary.poi_roles)
         AND boundary.boundary_geom IS NOT NULL
         AND ST_Contains(boundary.boundary_geom, poi_point.point_geom)
       WHERE poi_point.point_geom IS NOT NULL
       ORDER BY ST_Area(boundary.boundary_geom) ASC
-      LIMIT 1
     `, [poi.id]);
-    context = contextResult.rows[0]?.name || '';
+    boundaries = contextResult.rows.map(r => r.name).filter(Boolean);
   } catch (err) {
     console.warn(`[Serper] PostGIS grounding unavailable, using ungrounded search: ${err.message}`);
   }
 
+  const context = boundaries.join(', ');
+
   const query = context
-    ? `${poi.name} ${context} news`
-    : `${poi.name} news`;
+    ? `${prefix} for ${poi.name} in ${context}`
+    : `${prefix} for ${poi.name}`;
 
   console.log(`[Serper] Query: "${query}" (grounded: ${!!context})`);
 
@@ -88,7 +100,7 @@ export async function searchNewsUrls(pool, poi) {
       'X-API-KEY': apiKey,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ q: query })
+    body: JSON.stringify({ q: query, num: maxResults })
   });
 
   if (!response.ok) {
@@ -105,12 +117,13 @@ export async function searchNewsUrls(pool, poi) {
     date: r.date || null
   }));
 
-  console.log(`[Serper] Found ${urls.length} external news URLs (${urls.filter(u => u.date).length} with dates)`);
+  console.log(`[Serper] Found ${urls.length} external ${contentType} URLs (${urls.filter(u => u.date).length} with dates)`);
 
   return {
     query,
     grounded: !!context,
     groundingContext: context,
+    boundaries,
     urls,
     credits: searchResults.credits || 1
   };

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -451,7 +451,7 @@ export async function runTrailStatusCollection(pool, boss, options = {}) {
     let trails;
     if (poiIds && poiIds.length > 0) {
       const trailsQuery = await pool.query(`
-        SELECT id, name, poi_type, status_url, brief_description
+        SELECT id, name, poi_roles, status_url, brief_description
         FROM pois
         WHERE id = ANY($1)
         AND status_url IS NOT NULL
@@ -461,7 +461,7 @@ export async function runTrailStatusCollection(pool, boss, options = {}) {
       trails = trailsQuery.rows;
     } else {
       const trailsQuery = await pool.query(`
-        SELECT id, name, poi_type, status_url, brief_description
+        SELECT id, name, poi_roles, status_url, brief_description
         FROM pois
         WHERE status_url IS NOT NULL
         AND status_url != ''
@@ -583,7 +583,7 @@ export async function processTrailStatusCollectionJob(pool, jobId, poiIds, sheet
       onItemStart: async (poiId, { slotId, jobId: jid }) => {
         // Get trail data for slot assignment
         const poiResult = await pool.query(`
-          SELECT id, name, poi_type, status_url, brief_description
+          SELECT id, name, poi_roles, status_url, brief_description
           FROM pois WHERE id = $1
         `, [poiId]);
 
@@ -607,7 +607,7 @@ export async function processTrailStatusCollectionJob(pool, jobId, poiIds, sheet
       collectFn: async (poiId, { index, total }) => {
         // Get trail data
         const poiResult = await pool.query(`
-          SELECT id, name, poi_type, status_url, brief_description
+          SELECT id, name, poi_roles, status_url, brief_description
           FROM pois WHERE id = $1
         `, [poiId]);
 

--- a/backend/tests/database.integration.test.js
+++ b/backend/tests/database.integration.test.js
@@ -58,7 +58,7 @@ describe('Database Schema Tests', () => {
     const columns = result.rows.map(r => r.column_name);
     expect(columns).toContain('id');
     expect(columns).toContain('name');
-    expect(columns).toContain('poi_type');
+    expect(columns).toContain('poi_roles');
     expect(columns).toContain('latitude');
     expect(columns).toContain('longitude');
     expect(columns).toContain('events_url');
@@ -178,15 +178,15 @@ describe('PostGIS / Geographic Grounding Tests', () => {
     // columns being missing — both of which silently degrade to ungrounded
     // searches at runtime.
     await pool.query(`
-      INSERT INTO pois (name, poi_type, latitude, longitude, boundary_geom)
+      INSERT INTO pois (name, poi_roles, latitude, longitude, boundary_geom)
       VALUES (
-        '_test_boundary', 'boundary', 41.3, -81.6,
+        '_test_boundary', '{boundary}', 41.3, -81.6,
         ST_MakeEnvelope(-82.0, 41.0, -81.0, 41.6, 4326)
       )
     `);
     const testPoi = await pool.query(`
-      INSERT INTO pois (name, poi_type, latitude, longitude)
-      VALUES ('_test_point', 'point', 41.2, -81.5)
+      INSERT INTO pois (name, poi_roles, latitude, longitude)
+      VALUES ('_test_point', '{point}', 41.2, -81.5)
       RETURNING id
     `);
     const poiId = testPoi.rows[0].id;
@@ -197,8 +197,8 @@ describe('PostGIS / Geographic Grounding Tests', () => {
           SELECT
             id,
             CASE
-              WHEN poi_type = 'point' AND geom IS NOT NULL THEN geom
-              WHEN poi_type IN ('trail', 'boundary', 'river') AND geometry IS NOT NULL THEN
+              WHEN 'point' = ANY(poi_roles) AND geom IS NOT NULL THEN geom
+              WHEN poi_roles && ARRAY['trail','boundary','river']::text[] AND geometry IS NOT NULL THEN
                 ST_StartPoint(ST_GeometryN(ST_GeomFromGeoJSON(geometry::text), 1))
               ELSE NULL
             END as point_geom
@@ -208,12 +208,11 @@ describe('PostGIS / Geographic Grounding Tests', () => {
         SELECT boundary.name
         FROM poi_point
         LEFT JOIN pois AS boundary
-          ON boundary.poi_type = 'boundary'
+          ON 'boundary' = ANY(boundary.poi_roles)
           AND boundary.boundary_geom IS NOT NULL
           AND ST_Contains(boundary.boundary_geom, poi_point.point_geom)
         WHERE poi_point.point_geom IS NOT NULL
         ORDER BY ST_Area(boundary.boundary_geom) ASC
-        LIMIT 1
       `, [poiId]);
 
       // A point POI uses lat/lon, not geom, so grounding via geom column won't
@@ -228,9 +227,9 @@ describe('PostGIS / Geographic Grounding Tests', () => {
 describe('Database Query Tests', () => {
   it('should query POIs successfully', async () => {
     const result = await pool.query(`
-      SELECT id, name, poi_type, latitude, longitude
+      SELECT id, name, poi_roles, latitude, longitude
       FROM pois
-      WHERE poi_type = 'point'
+      WHERE 'point' = ANY(poi_roles)
       LIMIT 10
     `);
 
@@ -239,7 +238,7 @@ describe('Database Query Tests', () => {
     if (result.rows.length > 0) {
       expect(result.rows[0]).toHaveProperty('id');
       expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0].poi_type).toBe('point');
+      expect(result.rows[0].poi_roles).toContain('point');
     }
   });
 

--- a/backend/tests/fixtures/test-seed-data.sql
+++ b/backend/tests/fixtures/test-seed-data.sql
@@ -7,25 +7,25 @@
 --
 
 -- Insert 20 sample POIs for testing (alphabetically ordered for predictable tests)
-INSERT INTO pois (id, name, poi_type, latitude, longitude, brief_description, more_info_link) VALUES
-(1, 'Akron Hebrew Cemetery', 'point', 41.0850, -81.5150, 'Historic cemetery', 'https://example.com/cemetery'),
-(2, 'Boston Store', 'point', 41.2567, -81.5678, 'Visitor center', 'https://example.com/boston-store'),
-(3, 'Brandywine Falls', 'point', 41.2712, -81.5567, 'Beautiful waterfall', 'https://example.com/brandywine'),
-(4, 'Canal Exploration Center', 'point', 41.2456, -81.5234, 'Interactive museum', 'https://example.com/canal'),
-(5, 'Cuyahoga Valley Scenic Railroad', 'point', 41.2389, -81.5012, 'Historic train', 'https://example.com/railroad'),
-(6, 'Deep Lock Quarry', 'point', 41.2156, -81.5678, 'Historic quarry', 'https://example.com/quarry'),
-(7, 'Everett Covered Bridge', 'point', 41.2512, -81.5456, 'Covered bridge', 'https://example.com/bridge'),
-(8, 'Frazee House', 'point', 41.2789, -81.5345, 'Historic house', 'https://example.com/frazee'),
-(9, 'Happy Days Lodge', 'point', 41.2645, -81.5234, 'Visitor lodge', 'https://example.com/happy-days'),
-(10, 'Howe Meadow', 'point', 41.2534, -81.5567, 'Nature area', 'https://example.com/howe'),
-(11, 'Hunt Farm Visitor Center', 'point', 41.2678, -81.5123, 'Visitor center', 'https://example.com/hunt-farm'),
-(12, 'Indigo Lake', 'point', 41.2845, -81.5678, 'Scenic lake', 'https://example.com/indigo'),
-(13, 'Jaite Mill', 'point', 41.2412, -81.5345, 'Historic mill', 'https://example.com/jaite'),
-(14, 'Kendall Lake', 'point', 41.2567, -81.5456, 'Fishing lake', 'https://example.com/kendall'),
-(15, 'Lock 29', 'point', 41.2456, -81.5234, 'Canal lock', 'https://example.com/lock29'),
-(16, 'Beaver Marsh', 'point', 41.2389, -81.5567, 'Wetland area', 'https://example.com/beaver'),
-(17, 'Blue Hen Falls', 'point', 41.2712, -81.5012, 'Small waterfall', 'https://example.com/blue-hen'),
-(18, 'Bridal Veil Falls', 'point', 41.2845, -81.5678, 'Seasonal waterfall', 'https://example.com/bridal-veil'),
-(19, 'Station Road Bridge', 'point', 41.2534, -81.5345, 'Historic bridge', 'https://example.com/station-road'),
-(20, 'Trail Mix', 'point', 41.2678, -81.5123, 'Trail junction', 'https://example.com/trail-mix')
+INSERT INTO pois (id, name, poi_roles, latitude, longitude, brief_description, more_info_link) VALUES
+(1, 'Akron Hebrew Cemetery', '{point}', 41.0850, -81.5150, 'Historic cemetery', 'https://example.com/cemetery'),
+(2, 'Boston Store', '{point}', 41.2567, -81.5678, 'Visitor center', 'https://example.com/boston-store'),
+(3, 'Brandywine Falls', '{point}', 41.2712, -81.5567, 'Beautiful waterfall', 'https://example.com/brandywine'),
+(4, 'Canal Exploration Center', '{point}', 41.2456, -81.5234, 'Interactive museum', 'https://example.com/canal'),
+(5, 'Cuyahoga Valley Scenic Railroad', '{point}', 41.2389, -81.5012, 'Historic train', 'https://example.com/railroad'),
+(6, 'Deep Lock Quarry', '{point}', 41.2156, -81.5678, 'Historic quarry', 'https://example.com/quarry'),
+(7, 'Everett Covered Bridge', '{point}', 41.2512, -81.5456, 'Covered bridge', 'https://example.com/bridge'),
+(8, 'Frazee House', '{point}', 41.2789, -81.5345, 'Historic house', 'https://example.com/frazee'),
+(9, 'Happy Days Lodge', '{point}', 41.2645, -81.5234, 'Visitor lodge', 'https://example.com/happy-days'),
+(10, 'Howe Meadow', '{point}', 41.2534, -81.5567, 'Nature area', 'https://example.com/howe'),
+(11, 'Hunt Farm Visitor Center', '{point}', 41.2678, -81.5123, 'Visitor center', 'https://example.com/hunt-farm'),
+(12, 'Indigo Lake', '{point}', 41.2845, -81.5678, 'Scenic lake', 'https://example.com/indigo'),
+(13, 'Jaite Mill', '{point}', 41.2412, -81.5345, 'Historic mill', 'https://example.com/jaite'),
+(14, 'Kendall Lake', '{point}', 41.2567, -81.5456, 'Fishing lake', 'https://example.com/kendall'),
+(15, 'Lock 29', '{point}', 41.2456, -81.5234, 'Canal lock', 'https://example.com/lock29'),
+(16, 'Beaver Marsh', '{point}', 41.2389, -81.5567, 'Wetland area', 'https://example.com/beaver'),
+(17, 'Blue Hen Falls', '{point}', 41.2712, -81.5012, 'Small waterfall', 'https://example.com/blue-hen'),
+(18, 'Bridal Veil Falls', '{point}', 41.2845, -81.5678, 'Seasonal waterfall', 'https://example.com/bridal-veil'),
+(19, 'Station Road Bridge', '{point}', 41.2534, -81.5345, 'Historic bridge', 'https://example.com/station-road'),
+(20, 'Trail Mix', '{point}', 41.2678, -81.5123, 'Trail junction', 'https://example.com/trail-mix')
 ON CONFLICT (id) DO NOTHING;

--- a/backend/tests/serperService.unit.test.js
+++ b/backend/tests/serperService.unit.test.js
@@ -18,10 +18,11 @@ describe('Serper Service', () => {
       id: 123,
       name: 'Ledges Trail',
       latitude: 41.2415,
-      longitude: -81.5156
+      longitude: -81.5156,
+      poi_roles: ['trail']
     };
 
-    it('should construct grounded query when POI is in a boundary', async () => {
+    it('should construct grounded query with single boundary', async () => {
       const mockPool = {
         query: vi.fn()
           .mockResolvedValueOnce({
@@ -45,9 +46,10 @@ describe('Serper Service', () => {
 
       const result = await searchNewsUrls(mockPool, mockPoi);
 
-      expect(result.query).toBe('Ledges Trail Cuyahoga Valley National Park news');
+      expect(result.query).toBe('Latest news for Ledges Trail in Cuyahoga Valley National Park');
       expect(result.grounded).toBe(true);
       expect(result.groundingContext).toBe('Cuyahoga Valley National Park');
+      expect(result.boundaries).toEqual(['Cuyahoga Valley National Park']);
       expect(result.urls).toHaveLength(2);
       expect(result.urls[0].url).toBe('https://example.com/news1');
       expect(result.urls[0].date).toBe('2026-04-01');
@@ -62,9 +64,82 @@ describe('Serper Service', () => {
             'X-API-KEY': 'test-api-key-123',
             'Content-Type': 'application/json'
           }),
-          body: JSON.stringify({ q: 'Ledges Trail Cuyahoga Valley National Park news' })
+          body: JSON.stringify({ q: 'Latest news for Ledges Trail in Cuyahoga Valley National Park', num: 3 })
         })
       );
+    });
+
+    it('should construct multi-boundary grounded query (smallest area first)', async () => {
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({
+            rows: [{ value: 'test-api-key-123' }]
+          })
+          .mockResolvedValueOnce({
+            rows: [
+              { name: 'Cuyahoga Falls' },
+              { name: 'Cuyahoga Valley National Park' }
+            ]
+          })
+      };
+
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          organic: [
+            { link: 'https://example.com/news1', title: 'News 1', snippet: 'Snippet 1' }
+          ],
+          credits: 1
+        })
+      });
+
+      const result = await searchNewsUrls(mockPool, mockPoi);
+
+      expect(result.query).toBe('Latest news for Ledges Trail in Cuyahoga Falls, Cuyahoga Valley National Park');
+      expect(result.grounded).toBe(true);
+      expect(result.boundaries).toEqual(['Cuyahoga Falls', 'Cuyahoga Valley National Park']);
+    });
+
+    it('should use events prefix when contentType is events', async () => {
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({
+            rows: [{ value: 'test-api-key-123' }]
+          })
+          .mockResolvedValueOnce({
+            rows: [{ name: 'Cuyahoga Valley National Park' }]
+          })
+      };
+
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          organic: [{ link: 'https://example.com/event1', title: 'Event 1', snippet: 'Snippet 1' }],
+          credits: 1
+        })
+      });
+
+      const result = await searchNewsUrls(mockPool, mockPoi, { contentType: 'events' });
+
+      expect(result.query).toBe('Upcoming events for Ledges Trail in Cuyahoga Valley National Park');
+    });
+
+    it('should include num: 3 in Serper API call body', async () => {
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({ rows: [{ value: 'test-api-key-123' }] })
+          .mockResolvedValueOnce({ rows: [] })
+      };
+
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ organic: [], credits: 1 })
+      });
+
+      await searchNewsUrls(mockPool, mockPoi);
+
+      const callBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(callBody.num).toBe(3);
     });
 
     it('should construct ungrounded query when POI is outside boundaries', async () => {
@@ -84,9 +159,37 @@ describe('Serper Service', () => {
 
       const result = await searchNewsUrls(mockPool, mockPoi);
 
-      expect(result.query).toBe('Ledges Trail news');
+      expect(result.query).toBe('Latest news for Ledges Trail');
       expect(result.grounded).toBe(false);
       expect(result.groundingContext).toBe('');
+      expect(result.boundaries).toEqual([]);
+    });
+
+    it('should use role-based geometry detection (poi_roles not poi_type)', async () => {
+      const pointPoi = {
+        id: 456,
+        name: 'Happy Days Visitor Center',
+        poi_roles: ['point']
+      };
+
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({ rows: [{ value: 'test-api-key-123' }] })
+          .mockResolvedValueOnce({ rows: [{ name: 'Cuyahoga Valley National Park' }] })
+      };
+
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ organic: [], credits: 1 })
+      });
+
+      const result = await searchNewsUrls(mockPool, pointPoi);
+
+      // Verify the boundary query used poi_roles check (not poi_type)
+      const boundaryQueryCall = mockPool.query.mock.calls[1][0];
+      expect(boundaryQueryCall).toContain("'point' = ANY(poi_roles)");
+      expect(boundaryQueryCall).toContain("'boundary' = ANY(boundary.poi_roles)");
+      expect(boundaryQueryCall).not.toContain('poi_type');
     });
 
     it('should throw error when API key not configured', async () => {

--- a/backend/tests/trailStatus.integration.test.js
+++ b/backend/tests/trailStatus.integration.test.js
@@ -64,15 +64,15 @@ describe('Trail Status Integration Tests', () => {
     console.log(`[Test Setup] Inserted Twitter cookies for authenticated access`);
 
     // Remove any existing East Rim trails (including variations) to ensure clean state
-    await pool.query(`DELETE FROM pois WHERE name LIKE '%East Rim%' AND poi_type = 'trail'`);
+    await pool.query(`DELETE FROM pois WHERE name LIKE '%East Rim%' AND 'trail' = ANY(poi_roles)`);
     console.log(`[Test Setup] Removed any existing East Rim trail entries`);
 
     // Insert East Rim Trail with explicit ID (avoids sequence conflicts from seed data)
     const maxId = await pool.query(`SELECT COALESCE(MAX(id), 0) as max_id FROM pois`);
     const nextId = maxId.rows[0].max_id + 1;
     await pool.query(`
-      INSERT INTO pois (id, name, poi_type, status_url, brief_description, latitude, longitude)
-      VALUES ($1, $2, 'trail', $3, 'MTB trail system in Cuyahoga Valley National Park', 41.2275, -81.5558)
+      INSERT INTO pois (id, name, poi_roles, status_url, brief_description, latitude, longitude)
+      VALUES ($1, $2, '{trail}', $3, 'MTB trail system in Cuyahoga Valley National Park', 41.2275, -81.5558)
     `, [nextId, EAST_RIM_NAME, EAST_RIM_STATUS_URL]);
     console.log(`[Test Setup] Created ${EAST_RIM_NAME} (id=${nextId}) with status_url: ${EAST_RIM_STATUS_URL}`);
 
@@ -127,9 +127,9 @@ describe('Trail Status Integration Tests', () => {
   describe('East Rim Trail Configuration', () => {
     it('should have East Rim Trail in the database', async () => {
       const result = await pool.query(`
-        SELECT id, name, status_url, poi_type
+        SELECT id, name, status_url, poi_roles
         FROM pois
-        WHERE name = $1 AND poi_type = 'trail'
+        WHERE name = $1 AND 'trail' = ANY(poi_roles)
       `, [EAST_RIM_NAME]);
 
       expect(result.rows.length).toBe(1);
@@ -140,7 +140,7 @@ describe('Trail Status Integration Tests', () => {
       const result = await pool.query(`
         SELECT id, name, status_url
         FROM pois
-        WHERE name = $1 AND poi_type = 'trail'
+        WHERE name = $1 AND 'trail' = ANY(poi_roles)
       `, [EAST_RIM_NAME]);
 
       expect(result.rows.length).toBe(1);
@@ -281,7 +281,7 @@ describe('Trail Status Integration Tests', () => {
     it.skipIf(!process.env.GEMINI_API_KEY)('should collect status for East Rim Trail via AI', async () => {
       // Get East Rim Trail
       const poiResult = await pool.query(`
-        SELECT id, name, poi_type, status_url, brief_description
+        SELECT id, name, poi_roles, status_url, brief_description
         FROM pois
         WHERE name = $1
       `, [EAST_RIM_NAME]);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1324,7 +1324,6 @@ function AppContent() {
       more_info_link: '',
       events_url: '',
       news_url: '',
-      poi_type: 'point',
       poi_roles: ['organization'],
       _poisInBounds: poisInBounds,
       _selectedPoiIds: new Set(poisInBounds.map(p => p.id))
@@ -1370,7 +1369,6 @@ function AppContent() {
         brief_description: organizationData.brief_description,
         property_owner: organizationData.property_owner,
         more_info_link: organizationData.more_info_link,
-        poi_type: 'point',
         poi_roles: ['organization']
       })
     });
@@ -1912,7 +1910,7 @@ function AppContent() {
             setCurrentMtbIndex(newIndex);
 
             // Select the next/previous trail
-            if (nextTrail.poi_roles?.includes('point') || nextTrail.poi_type === 'point') {
+            if (nextTrail.poi_roles?.includes('point')) {
               const fullDestination = destinations?.find(d => d.id === nextTrail.id);
               if (fullDestination) {
                 setSelectedDestination(fullDestination);

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -461,7 +461,7 @@ const ResultsTab = memo(function ResultsTab({
                 {activeSubTab === 'mtb'
                   ? 'Configure status_url on trails to enable status tracking.'
                   : activeSubTab === 'organizations'
-                  ? 'Create virtual POIs with poi_type="organization" to add organizations.'
+                  ? 'Create POIs with poi_roles including "organization" to add organizations.'
                   : 'Try zooming out or panning to see more locations.'}
               </div>
             </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -226,7 +226,7 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
             <span className="poi-type-badge virtual">
               Organization
             </span>
-          ) : destination.poi_type === 'point' && destination.status_url ? (
+          ) : destination.poi_roles?.includes('point') && destination.status_url ? (
             <span className="poi-type-badge mtb">
               MTB Trailhead
             </span>
@@ -3562,11 +3562,11 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         ) : media.length > 0 ? (
           <Mosaic media={media} poiId={destination?.id} user={user} onMediaUpdate={handleMediaUpdate} />
         ) : !mediaLoading && destination?.has_primary_image ? (
-          <div className={`sidebar-image ${destination?.poi_type === 'virtual' ? 'virtual-thumbnail' : ''}`}>
+          <div className={`sidebar-image ${destination?.poi_roles?.includes('organization') ? 'virtual-thumbnail' : ''}`}>
             <img
               src={`/api/pois/${destination.id}/thumbnail?size=medium&v=${destination.updated_at || Date.now()}`}
               alt={destination?.name}
-              className={destination?.poi_type === 'virtual' ? 'logo-image' : ''}
+              className={destination?.poi_roles?.includes('organization') ? 'logo-image' : ''}
               onError={(e) => {
                 e.target.style.display = 'none';
                 e.target.parentElement.style.display = 'none';

--- a/frontend/src/components/StatusTab.jsx
+++ b/frontend/src/components/StatusTab.jsx
@@ -153,7 +153,7 @@ const StatusTab = memo(function StatusTab({
     };
 
     // Handle both point POIs and linear features
-    if (trail.poi_roles?.includes('point') || trail.poi_type === 'point') {
+    if (trail.poi_roles?.includes('point')) {
       // Find the full destination object
       const fullDestination = destinations?.find(d => d.id === trail.id);
       if (fullDestination) {


### PR DESCRIPTION
## Summary

- **Multi-boundary grounding**: Serper queries now include all containing geographic boundaries smallest→largest: `"Latest news for Beaver Marsh in Cuyahoga Falls, Cuyahoga Valley National Park"`
- **Events Phase II**: Events now get their own Serper search (`"Upcoming events for ..."`) — previously only news had external search
- **Serper results capped at 3**: Configurable via `serper_max_results` admin setting (default 3)
- **Role-based collection filter**: Skips trail and boundary POIs entirely — only `point`, `organization`, and `river` POIs get Serper searches (226 POIs vs 411 previously)
- **`poi_type` column removed**: All logic now uses `poi_roles` array. Migration 025 renames `virtual`→`organization`, migration 026 drops `poi_type` column

## Test plan
- [ ] All 270 tests pass
- [ ] Collection run completes in significantly less time than 92 minutes
- [ ] Serper queries in logs show multi-boundary format
- [ ] Events show up from Serper results
- [ ] Trail and boundary POIs show `Skipping: no collectible role` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)