### PR TITLE
feat: add event datetime consensus model for start/end times

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -146,6 +146,8 @@ export async function extractPageContent(url, options = {}) {
 
         // JSON-LD: parse all ld+json blocks, collect date fields from any schema type
         const jsonLdDates = [];
+        let eventStartDate = null;
+        let eventEndDate = null;
         document.querySelectorAll('script[type="application/ld+json"]').forEach(script => {
           try {
             const data = JSON.parse(script.textContent);
@@ -158,6 +160,18 @@ export async function extractPageContent(url, options = {}) {
                 item['@graph']?.map?.(n => n.datePublished || n.startDate)
               ].flat().filter(Boolean);
               jsonLdDates.push(...candidates);
+
+              // Event-specific: extract startDate/endDate with full datetime precision
+              if (!eventStartDate) {
+                eventStartDate = item.startDate
+                  || item['@graph']?.find?.(n => n.startDate)?.startDate
+                  || null;
+              }
+              if (!eventEndDate) {
+                eventEndDate = item.endDate
+                  || item['@graph']?.find?.(n => n.endDate)?.endDate
+                  || null;
+              }
             }
           } catch { /* ignore malformed JSON-LD */ }
         });
@@ -175,7 +189,9 @@ export async function extractPageContent(url, options = {}) {
           parselyPubDate: getMetaName('parsely-pub-date'),
           dcDate: getMetaName('dc.date'),
           jsonLdDates,
-          timeDates
+          timeDates,
+          eventStartDate,
+          eventEndDate
         };
       });
 

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -255,6 +255,64 @@ export function scoreDateConsensus(sources = {}) {
 }
 
 /**
+ * Normalize raw datetime strings from event extraction sources to ISO 8601
+ * (YYYY-MM-DDTHH:MM:SS). Same shape as normalizeDateSources but preserves times.
+ *
+ * @param {Object} rawSources - Raw extracted datetime strings by source
+ * @param {string} [timezone] - IANA timezone for chrono-node parsing
+ * @returns {Object} Normalized sources with valid YYYY-MM-DDTHH:MM:SS strings
+ */
+export function normalizeEventDateSources(rawSources = {}, timezone = 'America/New_York') {
+  const norm = (raw) => (raw ? parseDateTime(String(raw), timezone) : null);
+  const normList = (arr) => (arr || []).map(norm).filter(Boolean);
+
+  return {
+    jsonLd:   normList(rawSources.jsonLd),
+    llm:      norm(rawSources.llm),
+    meta:     normList(rawSources.meta),
+    timeTags: normList(rawSources.timeTags),
+    url:      norm(rawSources.url)
+  };
+}
+
+/**
+ * Consensus datetime scoring for events. Same algorithm as scoreDateConsensus
+ * but operates on full datetime strings (YYYY-MM-DDTHH:MM:SS).
+ *
+ * @param {Object} sources - Normalized datetime strings by source (from normalizeEventDateSources)
+ * @returns {{ datetime: string|null, score: number, sourceMap: Object }}
+ */
+export function scoreEventDateTimeConsensus(sources = {}) {
+  const scores = {};
+  const sourceMap = {};
+
+  const add = (datetime, weight, label) => {
+    if (!datetime) return;
+    scores[datetime] = (scores[datetime] || 0) + weight;
+    if (!sourceMap[datetime]) sourceMap[datetime] = [];
+    sourceMap[datetime].push(label);
+  };
+
+  for (const d of (sources.jsonLd || [])) add(d, 3, 'json-ld');
+  add(sources.llm, 2, 'llm');
+  for (const d of (sources.meta || [])) add(d, 1, 'meta');
+  for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');
+  add(sources.url, 1, 'url');
+
+  if (Object.keys(scores).length === 0) {
+    return { datetime: null, score: 0, sourceMap: {} };
+  }
+
+  // Pick highest score; break ties by choosing newest
+  const bestDatetime = Object.keys(scores).reduce((a, b) => {
+    if (scores[a] !== scores[b]) return scores[a] > scores[b] ? a : b;
+    return a > b ? a : b;
+  });
+
+  return { datetime: bestDatetime, score: scores[bestDatetime], sourceMap };
+}
+
+/**
  * Find start/end dates and times for an event from rendered page text.
  * @param {string} text - Rendered page content
  * @param {string} title - Event title

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -9,7 +9,7 @@
  */
 
 import { generateTextWithCustomPrompt as geminiGenerateText } from './geminiService.js';
