### PR TITLE
fix: shared date scoring, uploadDate extraction, JSON-LD 4pt

### DIFF
--- a/backend/services/contentExtractor.js
+++ b/backend/services/contentExtractor.js
@@ -155,8 +155,9 @@ export async function extractPageContent(url, options = {}) {
             for (const item of items) {
               const candidates = [
                 item.datePublished,
+                item.uploadDate,
                 item.startDate,
-                item['@graph']?.map?.(n => n.datePublished || n.startDate)
+                item['@graph']?.map?.(n => n.datePublished || n.uploadDate || n.startDate)
               ].flat().filter(Boolean);
               jsonLdDates.push(...candidates);
 

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -224,7 +224,7 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
  * Score deterministic date sources (everything except LLM).
  *
  * Weights:
- *   JSON-LD datePublished / startDate  — 3 pts (most authoritative structured data)
+ *   JSON-LD datePublished / startDate  — 4 pts (most authoritative structured data)
  *   Meta tags (OG, Parsely, DC)         — 1 pt  (common but editable by CMS)
  *   HTML <time datetime>                — 1 pt  (structural HTML, usually reliable)
  *   URL path date                       — 1 pt  (static, never wrong when present)
@@ -232,7 +232,7 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
  * LLM scoring is handled separately by scoreLlmConsensus() and added after.
  *
  * @param {Object} sources - Normalized date strings by source (from normalizeDateSources)
- * @param {string[]} sources.jsonLd   - ISO dates from JSON-LD (weight 3 each)
+ * @param {string[]} sources.jsonLd   - ISO dates from JSON-LD (weight 4 each)
  * @param {string[]} sources.meta     - ISO dates from meta tags (weight 1 each)
  * @param {string[]} sources.timeTags - ISO dates from <time> elements (weight 1 each)
  * @param {string|null} sources.url   - ISO date from URL path (weight 1)
@@ -250,7 +250,7 @@ export function scoreDeterministicSources(sources = {}) {
     sourceMap[date].push(label);
   };
 
-  for (const d of (sources.jsonLd || [])) add(d, 3, 'json-ld');
+  for (const d of (sources.jsonLd || [])) add(d, 4, 'json-ld');
   for (const d of (sources.meta || [])) add(d, 1, 'meta');
   for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');
   add(sources.url, 1, 'url');
@@ -382,7 +382,7 @@ export function scoreEventDateTimeConsensus(sources = {}) {
     sourceMap[datetime].push(label);
   };
 
-  for (const d of (sources.jsonLd || [])) add(d, 3, 'json-ld');
+  for (const d of (sources.jsonLd || [])) add(d, 4, 'json-ld');
   add(sources.llm, 2, 'llm');
   for (const d of (sources.meta || [])) add(d, 1, 'meta');
   for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -8,8 +8,8 @@ import { moderateContent, moderatePhoto, createGeminiClient, GEMINI_MODEL } from
 import { extractPageContent } from './contentExtractor.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
-import { parseDate, extractUrlDate, normalizeDateSources, scoreDateConsensus } from './dateExtractor.js';
-import { runLlmDateVotes, normalizeRenderUrl } from './newsService.js';
+import { parseDate } from './dateExtractor.js';
+import { scoreNewsDate, normalizeRenderUrl } from './newsService.js';
 
 const TABLE_MAP = {
   news: 'poi_news',
@@ -258,41 +258,40 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       let newScore = dateScore;
       let newDate = row.publication_date;
 
+      // Extract page content if URL is available
+      let pageContent = null;
+      let ogDates = {};
       if (row.source_url && isSafePublicUrl(row.source_url)) {
         try {
           const renderUrl = normalizeRenderUrl(row.source_url);
           const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
-
           if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
-            // Collect deterministic sources
-            const od = extracted.ogDates || {};
-            const rawSources = {
-              jsonLd:   od.jsonLdDates || [],
-              meta:     [od.publishedTime, od.parselyPubDate, od.dcDate].filter(Boolean),
-              timeTags: od.timeDates || [],
-              url:      extractUrlDate(row.source_url)
-            };
-
-            // LLM multi-vote
-            const dateText = extracted.rawText || extracted.markdown;
-            const llmResults = await runLlmDateVotes(pool, dateText.substring(0, 2000));
-
-            // Score
-            const normalizedSources = normalizeDateSources(rawSources);
-            const consensus = scoreDateConsensus(normalizedSources, llmResults);
-
-            if (consensus.date) {
-              newDate = consensus.date;
-              newScore = consensus.score;
-            }
-
-            logInfo(itemRunId, 'moderation', null, row.title,
-              `Rescored ${contentType} #${contentId}: ${newDate || 'none'} (score=${newScore}, sources=${JSON.stringify(consensus.sourceMap)})`);
+            pageContent = extracted.rawText || extracted.markdown;
+            ogDates = extracted.ogDates || {};
           }
         } catch (err) {
-          console.error(`[Moderation] ${contentType} #${contentId}: rescore failed: ${err.message}`);
-          logError(itemRunId, 'moderation', null, row.title, `Rescore failed: ${err.message}`);
+          console.error(`[Moderation] ${contentType} #${contentId}: page extraction failed: ${err.message}`);
+          logError(itemRunId, 'moderation', null, row.title, `Page extraction failed: ${err.message}`);
         }
+      }
+
+      // Score using shared function (same code path as collection, but with title+description)
+      try {
+        const consensus = await scoreNewsDate(pool, {
+          title: row.title, description: row.description,
+          pageContent, ogDates, sourceUrl: row.source_url
+        });
+
+        if (consensus.date) {
+          newDate = consensus.date;
+          newScore = consensus.score;
+        }
+
+        logInfo(itemRunId, 'moderation', null, row.title,
+          `Rescored ${contentType} #${contentId}: ${newDate || 'none'} (score=${newScore}, sources=${JSON.stringify(consensus.sourceMap)})`);
+      } catch (err) {
+        console.error(`[Moderation] ${contentType} #${contentId}: date scoring failed: ${err.message}`);
+        logError(itemRunId, 'moderation', null, row.title, `Date scoring failed: ${err.message}`);
       }
 
       const resolvedStatus = forceStatus ? forceStatus
@@ -686,27 +685,50 @@ export async function fixDate(pool, contentType, contentId) {
   }
 
   const table = TABLE_MAP[contentType];
+  const descField = contentType === 'news' ? 'summary' : 'description';
 
-  // Reset score to force processItem to re-render and rescore
+  const itemQuery = await pool.query(
+    `SELECT t.id, t.title, t.${descField} AS description, t.source_url
+     FROM ${table} t WHERE t.id = $1`, [contentId]
+  );
+  if (!itemQuery.rows.length) throw new Error(`${contentType} #${contentId} not found`);
+  const item = itemQuery.rows[0];
+
+  // Extract page content (same as collection)
+  let pageContent = null;
+  let ogDates = {};
+  if (item.source_url && isSafePublicUrl(item.source_url)) {
+    try {
+      const renderUrl = normalizeRenderUrl(item.source_url);
+      const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
+      if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
+        pageContent = extracted.rawText || extracted.markdown;
+        ogDates = extracted.ogDates || {};
+      }
+    } catch (err) {
+      console.error(`[Moderation] fixDate ${contentType} #${contentId}: page extraction failed: ${err.message}`);
+    }
+  }
+
+  // Score using the same shared function as collection
+  const consensus = await scoreNewsDate(pool, {
+    title: item.title, description: item.description,
+    pageContent, ogDates, sourceUrl: item.source_url
+  });
+
+  // Update the item
+  const newDate = consensus.date || null;
+  const newScore = consensus.score || 0;
   await pool.query(
-    `UPDATE ${table} SET date_consensus_score = 0, moderation_processed = false WHERE id = $1`,
-    [contentId]
+    `UPDATE ${table} SET publication_date = $1, date_consensus_score = $2, moderation_processed = true WHERE id = $3`,
+    [newDate, newScore, contentId]
   );
 
-  // Run through the full consensus pipeline
-  await processItem(pool, contentType, contentId);
-
-  // Return the updated state
-  const updated = await pool.query(
-    `SELECT publication_date, date_consensus_score FROM ${table} WHERE id = $1`,
-    [contentId]
-  );
-  const row = updated.rows[0];
   return {
-    date_updated: !!row.publication_date,
-    publication_date: row.publication_date,
-    date_consensus_score: row.date_consensus_score,
-    reasoning: `Rescored via consensus pipeline (score=${row.date_consensus_score})`
+    date_updated: !!newDate,
+    publication_date: newDate,
+    date_consensus_score: newScore,
+    reasoning: `Rescored via scoreNewsDate (score=${newScore})`
   };
 }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -54,6 +54,43 @@ export async function runLlmDateVotes(pool, snippet, numVotes = LLM_DATE_VOTES) 
   return results;
 }
 
