### PR TITLE
feat: LLM content relevance voting, remove auto-approval

### DIFF
--- a/backend/migrations/031_add_relevance_signals.sql
+++ b/backend/migrations/031_add_relevance_signals.sql
@@ -1,0 +1,4 @@
+-- LLM content relevance voting signals.
+-- Stores raw vote results so items can be rescored without re-calling the LLM.
+ALTER TABLE poi_news ADD COLUMN IF NOT EXISTS relevance_signals JSONB;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS relevance_signals JSONB;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2648,8 +2648,8 @@ async function start() {
       }
     }, 'moderation-sweep'));
 
-    // Schedule moderation sweep daily at 7 AM — runs after 6 AM news collection completes
-    await scheduleModerationSweep('0 7 * * *');
+    // Schedule moderation sweep every 15 minutes — relevance voting + promotion
+    await scheduleModerationSweep('*/15 * * * *');
 
     // Register newsletter email processing handler
     await registerNewsletterHandler(async (emailId) => {

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -4,7 +4,7 @@
  * Processes pending items via pg-boss queue, auto-approves high-confidence content.
  */
 
-import { moderateContent, moderatePhoto, createGeminiClient, GEMINI_MODEL } from './geminiService.js';
+import { moderateContent, moderatePhoto, createGeminiClient, GEMINI_MODEL, generateTextWithCustomPrompt } from './geminiService.js';
 import { extractPageContent } from './contentExtractor.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
@@ -171,6 +171,43 @@ async function attemptDeepCrawl(pool, contentType, contentId, row, scoring) {
 }
 
 /**
+ * Run LLM content relevance voting — 3 parallel yes/no votes.
+ * Returns array of { relevant: boolean, reasoning: string }.
+ */
+async function runContentRelevanceVotes(pool, { title, description, poiName, contentType }, numVotes = 3) {
+  const prompt = `You are evaluating content for "Roots of The Valley," a guide to Cuyahoga Valley National Park.
+
+Title: "${title}"
+Summary: "${description || '(none)'}"
+Location: ${poiName || '(unknown)'}
+Type: ${contentType}
+
+Is this actual ${contentType} relevant to Cuyahoga Valley National Park visitors?
+Consider: Is it about the park region? Does it connect to nature, trails, recreation,
+conservation, history, ecology, wildlife, or community stewardship? Is it timely
+(actual news/event, not a static reference page)?
+
+Return ONLY valid JSON: {"relevant": true, "reasoning": "one sentence why"}`;
+
+  const results = await Promise.all(
+    Array.from({ length: numVotes }, () =>
+      generateTextWithCustomPrompt(pool, prompt)
+        .then(r => {
+          const raw = (r || '').trim().replace(/^```json\s*/, '').replace(/\s*```$/, '');
+          try {
+            const parsed = JSON.parse(raw);
+            return { relevant: !!parsed.relevant, reasoning: parsed.reasoning || '' };
+          } catch {
+            return null;
+          }
+        })
+        .catch(() => null)
+    )
+  );
+  return results.filter(Boolean);
+}
+
+/**
  * Process a single moderation item (called by pg-boss worker)
  * @param {Pool} pool - Database connection pool
  * @param {string} contentType - 'news', 'event', or 'photo'
@@ -181,10 +218,9 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
   console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
-    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_auto_approve_threshold', 'moderation_news_date_threshold')`
+    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_threshold', 'moderation_news_date_threshold')`
   );
   const settings = Object.fromEntries(settingsRows.rows.map(r => [r.key, r.value]));
-  const autoApproveEnabled = settings.moderation_auto_approve_enabled !== 'false';
   const parsedNewsThreshold = parseInt(settings.moderation_news_date_threshold);
   const newsDateThreshold = Number.isNaN(parsedNewsThreshold) ? 4 : parsedNewsThreshold;
   const parsedPhotoThreshold = parseFloat(settings.moderation_auto_approve_threshold);
@@ -242,37 +278,23 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     }
 
     let dateScore = row.date_consensus_score || 0;
+    let newScore = dateScore;
+    let newDate = row.publication_date;
 
-    // Fast path: already scored >= threshold during collection — just apply threshold
-    if (dateScore >= newsDateThreshold && !forceStatus) {
-      scoring = { confidence_score: dateScore / 8.0, reasoning: `Date consensus score: ${dateScore}/8` };
-      await pool.query(
-        `UPDATE ${table} SET moderation_processed = true, moderation_status = $1 WHERE id = $2`,
-        [autoApproveEnabled ? 'auto_approved' : 'pending', contentId]
-      );
-    } else {
-      // Slow path: re-render and rescore with full consensus pipeline
+    // --- Step 1: Date scoring (rescore from cached signals or full extraction) ---
+    if (dateScore < newsDateThreshold || forceStatus) {
       console.log(`[Moderation] ${contentType} #${contentId}: rescoring (current score=${dateScore}, threshold=${newsDateThreshold})`);
       logInfo(itemRunId, 'moderation', null, row.title, `Rescoring ${contentType} #${contentId} (score=${dateScore})`);
 
-      let newScore = dateScore;
-      let newDate = row.publication_date;
-
       try {
         let consensus;
-
         if (row.date_signals) {
-          // Fast path: rescore from cached signals (no Playwright, no LLM calls)
           const signals = row.date_signals;
-          const deterministicSources = {
-            jsonLd: signals.jsonLd || [],
-            meta: signals.meta || [],
-            timeTags: signals.timeTags || [],
-            url: signals.url || null
-          };
-          consensus = scoreDateConsensus(deterministicSources, signals.llmVotes || []);
+          consensus = scoreDateConsensus(
+            { jsonLd: signals.jsonLd || [], meta: signals.meta || [], timeTags: signals.timeTags || [], url: signals.url || null },
+            signals.llmVotes || []
+          );
         } else {
-          // Slow path: no cached signals — render + LLM
           let pageContent = null;
           let ogDates = {};
           if (row.source_url && isSafePublicUrl(row.source_url)) {
@@ -305,19 +327,58 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         console.error(`[Moderation] ${contentType} #${contentId}: date scoring failed: ${err.message}`);
         logError(itemRunId, 'moderation', null, row.title, `Date scoring failed: ${err.message}`);
       }
-
-      const resolvedStatus = forceStatus ? forceStatus
-        : autoApproveEnabled && newScore >= newsDateThreshold ? 'auto_approved'
-        : 'pending';
-
-      scoring = { confidence_score: newScore / 8.0, reasoning: `Date consensus score: ${newScore}/8` };
-      await pool.query(
-        `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
-                publication_date = $2, date_consensus_score = $3
-         WHERE id = $4`,
-        [resolvedStatus, newDate, newScore, contentId]
-      );
     }
+
+    // --- Step 2: Content relevance voting (3 LLM votes) ---
+    let relevanceVotes = [];
+    try {
+      relevanceVotes = await runContentRelevanceVotes(pool, {
+        title: row.title, description: row.description,
+        poiName: row.poi_name, contentType
+      });
+
+      const yesCount = relevanceVotes.filter(v => v.relevant).length;
+      const noCount = relevanceVotes.filter(v => !v.relevant).length;
+      console.log(`[Moderation] ${contentType} #${contentId}: relevance votes ${yesCount}/${relevanceVotes.length} yes`);
+      logInfo(itemRunId, 'moderation', null, row.title,
+        `Relevance ${contentType} #${contentId}: ${yesCount}/${relevanceVotes.length} yes`);
+    } catch (err) {
+      console.error(`[Moderation] ${contentType} #${contentId}: relevance voting failed: ${err.message}`);
+      logError(itemRunId, 'moderation', null, row.title, `Relevance voting failed: ${err.message}`);
+    }
+
+    // --- Step 3: Decision ---
+    const yesCount = relevanceVotes.filter(v => v.relevant).length;
+    const noCount = relevanceVotes.filter(v => !v.relevant).length;
+    const unanimousYes = relevanceVotes.length >= 3 && yesCount === relevanceVotes.length;
+    const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
+
+    let resolvedStatus;
+    let reasoning;
+    if (forceStatus) {
+      resolvedStatus = forceStatus;
+      reasoning = `Forced to ${forceStatus}`;
+    } else if (unanimousNo) {
+      resolvedStatus = 'rejected';
+      reasoning = `Rejected: relevance vote unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})`;
+    } else if (unanimousYes && newScore >= newsDateThreshold) {
+      resolvedStatus = 'published';
+      reasoning = `Published: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${newsDateThreshold}`;
+    } else {
+      resolvedStatus = 'pending';
+      reasoning = `Pending: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${newsDateThreshold}`;
+    }
+
+    scoring = { confidence_score: newScore / 8.0, reasoning };
+    await pool.query(
+      `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
+              publication_date = $2, date_consensus_score = $3,
+              ai_reasoning = $4, relevance_signals = $5
+       WHERE id = $6`,
+      [resolvedStatus, newDate, newScore, reasoning,
+       relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
+       contentId]
+    );
 
   } else if (contentType === 'photo') {
     const photoQuery = await pool.query(

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1217,14 +1217,6 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   let duplicateCount = 0;
   const { skipDateFilter = false, log = null } = options;
 
-  const moderationRows = await pool.query(
-    "SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_news_date_threshold')"
-  );
-  const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
-  const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
-  const parsedThreshold = parseInt(moderationSettings.moderation_news_date_threshold);
-  const newsDateThreshold = Number.isNaN(parsedThreshold) ? 4 : parsedThreshold;
-
   // Calculate date strings (YYYY-MM-DD) to avoid timezone issues
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
@@ -1301,9 +1293,8 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         continue;
       }
 
-      // New item — auto-approve if date consensus score meets threshold and auto-approve is enabled
+      // All new items enter as pending — moderation sweep handles relevance voting + promotion
       const dateScore = item.date_consensus_score || 0;
-      const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
         INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
@@ -1316,12 +1307,12 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         item.news_type || 'general',
         item.published_date || null,
         dateScore,
-        status,
+        'pending',
         item.rendered_content || null,
         item.date_signals ? JSON.stringify(item.date_signals) : null
       ]);
       savedCount++;
-      if (log) log(`[Save] Saved (${status}): "${item.title}" (${item.published_date || 'no date'}, score=${dateScore}) → ${resolvedUrl}`);
+      if (log) log(`[Save] Saved (pending): "${item.title}" (${item.published_date || 'no date'}, score=${dateScore}) → ${resolvedUrl}`);
     } catch (error) {
       if (log) log(`[Save] Error: "${item.title}" — ${error.message}`);
       console.error(`Error saving news item for POI ${poiId}:`, error.message);
@@ -1341,14 +1332,6 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
   const { log = null } = options;
-
-  const moderationRows = await pool.query(
-    "SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_enabled', 'moderation_news_date_threshold')"
-  );
-  const moderationSettings = Object.fromEntries(moderationRows.rows.map(r => [r.key, r.value]));
-  const autoApproveEnabled = moderationSettings.moderation_auto_approve_enabled !== 'false';
-  const parsedThreshold = parseInt(moderationSettings.moderation_news_date_threshold);
-  const newsDateThreshold = Number.isNaN(parsedThreshold) ? 4 : parsedThreshold;
 
   for (const item of eventItems) {
     try {
@@ -1411,9 +1394,8 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         continue;
       }
 
-      // New event — auto-approve if date consensus score meets threshold and auto-approve is enabled
+      // All new events enter as pending — moderation sweep handles relevance voting + promotion
       const dateScore = item.date_consensus_score || 0;
-      const status = autoApproveEnabled && dateScore >= newsDateThreshold ? 'auto_approved' : 'pending';
       await pool.query(`
         INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
@@ -1428,12 +1410,12 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         resolvedUrl,
         item.start_date || null,
         dateScore,
-        status,
+        'pending',
         item.rendered_content || null,
         item.date_signals ? JSON.stringify(item.date_signals) : null
       ]);
       savedCount++;
-      if (log) log(`[Save] Saved event (${status}): "${item.title}" (${item.start_date}, score=${dateScore}) → ${resolvedUrl}`);
+      if (log) log(`[Save] Saved event (pending): "${item.title}" (${item.start_date}, score=${dateScore}) → ${resolvedUrl}`);
     } catch (error) {
       if (log) log(`[Save] Error: "${item.title}" — ${error.message}`);
       console.error(`Error saving event for POI ${poiId}:`, error.message);


### PR DESCRIPTION
## Summary
- Replace date-based auto-approval with 3-vote LLM content relevance consensus
- 3/3 YES + date score >= threshold → auto-publish; 3/3 NO → auto-reject; mixed → pending
- All items enter as pending at collection time (no more auto_approved status at save)
- Sweep runs every 15 minutes instead of daily at 7AM
- New `relevance_signals` JSONB column stores raw vote results for rescoring

## Test plan
- [ ] Trigger collection — verify items enter as pending
- [ ] Run moderation sweep — verify relevance voting runs and items get promoted/rejected/left pending
- [ ] Check relevance_signals column populated in DB
- [ ] Verify Norfolk Southern-type content gets rejected by relevance votes

🤖 Generated with [Claude Code](https://claude.com/claude-code)