### PR TITLE
fix: smart event date display, always-visible URLs, cleanup debug logging

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -385,7 +385,6 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     // --- Event datetime consensus: separate start and end pipelines ---
 
     // [1] Collect raw datetime sources for start and end
-    logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] Raw sources: eventStartDate=${od.eventStartDate}, eventEndDate=${od.eventEndDate}, timeDates=${JSON.stringify(od.timeDates?.slice(0, 4))}`);
     const startSources = {
       jsonLd:   od.eventStartDate ? [od.eventStartDate] : [],
       meta:     [],
@@ -411,19 +410,13 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
       const datePrompt = `Extract the event start and end date/time from this page. The current year is ${new Date().getFullYear()}. If no year is shown, assume the current year. Return ONLY a JSON object like {"start":"YYYY-MM-DDTHH:MM","end":"YYYY-MM-DDTHH:MM"} or {"start":"YYYY-MM-DDTHH:MM","end":null} if no end time. Return {"start":null,"end":null} if no dates found.\n\n${snippet}`;
       const llmResult = await generateTextWithCustomPrompt(pool, datePrompt);
       const raw = (llmResult.response || '').trim();
-      logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] LLM raw response: ${raw.substring(0, 200)}`);
       try {
         const cleaned = raw.replace(/^```json\s*/, '').replace(/\s*```$/, '');
         const parsed = JSON.parse(cleaned);
         if (parsed.start && typeof parsed.start === 'string') startSources.llm = parsed.start;
         if (parsed.end && typeof parsed.end === 'string') endSources.llm = parsed.end;
-        logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] LLM parsed: start=${startSources.llm}, end=${endSources.llm}`);
-      } catch (parseErr) {
-        logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] LLM parse failed: ${parseErr.message}`);
-      }
-    } catch (llmErr) {
-      logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Dates] LLM call failed: ${llmErr.message}`);
-    }
+      } catch { /* LLM returned non-JSON — skip */ }
+    } catch { /* LLM extraction is best-effort */ }
 
     // [3] Normalize to YYYY-MM-DDTHH:MM:SS
     const normStart = normalizeEventDateSources(startSources, timezone);

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -1027,9 +1027,24 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
                       {/* Event dates */}
                       {item.content_type === 'event' && (item.start_date || item.end_date) && (
                         <div style={{ fontSize: '0.78rem', color: '#7b1fa2', fontWeight: '500', margin: '2px 0' }}>
-                          {item.start_date && formatEventDate(item.start_date)}
-                          {item.start_date && item.end_date && ' — '}
-                          {item.end_date && formatEventDate(item.end_date)}
+                          {(() => {
+                            const startStr = String(item.start_date || '');
+                            const endStr = String(item.end_date || '');
+                            const startDateOnly = startStr.substring(0, 10);
+                            const endDateOnly = endStr.substring(0, 10);
+                            const startHasTime = startStr.includes('T') && !startStr.endsWith('T00:00:00');
+                            const endHasTime = endStr.includes('T') && !endStr.endsWith('T00:00:00');
+                            const sameDay = endDateOnly === startDateOnly;
+                            const fmtDate = (s) => new Date(s).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' });
+                            const fmtTime = (s) => new Date(s).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' });
+
+                            if (sameDay && startHasTime) {
+                              return `${fmtDate(startStr)}, ${fmtTime(startStr)}${endHasTime ? ` – ${fmtTime(endStr)}` : ''}`;
+                            } else if (endStr && !sameDay) {
+                              return `${fmtDate(startStr)} – ${fmtDate(endStr)}`;
+                            }
+                            return fmtDate(startStr);
+                          })()}
                         </div>
                       )}
 
@@ -1051,8 +1066,8 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
                         </a>
                       )}
 
-                      {/* Source URL (expanded, read-only) */}
-                      {isExpanded && item.source_url && (
+                      {/* Source URL (always visible) */}
+                      {item.source_url && (
                         <div style={{ margin: '4px 0', fontSize: '0.78rem' }}>
                           <a href={item.source_url} target="_blank" rel="noopener noreferrer" style={{ color: '#1976d2' }}>
                             {item.source_url}

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -184,10 +184,38 @@ export function EventItemCard({ item, onDelete, deleting, isAdmin }) {
         )}
       </div>
       <div className="item-card-date-row">
-        {formatPublicationDate(item.start_date)}
-        {item.end_date && item.end_date !== item.start_date && (
-          <> - {formatPublicationDate(item.end_date)}</>
-        )}
+        {(() => {
+          const startStr = String(item.start_date || '');
+          const endStr = String(item.end_date || '');
+          const startDateOnly = startStr.substring(0, 10);
+          const endDateOnly = endStr.substring(0, 10);
+          const startHasTime = startStr.includes('T') && !startStr.endsWith('T00:00:00');
+          const endHasTime = endStr.includes('T') && !endStr.endsWith('T00:00:00');
+          const sameDay = endDateOnly === startDateOnly;
+
+          if (sameDay && startHasTime) {
+            // Same-day event with times: "Sun, Apr 19, 2026, 10:30 AM – 12:00 PM"
+            const startDate = new Date(startStr);
+            const dateLabel = startDate.toLocaleDateString('en-US', {
+              weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
+            });
+            const startTime = startDate.toLocaleTimeString('en-US', {
+              hour: 'numeric', minute: '2-digit', timeZone: 'UTC'
+            });
+            if (endHasTime) {
+              const endTime = new Date(endStr).toLocaleTimeString('en-US', {
+                hour: 'numeric', minute: '2-digit', timeZone: 'UTC'
+              });
+              return `${dateLabel}, ${startTime} – ${endTime}`;
+            }
+            return `${dateLabel}, ${startTime}`;
+          } else if (endStr && !sameDay) {
+            // Multi-day event: "Apr 5 – Apr 26, 2026"
+            return <>{formatPublicationDate(startStr)} – {formatPublicationDate(endStr)}</>;
+          }
+          // Date only or no end date
+          return formatPublicationDate(startStr);
+        })()}
       </div>
       {item.description && <p className="item-card-summary">{item.description}</p>}
       <div className="item-card-meta">


### PR DESCRIPTION
## Summary
- Same-day events show times instead of redundant date range: "Sun, Apr 19, 10:30 AM – 12:00 PM"
- Multi-day events show date range: "Apr 5 – Apr 26, 2026"
- Source URLs always visible in moderation inbox (not gated behind "Show more")
- Remove debug logging from event datetime consensus (raw sources, LLM snippet, LLM response)

## Test plan
- [x] 305 tests pass
- [ ] Check moderation inbox shows URL without expanding
- [ ] Check events page shows times for same-day events

🤖 Generated with [Claude Code](https://claude.com/claude-code)