### PR TITLE
fix: reduce crawl concurrency to prevent rate limiting

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -337,19 +337,36 @@ IMPORTANT:
  * Run up to `limit` async tasks concurrently.
  * Each task is a zero-arg function returning a Promise.
  * Results are returned in original order; individual errors are caught and re-thrown per-task.
- * @param {number} delayMs - Optional delay (ms) between dispatching tasks to avoid rate limiting
+ * @param {number} delayMs - Optional delay (ms) between dispatching each new task to avoid rate limiting
  */
 async function runConcurrent(tasks, limit = 10, delayMs = 0) {
   const results = new Array(tasks.length);
-  let idx = 0;
-  async function worker() {
-    while (idx < tasks.length) {
-      const i = idx++;
-      if (delayMs > 0 && i > 0) await new Promise(r => setTimeout(r, delayMs));
-      try { results[i] = await tasks[i](); } catch (e) { results[i] = e instanceof Error ? e : new Error(String(e)); }
+
+  if (delayMs <= 0) {
+    // Fast path: worker pool with no delays
+    let idx = 0;
+    async function worker() {
+      while (idx < tasks.length) {
+        const i = idx++;
+        try { results[i] = await tasks[i](); } catch (e) { results[i] = e instanceof Error ? e : new Error(String(e)); }
+      }
     }
+    await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, worker));
+  } else {
+    // Staggered dispatch: one task dispatched every delayMs, max `limit` in flight
+    const inFlight = new Set();
+    for (let i = 0; i < tasks.length; i++) {
+      if (i > 0) await new Promise(r => setTimeout(r, delayMs));
+      while (inFlight.size >= limit) await Promise.race(inFlight);
+      const p = (async () => {
+        try { results[i] = await tasks[i](); } catch (e) { results[i] = e instanceof Error ? e : new Error(String(e)); }
+      })();
+      const tracked = p.then(() => inFlight.delete(tracked), () => inFlight.delete(tracked));
+      inFlight.add(tracked);
+    }
+    await Promise.all(inFlight);
   }
-  await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, worker));
+
   return results;
 }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -337,13 +337,15 @@ IMPORTANT:
  * Run up to `limit` async tasks concurrently.
  * Each task is a zero-arg function returning a Promise.
  * Results are returned in original order; individual errors are caught and re-thrown per-task.
+ * @param {number} delayMs - Optional delay (ms) between dispatching tasks to avoid rate limiting
  */
-async function runConcurrent(tasks, limit = 10) {
+async function runConcurrent(tasks, limit = 10, delayMs = 0) {
   const results = new Array(tasks.length);
   let idx = 0;
   async function worker() {
     while (idx < tasks.length) {
       const i = idx++;
+      if (delayMs > 0 && i > 0) await new Promise(r => setTimeout(r, delayMs));
       try { results[i] = await tasks[i](); } catch (e) { results[i] = e instanceof Error ? e : new Error(String(e)); }
     }
   }
@@ -557,7 +559,7 @@ async function crawlWithClassification(pool, startUrl, contentType, poi, sheets,
           await processLevel(validLinks, depth + 1);
         }
       }
-    }), 10);
+    }), 3, 2000);
   }
 
   await processLevel([startUrl], 0);


### PR DESCRIPTION
## Summary
- Reduced `crawlWithClassification` concurrency from 10 to 3 concurrent page renders per domain
- Added 2-second stagger delay between dispatching new requests within `runConcurrent`
- Prevents sites (e.g., cvsr.org) from rate-limiting or dropping connections during Phase I crawl
- No impact on other `runConcurrent` callers — delay defaults to 0

## Test plan
- [x] Container build passes
- [x] Test suite passes
- [ ] Verify events collection against cvsr.org no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)