### PR TITLE
fix: stop discarding future dates in consensus scoring

### DIFF
--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -226,14 +226,12 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
  * @returns {{ date: string|null, score: number, confidence: 'exact'|'estimated'|'unknown', sourceMap: Object }}
  */
 export function scoreDateConsensus(sources = {}) {
-  const today = new Date().toISOString().substring(0, 10);
-
   // Accumulate score per date
   const scores = {}; // date → total score
   const sourceMap = {}; // date → [source labels]
 
   const add = (date, weight, label) => {
-    if (!date || date > today) return; // discard future dates (normalizeDateSources may pass them through)
+    if (!date) return;
     scores[date] = (scores[date] || 0) + weight;
     if (!sourceMap[date]) sourceMap[date] = [];
     sourceMap[date].push(label);
@@ -258,11 +256,11 @@ export function scoreDateConsensus(sources = {}) {
     return { date: null, score: 0, confidence: 'unknown', sourceMap: {} };
   }
 
-  // Pick the date with the highest score; break ties by choosing the oldest
-  // (publication date is almost always earlier than modification date)
+  // Pick the date with the highest score; break ties by choosing the newest
+  // (event startDate is newer than datePublished/dateModified in JSON-LD)
   const bestDate = Object.keys(scores).reduce((a, b) => {
     if (scores[a] !== scores[b]) return scores[a] > scores[b] ? a : b;
-    return a < b ? a : b; // prefer older date on tie
+    return a > b ? a : b; // prefer newer date on tie
   });
 
   const bestScore = scores[bestDate];

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -115,21 +115,21 @@ describe('scoreDateConsensus', () => {
     expect(result.confidence).toBe('exact');
   });
 
-  it('breaks ties by choosing the oldest date', () => {
+  it('breaks ties by choosing the newest date', () => {
     const result = scoreDateConsensus({
       meta: ['2024-03-10'],
       url: '2024-03-12'
     });
-    expect(result.date).toBe('2024-03-10');
+    expect(result.date).toBe('2024-03-12');
   });
 
-  it('discards future dates', () => {
+  it('scores future dates normally (needed for events)', () => {
     const result = scoreDateConsensus({
       jsonLd: ['2099-12-31'],
       url: '2024-01-15'
     });
-    expect(result.date).toBe('2024-01-15');
-    expect(result.score).toBe(1);
+    expect(result.date).toBe('2099-12-31');
+    expect(result.score).toBe(3);
   });
 
   it('accumulates score across matching dates from different sources', () => {
@@ -145,11 +145,11 @@ describe('scoreDateConsensus', () => {
     expect(result.confidence).toBe('exact');
   });
 
-  it('handles multiple JSON-LD dates — picks oldest on tie', () => {
+  it('handles multiple JSON-LD dates — picks newest on tie', () => {
     const result = scoreDateConsensus({
       jsonLd: ['2024-05-01', '2024-06-15'],
     });
-    expect(result.date).toBe('2024-05-01');
+    expect(result.date).toBe('2024-06-15');
     expect(result.score).toBe(3);
   });
 


### PR DESCRIPTION
## Summary
- Removed future date filter from `scoreDateConsensus()` — event `startDate` values were being discarded, causing all events to inherit `datePublished` and get skipped as "past events"
- Flipped tie-breaker from oldest-wins to newest-wins so event dates beat publication dates when scores are equal
- Updated 3 unit tests to match new behavior

## Test plan
- [x] All 22 dateExtractor unit tests pass
- [ ] Verify Summit Metro Parks events collection picks up future event dates after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)