### PR TITLE
fix: add watchdog to browser pool for hung acquisitions

### DIFF
--- a/backend/services/browserPool.js
+++ b/backend/services/browserPool.js
@@ -17,6 +17,9 @@
  *
  * Idle behaviour: the browser closes 30 s after the last context is
  * released, freeing memory between collection runs.
+ *
+ * Watchdog: 90 s per-acquisition timeout force-kills the browser if
+ * releaseBrowser() is never called (above jsRenderer's 60 s hard timeout).
  */
 
 import { chromium } from 'playwright';
@@ -25,6 +28,10 @@ let sharedBrowser = null;
 let browserRefCount = 0;
 let browserCloseTimer = null;
 let launchPromise = null; // Prevents concurrent launches (race condition fix)
+
+const WATCHDOG_TIMEOUT_MS = 90_000;
+const watchdogTimers = new Map(); // acquisitionId → timeoutId
+let nextAcquisitionId = 0;
 
 const LAUNCH_OPTIONS = {
   headless: true,
@@ -39,9 +46,7 @@ const LAUNCH_OPTIONS = {
 };
 
 /**
- * Acquire the shared browser, launching it if not running.
- * Every call must be paired with releaseBrowser().
- * @returns {Promise<import('playwright').Browser>}
+ * @returns {Promise<{browser: import('playwright').Browser, acquisitionId: number}>}
  */
 export async function acquireBrowser() {
   if (browserCloseTimer) {
@@ -61,14 +66,38 @@ export async function acquireBrowser() {
     await launchPromise;
   }
   browserRefCount++;
-  return sharedBrowser;
+
+  const id = nextAcquisitionId++;
+  const timer = setTimeout(async () => {
+    console.error(`[BrowserPool] Watchdog: acquisition ${id} held browser for >${WATCHDOG_TIMEOUT_MS / 1000}s without release — force-killing (refCount was ${browserRefCount})`);
+    watchdogTimers.delete(id);
+    const browser = sharedBrowser;
+    sharedBrowser = null;
+    browserRefCount = 0;
+    launchPromise = null;
+    if (browserCloseTimer) {
+      clearTimeout(browserCloseTimer);
+      browserCloseTimer = null;
+    }
+    for (const [, t] of watchdogTimers) clearTimeout(t);
+    watchdogTimers.clear();
+    if (browser) await browser.close().catch(() => {});
+  }, WATCHDOG_TIMEOUT_MS);
+  watchdogTimers.set(id, timer);
+
+  return { browser: sharedBrowser, acquisitionId: id };
 }
 
 /**
  * Release a browser reference acquired with acquireBrowser().
  * Schedules the browser to close after 30 s of full idle.
+ * @param {number} [acquisitionId] - The id returned by acquireBrowser(). Clears the watchdog.
  */
-export function releaseBrowser() {
+export function releaseBrowser(acquisitionId) {
+  if (acquisitionId != null && watchdogTimers.has(acquisitionId)) {
+    clearTimeout(watchdogTimers.get(acquisitionId));
+    watchdogTimers.delete(acquisitionId);
+  }
   browserRefCount--;
   if (browserRefCount < 0) {
     console.error('[BrowserPool] BUG: releaseBrowser() called more times than acquireBrowser() — resetting to 0');

--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -62,6 +62,7 @@ export async function extractPageContent(url, options = {}) {
 
   let context = null;
   let hardTimeoutId;
+  let acquisitionId = null;
 
   try {
     const hardTimeoutPromise = new Promise((_, reject) => {
@@ -71,7 +72,9 @@ export async function extractPageContent(url, options = {}) {
     });
 
     const extractionPromise = (async () => {
-      const browser = await acquireBrowser();
+      const acquired = await acquireBrowser();
+      const browser = acquired.browser;
+      acquisitionId = acquired.acquisitionId;
 
       context = await browser.newContext({
         ...STEALTH_CONTEXT,
@@ -231,7 +234,7 @@ export async function extractPageContent(url, options = {}) {
 
       await context.close();
       context = null;
-      releaseBrowser();
+      releaseBrowser(acquisitionId);
 
       const dom = new JSDOM(html, { url });
       const reader = new Readability(dom.window.document, {
@@ -283,7 +286,7 @@ export async function extractPageContent(url, options = {}) {
     clearTimeout(hardTimeoutId);
     if (context) {
       await context.close().catch(() => {});
-      releaseBrowser();
+      releaseBrowser(acquisitionId);
     }
   }
 }

--- a/backend/services/jsRenderer.js
+++ b/backend/services/jsRenderer.js
@@ -200,9 +200,9 @@ export async function renderJavaScriptPage(url, options = {}) {
 
   console.log(`[JS Renderer] Acquiring browser context for: ${url}`);
 
-  // Track the BrowserContext for cleanup on hard timeout.
+  // Track the BrowserContext and acquisitionId for cleanup on hard timeout.
   // We close only the context, never the shared browser process.
-  let contextRef = { context: null };
+  let contextRef = { context: null, acquisitionId: null };
   let hardTimeoutId;
   let isTimedOut = false;
 
@@ -214,7 +214,7 @@ export async function renderJavaScriptPage(url, options = {}) {
       if (contextRef.context) {
         try {
           await contextRef.context.close();
-          releaseBrowser();
+          releaseBrowser(contextRef.acquisitionId);
           console.log(`[JS Renderer] ✓ Context force-closed after hard timeout`);
         } catch (closeError) {
           console.error(`[JS Renderer] Failed to force-close context: ${closeError.message}`);
@@ -255,7 +255,7 @@ export async function renderJavaScriptPage(url, options = {}) {
     if (isTimedOut && contextRef.context) {
       try {
         await contextRef.context.close();
-        releaseBrowser();
+        releaseBrowser(contextRef.acquisitionId);
       } catch (e) {
         // Ignore - context may already be closed
       }
@@ -271,7 +271,8 @@ async function renderJavaScriptPageInternal(url, options) {
 
   let context = null;
   try {
-    const browser = await acquireBrowser();
+    const { browser, acquisitionId } = await acquireBrowser();
+    contextRef.acquisitionId = acquisitionId;
 
     context = await browser.newContext({
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
@@ -510,7 +511,7 @@ async function renderJavaScriptPageInternal(url, options) {
     console.log(`[JS Renderer]   Found ${content.links.length} links on page`);
 
     await context.close();
-    releaseBrowser();
+    releaseBrowser(contextRef.acquisitionId);
 
     return {
       ...content,
@@ -522,7 +523,7 @@ async function renderJavaScriptPageInternal(url, options) {
 
     if (context) {
       await context.close().catch(() => {});
-      releaseBrowser();
+      releaseBrowser(contextRef.acquisitionId);
     }
 
     return {


### PR DESCRIPTION
## Summary
- Add 90s per-acquisition watchdog timeout to `browserPool.js`
- If `releaseBrowser()` is never called within 90s, force-kill the browser process and reset all state
- Prevents hung renders from leaking the Chromium process indefinitely
- Updated `jsRenderer.js` and `contentExtractor.js` to pass `acquisitionId` through acquire/release cycle

## Test plan
- [x] 292 tests pass, 1 skipped
- [x] Gourmand: 0 new violations (17 pre-existing)
- [ ] Gemini code review
- [ ] Monitor production for watchdog log messages after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)