### PR TITLE
feat: multi-size thumbnails, lightbox redesign, sidebar image cleanup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -987,6 +987,7 @@ app.get('/api/pois/:id/image', async (req, res) => {
 app.get('/api/pois/:id/thumbnail', async (req, res) => {
   try {
     const { id } = req.params;
+    const size = req.query.size; // small, medium, large — passed through to image server
 
     // Fix: Query poi_media table for primary image (Gatehouse finding)
     const result = await pool.query(`
@@ -1015,11 +1016,13 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
       return res.status(404).json({ error: 'Image not found' });
     }
 
+    const sizeParam = size && ['small', 'medium', 'large'].includes(size) ? `?size=${size}` : '';
+
     if (!imageServerClient.initialized) {
       // Development fallback: proxy from production asset endpoint when IMAGE_SERVER_URL not configured
       if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
         try {
-          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail`;
+          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail${sizeParam}`;
           const productionResponse = await fetch(productionUrl);
 
           if (!productionResponse.ok) {
@@ -1043,7 +1046,7 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
       return res.status(404).json({ error: 'Image not found' });
     }
 
-    const thumbnailResult = await imageServerClient.fetchThumbnailData(assetId);
+    const thumbnailResult = await imageServerClient.fetchThumbnailData(assetId, size);
     if (!thumbnailResult.success) {
       console.error(`[Thumbnail] Fetch failed for POI ${id}:`, thumbnailResult.error);
       return res.status(404).json({ error: 'Image not found' });
@@ -1132,7 +1135,8 @@ app.get('/api/pois/:id/media', async (req, res) => {
       } else {
         // Image or video from image server
         item.asset_id = media.image_server_asset_id;
-        item.thumbnail_url = `/api/assets/${media.image_server_asset_id}/thumbnail`;
+        item.thumbnail_url = `/api/assets/${media.image_server_asset_id}/thumbnail?size=small`;
+        item.medium_url = `/api/assets/${media.image_server_asset_id}/thumbnail?size=medium`;
         item.full_url = `/api/assets/${media.image_server_asset_id}/original`;
       }
 
@@ -1480,6 +1484,8 @@ app.patch('/api/pois/:poiId/media/:mediaId/set-primary', isAuthenticated, async 
 app.get('/api/assets/:assetId/thumbnail', assetProxyLimiter, async (req, res) => {
   try {
     const { assetId } = req.params;
+    const size = req.query.size; // small, medium, large — passed through to image server
+    const sizeParam = size && ['small', 'medium', 'large'].includes(size) ? `?size=${size}` : '';
 
     // Fix: Validate assetId format to prevent SSRF (Gatehouse finding)
     if (!/^[a-zA-Z0-9_-]{1,100}$/.test(assetId)) {
@@ -1490,7 +1496,7 @@ app.get('/api/assets/:assetId/thumbnail', assetProxyLimiter, async (req, res) =>
       // Development fallback: proxy from production when IMAGE_SERVER_URL not configured
       if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
         try {
-          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail`;
+          const productionUrl = `https://rootsofthevalley.org/api/assets/${assetId}/thumbnail${sizeParam}`;
           const productionResponse = await fetch(productionUrl);
 
           if (!productionResponse.ok) {
@@ -1518,7 +1524,7 @@ app.get('/api/assets/:assetId/thumbnail', assetProxyLimiter, async (req, res) =>
       return res.status(503).json({ error: 'Image service unavailable' });
     }
 
-    const result = await imageServerClient.fetchThumbnailData(assetId);
+    const result = await imageServerClient.fetchThumbnailData(assetId, size);
     if (!result.success) {
       // Fix: Map upstream errors correctly (Gemini review - proxy error handling)
       // 404 = asset doesn't exist, 502/503 = image server down

--- a/backend/services/imageServerClient.js
+++ b/backend/services/imageServerClient.js
@@ -168,13 +168,14 @@ class ImageServerClient {
   /**
    * Fetch thumbnail data (for proxying to frontend)
    */
-  async fetchThumbnailData(assetId) {
+  async fetchThumbnailData(assetId, size) {
     if (!this.initialized || !assetId) {
       return { success: false, error: 'Image server not configured or no asset ID' };
     }
 
     try {
-      const response = await fetch(`${this.serverUrl}/api/assets/${assetId}/thumbnail`);
+      const sizeParam = size && ['small', 'medium', 'large'].includes(size) ? `?size=${size}` : '';
+      const response = await fetch(`${this.serverUrl}/api/assets/${assetId}/thumbnail${sizeParam}`);
 
       if (!response.ok) {
         // Fix: Return detailed error status for better error handling (Gemini review)

--- a/frontend/src/components/Lightbox.css
+++ b/frontend/src/components/Lightbox.css
@@ -8,8 +8,7 @@
   background-color: rgba(0, 0, 0, 0.95);
   z-index: 10001;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
   animation: fadeIn 0.2s ease-in-out;
 }
 
@@ -22,7 +21,7 @@
   }
 }
 
-/* Lightbox Container */
+/* Lightbox Container — vertical flex: counter+thumbnails, image, buttons */
 .lightbox-container {
   position: relative;
   width: 100%;
@@ -30,24 +29,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 60px 80px 120px;
 }
 
 /* Close Button */
 .lightbox-close {
   position: absolute;
-  top: 20px;
-  right: 20px;
+  top: 10px;
+  right: 10px;
   background: rgba(255, 255, 255, 0.2);
   border: none;
   color: white;
-  font-size: 36px;
-  width: 48px;
-  height: 48px;
+  font-size: 32px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   cursor: pointer;
-  z-index: 10001;
+  z-index: 10002;
   transition: background-color 0.2s;
   display: flex;
   align-items: center;
@@ -72,7 +69,7 @@
   height: 60px;
   border-radius: 50%;
   cursor: pointer;
-  z-index: 10001;
+  z-index: 10002;
   transition: background-color 0.2s;
   display: flex;
   align-items: center;
@@ -85,21 +82,121 @@
 }
 
 .lightbox-arrow-left {
-  left: 20px;
+  left: 10px;
 }
 
 .lightbox-arrow-right {
-  right: 20px;
+  right: 10px;
 }
 
-/* Main Media Container */
+/* Top bar: counter + thumbnails */
+.lightbox-top-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 0;
+  flex-shrink: 0;
+}
+
+/* Counter */
+.lightbox-counter {
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+/* Thumbnail Strip */
+.lightbox-thumbnails {
+  display: flex;
+  gap: 6px;
+  max-width: calc(100vw - 40px);
+  overflow-x: auto;
+  padding: 6px;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 6px;
+}
+
+.lightbox-thumbnails::-webkit-scrollbar {
+  height: 4px;
+}
+
+.lightbox-thumbnails::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+}
+
+.lightbox-thumbnails::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+}
+
+/* Thumbnail */
+.lightbox-thumbnail {
+  position: relative;
+  width: 60px;
+  height: 45px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  border-radius: 3px;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: border-color 0.2s, opacity 0.2s;
+}
+
+.lightbox-thumbnail:hover {
+  opacity: 0.8;
+}
+
+.lightbox-thumbnail.active {
+  border-color: white;
+}
+
+.lightbox-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.lightbox-thumbnail:focus {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+/* Thumbnail Media Indicators */
+.thumbnail-video-indicator,
+.thumbnail-youtube-indicator,
+.thumbnail-pending-indicator {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-size: 9px;
+  font-weight: bold;
+}
+
+.thumbnail-pending-indicator {
+  background: rgba(255, 165, 0, 0.9);
+  bottom: 2px;
+  left: 2px;
+  right: auto;
+}
+
+/* Main Media Container — fills available space between top bar and buttons */
 .lightbox-main {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  max-width: 100%;
-  max-height: calc(100vh - 180px); /* Leave space for thumbnails and caption */
+  width: 100%;
+  min-height: 0;
+  position: relative;
+  padding: 0 70px;
 }
 
 /* Image */
@@ -137,290 +234,127 @@
 
 /* Caption */
 .lightbox-caption {
-  margin-top: 16px;
+  margin-top: 8px;
   color: white;
-  font-size: 16px;
+  font-size: 14px;
   text-align: center;
   max-width: 800px;
+  flex-shrink: 0;
 }
 
-/* Counter */
-.lightbox-counter {
+/* Image status badges — shared styling */
+.lightbox-pending-badge,
+.lightbox-primary-badge {
   position: absolute;
-  top: 20px;
+  top: 10px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.6);
-  color: white;
-  padding: 8px 16px;
-  border-radius: 20px;
-  font-size: 14px;
-  z-index: 10001;
-}
-
-/* Pending Review Badge */
-.lightbox-pending-badge {
-  position: absolute;
-  top: 70px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(255, 165, 0, 0.95);
-  color: white;
-  padding: 10px 20px;
-  border-radius: 20px;
-  font-size: 15px;
+  padding: 5px 12px;
+  border-radius: 12px;
+  font-size: 11px;
   font-weight: 600;
-  z-index: 10001;
+  z-index: 10002;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
-/* Primary Image Badge */
+.lightbox-pending-badge {
+  background: rgba(255, 165, 0, 0.95);
+  color: white;
+}
+
 .lightbox-primary-badge {
-  position: absolute;
-  top: 70px;
-  left: 50%;
-  transform: translateX(-50%);
   background: rgba(255, 193, 7, 0.95);
   color: #333;
-  padding: 12px 24px;
-  border-radius: 25px;
-  font-size: 18px;
-  font-weight: 700;
-  z-index: 10001;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  box-shadow: 0 4px 12px rgba(255, 193, 7, 0.4);
 }
 
-/* Thumbnail Strip */
-.lightbox-thumbnails {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+/* Bottom action bar */
+.lightbox-bottom-bar {
   display: flex;
-  gap: 8px;
-  max-width: calc(100vw - 40px);
-  overflow-x: auto;
-  padding: 10px;
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 8px;
-}
-
-.lightbox-thumbnails::-webkit-scrollbar {
-  height: 6px;
-}
-
-.lightbox-thumbnails::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 3px;
-}
-
-.lightbox-thumbnails::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 3px;
-}
-
-/* Thumbnail */
-.lightbox-thumbnail {
-  position: relative;
-  width: 80px;
-  height: 60px;
-  cursor: pointer;
-  border: 2px solid transparent;
-  border-radius: 4px;
-  overflow: hidden;
-  flex-shrink: 0;
-  transition: border-color 0.2s, opacity 0.2s;
-}
-
-.lightbox-thumbnail:hover {
-  opacity: 0.8;
-}
-
-.lightbox-thumbnail.active {
-  border-color: white;
-}
-
-.lightbox-thumbnail img {
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  padding: 12px 20px;
+  flex-shrink: 0;
 }
 
-.lightbox-thumbnail:focus {
-  outline: 2px solid white;
-  outline-offset: 2px;
-}
-
-/* Thumbnail Media Indicators */
-.thumbnail-video-indicator,
-.thumbnail-youtube-indicator,
-.thumbnail-pending-indicator {
-  position: absolute;
-  bottom: 4px;
-  right: 4px;
-  background: rgba(0, 0, 0, 0.7);
+/* Lightbox action buttons */
+.lightbox-set-primary,
+.lightbox-delete-media,
+.lightbox-add-media {
+  width: 110px;
   color: white;
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 10px;
-  font-weight: bold;
+  border: none;
+  padding: 8px 0;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  text-align: center;
 }
 
-.thumbnail-pending-indicator {
-  background: rgba(255, 165, 0, 0.9);
-  bottom: 4px;
-  left: 4px;
-  right: auto;
-}
-
-/* Set as Primary Button */
 .lightbox-set-primary {
-  position: absolute;
-  bottom: 90px;
-  right: 20px;
-  width: 180px;
-  height: 48px;
-  background: #28a745;
-  color: white;
-  border: none;
-  padding: 0 24px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  z-index: 10002;
-  transition: background-color 0.2s, transform 0.1s;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background: #007bff;
 }
-
 .lightbox-set-primary:hover {
-  background: #218838;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  background: #0069d9;
 }
 
-.lightbox-set-primary:active {
-  transform: translateY(0);
-}
-
-.lightbox-set-primary:disabled {
-  background: #6c757d;
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-/* Delete Media Button */
 .lightbox-delete-media {
-  position: absolute;
-  bottom: 30px;
-  left: 20px;
-  width: 180px;
-  height: 48px;
   background: #dc3545;
-  color: white;
-  border: none;
-  padding: 0 24px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  z-index: 10002;
-  transition: background-color 0.2s, transform 0.1s;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
-
 .lightbox-delete-media:hover {
   background: #c82333;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
-.lightbox-delete-media:active {
-  transform: translateY(0);
+.lightbox-add-media {
+  background: #28a745;
+}
+.lightbox-add-media:hover {
+  background: #218838;
 }
 
+.lightbox-set-primary:disabled,
 .lightbox-delete-media:disabled {
   background: #6c757d;
   cursor: not-allowed;
   opacity: 0.6;
 }
 
-/* Add Media Button */
-.lightbox-add-media {
-  position: absolute;
-  bottom: 30px;
-  right: 20px;
-  width: 180px;
-  height: 48px;
-  background: #28a745;
-  color: white;
-  border: none;
-  padding: 0 24px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  z-index: 10002;
-  transition: background-color 0.2s, transform 0.1s;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.lightbox-add-media:hover {
-  background: #218838;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.lightbox-add-media:active {
-  transform: translateY(0);
-}
-
 /* Mobile Responsiveness */
 @media (max-width: 768px) {
-  .lightbox-container {
-    padding: 80px 20px 140px;
+  .lightbox-main {
+    padding: 0 40px;
   }
 
   .lightbox-arrow {
-    width: 44px;
-    height: 44px;
-    font-size: 36px;
-  }
-
-  .lightbox-arrow-left {
-    left: 10px;
-  }
-
-  .lightbox-arrow-right {
-    right: 10px;
-  }
-
-  .lightbox-close {
-    top: 10px;
-    right: 10px;
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
     font-size: 28px;
   }
 
-  .lightbox-counter {
-    top: 10px;
+  .lightbox-arrow-left {
+    left: 4px;
   }
 
-  .lightbox-thumbnails {
-    bottom: 10px;
+  .lightbox-arrow-right {
+    right: 4px;
+  }
+
+  .lightbox-bottom-bar {
+    padding: 10px 10px;
+    gap: 8px;
+  }
+
+  .lightbox-set-primary,
+  .lightbox-delete-media,
+  .lightbox-add-media {
+    width: 95px;
+    padding: 8px 0;
+    font-size: 11px;
   }
 
   .lightbox-youtube-container {
@@ -429,37 +363,4 @@
     max-height: none;
   }
 
-  .lightbox-set-primary {
-    bottom: 85px;
-    right: 10px;
-    width: 160px;
-    height: 44px;
-    padding: 0 16px;
-    font-size: 13px;
-  }
-
-  .lightbox-delete-media {
-    bottom: 30px;
-    left: 10px;
-    width: 160px;
-    height: 44px;
-    padding: 0 16px;
-    font-size: 13px;
-  }
-
-  .lightbox-add-media {
-    bottom: 30px;
-    right: 10px;
-    width: 160px;
-    height: 44px;
-    padding: 0 16px;
-    font-size: 13px;
-  }
-}
-
-/* Tablet */
-@media (min-width: 769px) and (max-width: 1024px) {
-  .lightbox-container {
-    padding: 80px 40px 140px;
-  }
 }

--- a/frontend/src/components/Lightbox.jsx
+++ b/frontend/src/components/Lightbox.jsx
@@ -270,7 +270,7 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
         {/* Bottom action bar */}
         {user && (
           <div className="lightbox-bottom-bar">
-            {(currentMedia.uploaded_by_user || user.role === 'admin' || user.role === 'media_admin') ? (
+            {(currentMedia.uploaded_by_user || user.role === 'admin' || user.role === 'media_admin') && (
               <button
                 className="lightbox-delete-media"
                 onClick={(e) => {
@@ -282,8 +282,8 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
               >
                 {deleting ? 'Deleting...' : 'Delete'}
               </button>
-            ) : <div />}
-            {user && (user.role === 'admin' || user.role === 'media_admin') &&
+            )}
+            {(user.role === 'admin' || user.role === 'media_admin') &&
              currentMedia.role !== 'primary' &&
              ['published', 'auto_approved'].includes(currentMedia.moderation_status) && (
               <button

--- a/frontend/src/components/Lightbox.jsx
+++ b/frontend/src/components/Lightbox.jsx
@@ -201,9 +201,63 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
           </>
         )}
 
-        {/* Main Media */}
+        {/* Top bar: counter + thumbnail strip */}
+        <div className="lightbox-top-bar">
+          <div className="lightbox-counter">
+            {currentIndex + 1} / {media.length}
+          </div>
+          {media.length > 1 && (
+            <div className="lightbox-thumbnails">
+              {media.map((item, index) => (
+                <div
+                  key={item.id}
+                  className={`lightbox-thumbnail ${
+                    index === currentIndex ? 'active' : ''
+                  }`}
+                  onClick={() => setCurrentIndex(index)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      setCurrentIndex(index);
+                    }
+                  }}
+                >
+                  <img
+                    src={item.thumbnail_url}
+                    alt={item.caption || `Thumbnail ${index + 1}`}
+                  />
+                  {item.media_type === 'video' && (
+                    <div className="thumbnail-video-indicator">▶</div>
+                  )}
+                  {item.media_type === 'youtube' && (
+                    <div className="thumbnail-youtube-indicator">YT</div>
+                  )}
+                  {item.moderation_status === 'pending' && (
+                    <div className="thumbnail-pending-indicator">⏱</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Main Media with badges overlaid */}
         <div className="lightbox-main">
           {renderMedia()}
+
+          {/* Badges positioned over the image */}
+          {currentMedia.moderation_status === 'pending' && (
+            <div className="lightbox-pending-badge">
+              ⏱ Pending Review
+            </div>
+          )}
+          {currentMedia.role === 'primary' && (
+            <div className="lightbox-primary-badge">
+              ⭐ Primary
+            </div>
+          )}
+
         </div>
 
         {/* Caption */}
@@ -213,105 +267,48 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
           </div>
         )}
 
-        {/* Pending indicator for user's own uploads */}
-        {currentMedia.moderation_status === 'pending' && (
-          <div className="lightbox-pending-badge">
-            ⏱ Pending Review
-          </div>
-        )}
-
-        {/* Primary image indicator */}
-        {currentMedia.role === 'primary' && (
-          <div className="lightbox-primary-badge">
-            ⭐ Primary Image
-          </div>
-        )}
-
-        {/* Counter */}
-        <div className="lightbox-counter">
-          {currentIndex + 1} / {media.length}
-        </div>
-
-        {/* Thumbnail Strip */}
-        {media.length > 1 && (
-          <div className="lightbox-thumbnails">
-            {media.map((item, index) => (
-              <div
-                key={item.id}
-                className={`lightbox-thumbnail ${
-                  index === currentIndex ? 'active' : ''
-                }`}
-                onClick={() => setCurrentIndex(index)}
-                role="button"
-                tabIndex={0}
-                onKeyPress={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    setCurrentIndex(index);
-                  }
-                }}
-              >
-                <img
-                  src={item.thumbnail_url}
-                  alt={item.caption || `Thumbnail ${index + 1}`}
-                />
-                {item.media_type === 'video' && (
-                  <div className="thumbnail-video-indicator">▶</div>
-                )}
-                {item.media_type === 'youtube' && (
-                  <div className="thumbnail-youtube-indicator">YT</div>
-                )}
-                {item.moderation_status === 'pending' && (
-                  <div className="thumbnail-pending-indicator">⏱</div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Set as Primary button for admins on non-primary published images */}
-        {user && (user.role === 'admin' || user.role === 'media_admin') &&
-         currentMedia.role !== 'primary' &&
-         ['published', 'auto_approved'].includes(currentMedia.moderation_status) && (
-          <button
-            className="lightbox-set-primary"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleSetPrimary();
-            }}
-            disabled={settingPrimary}
-            aria-label="Set as primary image"
-          >
-            {settingPrimary ? 'Setting...' : '⭐ Set as Primary'}
-          </button>
-        )}
-
-        {/* Delete button for user's own uploads or admins */}
-        {user && (currentMedia.uploaded_by_user || user.role === 'admin' || user.role === 'media_admin') && (
-          <button
-            className="lightbox-delete-media"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDelete();
-            }}
-            disabled={deleting}
-            aria-label="Delete this image"
-          >
-            {deleting ? 'Deleting...' : '🗑 Delete'}
-          </button>
-        )}
-
-        {/* Add Photo/Video button for authenticated users */}
+        {/* Bottom action bar */}
         {user && (
-          <button
-            className="lightbox-add-media"
-            onClick={(e) => {
-              e.stopPropagation();
-              setUploadModalOpen(true);
-            }}
-            aria-label="Add photo or video"
-          >
-            + Add Photo/Video
-          </button>
+          <div className="lightbox-bottom-bar">
+            {(currentMedia.uploaded_by_user || user.role === 'admin' || user.role === 'media_admin') ? (
+              <button
+                className="lightbox-delete-media"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDelete();
+                }}
+                disabled={deleting}
+                aria-label="Delete this image"
+              >
+                {deleting ? 'Deleting...' : 'Delete'}
+              </button>
+            ) : <div />}
+            {user && (user.role === 'admin' || user.role === 'media_admin') &&
+             currentMedia.role !== 'primary' &&
+             ['published', 'auto_approved'].includes(currentMedia.moderation_status) && (
+              <button
+                className="lightbox-set-primary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSetPrimary();
+                }}
+                disabled={settingPrimary}
+                aria-label="Set as primary image"
+              >
+                {settingPrimary ? 'Setting...' : 'Set Primary'}
+              </button>
+            )}
+            <button
+              className="lightbox-add-media"
+              onClick={(e) => {
+                e.stopPropagation();
+                setUploadModalOpen(true);
+              }}
+              aria-label="Add photo or video"
+            >
+              Add Media
+            </button>
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/Mosaic.jsx
+++ b/frontend/src/components/Mosaic.jsx
@@ -45,7 +45,7 @@ function Mosaic({ media, allMedia, poiId, user, onMediaUpdate }) {
             }}
           >
             <img
-              src={item.full_url || item.thumbnail_url}
+              src={item.medium_url || item.thumbnail_url}
               alt={item.caption || `POI image ${index + 1}`}
               className="mosaic-image"
             />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3229,17 +3229,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
             />
           ) : media.length > 0 ? (
             <Mosaic media={media} allMedia={allMedia} poiId={linearFeature?.id} user={user} onMediaUpdate={handleMediaUpdate} />
-          ) : !mediaLoading && linearFeature?.has_primary_image ? (
-            <div className="sidebar-image">
-              <img
-                src={`/api/pois/${linearFeature.id}/thumbnail?size=medium&v=${linearFeature.updated_at || Date.now()}`}
-                alt={linearFeature?.name}
-                onError={(e) => {
-                  e.target.style.display = 'none';
-                  e.target.parentElement.style.display = 'none';
-                }}
-              />
-            </div>
           ) : user && linearFeature?.id && !mediaLoading ? (
             <div className="sidebar-no-media">
               <button
@@ -3251,8 +3240,8 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
             </div>
           ) : null}
 
-          {/* Navigation chevrons on image - mobile only */}
-          {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && (
+          {/* Navigation chevrons on image - mobile only, only when image is visible */}
+          {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
             <>
               {currentIndex > 0 && (
                 <button
@@ -3568,18 +3557,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
           />
         ) : media.length > 0 ? (
           <Mosaic media={media} allMedia={allMedia} poiId={destination?.id} user={user} onMediaUpdate={handleMediaUpdate} />
-        ) : !mediaLoading && destination?.has_primary_image ? (
-          <div className={`sidebar-image ${destination?.poi_roles?.includes('organization') ? 'virtual-thumbnail' : ''}`}>
-            <img
-              src={`/api/pois/${destination.id}/thumbnail?size=medium&v=${destination.updated_at || Date.now()}`}
-              alt={destination?.name}
-              className={destination?.poi_roles?.includes('organization') ? 'logo-image' : ''}
-              onError={(e) => {
-                e.target.style.display = 'none';
-                e.target.parentElement.style.display = 'none';
-              }}
-            />
-          </div>
         ) : user && destination?.id && !mediaLoading ? (
           <div className="sidebar-no-media">
             <button
@@ -3591,8 +3568,8 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
           </div>
         ) : null}
 
-        {/* Navigation chevrons on image - mobile only */}
-        {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && (
+        {/* Navigation chevrons on image - mobile only, only when image is visible */}
+        {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
           <>
             {currentIndex > 0 && (
               <button

--- a/run.sh
+++ b/run.sh
@@ -179,7 +179,7 @@ ENVFILE
             -p 2525:25 \
             $MCP_PORT_MAP \
             --tmpfs /run \
-            -v ~/.rotv/environment-dev:/etc/rotv/environment:ro,Z \
+            -v ~/.rotv/environment-dev:/etc/rotv/environment:ro \
             $STORAGE_MOUNT \
             $SEED_MOUNT \
             "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- Mosaic hero images use medium thumbnails (600px, 46KB) instead of originals (823KB)
- ROTV proxy passes `size` param through to image server for small/medium/large thumbnails
- Sidebar no longer relies on stale `has_primary_image` flag — media API is source of truth
- Lightbox redesigned: thumbnail carousel on top, badges over image, action buttons in bottom bar
- Fix dev environment bind mount (`run.sh` `:ro,Z` → `:ro`) that truncated the env file

Depends on: crunchtools/image-server#3 (already deployed)

## Test plan
- [ ] Mosaic images are sharp (medium 600px, not blurry 250px thumbnails)
- [ ] POIs without images show "Add Photo/Video" button, no broken images
- [ ] Lightbox: carousel at top, Delete/Set Primary/Add Media buttons equal width at bottom
- [ ] Lightbox: Primary badge centered above image
- [ ] Mobile and desktop lightbox layouts correct
- [ ] Nav chevrons don't appear when POI has no image

🤖 Generated with [Claude Code](https://claude.com/claude-code)