### PR TITLE
feat: cache rendered content and date signals at collection

### DIFF
--- a/backend/migrations/030_add_rendered_content.sql
+++ b/backend/migrations/030_add_rendered_content.sql
@@ -1,0 +1,10 @@
+-- Cache rendered page content and date signals at collection time.
+-- Eliminates redundant Playwright rendering and LLM calls during moderation.
+-- rendered_content: full extracted page text (rawText from contentExtractor)
+-- date_signals: all raw date sources + LLM votes as JSONB (enables rescoring without re-crawling)
+
+ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS rendered_content TEXT;
+ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS date_signals JSONB;
+
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS rendered_content TEXT;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS date_signals JSONB;

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -8,7 +8,7 @@ import { moderateContent, moderatePhoto, createGeminiClient, GEMINI_MODEL } from
 import { extractPageContent } from './contentExtractor.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
-import { parseDate } from './dateExtractor.js';
+import { parseDate, scoreDateConsensus } from './dateExtractor.js';
 import { scoreNewsDate, normalizeRenderUrl } from './newsService.js';
 
 const TABLE_MAP = {
@@ -199,7 +199,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
 
     const itemQuery = await pool.query(
       `SELECT t.id, t.title, t.${descField} AS description, t.source_url, t.publication_date,
-              t.date_consensus_score, p.name as poi_name${extraFields}
+              t.date_consensus_score, t.rendered_content, t.date_signals, p.name as poi_name${extraFields}
        FROM ${table} t
        LEFT JOIN pois p ON t.poi_id = p.id
        WHERE t.id = $1`, [contentId]
@@ -258,29 +258,41 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       let newScore = dateScore;
       let newDate = row.publication_date;
 
-      // Extract page content if URL is available
-      let pageContent = null;
-      let ogDates = {};
-      if (row.source_url && isSafePublicUrl(row.source_url)) {
-        try {
-          const renderUrl = normalizeRenderUrl(row.source_url);
-          const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
-          if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
-            pageContent = extracted.rawText || extracted.markdown;
-            ogDates = extracted.ogDates || {};
-          }
-        } catch (err) {
-          console.error(`[Moderation] ${contentType} #${contentId}: page extraction failed: ${err.message}`);
-          logError(itemRunId, 'moderation', null, row.title, `Page extraction failed: ${err.message}`);
-        }
-      }
-
-      // Score using shared function (same code path as collection, but with title+description)
       try {
-        const consensus = await scoreNewsDate(pool, {
-          title: row.title, description: row.description,
-          pageContent, ogDates, sourceUrl: row.source_url
-        });
+        let consensus;
+
+        if (row.date_signals) {
+          // Fast path: rescore from cached signals (no Playwright, no LLM calls)
+          const signals = row.date_signals;
+          const deterministicSources = {
+            jsonLd: signals.jsonLd || [],
+            meta: signals.meta || [],
+            timeTags: signals.timeTags || [],
+            url: signals.url || null
+          };
+          consensus = scoreDateConsensus(deterministicSources, signals.llmVotes || []);
+        } else {
+          // Slow path: no cached signals — render + LLM
+          let pageContent = null;
+          let ogDates = {};
+          if (row.source_url && isSafePublicUrl(row.source_url)) {
+            try {
+              const renderUrl = normalizeRenderUrl(row.source_url);
+              const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
+              if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
+                pageContent = extracted.rawText || extracted.markdown;
+                ogDates = extracted.ogDates || {};
+              }
+            } catch (err) {
+              console.error(`[Moderation] ${contentType} #${contentId}: page extraction failed: ${err.message}`);
+              logError(itemRunId, 'moderation', null, row.title, `Page extraction failed: ${err.message}`);
+            }
+          }
+          consensus = await scoreNewsDate(pool, {
+            title: row.title, description: row.description,
+            pageContent, ogDates, sourceUrl: row.source_url
+          });
+        }
 
         if (consensus.date) {
           newDate = consensus.date;
@@ -688,33 +700,49 @@ export async function fixDate(pool, contentType, contentId) {
   const descField = contentType === 'news' ? 'summary' : 'description';
 
   const itemQuery = await pool.query(
-    `SELECT t.id, t.title, t.${descField} AS description, t.source_url
+    `SELECT t.id, t.title, t.${descField} AS description, t.source_url,
+            t.rendered_content, t.date_signals
      FROM ${table} t WHERE t.id = $1`, [contentId]
   );
   if (!itemQuery.rows.length) throw new Error(`${contentType} #${contentId} not found`);
   const item = itemQuery.rows[0];
 
-  // Extract page content (same as collection)
-  let pageContent = null;
-  let ogDates = {};
-  if (item.source_url && isSafePublicUrl(item.source_url)) {
-    try {
-      const renderUrl = normalizeRenderUrl(item.source_url);
-      const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
-      if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
-        pageContent = extracted.rawText || extracted.markdown;
-        ogDates = extracted.ogDates || {};
-      }
-    } catch (err) {
-      console.error(`[Moderation] fixDate ${contentType} #${contentId}: page extraction failed: ${err.message}`);
-    }
-  }
+  let consensus;
 
-  // Score using the same shared function as collection
-  const consensus = await scoreNewsDate(pool, {
-    title: item.title, description: item.description,
-    pageContent, ogDates, sourceUrl: item.source_url
-  });
+  if (item.date_signals) {
+    // Fast path: rescore from cached signals (no Playwright, no LLM calls)
+    console.log(`[Moderation] fixDate ${contentType} #${contentId}: rescoring from cached date_signals`);
+    const signals = item.date_signals;
+    const deterministicSources = {
+      jsonLd: signals.jsonLd || [],
+      meta: signals.meta || [],
+      timeTags: signals.timeTags || [],
+      url: signals.url || null
+    };
+    consensus = scoreDateConsensus(deterministicSources, signals.llmVotes || []);
+  } else {
+    // Slow path: no cached signals (human-submitted or legacy) — render + LLM
+    console.log(`[Moderation] fixDate ${contentType} #${contentId}: no cached signals, running full extraction`);
+    let pageContent = null;
+    let ogDates = {};
+    if (item.source_url && isSafePublicUrl(item.source_url)) {
+      try {
+        const renderUrl = normalizeRenderUrl(item.source_url);
+        const extracted = await extractPageContent(renderUrl, { timeout: 30000, hardTimeout: 60000 });
+        if (extracted.reachable && extracted.markdown && extracted.markdown.length >= 200) {
+          pageContent = extracted.rawText || extracted.markdown;
+          ogDates = extracted.ogDates || {};
+        }
+      } catch (err) {
+        console.error(`[Moderation] fixDate ${contentType} #${contentId}: page extraction failed: ${err.message}`);
+      }
+    }
+
+    consensus = await scoreNewsDate(pool, {
+      title: item.title, description: item.description,
+      pageContent, ogDates, sourceUrl: item.source_url
+    });
+  }
 
   // Update the item
   const newDate = consensus.date || null;

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -88,7 +88,19 @@ export async function scoreNewsDate(pool, { title, description, pageContent, ogD
     : [];
 
   const normalizedSources = normalizeDateSources(rawSources, timezone);
-  return scoreDateConsensus(normalizedSources, llmResults);
+  const consensus = scoreDateConsensus(normalizedSources, llmResults);
+
+  // Return raw signals alongside consensus so callers can save them for rescoring
+  return {
+    ...consensus,
+    rawSignals: {
+      jsonLd: normalizedSources.jsonLd || [],
+      meta: normalizedSources.meta || [],
+      timeTags: normalizedSources.timeTags || [],
+      url: normalizedSources.url || null,
+      llmVotes: llmResults
+    }
+  };
 }
 
 export function resetJobUsage() {
@@ -491,6 +503,7 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   let primaryDate = null;
   let dateScore = 0;
   let dateSourceMap = {};
+  let dateSignals = null;
   let eventStartDateTime = null;
   let eventStartScore = 0;
   let eventEndDateTime = null;
@@ -551,6 +564,12 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     dateScore = eventStartScore;
     dateSourceMap = startConsensus.sourceMap;
 
+    // Save raw event date signals for rescoring
+    dateSignals = {
+      start: { jsonLd: startSources.jsonLd, timeTags: startSources.timeTags, url: startSources.url, llm: startSources.llm },
+      end: { jsonLd: endSources.jsonLd, timeTags: endSources.timeTags, url: endSources.url, llm: endSources.llm }
+    };
+
     logInfo(jobId, jobType, poi.id, poi.name,
       `${phase}: [Dates] start=${eventStartDateTime || 'none'} (score=${eventStartScore}, sources=${JSON.stringify(startConsensus.sourceMap)}), end=${eventEndDateTime || 'none'} (score=${eventEndScore}) from ${url}`);
 
@@ -566,6 +585,7 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     primaryDate = consensus.date;
     dateScore = consensus.score;
     dateSourceMap = consensus.sourceMap;
+    dateSignals = consensus.rawSignals;
 
     logInfo(jobId, jobType, poi.id, poi.name,
       `${phase}: [Dates] ${primaryDate || 'none'} (score=${dateScore}, sources=${JSON.stringify(dateSourceMap)}) from ${url}`);
@@ -582,10 +602,14 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
   // The crawler already resolved listings → detail pages before we get here.
   const result = parseGeminiResponse(aiResult.response);
 
+  const renderedContent = extracted.rawText || extracted.markdown || null;
+
   for (const item of (result.news || [])) {
     item.source_url = url;
     item.published_date = primaryDate;
     item.date_consensus_score = dateScore;
+    item.rendered_content = renderedContent;
+    item.date_signals = dateSignals;
   }
 
   for (const event of (result.events || [])) {
@@ -593,6 +617,8 @@ async function processOneUrl(pool, url, poi, contentType, options = {}) {
     event.start_date = eventStartDateTime || primaryDate;
     event.end_date = eventEndDateTime || null;
     event.date_consensus_score = eventStartScore || dateScore;
+    event.rendered_content = renderedContent;
+    event.date_signals = dateSignals;
   }
 
   logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Summarize] ${result.news?.length || 0} news, ${result.events?.length || 0} events from ${url}`);
@@ -1279,8 +1305,8 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
       const dateScore = item.date_consensus_score || 0;
       const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
-        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       `, [
         poiId,
         item.title,
@@ -1290,7 +1316,9 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         item.news_type || 'general',
         item.published_date || null,
         dateScore,
-        status
+        status,
+        item.rendered_content || null,
+        item.date_signals ? JSON.stringify(item.date_signals) : null
       ]);
       savedCount++;
       if (log) log(`[Save] Saved (${status}): "${item.title}" (${item.published_date || 'no date'}, score=${dateScore}) → ${resolvedUrl}`);
@@ -1387,8 +1415,8 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
       const dateScore = item.date_consensus_score || 0;
       const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
-        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       `, [
         poiId,
         item.title,
@@ -1400,7 +1428,9 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         resolvedUrl,
         item.start_date || null,
         dateScore,
-        status
+        status,
+        item.rendered_content || null,
+        item.date_signals ? JSON.stringify(item.date_signals) : null
       ]);
       savedCount++;
       if (log) log(`[Save] Saved event (${status}): "${item.title}" (${item.start_date}, score=${dateScore}) → ${resolvedUrl}`);


### PR DESCRIPTION
## Summary
- Save rendered page text (`rendered_content`) and all raw date signals (`date_signals` JSONB) during collection
- Moderation sweep and Fix Date rescore instantly from cached signals — no Playwright, no LLM calls
- Falls back to full extraction for human-submitted and legacy items
- `scoreNewsDate()` returns `rawSignals` alongside consensus for callers to persist

## Test plan
- [ ] Run collection on a POI — verify `rendered_content` and `date_signals` populated
- [ ] Fix Date on AI-collected item — verify instant rescore from cache (check logs)
- [ ] Fix Date on legacy item (no signals) — verify full extraction fallback
- [ ] Moderation sweep uses cached signals for AI items

🤖 Generated with [Claude Code](https://claude.com/claude-code)