### PR TITLE
refactor: replace date_confidence with date_consensus_score

### DIFF
--- a/backend/migrations/028_replace_date_confidence.sql
+++ b/backend/migrations/028_replace_date_confidence.sql
@@ -1,0 +1,27 @@
+-- Migration 028: Replace date_confidence with date_consensus_score
+--
+-- date_confidence was a text label (exact/estimated/unknown) that lossy-bucketed
+-- the numeric consensus score from the date extraction pipeline. Now we store
+-- the raw integer score (0-8) directly so the moderation sweep can use it
+-- for auto-approve decisions without re-rendering pages.
+
+-- 1. Add date_consensus_score to poi_news and poi_events
+ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS date_consensus_score INTEGER DEFAULT 0;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS date_consensus_score INTEGER DEFAULT 0;
+
+-- 2. Backfill from existing date_confidence
+UPDATE poi_news SET date_consensus_score = CASE
+  WHEN date_confidence = 'exact' THEN 6
+  WHEN date_confidence = 'estimated' THEN 2
+  ELSE 0
+END WHERE date_consensus_score = 0 OR date_consensus_score IS NULL;
+
+UPDATE poi_events SET date_consensus_score = CASE
+  WHEN date_confidence = 'exact' THEN 6
+  WHEN date_confidence = 'estimated' THEN 2
+  ELSE 0
+END WHERE date_consensus_score = 0 OR date_consensus_score IS NULL;
+
+-- 3. Drop the vestigial date_confidence column
+ALTER TABLE poi_news DROP COLUMN IF EXISTS date_confidence;
+ALTER TABLE poi_events DROP COLUMN IF EXISTS date_confidence;

--- a/backend/migrations/028_replace_date_confidence.sql
+++ b/backend/migrations/028_replace_date_confidence.sql
@@ -22,6 +22,19 @@ UPDATE poi_events SET date_consensus_score = CASE
   ELSE 0
 END WHERE date_consensus_score = 0 OR date_consensus_score IS NULL;
 
--- 3. Drop the vestigial date_confidence column
+-- 3. Add CHECK constraint for valid score range (0-8)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_news_date_score_range') THEN
+        ALTER TABLE poi_news ADD CONSTRAINT chk_news_date_score_range
+            CHECK (date_consensus_score >= 0 AND date_consensus_score <= 8);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_events_date_score_range') THEN
+        ALTER TABLE poi_events ADD CONSTRAINT chk_events_date_score_range
+            CHECK (date_consensus_score >= 0 AND date_consensus_score <= 8);
+    END IF;
+END $$;
+
+-- 4. Drop the vestigial date_confidence column
 ALTER TABLE poi_news DROP COLUMN IF EXISTS date_confidence;
 ALTER TABLE poi_events DROP COLUMN IF EXISTS date_confidence;

--- a/backend/server.js
+++ b/backend/server.js
@@ -777,7 +777,7 @@ async function initDatabase() {
     await client.query(`ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS submitted_by INTEGER REFERENCES users(id)`);
     await client.query(`ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS weekly_newsletter BOOLEAN DEFAULT FALSE`);
     await client.query(`ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS publication_date DATE`);
-    await client.query(`ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS date_confidence VARCHAR(10) DEFAULT 'unknown'`);
+    await client.query(`ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS date_consensus_score INTEGER DEFAULT 0`);
     await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_news_moderation ON poi_news(moderation_status)`);
 
     // Moderation columns on poi_events
@@ -790,7 +790,7 @@ async function initDatabase() {
     await client.query(`ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS submitted_by INTEGER REFERENCES users(id)`);
     await client.query(`ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS weekly_newsletter BOOLEAN DEFAULT FALSE`);
     await client.query(`ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS publication_date DATE`);
-    await client.query(`ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS date_confidence VARCHAR(10) DEFAULT 'unknown'`);
+    await client.query(`ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS date_consensus_score INTEGER DEFAULT 0`);
     await client.query(`CREATE INDEX IF NOT EXISTS idx_poi_events_moderation ON poi_events(moderation_status)`);
 
     // Photo submissions table
@@ -821,19 +821,19 @@ async function initDatabase() {
         SELECT id, 'news' AS content_type, poi_id, title, summary AS description,
                moderation_status, confidence_score, ai_reasoning,
                submitted_by, moderated_by, moderated_at, collection_date AS created_at,
-               content_source, publication_date, date_confidence
+               content_source, publication_date, date_consensus_score
         FROM poi_news WHERE moderation_status = 'pending'
         UNION ALL
         SELECT id, 'event' AS content_type, poi_id, title, description,
                moderation_status, confidence_score, ai_reasoning,
                submitted_by, moderated_by, moderated_at, collection_date AS created_at,
-               content_source, publication_date, date_confidence
+               content_source, publication_date, date_consensus_score
         FROM poi_events WHERE moderation_status = 'pending'
         UNION ALL
         SELECT id, 'photo' AS content_type, poi_id, original_filename AS title, caption AS description,
                moderation_status, confidence_score, ai_reasoning,
                submitted_by, moderated_by, moderated_at, created_at,
-               NULL AS content_source, NULL::DATE AS publication_date, NULL::VARCHAR(10) AS date_confidence
+               NULL AS content_source, NULL::DATE AS publication_date, 0 AS date_consensus_score
         FROM photo_submissions WHERE moderation_status = 'pending'
         ORDER BY created_at DESC
     `);
