### PR TITLE
fix: sort approved moderation items by publication date

### DIFF
--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -811,7 +811,10 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
 
   const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
 
-  const wrappedQuery = `SELECT * FROM (${baseQuery}) AS q ${whereClause} ORDER BY created_at DESC LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
+  const orderBy = status === 'approved'
+    ? 'ORDER BY COALESCE(publication_date, created_at::date) DESC, created_at DESC'
+    : 'ORDER BY created_at DESC';
+  const wrappedQuery = `SELECT * FROM (${baseQuery}) AS q ${whereClause} ${orderBy} LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
   const countQuery = `SELECT COUNT(*) FROM (${baseQuery}) AS q ${whereClause}`;
 
   params.push(limit, offset);


### PR DESCRIPTION
## Summary
- Approved moderation items now sort by `publication_date DESC` to match the public News tab
- Pending items keep `collection_date DESC` sort for triage workflow

## Test plan
- [ ] Filter moderation queue to approved news, verify order matches News tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)