+/**
+ * Score a news item's publication date using deterministic sources + LLM multi-vote.
+ * Single source of truth — used by both collection (newsService) and moderation (moderationService).
+ *
+ * @param {Pool} pool - Database connection pool
+ * @param {Object} params
+ * @param {string} params.title - Item title
+ * @param {string} params.description - Item summary/description
+ * @param {string} params.pageContent - Extracted page text (rawText or markdown)
+ * @param {Object} params.ogDates - OG/meta date objects from page extraction
+ * @param {string} params.sourceUrl - Source URL for URL-based date extraction
+ * @param {string} [params.timezone] - IANA timezone for normalization
+ * @returns {Object} { date, score, sourceMap }
+ */
+export async function scoreNewsDate(pool, { title, description, pageContent, ogDates, sourceUrl, timezone }) {
+  const od = ogDates || {};
+  const rawSources = {
+    jsonLd:   od.jsonLdDates || [],
+    meta:     [od.publishedTime, od.parselyPubDate, od.dcDate].filter(Boolean),
+    timeTags: od.timeDates || [],
+    url:      extractUrlDate(sourceUrl)
+  };
+
+  // Build LLM input: title + description first, then page content, capped at 2000 chars
+  const itemContext = `${title || ''}\n${description || ''}`.trim();
+  const dateText = itemContext
+    ? `${itemContext}\n\n${pageContent || ''}`.substring(0, 2000)
+    : (pageContent || '').substring(0, 2000);
+
+  const llmResults = dateText.length >= 20
+    ? await runLlmDateVotes(pool, dateText)
+    : [];
+
+  const normalizedSources = normalizeDateSources(rawSources, timezone);
+  return scoreDateConsensus(normalizedSources, llmResults);
+}
+
 export function resetJobUsage() {
   geminiCallCount = 0;
 }