@@ -1922,7 +1922,7 @@ app.get('/api/pois/:id/news', async (req, res) => {
     const limit = parseInt(req.query.limit) || 50;
     const newsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
-             n.publication_date, n.date_confidence, n.collection_date,
+             n.publication_date, n.date_consensus_score, n.collection_date,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
       LEFT JOIN poi_news_urls u ON u.news_id = n.id
@@ -2112,7 +2112,7 @@ app.get('/api/news/recent', async (req, res) => {
     const limit = parseInt(req.query.limit) || 500;
     const recentNewsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
-             n.publication_date, n.date_confidence, n.collection_date,
+             n.publication_date, n.date_consensus_score, n.collection_date,
              p.id as poi_id, p.name as poi_name, p.poi_roles,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -210,12 +210,11 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
  *   HTML <time datetime>                — 1 pt  (structural HTML, usually reliable)
  *   URL path /YYYY/MM/DD/               — 1 pt  (static, never wrong when present)
  *
- * A date that accumulates ≥ 4 pts is "verified" (stored as date_confidence='exact').
- * A date that accumulates 1-3 pts is "estimated" (date_confidence='estimated').
- * No date → date_confidence='unknown'.
+ * A date that accumulates ≥ 4 pts is considered verified (auto-approve eligible).
+ * A date that accumulates 1-3 pts needs human review.
+ * No date → score 0, needs human review.
  *
- * Expects pre-normalized sources from normalizeDateSources() — all values are
- * already valid YYYY-MM-DD strings. No re-parsing happens here.
+ * The raw score is stored as date_consensus_score in the database.
  *
  * @param {Object} sources - Normalized date strings by source (from normalizeDateSources)
  * @param {string[]} sources.jsonLd   - ISO dates from JSON-LD (weight 3 each)
@@ -223,52 +222,37 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
  * @param {string[]} sources.meta     - ISO dates from meta tags (weight 1 each)
  * @param {string[]} sources.timeTags - ISO dates from <time> elements (weight 1 each)
  * @param {string|null} sources.url   - ISO date from URL path (weight 1)
- * @returns {{ date: string|null, score: number, confidence: 'exact'|'estimated'|'unknown', sourceMap: Object }}
+ * @returns {{ date: string|null, score: number, sourceMap: Object }}
  */
 export function scoreDateConsensus(sources = {}) {
   const today = new Date().toISOString().substring(0, 10);
 
-  // Accumulate score per date
-  const scores = {}; // date → total score
-  const sourceMap = {}; // date → [source labels]
+  const scores = {};
+  const sourceMap = {};
 
   const add = (date, weight, label) => {
-    if (!date || date > today) return; // discard future dates (normalizeDateSources may pass them through)
+    if (!date || date > today) return;
     scores[date] = (scores[date] || 0) + weight;
     if (!sourceMap[date]) sourceMap[date] = [];
     sourceMap[date].push(label);
   };
 
-  // JSON-LD sources (3 pts each)
   for (const d of (sources.jsonLd || [])) add(d, 3, 'json-ld');
-
-  // LLM extraction (2 pts)
   add(sources.llm, 2, 'llm');
-
-  // Meta tag sources (1 pt each)
   for (const d of (sources.meta || [])) add(d, 1, 'meta');
-
-  // <time> tag sources (1 pt each)
   for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');
-
-  // URL date pattern (1 pt)
   add(sources.url, 1, 'url');
 
   if (Object.keys(scores).length === 0) {
-    return { date: null, score: 0, confidence: 'unknown', sourceMap: {} };
+    return { date: null, score: 0, sourceMap: {} };
   }
 
-  // Pick the date with the highest score; break ties by choosing the oldest
-  // (publication date is almost always earlier than modification date)
   const bestDate = Object.keys(scores).reduce((a, b) => {
     if (scores[a] !== scores[b]) return scores[a] > scores[b] ? a : b;
-    return a < b ? a : b; // prefer older date on tie
+    return a < b ? a : b;
   });
 
-  const bestScore = scores[bestDate];
-  const confidence = bestScore >= 4 ? 'exact' : 'estimated';
-
-  return { date: bestDate, score: bestScore, confidence, sourceMap };
+  return { date: bestDate, score: scores[bestDate], sourceMap };
 }
 
 /**

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -118,7 +118,7 @@ function registerTools(server, pool, boss) {
       const result = await pool.query(`
         SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
                n.moderation_status, n.confidence_score, n.content_source,
-               n.publication_date, n.date_confidence, n.collection_date,
+               n.publication_date, n.date_consensus_score, n.collection_date,
                COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
         FROM poi_news n
         LEFT JOIN poi_news_urls u ON u.news_id = n.id
@@ -142,7 +142,7 @@ function registerTools(server, pool, boss) {
       const result = await pool.query(`
         SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
                e.location_details, e.source_url, e.moderation_status, e.confidence_score, e.content_source,
-               e.publication_date, e.date_confidence, e.collection_date,
+               e.publication_date, e.date_consensus_score, e.collection_date,
                COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
         FROM poi_events e
         LEFT JOIN poi_event_urls u ON u.event_id = e.id
@@ -357,7 +357,7 @@ function registerTools(server, pool, boss) {
       const result = await fixDate(pool, content_type, id);
       let msg = `Fix date for ${content_type} #${id}: `;
       if (result.date_updated) {
-        msg += `Date set to ${result.publication_date} (${result.date_confidence}).`;
+        msg += `Date set to ${result.publication_date} (${result.date_consensus_score}).`;
       } else {
         msg += `Could not determine date.`;
       }

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -180,11 +180,12 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
   console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
-    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold')`
+    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold', 'moderation_news_date_threshold')`
   );
   const settings = Object.fromEntries(settingsRows.rows.map(r => [r.key, r.value]));
   const autoApproveEnabled = settings.moderation_auto_approve_enabled !== 'false';
-  const threshold = parseFloat(settings.moderation_auto_approve_threshold) || 0.9;
+  const newsDateThreshold = parseInt(settings.moderation_news_date_threshold) || 4;
+  const photoThreshold = parseFloat(settings.moderation_auto_approve_threshold) || 0.9;
 
   let scoring;
 
@@ -228,7 +229,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     // Auto-approve based on date consensus score (no re-render needed)
     const dateScore = row.date_consensus_score || 0;
     const resolvedStatus = forceStatus ? forceStatus
-      : dateScore >= 4 ? 'auto_approved'
+      : autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved'
       : 'pending';
 
     scoring = { confidence_score: dateScore / 8.0, reasoning: `Date consensus score: ${dateScore}/8` };
@@ -278,7 +279,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     // Auto-approve based on date consensus score (no re-render needed)
     const dateScore = row.date_consensus_score || 0;
     const resolvedStatus = forceStatus ? forceStatus
-      : dateScore >= 4 ? 'auto_approved'
+      : autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved'
       : 'pending';
 
     scoring = { confidence_score: dateScore / 8.0, reasoning: `Date consensus score: ${dateScore}/8` };
@@ -307,7 +308,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     });
 
     const resolvedStatus = forceStatus ? forceStatus
-      : autoApproveEnabled && scoring.confidence_score >= threshold
+      : autoApproveEnabled && scoring.confidence_score >= photoThreshold
       ? 'auto_approved' : 'pending';
 
     await pool.query(
@@ -316,8 +317,9 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     );
   }
 
-  const decision = scoring?.confidence_score >= threshold ? 'auto_approved'
-    : scoring?.confidence_score < rejectFloor ? 'rejected' : 'pending';
+  const decision = contentType === 'photo'
+    ? (scoring?.confidence_score >= photoThreshold ? 'auto_approved' : 'pending')
+    : (scoring?.confidence_score >= (newsDateThreshold / 8.0) ? 'auto_approved' : 'pending');
   console.log(`[Moderation] ${contentType} #${contentId}: score=${scoring?.confidence_score}`);
   logInfo(itemRunId || 0, 'moderation', null, null,
     `Score ${contentType} #${contentId}: ${scoring?.confidence_score?.toFixed(2)} → ${decision}`,

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -184,8 +184,10 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
   );
   const settings = Object.fromEntries(settingsRows.rows.map(r => [r.key, r.value]));
   const autoApproveEnabled = settings.moderation_auto_approve_enabled !== 'false';
-  const newsDateThreshold = parseInt(settings.moderation_news_date_threshold) || 4;
-  const photoThreshold = parseFloat(settings.moderation_auto_approve_threshold) || 0.9;
+  const parsedNewsThreshold = parseInt(settings.moderation_news_date_threshold);
+  const newsDateThreshold = Number.isNaN(parsedNewsThreshold) ? 4 : parsedNewsThreshold;
+  const parsedPhotoThreshold = parseFloat(settings.moderation_auto_approve_threshold);
+  const photoThreshold = Number.isNaN(parsedPhotoThreshold) ? 0.9 : parsedPhotoThreshold;
 
   let scoring;
 

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -67,29 +67,19 @@ function isSafePublicUrl(urlStr) {
 
 /**
  * Extract and validate publication date fields from AI scoring response.
- * Returns { publicationDate, dateConfidence } with safe defaults.
+ * Returns { publicationDate } with safe defaults.
  */
 function extractDateFields(scoring) {
   let publicationDate = null;
-  let dateConfidence = 'unknown';
 
   if (scoring.publication_date) {
-    // Normalize through chrono-node first — handles natural language, European format, etc.
     const normalized = parseDate(String(scoring.publication_date));
     if (normalized) {
       publicationDate = normalized;
-      dateConfidence = scoring.date_confidence || 'estimated';
     }
-  } else if (scoring.date_confidence) {
-    dateConfidence = scoring.date_confidence;
   }
 
-  // Ensure confidence is a valid enum value
-  if (!['exact', 'estimated', 'unknown'].includes(dateConfidence)) {
-    dateConfidence = 'unknown';
-  }
-
-  return { publicationDate, dateConfidence };
+  return { publicationDate };
 }
 
 /**
@@ -190,38 +180,17 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
   console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
-    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold', 'moderation_auto_reject_floor', 'moderation_trusted_domains', 'moderation_competitor_domains')`
+    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold')`
   );
   const settings = Object.fromEntries(settingsRows.rows.map(r => [r.key, r.value]));
   const autoApproveEnabled = settings.moderation_auto_approve_enabled !== 'false';
   const threshold = parseFloat(settings.moderation_auto_approve_threshold) || 0.9;
-  const rejectFloor = parseFloat(settings.moderation_auto_reject_floor) || 0.5;
-
-  // Parse domain lists from settings (stored as JSON arrays)
-  const parseDomainList = (jsonString, name) => {
-    try {
-      const parsed = JSON.parse(jsonString || '[]');
-      if (Array.isArray(parsed)) return parsed;
-      console.warn(`[Moderation] ${name} is not an array, defaulting to empty`);
-      return [];
-    } catch (e) {
-      console.warn(`[Moderation] Failed to parse ${name}:`, e.message);
-      return [];
-    }
-  };
-  const trustedDomains = parseDomainList(settings.moderation_trusted_domains, 'moderation_trusted_domains');
-  const competitorDomains = parseDomainList(settings.moderation_competitor_domains, 'moderation_competitor_domains');
-
-  // Create Sets once for performance (avoids re-creating on every URL check)
-  // Filter to only strings to avoid TypeError on non-string elements
-  const trustedSet = new Set(trustedDomains.filter(d => typeof d === 'string').map(d => d.toLowerCase()));
-  const competitorSet = new Set(competitorDomains.filter(d => typeof d === 'string').map(d => d.toLowerCase()));
 
   let scoring;
 
   if (contentType === 'news') {
     const newsQuery = await pool.query(
-      `SELECT n.id, n.title, n.summary, n.source_url, n.publication_date, n.date_confidence, p.name as poi_name
+      `SELECT n.id, n.title, n.summary, n.source_url, n.publication_date, n.date_consensus_score, p.name as poi_name
        FROM poi_news n
        LEFT JOIN pois p ON n.poi_id = p.id
        WHERE n.id = $1`, [contentId]
@@ -229,6 +198,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     if (!newsQuery.rows.length) return;
     const row = newsQuery.rows[0];
 
+    // Duplicate check (cheap DB query)
     const dupCheck = await pool.query(
       `SELECT id FROM poi_news WHERE LOWER(title) = LOWER($1) AND id != $2
        AND moderation_status IN ('published', 'auto_approved') LIMIT 1`,
@@ -244,97 +214,33 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       return;
     }
 
+    // No source URL check (cheap)
     if (!row.source_url || !row.source_url.trim()) {
-      scoring = { confidence_score: 0, reasoning: 'Rejected: no source URL (Read More link required)', issues: ['missing_source_url'] };
       await pool.query(
-        `UPDATE poi_news SET confidence_score = $1, ai_reasoning = $2, moderation_status = 'rejected' WHERE id = $3`,
-        [scoring.confidence_score, scoring.reasoning, contentId]
+        `UPDATE poi_news SET confidence_score = 0, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
+        ['Rejected: no source URL (Read More link required)', contentId]
       );
       console.log(`[Moderation] news #${contentId}: rejected (no source URL)`);
       logInfo(itemRunId, 'moderation', null, row.title, `Rejected news #${contentId}: no source URL`, { completed: true });
       return;
     }
 
-    const sourceCheck = await extractPageContent(row.source_url);
-    if (!sourceCheck.reachable) {
-      await pool.query(
-        `UPDATE poi_news SET confidence_score = 0, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
-        [`Rejected: source URL unreachable (${sourceCheck.reason})`, contentId]
-      );
-      console.log(`[Moderation] news #${contentId}: rejected (source URL unreachable: ${sourceCheck.reason})`);
-      logInfo(itemRunId, 'moderation', null, row.title, `Rejected news #${contentId}: URL unreachable (${sourceCheck.reason})`, { completed: true });
-      return;
-    }
-
-    scoring = await moderateContent(pool, {
-      type: 'news',
-      title: row.title,
-      summary: row.summary,
-      source_url: row.source_url,
-      source_page_content: sourceCheck.markdown,
-      poi_name: row.poi_name
-    });
-
-    let issuesList = scoring.issues || [];
-    let foundIssue = REJECTION_ISSUES.find(i => issuesList.includes(i));
-
-    if (foundIssue === 'content_not_on_source_page') {
-      ({ scoring, foundIssue } = await attemptDeepCrawl(pool, 'news', contentId, row, scoring));
-    }
-
-    // Use dates from collection (set by chrono-node), not from Gemini moderation
-    // Use toISOString() for Date objects to avoid losing the year in .toString() output
-    const newsPubDate = row.publication_date ? parseDate(
-      row.publication_date instanceof Date ? row.publication_date.toISOString().slice(0, 10) : String(row.publication_date).slice(0, 10)
-    ) : null;
-    const newsDateConf = newsPubDate ? (row.date_confidence || 'estimated') : 'unknown';
-
-    // Apply quality filters to adjust confidence_score
-    scoring = applyQualityFilters(scoring, row.source_url, { publicationDate: newsPubDate, dateConfidence: newsDateConf }, trustedSet, competitorSet);
-
-    // Re-serialize issues after quality filters
-    const newsIssuesJson = serializeIssues(scoring);
-
-    // Re-check issues list after quality filters may have added new issues
-    issuesList = scoring.issues || [];
-    foundIssue = REJECTION_ISSUES.find(i => issuesList.includes(i));
-
-    if (foundIssue) {
-      await pool.query(
-        `UPDATE poi_news SET confidence_score = $1, ai_reasoning = $2, moderation_status = 'rejected',
-         publication_date = $3, date_confidence = $4, ai_issues = $5 WHERE id = $6`,
-        [scoring.confidence_score, scoring.reasoning, newsPubDate, newsDateConf, newsIssuesJson, contentId]
-      );
-      console.log(`[Moderation] news #${contentId}: rejected (${foundIssue})`);
-      return;
-    }
-
-    if (scoring.confidence_score < rejectFloor) {
-      await pool.query(
-        `UPDATE poi_news SET confidence_score = $1, ai_reasoning = $2, moderation_status = 'rejected',
-         publication_date = $3, date_confidence = $4, ai_issues = $5 WHERE id = $6`,
-        [scoring.confidence_score, scoring.reasoning, newsPubDate, newsDateConf, newsIssuesJson, contentId]
-      );
-      console.log(`[Moderation] news #${contentId}: rejected (score ${scoring.confidence_score} below floor ${rejectFloor})`);
-      return;
-    }
-
-    // Hold items with unknown publication date for human review regardless of score
+    // Auto-approve based on date consensus score (no re-render needed)
+    const dateScore = row.date_consensus_score || 0;
     const resolvedStatus = forceStatus ? forceStatus
-      : newsDateConf === 'unknown' ? 'pending'
-      : autoApproveEnabled && scoring.confidence_score >= threshold ? 'auto_approved'
+      : dateScore >= 4 ? 'auto_approved'
       : 'pending';
 
+    scoring = { confidence_score: dateScore / 8.0, reasoning: `Date consensus score: ${dateScore}/8` };
     await pool.query(
-      `UPDATE poi_news SET confidence_score = $1, ai_reasoning = $2, moderation_status = $3,
-       publication_date = $4, date_confidence = $5, ai_issues = $6 WHERE id = $7`,
-      [scoring.confidence_score, scoring.reasoning, resolvedStatus, newsPubDate, newsDateConf, newsIssuesJson, contentId]
+      `UPDATE poi_news SET confidence_score = $1, ai_reasoning = $2, moderation_status = $3 WHERE id = $4`,
+      [scoring.confidence_score, scoring.reasoning, resolvedStatus, contentId]
     );
 
   } else if (contentType === 'event') {
     const eventQuery = await pool.query(
       `SELECT e.id, e.title, e.description, e.source_url, e.start_date, e.content_source,
-              e.publication_date, e.date_confidence, p.name as poi_name
+              e.publication_date, e.date_consensus_score, p.name as poi_name
        FROM poi_events e
        LEFT JOIN pois p ON e.poi_id = p.id
        WHERE e.id = $1`, [contentId]
@@ -342,6 +248,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     if (!eventQuery.rows.length) return;
     const row = eventQuery.rows[0];
 
+    // Duplicate check (cheap DB query)
     const dupCheck = await pool.query(
       `SELECT id FROM poi_events WHERE LOWER(title) = LOWER($1) AND start_date = $2 AND id != $3
        AND moderation_status IN ('published', 'auto_approved') LIMIT 1`,
@@ -357,6 +264,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       return;
     }
 
+    // No source URL check for non-human items (cheap)
     if (row.content_source !== 'human' && (!row.source_url || !row.source_url.trim())) {
       await pool.query(
         `UPDATE poi_events SET confidence_score = 0, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
@@ -367,93 +275,16 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       return;
     }
 
-    let eventSourceContent = null;
-    if (row.source_url && row.source_url.trim()) {
-      const sourceCheck = await extractPageContent(row.source_url);
-      if (!sourceCheck.reachable) {
-        await pool.query(
-          `UPDATE poi_events SET confidence_score = 0, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
-          [`Rejected: source URL unreachable (${sourceCheck.reason})`, contentId]
-        );
-        console.log(`[Moderation] event #${contentId}: rejected (source URL unreachable: ${sourceCheck.reason})`);
-        logInfo(itemRunId, 'moderation', null, row.title, `Rejected event #${contentId}: URL unreachable (${sourceCheck.reason})`, { completed: true });
-        return;
-      }
-      eventSourceContent = sourceCheck.markdown;
-    }
-
-    scoring = await moderateContent(pool, {
-      type: 'event',
-      title: row.title,
-      summary: row.description,
-      source_url: row.source_url,
-      source_page_content: eventSourceContent,
-      poi_name: row.poi_name
-    });
-
-    let eventIssuesList = scoring.issues || [];
-    let eventFoundIssue = REJECTION_ISSUES.find(i => eventIssuesList.includes(i));
-
-    if (eventFoundIssue === 'content_not_on_source_page') {
-      ({ scoring, foundIssue: eventFoundIssue } = await attemptDeepCrawl(pool, 'event', contentId, row, scoring));
-    }
-
-    // Use dates from collection (set by chrono-node), not from Gemini moderation
-    // Use toISOString() for Date objects to avoid losing the year in .toString() output
-    let eventPubDate = row.publication_date ? parseDate(
-      row.publication_date instanceof Date ? row.publication_date.toISOString().slice(0, 10) : String(row.publication_date).slice(0, 10)
-    ) : null;
-    let eventDateConf = eventPubDate ? (row.date_confidence || 'estimated') : 'unknown';
-
-    // Fallback: events with start_date but no pub date shouldn't get stuck as 'unknown'
-    if (eventDateConf === 'unknown' && row.start_date) {
-      const startStr = row.start_date instanceof Date ? row.start_date.toISOString().slice(0, 10) : String(row.start_date).slice(0, 10);
-      if (/^\d{4}-\d{2}-\d{2}$/.test(startStr)) {
-        eventPubDate = startStr;
-        eventDateConf = 'estimated';
-      }
-    }
-
-    // Apply quality filters to adjust confidence_score
-    scoring = applyQualityFilters(scoring, row.source_url, { publicationDate: eventPubDate, dateConfidence: eventDateConf }, trustedSet, competitorSet);
-
-    // Re-serialize issues after quality filters
-    const eventIssuesJson = serializeIssues(scoring);
-
-    // Re-check issues list after quality filters may have added new issues
-    eventIssuesList = scoring.issues || [];
-    eventFoundIssue = REJECTION_ISSUES.find(i => eventIssuesList.includes(i));
-
-    if (eventFoundIssue) {
-      await pool.query(
-        `UPDATE poi_events SET confidence_score = $1, ai_reasoning = $2, moderation_status = 'rejected',
-         publication_date = $3, date_confidence = $4, ai_issues = $5 WHERE id = $6`,
-        [scoring.confidence_score, scoring.reasoning, eventPubDate, eventDateConf, eventIssuesJson, contentId]
-      );
-      console.log(`[Moderation] event #${contentId}: rejected (${eventFoundIssue})`);
-      return;
-    }
-
-    if (scoring.confidence_score < rejectFloor) {
-      await pool.query(
-        `UPDATE poi_events SET confidence_score = $1, ai_reasoning = $2, moderation_status = 'rejected',
-         publication_date = $3, date_confidence = $4, ai_issues = $5 WHERE id = $6`,
-        [scoring.confidence_score, scoring.reasoning, eventPubDate, eventDateConf, eventIssuesJson, contentId]
-      );
-      console.log(`[Moderation] event #${contentId}: rejected (score ${scoring.confidence_score} below floor ${rejectFloor})`);
-      return;
-    }
-
-    // Hold items with unknown publication date for human review regardless of score
+    // Auto-approve based on date consensus score (no re-render needed)
+    const dateScore = row.date_consensus_score || 0;
     const resolvedStatus = forceStatus ? forceStatus
-      : eventDateConf === 'unknown' ? 'pending'
-      : autoApproveEnabled && scoring.confidence_score >= threshold ? 'auto_approved'
+      : dateScore >= 4 ? 'auto_approved'
       : 'pending';
 
+    scoring = { confidence_score: dateScore / 8.0, reasoning: `Date consensus score: ${dateScore}/8` };
     await pool.query(
-      `UPDATE poi_events SET confidence_score = $1, ai_reasoning = $2, moderation_status = $3,
-       publication_date = $4, date_confidence = $5, ai_issues = $6 WHERE id = $7`,
-      [scoring.confidence_score, scoring.reasoning, resolvedStatus, eventPubDate, eventDateConf, eventIssuesJson, contentId]
+      `UPDATE poi_events SET confidence_score = $1, ai_reasoning = $2, moderation_status = $3 WHERE id = $4`,
+      [scoring.confidence_score, scoring.reasoning, resolvedStatus, contentId]
     );
 
   } else if (contentType === 'photo') {
@@ -636,9 +467,9 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
     }
   }
 
-  // When admin sets publication_date, mark confidence as 'exact' (only for news/events, not photos)
+  // When admin sets publication_date, set high consensus score (only for news/events, not photos)
   if (edits.publication_date && contentType !== 'photo') {
-    setClauses.push(`date_confidence = 'exact'`);
+    setClauses.push(`date_consensus_score = 6`);
   }
 
   if (publish) {
@@ -836,7 +667,7 @@ export async function fixDate(pool, contentType, contentId) {
 
   const extraFields = contentType === 'event' ? ', t.start_date, t.end_date' : '';
   const itemQuery = await pool.query(
-    `SELECT t.id, t.title, t.${descField} AS description, t.source_url, t.publication_date, t.date_confidence, p.name AS poi_name${extraFields}
+    `SELECT t.id, t.title, t.${descField} AS description, t.source_url, t.publication_date, t.date_consensus_score, p.name AS poi_name${extraFields}
      FROM ${table} t
      LEFT JOIN pois p ON t.poi_id = p.id
      WHERE t.id = $1`,
@@ -871,7 +702,7 @@ export async function fixDate(pool, contentType, contentId) {
       // Fast path: chrono-node found a date, skip Gemini
       if (contentType === 'event') {
         const eventDates = findEventDates(pageContent, item.title, 'America/New_York');
-        const setClauses = ['publication_date = $2', "date_confidence = 'exact'"];
+        const setClauses = ['publication_date = $2', 'date_consensus_score = 6'];
         const values = [contentId, chronoPubDate];
         let idx = 3;
         if (eventDates.startDate) {
@@ -894,14 +725,14 @@ export async function fixDate(pool, contentType, contentId) {
         console.log(`[Moderation] Fix date via chrono-node: ${contentType} #${contentId} → pub=${chronoPubDate}, start=${eventDates.startDate}`);
       } else {
         await pool.query(
-          `UPDATE ${table} SET publication_date = $1, date_confidence = 'exact' WHERE id = $2`,
+          `UPDATE ${table} SET publication_date = $1, date_consensus_score = 6 WHERE id = $2`,
           [chronoPubDate, contentId]
         );
         console.log(`[Moderation] Fix date via chrono-node: ${contentType} #${contentId} → ${chronoPubDate}`);
       }
       logInfo(runId, 'moderation', null, item.title, `Fix Date: ${chronoPubDate} (chrono-node)`, { completed: true, publication_date: chronoPubDate });
       await flushJobLogs();
-      return { date_updated: true, publication_date: chronoPubDate, date_confidence: 'exact', reasoning: 'Extracted by chrono-node' };
+      return { date_updated: true, publication_date: chronoPubDate, date_consensus_score: 6, reasoning: 'Extracted by chrono-node' };
     }
   }
 
@@ -930,11 +761,9 @@ Look for:
 - References to specific dated events that pin down the timeframe${eventDateInstructions}
 
 Return ONLY valid JSON (no markdown, no code blocks):
-{"publication_date": "YYYY-MM-DD", "date_confidence": "exact", "reasoning": "Found date in..."${eventJsonFields}}
+{"publication_date": "YYYY-MM-DD", "reasoning": "Found date in..."${eventJsonFields}}
 
-If exact date found, use date_confidence "exact".
-If estimated from context, use "estimated".
-If truly impossible to determine, use "unknown" and set publication_date to null.`;
+If truly impossible to determine, set publication_date to null.`;
 
   const genAI = await createGeminiClient(pool);
   const model = genAI.getGenerativeModel({
@@ -976,7 +805,7 @@ If truly impossible to determine, use "unknown" and set publication_date to null
   if (result.start_date) result.start_date = parseDate(result.start_date) || result.start_date;
   if (result.end_date) result.end_date = parseDate(result.end_date) || result.end_date;
 
-  const { publicationDate, dateConfidence } = extractDateFields(result);
+  const { publicationDate } = extractDateFields(result);
 
   // For events, also extract start_date/end_date with optional times
   let startDateStr = null;
@@ -997,11 +826,11 @@ If truly impossible to determine, use "unknown" and set publication_date to null
   const anyDateFound = publicationDate || startDateStr;
 
   if (anyDateFound) {
+    // AI fix-date sets score to 6 (equivalent of verified consensus)
     if (contentType === 'event' && (startDateStr || endDateStr)) {
-      // Update publication_date + event dates
-      const setClauses = ['date_confidence = $2'];
-      const values = [contentId, dateConfidence];
-      let idx = 3;
+      const setClauses = ['date_consensus_score = 6'];
+      const values = [contentId];
+      let idx = 2;
       if (publicationDate) {
         setClauses.push(`publication_date = $${idx}`);
         values.push(publicationDate);
@@ -1021,20 +850,20 @@ If truly impossible to determine, use "unknown" and set publication_date to null
         `UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $1`,
         values
       );
-      console.log(`[Moderation] Fix date updated ${contentType} #${contentId}: pub=${publicationDate}, start=${startDateStr}, end=${endDateStr} (${dateConfidence})`);
+      console.log(`[Moderation] Fix date updated ${contentType} #${contentId}: pub=${publicationDate}, start=${startDateStr}, end=${endDateStr}`);
     } else {
       await pool.query(
-        `UPDATE ${table} SET publication_date = $1, date_confidence = $2 WHERE id = $3`,
-        [publicationDate, dateConfidence, contentId]
+        `UPDATE ${table} SET publication_date = $1, date_consensus_score = 6 WHERE id = $2`,
+        [publicationDate, contentId]
       );
-      console.log(`[Moderation] Fix date updated ${contentType} #${contentId}: ${publicationDate} (${dateConfidence})`);
+      console.log(`[Moderation] Fix date updated ${contentType} #${contentId}: ${publicationDate}`);
     }
-    logInfo(runId, 'moderation', null, item.title, `Fix Date: ${publicationDate || 'no pub date'} (${dateConfidence}, via AI)`, { completed: true, publication_date: publicationDate, date_confidence: dateConfidence, start_date: startDateStr, end_date: endDateStr });
+    logInfo(runId, 'moderation', null, item.title, `Fix Date: ${publicationDate || 'no pub date'} (score=6, via AI)`, { completed: true, publication_date: publicationDate, date_consensus_score: 6, start_date: startDateStr, end_date: endDateStr });
     await flushJobLogs();
     return {
       date_updated: true,
       publication_date: publicationDate,
-      date_confidence: dateConfidence,
+      date_consensus_score: 6,
       start_date: startDateStr || null,
       end_date: endDateStr || null,
       reasoning: result.reasoning || null
@@ -1062,7 +891,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
     SELECT n.id, 'news' AS content_type, n.poi_id, n.title, n.summary AS description,
            n.moderation_status, n.confidence_score, n.ai_reasoning, n.ai_issues,
            n.submitted_by, n.moderated_by, n.moderated_at, n.collection_date AS created_at, n.source_url,
-           n.content_source, n.publication_date, n.date_confidence,
+           n.content_source, n.publication_date, n.date_consensus_score,
            NULL::TIMESTAMPTZ AS start_date, NULL::TIMESTAMPTZ AS end_date,
            COUNT(u.id)::int AS additional_url_count,
            NULL::VARCHAR AS media_type, NULL::VARCHAR AS image_server_asset_id, NULL::VARCHAR AS role
@@ -1074,7 +903,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
     SELECT e.id, 'event' AS content_type, e.poi_id, e.title, e.description,
            e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
            e.submitted_by, e.moderated_by, e.moderated_at, e.collection_date AS created_at, e.source_url,
-           e.content_source, e.publication_date, e.date_confidence,
+           e.content_source, e.publication_date, e.date_consensus_score,
            e.start_date, e.end_date,
            COUNT(u.id)::int AS additional_url_count,
            NULL::VARCHAR AS media_type, NULL::VARCHAR AS image_server_asset_id, NULL::VARCHAR AS role
@@ -1091,7 +920,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
            caption AS description,
            moderation_status, confidence_score, ai_reasoning, NULL AS ai_issues,
            submitted_by, moderated_by, moderated_at, created_at, youtube_url AS source_url,
-           NULL AS content_source, NULL::DATE AS publication_date, NULL::VARCHAR AS date_confidence,
+           NULL AS content_source, NULL::DATE AS publication_date, 0 AS date_consensus_score,
            NULL::TIMESTAMPTZ AS start_date, NULL::TIMESTAMPTZ AS end_date,
            0 AS additional_url_count,
            media_type, image_server_asset_id, role

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -404,7 +404,7 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   const secondDate = dateHints.length > 1 ? dateHints[1].start?.substring(0, 10) : null;
 
   logInfo(jobId, jobType, poi.id, poi.name,
-    `${phase}: [Dates] ${primaryDate || 'none'} (score=${consensus.score}, confidence=${consensus.confidence}, sources=${JSON.stringify(consensus.sourceMap)}) from ${url}`);
+    `${phase}: [Dates] ${primaryDate || 'none'} (score=${consensus.score}, sources=${JSON.stringify(consensus.sourceMap)}) from ${url}`);
 
   // [Summarize]
   updateProgress(poi.id, { phase: 'summarize', message: url });
@@ -420,14 +420,14 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   for (const item of (result.news || [])) {
     item.source_url = url;
     item.published_date = primaryDate;
-    item.date_confidence = consensus.confidence;
+    item.date_consensus_score = consensus.score;
   }
 
   for (const event of (result.events || [])) {
     event.source_url = url;
     event.start_date = primaryDate;
     event.end_date = secondDate || null;
-    event.date_confidence = consensus.confidence;
+    event.date_consensus_score = consensus.score;
   }
 
   logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events from ${url}`);
@@ -1092,12 +1092,12 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         continue;
       }
 
-      // New item — save as pending for moderation
-      // Use consensus confidence if set by processOneUrl; fall back to binary exact/unknown
-      const dateConfidence = item.date_confidence || (item.published_date ? 'exact' : 'unknown');
+      // New item — auto-approve if date consensus score is high enough, otherwise pending
+      const dateScore = item.date_consensus_score || 0;
+      const status = dateScore >= 4 ? 'auto_approved' : 'pending';
       await pool.query(`
-        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_confidence, moderation_status)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
+        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       `, [
         poiId,
         item.title,
@@ -1106,10 +1106,11 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         item.source_name,
         item.news_type || 'general',
         item.published_date || null,
-        dateConfidence
+        dateScore,
+        status
       ]);
       savedCount++;
-      if (log) log(`[Save] Saved (pending): "${item.title}" (${item.published_date || 'no date'}, ${dateConfidence}) → ${resolvedUrl}`);
+      if (log) log(`[Save] Saved (${status}): "${item.title}" (${item.published_date || 'no date'}, score=${dateScore}) → ${resolvedUrl}`);
     } catch (error) {
       if (log) log(`[Save] Error: "${item.title}" — ${error.message}`);
       console.error(`Error saving news item for POI ${poiId}:`, error.message);
@@ -1194,12 +1195,12 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         continue;
       }
 
-      // New event — save as pending for moderation
-      // Use consensus confidence if set by processOneUrl; fall back to binary exact/unknown
-      const dateConfidence = item.date_confidence || (item.start_date ? 'exact' : 'unknown');
+      // New event — auto-approve if date consensus score is high enough, otherwise pending
+      const dateScore = item.date_consensus_score || 0;
+      const status = dateScore >= 4 ? 'auto_approved' : 'pending';
       await pool.query(`
-        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_confidence, moderation_status)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'pending')
+        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       `, [
         poiId,
         item.title,
@@ -1210,10 +1211,11 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         item.location_details,
         resolvedUrl,
         item.start_date || null,
-        dateConfidence
+        dateScore,
+        status
       ]);
       savedCount++;
-      if (log) log(`[Save] Saved event (pending): "${item.title}" (${item.start_date}, ${dateConfidence}) → ${resolvedUrl}`);
+      if (log) log(`[Save] Saved event (${status}): "${item.title}" (${item.start_date}, score=${dateScore}) → ${resolvedUrl}`);
     } catch (error) {
       if (log) log(`[Save] Error: "${item.title}" — ${error.message}`);
       console.error(`Error saving event for POI ${poiId}:`, error.message);

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1016,6 +1016,13 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   let duplicateCount = 0;
   const { skipDateFilter = false, log = null } = options;
 
+  const moderationRows = await pool.query(
+    "SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_news_date_threshold')"
+  );
+  const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
+  const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
+  const newsDateThreshold = parseInt(moderationSettings.moderation_news_date_threshold) || 4;
+
   // Calculate date strings (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
@@ -1092,9 +1099,9 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         continue;
       }
 
-      // New item — auto-approve if date consensus score is high enough, otherwise pending
+      // New item — auto-approve if date consensus score meets threshold and auto-approve is enabled
       const dateScore = item.date_consensus_score || 0;
-      const status = dateScore >= 4 ? 'auto_approved' : 'pending';
+      const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
         INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
@@ -1130,6 +1137,13 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
   const { log = null } = options;
+
+  const moderationRows = await pool.query(
+    "SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_news_date_threshold')"
+  );
+  const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
+  const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
+  const newsDateThreshold = parseInt(moderationSettings.moderation_news_date_threshold) || 4;
 
   // Get today's date as a string (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();
@@ -1195,9 +1209,9 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         continue;
       }
 
-      // New event — auto-approve if date consensus score is high enough, otherwise pending
+      // New event — auto-approve if date consensus score meets threshold and auto-approve is enabled
       const dateScore = item.date_consensus_score || 0;
-      const status = dateScore >= 4 ? 'auto_approved' : 'pending';
+      const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
         INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1021,7 +1021,8 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   );
   const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
   const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
-  const newsDateThreshold = parseInt(moderationSettings.moderation_news_date_threshold) || 4;
+  const parsedThreshold = parseInt(moderationSettings.moderation_news_date_threshold);
+  const newsDateThreshold = Number.isNaN(parsedThreshold) ? 4 : parsedThreshold;
 
   // Calculate date strings (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();
@@ -1143,7 +1144,8 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
   );
   const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
   const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
-  const newsDateThreshold = parseInt(moderationSettings.moderation_news_date_threshold) || 4;
+  const parsedThreshold = parseInt(moderationSettings.moderation_news_date_threshold);
+  const newsDateThreshold = Number.isNaN(parsedThreshold) ? 4 : parsedThreshold;
 
   // Get today's date as a string (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -80,31 +80,28 @@ describe('normalizeDateSources', () => {
 });
 
 describe('scoreDateConsensus', () => {
-  it('returns unknown confidence when no sources provided', () => {
+  it('returns score 0 when no sources provided', () => {
     const result = scoreDateConsensus({});
     expect(result.date).toBeNull();
-    expect(result.confidence).toBe('unknown');
     expect(result.score).toBe(0);
   });
 
-  it('scores JSON-LD at 3 pts — reaches exact threshold alone with any other source', () => {
+  it('scores JSON-LD at 3 pts — reaches verified threshold alone with any other source', () => {
     const result = scoreDateConsensus({
       jsonLd: ['2024-03-15'],
       url: '2024-03-15'
     });
     expect(result.date).toBe('2024-03-15');
     expect(result.score).toBe(4);
-    expect(result.confidence).toBe('exact');
   });
 
-  it('scores JSON-LD alone as estimated (3 pts < 4 threshold)', () => {
+  it('scores JSON-LD alone at 3 pts (below 4 threshold)', () => {
     const result = scoreDateConsensus({ jsonLd: ['2024-05-20'] });
     expect(result.date).toBe('2024-05-20');
     expect(result.score).toBe(3);
-    expect(result.confidence).toBe('estimated');
   });
 
-  it('reaches exact threshold with LLM + meta + URL (2+1+1=4)', () => {
+  it('reaches verified threshold with LLM + meta + URL (2+1+1=4)', () => {
     const result = scoreDateConsensus({
       llm: '2024-06-01',
       meta: ['2024-06-01'],
@@ -112,7 +109,6 @@ describe('scoreDateConsensus', () => {
     });
     expect(result.date).toBe('2024-06-01');
     expect(result.score).toBe(4);
-    expect(result.confidence).toBe('exact');
   });
 
   it('breaks ties by choosing the oldest date', () => {
@@ -142,7 +138,6 @@ describe('scoreDateConsensus', () => {
     // 3 + 2 + 1 + 1 = 7
     expect(result.date).toBe('2024-08-10');
     expect(result.score).toBe(7);
-    expect(result.confidence).toBe('exact');
   });
 
   it('handles multiple JSON-LD dates — picks oldest on tie', () => {

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -45,7 +45,7 @@ function DataCollectionSettings() {
 
   // Moderation configuration state
   const [moderationConfig, setModerationConfig] = useState({
-    enabled: true, autoApproveEnabled: true, autoApproveThreshold: 0.9, photoSubmissionsEnabled: false
+    enabled: true, autoApproveEnabled: true, newsDateThreshold: 4, photoConfidenceThreshold: 0.9, photoSubmissionsEnabled: false
   });
   const [moderationConfigLoading, setModerationConfigLoading] = useState(true);
   const [moderationConfigSaving, setModerationConfigSaving] = useState(false);
@@ -325,7 +325,8 @@ function DataCollectionSettings() {
         setModerationConfig({
           enabled: settings.moderation_enabled?.value !== 'false',
           autoApproveEnabled: settings.moderation_auto_approve_enabled?.value !== 'false',
-          autoApproveThreshold: parseFloat(settings.moderation_auto_approve_threshold?.value) || 0.9,
+          newsDateThreshold: parseInt(settings.moderation_news_date_threshold?.value) || 4,
+          photoConfidenceThreshold: parseFloat(settings.moderation_auto_approve_threshold?.value) || 0.9,
           photoSubmissionsEnabled: settings.photo_submissions_enabled?.value === 'true'
         });
       }
@@ -339,7 +340,8 @@ function DataCollectionSettings() {
       const settings = [
         { key: 'moderation_enabled', value: String(moderationConfig.enabled) },
         { key: 'moderation_auto_approve_enabled', value: String(moderationConfig.autoApproveEnabled) },
-        { key: 'moderation_auto_approve_threshold', value: String(moderationConfig.autoApproveThreshold) },
+        { key: 'moderation_news_date_threshold', value: String(moderationConfig.newsDateThreshold) },
+        { key: 'moderation_auto_approve_threshold', value: String(moderationConfig.photoConfidenceThreshold) },
         { key: 'photo_submissions_enabled', value: String(moderationConfig.photoSubmissionsEnabled) }
       ];
       for (const setting of settings) {
@@ -842,8 +844,14 @@ function DataCollectionSettings() {
               <span className="config-hint">Automatically publish items scoring above the threshold</span>
             </div>
             <div className="config-row">
-              <label>Auto-Approve Threshold:</label>
-              <input type="number" value={moderationConfig.autoApproveThreshold} onChange={e => setModerationConfig({...moderationConfig, autoApproveThreshold: parseFloat(e.target.value) || 0})}
+              <label>Minimum News & Events Date Consensus Score:</label>
+              <input type="number" value={moderationConfig.newsDateThreshold} onChange={e => setModerationConfig({...moderationConfig, newsDateThreshold: parseInt(e.target.value) || 0})}
+                min="0" max="8" step="1" disabled={moderationConfigSaving || !moderationConfig.enabled || !moderationConfig.autoApproveEnabled} style={{ width: '80px' }} />
+              <span className="config-hint">Score 0-8 (recommended: 4)</span>
+            </div>
+            <div className="config-row">
+              <label>Gemini Photo Confidence:</label>
+              <input type="number" value={moderationConfig.photoConfidenceThreshold} onChange={e => setModerationConfig({...moderationConfig, photoConfidenceThreshold: parseFloat(e.target.value) || 0})}
                 min="0" max="1" step="0.05" disabled={moderationConfigSaving || !moderationConfig.enabled || !moderationConfig.autoApproveEnabled} style={{ width: '80px' }} />
               <span className="config-hint">Score 0.0-1.0 (recommended: 0.9)</span>
             </div>

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -334,7 +334,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
       if (response.ok) {
         const data = await response.json();
         if (data.date_updated) {
-          const parts = [`${type} #${id} — date set: ${data.publication_date} (${data.date_confidence})`];
+          const parts = [`${type} #${id} — date set: ${data.publication_date} (score=${data.date_consensus_score})`];
           if (data.start_date) parts.push(`event: ${data.start_date}${data.end_date ? ' — ' + data.end_date : ''}`);
           notify('success', parts.join(', '));
         } else {
@@ -1080,7 +1080,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
                         const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
                         const hasNoDate = item.content_type === 'event'
                           ? !item.publication_date && !item.start_date
-                          : !item.publication_date || item.date_confidence === 'unknown';
+                          : !item.publication_date || !item.date_consensus_score;
                         const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
                         const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
                         const hasOther = issues.some(i => !urlIssueCodes.includes(i));


### PR DESCRIPTION
## Summary
- Replaces the lossy text label `date_confidence` (exact/estimated/unknown) with the raw numeric `date_consensus_score` (0-8) from the consensus date extraction pipeline
- Collection now auto-approves news/events with score >= 4 at save time — no moderation sweep needed for high-confidence items
- Moderation sweep dramatically simplified: removes expensive page re-rendering, Gemini content verification, deep crawl, and quality filters; keeps only duplicate and no-URL checks
- Net reduction of 163 lines of code

## Context
The vernal pools article (Summit Metro Parks) was stored with April 1st instead of April 2nd because the old chrono-node path grabbed the wrong date. The new consensus scoring system (PR #196) fixed this, but the moderation sweep was still re-rendering every page redundantly. This PR completes the transition by storing the numeric score and using it for auto-approve decisions.

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` passes (22 test files, 292 tests)
- [ ] Deploy and verify migration 028 runs cleanly
- [ ] Trigger news collection for Summit Metro Parks — items with score >= 4 should be auto_approved
- [ ] Verify moderation inbox shows remaining low-score items as pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)