### PR TITLE
fix: rename news_max_concurrency to max_concurrency

### DIFF
--- a/backend/migrations/027_rename_max_concurrency.sql
+++ b/backend/migrations/027_rename_max_concurrency.sql
@@ -1,0 +1,7 @@
+-- Migration 027: Rename news_max_concurrency to max_concurrency
+-- The concurrency setting applies to all collection runs (news, events, both),
+-- not just news. Rename the key to reflect this.
+
+UPDATE admin_settings
+SET key = 'max_concurrency'
+WHERE key = 'news_max_concurrency';

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -479,7 +479,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'results_subtabs_config',
       'buttondown_api_key',
       'buttondown_from_email',
-      'news_max_concurrency',
+      'max_concurrency',
       'max_search_urls'
     ];
     if (!allowedKeys.includes(key)) {

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1405,7 +1405,7 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
 
   // Read max concurrency from admin_settings at job start (falls back to module constant)
   const concurrencyResult = await pool.query(
-    "SELECT value FROM admin_settings WHERE key = 'news_max_concurrency'"
+    "SELECT value FROM admin_settings WHERE key = 'max_concurrency'"
   );
   const maxConcurrency = (() => {
     if (!concurrencyResult.rows.length) return MAX_CONCURRENCY;

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -500,7 +500,7 @@ function DataCollectionSettings() {
       const response = await fetch('/api/admin/settings', { credentials: 'include' });
       if (response.ok) {
         const settings = await response.json();
-        const val = parseInt(settings.news_max_concurrency?.value, 10);
+        const val = parseInt(settings.max_concurrency?.value, 10);
         setMaxConcurrency(Number.isFinite(val) && val >= 1 ? val : 10);
       }
     } catch (err) { console.error('Error fetching max concurrency:', err); }
@@ -510,7 +510,7 @@ function DataCollectionSettings() {
   const handleSaveMaxConcurrency = async () => {
     setMaxConcurrencySaving(true); setResult(null);
     try {
-      const response = await fetch('/api/admin/settings/news_max_concurrency', {
+      const response = await fetch('/api/admin/settings/max_concurrency', {
         method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
         body: JSON.stringify({ value: String(maxConcurrency) })
       });
@@ -1009,14 +1009,14 @@ function DataCollectionSettings() {
         )}
       </div>
 
-      {/* News Collection Concurrency */}
+      {/* Collection Concurrency */}
       <div className="ai-config-section">
-        <h4>News Collection Concurrency</h4>
-        <p className="settings-description">Maximum number of POIs processed simultaneously during a batch news collection run. Higher values finish faster but use more memory (each concurrent POI runs a browser context). Recommended: 5–10.</p>
+        <h4>MAX_CONCURRENCY — Collection Concurrency</h4>
+        <p className="settings-description">How many POIs run concurrently during a collection job (news, events, or both). Each slot opens a browser context — higher values finish faster but use more memory. Range: 1–50, default: 10.</p>
         {maxConcurrencyLoading ? <p>Loading...</p> : (
           <>
             <div className="config-row">
-              <label>Max Concurrent POIs</label>
+              <label>MAX_CONCURRENCY</label>
               <input
                 type="number"
                 min="1"
@@ -1029,7 +1029,7 @@ function DataCollectionSettings() {
               <span className="config-hint">Range: 1–50 (default: 10)</span>
             </div>
             <button className="action-btn primary" onClick={handleSaveMaxConcurrency} disabled={maxConcurrencySaving}>
-              {maxConcurrencySaving ? 'Saving...' : 'Save Concurrency'}
+              {maxConcurrencySaving ? 'Saving...' : 'Save'}
             </button>
           </>
         )}
@@ -1037,12 +1037,12 @@ function DataCollectionSettings() {
 
       {/* Max Serper URLs */}
       <div className="ai-config-section">
-        <h4>Serper URL Limit (Phase II)</h4>
-        <p className="settings-description">Maximum number of external Serper search result URLs crawled per POI during Phase II of all collection runs (news, events, and both). Serper returns up to 10 results by default; higher values require a paid Serper plan. Recommended: 5–10.</p>
+        <h4>MAX_SEARCH_URLS — Phase II URL Crawl Limit</h4>
+        <p className="settings-description">How many Serper search result URLs are crawled per POI during Phase II (runs for all collection types). Serper returns up to 10 results; raise this only if you have a paid Serper plan. Range: 1–20, default: 10.</p>
         {maxSearchUrlsLoading ? <p>Loading...</p> : (
           <>
             <div className="config-row">
-              <label>Max Serper URLs</label>
+              <label>MAX_SEARCH_URLS</label>
               <input
                 type="number"
                 min="1"
@@ -1055,7 +1055,7 @@ function DataCollectionSettings() {
               <span className="config-hint">Range: 1–20 (default: 10)</span>
             </div>
             <button className="action-btn primary" onClick={handleSaveMaxSearchUrls} disabled={maxSearchUrlsSaving}>
-              {maxSearchUrlsSaving ? 'Saving...' : 'Save Serper URL Limit'}
+              {maxSearchUrlsSaving ? 'Saving...' : 'Save'}
             </button>
           </>
         )}


### PR DESCRIPTION
## Summary
- Rename `news_max_concurrency` → `max_concurrency` in DB key, backend query, admin whitelist, and frontend
- Update admin UI to use canonical variable names (MAX_CONCURRENCY, MAX_SEARCH_URLS) with accurate descriptions
- Add migration 027 to rename the existing production row

## Test plan
- [x] All 270 tests pass
- [x] Gourmand: 0 violations
- [ ] Gemini code review
- [ ] Verify admin UI labels in browser after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)