### PR TITLE
fix: read job schedules from pg-boss instead of hardcoded registry

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4450,14 +4450,20 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       const boss = getJobScheduler();
 
       const jobs = await Promise.all(COLLECTION_TYPES.map(async (type) => {
-        // Get current schedule from admin_settings (overrides default)
-        const schedResult = await pool.query(
-          'SELECT value FROM admin_settings WHERE key = $1',
-          [`schedule_${type.scheduleJobName}`]
-        );
-        const currentSchedule = schedResult.rows.length > 0
-          ? schedResult.rows[0].value
-          : type.schedule;
+        // Read the actual schedule from pg-boss — single source of truth.
+        // Falls back to registry default only for jobs without a pg-boss schedule.
+        let currentSchedule = type.schedule;
+        if (type.scheduleJobName) {
+          try {
+            const pgbossResult = await pool.query(
+              'SELECT cron FROM pgboss.schedule WHERE name = $1',
+              [type.scheduleJobName]
+            );
+            if (pgbossResult.rows.length > 0) {
+              currentSchedule = pgbossResult.rows[0].cron;
+            }
+          } catch { /* pgboss.schedule may not exist on first boot */ }
+        }
 
         // Get queue size
         let queueSize = 0;

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -52,7 +52,7 @@ export const COLLECTION_TYPES = [
     icon: '\u{1F50D}',
     promptKeys: [],
     scheduleJobName: 'content-moderation-sweep',
-    schedule: '*/15 * * * *',
+    schedule: '0 7 * * *',
     statusTable: null,
     historyTypes: ['moderation'],
     triggerEndpoint: '/api/admin/moderation/sweep',

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -353,10 +353,10 @@ export async function queueModerationJob(contentType, contentId) {
 }
 
 /**
- * Schedule the moderation sweep job (every 15 minutes)
+ * Schedule the moderation sweep job (daily at 7 AM after news collection)
  * @param {string} cronExpression - Cron expression
  */
-export async function scheduleModerationSweep(cronExpression = '*/15 * * * *') {
+export async function scheduleModerationSweep(cronExpression = '0 7 * * *') {
   const scheduler = getJobScheduler();
 
   await scheduler.schedule(JOB_NAMES.CONTENT_MODERATION_SWEEP, cronExpression, {}, {


### PR DESCRIPTION
## Summary

- Jobs UI was showing stale schedule from `registry.js` instead of the actual pg-boss cron
- Now reads directly from `pgboss.schedule` table — the single source of truth
- Also fixed moderation sweep defaults from `*/15 * * * *` to `0 7 * * *`

## Test plan
- [ ] Verify moderation sweep shows `0 7 * * *` in the Jobs dashboard
- [ ] Change a schedule in the UI, verify it persists and displays correctly after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)