### PR TITLE
fix: skip nav menus in event LLM date extraction

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -401,8 +401,12 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     };
 
     // [2] LLM extraction — ask Gemini for start AND end datetime
+    // Skip nav menus by finding the first markdown heading (# Title), then send content from there
     try {
-      const datePrompt = `Extract the event start and end date/time from this page snippet. Return ONLY a JSON object like {"start":"YYYY-MM-DDTHH:MM","end":"YYYY-MM-DDTHH:MM"} or {"start":"YYYY-MM-DDTHH:MM","end":null} if no end time. Return {"start":null,"end":null} if no dates found.\n\n${extracted.markdown.substring(0, 1500)}`;
+      const headingIdx = extracted.markdown.search(/^#{1,3}\s+\S/m);
+      const contentStart = headingIdx >= 0 ? headingIdx : 0;
+      const snippet = extracted.markdown.substring(contentStart, contentStart + 2000);
+      const datePrompt = `Extract the event start and end date/time from this page. The current year is ${new Date().getFullYear()}. If no year is shown, assume the current year. Return ONLY a JSON object like {"start":"YYYY-MM-DDTHH:MM","end":"YYYY-MM-DDTHH:MM"} or {"start":"YYYY-MM-DDTHH:MM","end":null} if no end time. Return {"start":null,"end":null} if no dates found.\n\n${snippet}`;
       const llmResult = await generateTextWithCustomPrompt(pool, datePrompt);
       const raw = (llmResult.response || '').trim();
       logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] LLM raw response: ${raw.substring(0, 200)}`);


### PR DESCRIPTION
Gemini was returning null because the first 1500 chars was all nav links. Now skips to first heading and tells Gemini the current year.