-import { parseDate, extractDatesFromText, extractUrlDate, normalizeDateSources, scoreDateConsensus } from './dateExtractor.js';
+import { parseDate, parseDateTime, extractDatesFromText, extractUrlDate, normalizeDateSources, scoreDateConsensus, normalizeEventDateSources, scoreEventDateTimeConsensus } from './dateExtractor.js';
 
 // Gemini call counter for job usage stats
 let geminiCallCount = 0;
@@ -372,39 +372,96 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   //   URL path /YYYY/MM/DD/             : 1 pt
   updateProgress(poi.id, { phase: 'dates', message: url });
 
-  // --- [1] Collect raw date strings from all extraction sources ---
   const od = extracted.ogDates || {};
-  const rawSources = {
-    jsonLd:   od.jsonLdDates || [],
-    meta:     [od.publishedTime, od.parselyPubDate, od.dcDate].filter(Boolean),
-    timeTags: od.timeDates || [],
-    url:      extractUrlDate(url),
-    llm:      null  // filled below
-  };
+  let primaryDate = null;
+  let dateScore = 0;
+  let dateSourceMap = {};
+  let eventStartDateTime = null;
+  let eventStartScore = 0;
+  let eventEndDateTime = null;
+  let eventEndScore = 0;
 
-  // --- [2] LLM date extraction (lightweight Gemini call on first 1000 chars) ---
-  try {
-    const datePrompt = `Extract the primary publication or start date from this article/page snippet. Return ONLY the date in ISO format YYYY-MM-DD, or the word null if no date is present.\n\n${extracted.markdown.substring(0, 1000)}`;
-    const llmResult = await generateTextWithCustomPrompt(pool, datePrompt);
-    const raw = (llmResult.response || '').trim().replace(/^["']|["']$/g, '');
-    if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) rawSources.llm = raw;
-  } catch { /* LLM date extraction is best-effort */ }
+  if (contentType === 'event') {
+    // --- Event datetime consensus: separate start and end pipelines ---
 
-  // --- [3] Normalize: convert all raw strings to ISO 8601, discard unparseable ---
-  const normalizedSources = normalizeDateSources(rawSources, timezone);
+    // [1] Collect raw datetime sources for start and end
+    const startSources = {
+      jsonLd:   od.eventStartDate ? [od.eventStartDate] : [],
+      meta:     [],
+      timeTags: od.timeDates?.length > 0 ? [od.timeDates[0]] : [],
+      url:      extractUrlDate(url),
+      llm:      null
+    };
+    const endSources = {
+      jsonLd:   od.eventEndDate ? [od.eventEndDate] : [],
+      meta:     [],
+      timeTags: od.timeDates?.length > 1 ? [od.timeDates[1]] : [],
+      url:      null,
+      llm:      null
+    };
 
-  // --- [4] Score: consensus across normalized sources ---
-  const consensus = scoreDateConsensus(normalizedSources);
+    // [2] LLM extraction — ask Gemini for start AND end datetime
+    try {
+      const datePrompt = `Extract the event start and end date/time from this page snippet. Return ONLY a JSON object like {"start":"YYYY-MM-DDTHH:MM","end":"YYYY-MM-DDTHH:MM"} or {"start":"YYYY-MM-DDTHH:MM","end":null} if no end time. Return {"start":null,"end":null} if no dates found.\n\n${extracted.markdown.substring(0, 1500)}`;
+      const llmResult = await generateTextWithCustomPrompt(pool, datePrompt);
+      const raw = (llmResult.response || '').trim();
+      try {
+        const cleaned = raw.replace(/^```json\s*/, '').replace(/\s*```$/, '');
+        const parsed = JSON.parse(cleaned);
+        if (parsed.start && typeof parsed.start === 'string') startSources.llm = parsed.start;
+        if (parsed.end && typeof parsed.end === 'string') endSources.llm = parsed.end;
+      } catch { /* LLM returned non-JSON — skip */ }
+    } catch { /* LLM extraction is best-effort */ }
 
-  const primaryDate = consensus.date;
+    // [3] Normalize to YYYY-MM-DDTHH:MM:SS
+    const normStart = normalizeEventDateSources(startSources, timezone);
+    const normEnd = normalizeEventDateSources(endSources, timezone);
 
-  // chrono-node scan of article body — used only for event end_date fallback,
-  // NOT as a scored consensus source (too noisy for publication dates).
-  const dateHints = extractDatesFromText(extracted.markdown, timezone);
-  const secondDate = dateHints.length > 1 ? dateHints[1].start?.substring(0, 10) : null;
+    // [4] Score
+    const startConsensus = scoreEventDateTimeConsensus(normStart);
+    const endConsensus = scoreEventDateTimeConsensus(normEnd);
 
-  logInfo(jobId, jobType, poi.id, poi.name,
-    `${phase}: [Dates] ${primaryDate || 'none'} (score=${consensus.score}, sources=${JSON.stringify(consensus.sourceMap)}) from ${url}`);
+    eventStartDateTime = startConsensus.datetime;
+    eventStartScore = startConsensus.score;
+    eventEndDateTime = endConsensus.datetime;
+    eventEndScore = endConsensus.score;
+
+    // primaryDate and dateScore used for logging and fallback
+    primaryDate = eventStartDateTime?.substring(0, 10) || null;
+    dateScore = eventStartScore;
+    dateSourceMap = startConsensus.sourceMap;
+
+    logInfo(jobId, jobType, poi.id, poi.name,
+      `${phase}: [Dates] start=${eventStartDateTime || 'none'} (score=${eventStartScore}, sources=${JSON.stringify(startConsensus.sourceMap)}), end=${eventEndDateTime || 'none'} (score=${eventEndScore}) from ${url}`);
+
+  } else {
+    // --- News date consensus: existing pipeline (date-only) ---
+
+    const rawSources = {
+      jsonLd:   od.jsonLdDates || [],
+      meta:     [od.publishedTime, od.parselyPubDate, od.dcDate].filter(Boolean),
+      timeTags: od.timeDates || [],
+      url:      extractUrlDate(url),
+      llm:      null
+    };
+
+    try {
+      const datePrompt = `Extract the primary publication or start date from this article/page snippet. Return ONLY the date in ISO format YYYY-MM-DD, or the word null if no date is present.\n\n${extracted.markdown.substring(0, 1000)}`;
+      const llmResult = await generateTextWithCustomPrompt(pool, datePrompt);
+      const raw = (llmResult.response || '').trim().replace(/^["']|["']$/g, '');
+      if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) rawSources.llm = raw;
+    } catch { /* LLM date extraction is best-effort */ }
+
+    const normalizedSources = normalizeDateSources(rawSources, timezone);
+    const consensus = scoreDateConsensus(normalizedSources);
+
+    primaryDate = consensus.date;
+    dateScore = consensus.score;
+    dateSourceMap = consensus.sourceMap;
+
+    logInfo(jobId, jobType, poi.id, poi.name,
+      `${phase}: [Dates] ${primaryDate || 'none'} (score=${dateScore}, sources=${JSON.stringify(dateSourceMap)}) from ${url}`);
+  }
 
   // [Summarize]
   updateProgress(poi.id, { phase: 'summarize', message: url });
@@ -420,14 +477,14 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   for (const item of (result.news || [])) {
     item.source_url = url;
     item.published_date = primaryDate;
-    item.date_consensus_score = consensus.score;
+    item.date_consensus_score = dateScore;
   }
 
   for (const event of (result.events || [])) {
     event.source_url = url;
-    event.start_date = primaryDate;
-    event.end_date = secondDate || null;
-    event.date_consensus_score = consensus.score;
+    event.start_date = eventStartDateTime || primaryDate;
+    event.end_date = eventEndDateTime || null;
+    event.date_consensus_score = eventStartScore || dateScore;
   }
 
   logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events from ${url}`);
@@ -1149,11 +1206,19 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
 
   for (const item of eventItems) {
     try {
-      // Normalize event dates via chrono-node
-      item.start_date = parseDate(item.start_date) || item.start_date;
-      item.end_date = parseDate(item.end_date) || null;
+      // Normalize event dates — preserve datetimes if present, fall back to date-only
+      item.start_date = parseDateTime(item.start_date) || parseDate(item.start_date) || item.start_date;
+      item.end_date = parseDateTime(item.end_date) || parseDate(item.end_date) || null;
 
-      // Save all events regardless of date — past events provide historical value
+      // Default end time: if start has a time component but end is NULL, assume 60 minutes
+      if (item.start_date && !item.end_date && item.start_date.includes('T')) {
+        const startMs = new Date(item.start_date).getTime();
+        if (!isNaN(startMs)) {
+          const endDate = new Date(startMs + 60 * 60 * 1000);
+          const pad = (n) => String(n).padStart(2, '0');
+          item.end_date = `${endDate.getUTCFullYear()}-${pad(endDate.getUTCMonth() + 1)}-${pad(endDate.getUTCDate())}T${pad(endDate.getUTCHours())}:${pad(endDate.getUTCMinutes())}:${pad(endDate.getUTCSeconds())}`;
+        }
+      }
 
       // Resolve redirect URLs to final destination URLs
       const resolvedUrl = item.source_url ? await resolveRedirectUrl(item.source_url) : null;

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -4,7 +4,7 @@
  *   extractUrlDate → normalizeDateSources → scoreDateConsensus
  */
 import { describe, it, expect } from 'vitest';
-import { extractUrlDate, normalizeDateSources, scoreDateConsensus } from '../services/dateExtractor.js';
+import { extractUrlDate, normalizeDateSources, scoreDateConsensus, normalizeEventDateSources, scoreEventDateTimeConsensus } from '../services/dateExtractor.js';
 
 describe('extractUrlDate', () => {
   it('extracts /YYYY/MM/DD/ from a WordPress-style URL', () => {
@@ -155,5 +155,96 @@ describe('scoreDateConsensus', () => {
     });
     expect(result.sourceMap['2024-03-15']).toContain('json-ld');
     expect(result.sourceMap['2024-03-15']).toContain('url');
+  });
+});
+
+describe('normalizeEventDateSources', () => {
+  it('preserves time components from ISO datetime strings', () => {
+    const result = normalizeEventDateSources({ jsonLd: ['2026-04-22T10:30:00'] });
+    expect(result.jsonLd).toContain('2026-04-22T10:30:00');
+  });
+
+  it('parses datetime strings with timezone offsets', () => {
+    const result = normalizeEventDateSources({ jsonLd: ['2026-04-22T10:30:00-04:00'] });
+    expect(result.jsonLd.length).toBe(1);
+    expect(result.jsonLd[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('handles date-only strings by adding T00:00:00', () => {
+    const result = normalizeEventDateSources({ jsonLd: ['2026-04-22'] });
+    expect(result.jsonLd.length).toBe(1);
+    expect(result.jsonLd[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('discards unparseable strings', () => {
+    const result = normalizeEventDateSources({ jsonLd: ['not-a-date', '2026-04-22T10:30:00'] });
+    expect(result.jsonLd).not.toContain('not-a-date');
+    expect(result.jsonLd.length).toBe(1);
+  });
+
+  it('handles null/missing sources gracefully', () => {
+    const result = normalizeEventDateSources({ llm: null, url: null });
+    expect(result.llm).toBeNull();
+    expect(result.url).toBeNull();
+    expect(result.jsonLd).toEqual([]);
+  });
+});
+
+describe('scoreEventDateTimeConsensus', () => {
+  it('returns score 0 when no sources provided', () => {
+    const result = scoreEventDateTimeConsensus({});
+    expect(result.datetime).toBeNull();
+    expect(result.score).toBe(0);
+  });
+
+  it('scores JSON-LD datetime at 3 pts', () => {
+    const result = scoreEventDateTimeConsensus({ jsonLd: ['2026-04-22T10:30:00'] });
+    expect(result.datetime).toBe('2026-04-22T10:30:00');
+    expect(result.score).toBe(3);
+  });
+
+  it('reaches threshold with JSON-LD + time tag (3+1=4)', () => {
+    const result = scoreEventDateTimeConsensus({
+      jsonLd: ['2026-04-22T10:30:00'],
+      timeTags: ['2026-04-22T10:30:00']
+    });
+    expect(result.datetime).toBe('2026-04-22T10:30:00');
+    expect(result.score).toBe(4);
+  });
+
+  it('accumulates score across matching datetimes', () => {
+    const result = scoreEventDateTimeConsensus({
+      jsonLd: ['2026-04-22T10:30:00'],
+      llm: '2026-04-22T10:30:00',
+      timeTags: ['2026-04-22T10:30:00']
+    });
+    expect(result.datetime).toBe('2026-04-22T10:30:00');
+    expect(result.score).toBe(6);
+  });
+
+  it('picks highest-scoring datetime when sources disagree', () => {
+    const result = scoreEventDateTimeConsensus({
+      jsonLd: ['2026-04-22T10:30:00'],
+      llm: '2026-04-22T11:00:00'
+    });
+    expect(result.datetime).toBe('2026-04-22T10:30:00');
+    expect(result.score).toBe(3);
+  });
+
+  it('breaks ties by choosing newest datetime', () => {
+    const result = scoreEventDateTimeConsensus({
+      timeTags: ['2026-04-22T10:30:00'],
+      url: '2026-04-22T14:00:00'
+    });
+    expect(result.datetime).toBe('2026-04-22T14:00:00');
+  });
+
+  it('includes sourceMap in result', () => {
+    const result = scoreEventDateTimeConsensus({
+      jsonLd: ['2026-04-22T10:30:00'],
+      llm: '2026-04-22T10:30:00'
+    });
+    expect(result.sourceMap['2026-04-22T10:30:00']).toContain('json-ld');
+    expect(result.sourceMap['2026-04-22T10:30:00']).toContain('llm');
   });
 });


### PR DESCRIPTION
## Summary
- Events now get their own datetime consensus pipeline that preserves full datetimes (YYYY-MM-DDTHH:MM:SS) instead of stripping to date-only
- Two separate consensus runs: one for start datetime, one for end datetime — same scoring weights as news
- JSON-LD `startDate`/`endDate` extracted with full precision; LLM prompt asks for start AND end
- Start date score drives auto-approve; end date is nice-to-have (NULL doesn't block approval)
- When start time is known but end time is not, defaults to start + 60 minutes for Google Calendar
- News date pipeline is completely untouched (separate `if/else` branch on `contentType`)

## Test plan
- [x] All 304 tests pass (34 dateExtractor tests including 12 new event datetime tests)
- [x] Container builds successfully
- [ ] Deploy to lotor and trigger Summit Metro Parks collection
- [ ] Verify events show correct times (10:30 AM, not 12:00 AM) and correct end times

🤖 Generated with [Claude Code](https://claude.com/claude-code)