@@ -519,20 +556,12 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
 
   } else {
     // --- News date consensus: deterministic sources + LLM multi-vote ---
-
-    const rawSources = {
-      jsonLd:   od.jsonLdDates || [],
-      meta:     [od.publishedTime, od.parselyPubDate, od.dcDate].filter(Boolean),
-      timeTags: od.timeDates || [],
-      url:      extractUrlDate(url)
-    };
-
-    // LLM multi-vote date extraction (5 parallel calls with date seeding)
-    const dateText = extracted.rawText || extracted.markdown;
-    const llmResults = await runLlmDateVotes(pool, dateText.substring(0, 2000));
-
-    const normalizedSources = normalizeDateSources(rawSources, timezone);
-    const consensus = scoreDateConsensus(normalizedSources, llmResults);
+    // Uses shared scoreNewsDate (no title/description available yet — item hasn't been summarized)
+    const consensus = await scoreNewsDate(pool, {
+      title: null, description: null,
+      pageContent: extracted.rawText || extracted.markdown,
+      ogDates: od, sourceUrl: url, timezone
+    });
 
     primaryDate = consensus.date;
     dateScore = consensus.score;

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -184,19 +184,19 @@ describe('scoreDateConsensus', () => {
     expect(result.score).toBe(0);
   });
 
-  it('scores JSON-LD alone at 3 pts (deterministic only)', () => {
+  it('scores JSON-LD alone at 4 pts (deterministic only)', () => {
     const result = scoreDateConsensus({ jsonLd: ['2024-05-20'] }, []);
     expect(result.date).toBe('2024-05-20');
-    expect(result.score).toBe(3);
+    expect(result.score).toBe(4);
   });
 
-  it('scores JSON-LD + URL at 4 pts', () => {
+  it('scores JSON-LD + URL at 5 pts', () => {
     const result = scoreDateConsensus({
       jsonLd: ['2024-03-15'],
       url: '2024-03-15'
     }, []);
     expect(result.date).toBe('2024-03-15');
-    expect(result.score).toBe(4);
+    expect(result.score).toBe(5);
   });
 
   it('LLM consensus alone scores 4 pts (no deterministic sources)', () => {
@@ -208,13 +208,13 @@ describe('scoreDateConsensus', () => {
     expect(result.score).toBe(4);
   });
 
-  it('LLM consensus + agreeing JSON-LD scores 7 pts', () => {
+  it('LLM consensus + agreeing JSON-LD scores 8 pts', () => {
     const result = scoreDateConsensus(
       { jsonLd: ['2024-06-01'] },
       ['2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01']
     );
     expect(result.date).toBe('2024-06-01');
-    expect(result.score).toBe(7);  // 3 (json-ld) + 4 (llm-consensus, no competing)
+    expect(result.score).toBe(8);  // 4 (json-ld) + 4 (llm-consensus, no competing)
   });
 
   it('LLM consensus penalized when disagreeing with time-tags', () => {
@@ -332,19 +332,19 @@ describe('scoreEventDateTimeConsensus', () => {
     expect(result.score).toBe(0);
   });
 
-  it('scores JSON-LD datetime at 3 pts', () => {
+  it('scores JSON-LD datetime at 4 pts', () => {
     const result = scoreEventDateTimeConsensus({ jsonLd: ['2026-04-22T10:30'] });
     expect(result.datetime).toBe('2026-04-22T10:30');
-    expect(result.score).toBe(3);
+    expect(result.score).toBe(4);
   });
 
-  it('reaches threshold with JSON-LD + time tag (3+1=4)', () => {
+  it('reaches threshold with JSON-LD + time tag (4+1=5)', () => {
     const result = scoreEventDateTimeConsensus({
       jsonLd: ['2026-04-22T10:30'],
       timeTags: ['2026-04-22T10:30']
     });
     expect(result.datetime).toBe('2026-04-22T10:30');
-    expect(result.score).toBe(4);
+    expect(result.score).toBe(5);
   });
 
   it('accumulates score across matching datetimes', () => {
@@ -354,7 +354,7 @@ describe('scoreEventDateTimeConsensus', () => {
       timeTags: ['2026-04-22T10:30']
     });
     expect(result.datetime).toBe('2026-04-22T10:30');
-    expect(result.score).toBe(6);
+    expect(result.score).toBe(7);
   });
 
   it('picks highest-scoring datetime when sources disagree', () => {
@@ -363,7 +363,7 @@ describe('scoreEventDateTimeConsensus', () => {
       llm: '2026-04-22T11:00'
     });
     expect(result.datetime).toBe('2026-04-22T10:30');
-    expect(result.score).toBe(3);
+    expect(result.score).toBe(4);
   });
 
   it('breaks ties by choosing newest datetime', () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1788,7 +1788,13 @@ function AppContent() {
               {settingsTab === 'surfaces' && <SurfacesSettings />}
               {settingsTab === 'icons' && <IconsSettings />}
               {settingsTab === 'dataCollection' && <DataCollectionSettings />}
-              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} focusItemId={moderationFocusId} focusItemTitle={moderationFocusTitle} />}
+              {settingsTab === 'moderation' && <ModerationInbox onCountChange={refreshModerationCount} focusItemId={moderationFocusId} focusItemTitle={moderationFocusTitle} onSelectPoi={(poiId) => {
+                const poi = destinations.find(d => d.id === poiId);
+                if (poi) {
+                  setSelectedDestination(poi);
+                  setActiveTab('view');
+                }
+              }} />}
               {settingsTab === 'jobs' && <JobsDashboard expandTarget={jobsExpandTarget} onExpandTargetConsumed={() => setJobsExpandTarget(null)} />}
               {settingsTab === 'google' && (
                 <div className="google-integration-tab">

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -29,7 +29,7 @@ const FIELD_CONFIGS = {
   ]
 };
 
-function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
+function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectPoi }) {
   const [queue, setQueue] = useState([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -841,8 +841,8 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
             // Rendered as children of the shared card component (below the card body, above nothing)
             const moderationExtras = (
               <>
-                {/* Moderation badge row */}
-                <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center', marginTop: '6px' }}>
+                {/* Moderation badges — all on one line, wrapping when needed */}
+                <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center', margin: '10px 0 8px' }}>
                   {/* Item ID badge */}
                   <span style={badgeStyle('#757575')}>#{item.id}</span>
 
@@ -872,6 +872,25 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
                     </span>
                   )}
 
+                  {/* Triage chips — inline with other badges */}
+                  {item.content_type !== 'photo' && (() => {
+                    const issues = item.ai_issues ? (() => { try { return JSON.parse(item.ai_issues); } catch { return []; } })() : [];
+                    const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
+                    const hasNoDate = item.content_type === 'event'
+                      ? !item.publication_date && !item.start_date
+                      : !item.publication_date || !item.date_consensus_score;
+                    const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
+                    const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
+                    const hasOther = issues.some(i => !urlIssueCodes.includes(i));
+                    return (
+                      <>
+                        {hasNoDate && <span style={badgeStyle('#e65100')}>No Date</span>}
+                        {hasUrlIssue && <span style={badgeStyle('#e65100')}>{urlLabel}</span>}
+                        {hasOther && <span style={badgeStyle('#b71c1c')}>Other</span>}
+                      </>
+                    );
+                  })()}
+
                   {/* Confidence score */}
                   {item.confidence_score !== null && item.confidence_score !== undefined && (
                     <span style={{
@@ -888,30 +907,6 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
                     {item.moderated_at && ` · Mod: ${formatPublicationDate(item.moderated_at)}`}
                   </span>
                 </div>
-
-                {/* Triage chips — No Date, No URL / Wrong URL, Other */}
-                {item.content_type !== 'photo' && (() => {
-                  const issues = item.ai_issues ? (() => { try { return JSON.parse(item.ai_issues); } catch { return []; } })() : [];
-                  const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
-                  const hasNoDate = item.content_type === 'event'
-                    ? !item.publication_date && !item.start_date
-                    : !item.publication_date || !item.date_consensus_score;
-                  const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
-                  const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
-                  const hasOther = issues.some(i => !urlIssueCodes.includes(i));
-                  if (!hasNoDate && !hasUrlIssue && !hasOther) return null;
-                  const chipStyle = (color) => ({
-                    padding: '1px 8px', borderRadius: '8px', fontSize: '0.68rem',
-                    fontWeight: 'bold', backgroundColor: color, color: 'white'
-                  });
-                  return (
-                    <div style={{ display: 'flex', gap: '4px', marginTop: '3px' }}>
-                      {hasNoDate && <span style={chipStyle('#e65100')}>No Date</span>}
-                      {hasUrlIssue && <span style={chipStyle('#e65100')}>{urlLabel}</span>}
-                      {hasOther && <span style={chipStyle('#b71c1c')}>Other</span>}
-                    </div>
-                  );
-                })()}
 
                 {/* Edit form */}
                 {isEditing && (
@@ -1080,14 +1075,14 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle }) {
             if (item.content_type === 'news') {
               return (
                 <NewsCardBody key={itemKey} item={{ ...item, summary: item.description }}
-                  id={`moderation-item-${itemKey}`}>
+                  id={`moderation-item-${itemKey}`} onSelectPoi={onSelectPoi}>
                   {moderationExtras}
                 </NewsCardBody>
               );
             } else if (item.content_type === 'event') {
               return (
                 <EventCardBody key={itemKey} item={item}
-                  id={`moderation-item-${itemKey}`}>
+                  id={`moderation-item-${itemKey}`} onSelectPoi={onSelectPoi}>
                   {moderationExtras}
                 </EventCardBody>
               );

--- a/run.sh
+++ b/run.sh
@@ -140,9 +140,12 @@ case "${1:-help}" in
             SEED_MOUNT="-v $SEED_DATA_FILE:/tmp/seed-data.sql:ro"
         fi
 
-        # Create environment file for systemd services
+        # Create environment file for systemd services (only if it doesn't exist)
+        # This file is a long-lived artifact — edit it directly to add API keys
         mkdir -p ~/.rotv
-        cat > ~/.rotv/environment-dev <<ENVFILE
+        if [ ! -f ~/.rotv/environment-dev ]; then
+            echo "Creating ~/.rotv/environment-dev (edit this file to add API keys)"
+            cat > ~/.rotv/environment-dev <<ENVFILE
 NODE_ENV=test
 BYPASS_AUTH=true
 GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
@@ -162,6 +165,7 @@ PGUSER=${PGUSER:-postgres}
 PGPASSWORD=${PGPASSWORD:-rotv}
 PGDATABASE=${PGDATABASE:-rotv}
 ENVFILE
+        fi
 
         # Build MCP port mapping if token is configured
         MCP_PORT_MAP=""


### PR DESCRIPTION
## Summary
- Extract `scoreNewsDate()` shared function — collection, sweep, and Fix Date all use the same code path
- `fixDate()` calls `scoreNewsDate()` directly instead of going through `processItem`
- Add `uploadDate` to JSON-LD extraction in `contentExtractor.js` (fixes YouTube dates)
- Bump JSON-LD weight from 3 to 4 points (validated: no false positives in production data)
- POI links clickable in Moderation tab
- Moderation badges in single wrapping row
- `run.sh`: `environment-dev` treated as long-lived artifact (not clobbered on restart)

## Test plan
- [x] Fix Date works on YouTube item #53 (picks up uploadDate from JSON-LD)
- [x] POI links navigate to map from Moderation
- [x] Badges render in single row
- [ ] Run unit tests (dateExtractor assertions updated for 4pt weight)
- [ ] Verify collection still works (scoreNewsDate called with null title/description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)