### PR TITLE
fix: reject future-dated news + Reject button on approved items

### DIFF
--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -360,11 +360,17 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     const unanimousYes = relevanceVotes.length >= 3 && yesCount === relevanceVotes.length;
     const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
 
+    // Reject news with future publication dates
+    const isFutureDate = contentType === 'news' && newDate && new Date(newDate) > new Date();
+
     let resolvedStatus;
     let reasoning;
     if (forceStatus) {
       resolvedStatus = forceStatus;
       reasoning = `Forced to ${forceStatus}`;
+    } else if (isFutureDate) {
+      resolvedStatus = 'rejected';
+      reasoning = `Rejected: future publication date ${newDate}`;
     } else if (unanimousNo) {
       resolvedStatus = 'rejected';
       reasoning = `Rejected: relevance vote unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})`;

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -993,8 +993,12 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
                     </>
                   )}
                   {!isPending && (
-                    <button onClick={() => handleRequeue(item.content_type, item.id)}
-                      style={actionBtn()}>Requeue</button>
+                    <>
+                      <button onClick={() => handleReject(item.content_type, item.id)}
+                        style={actionBtn()}>Reject</button>
+                      <button onClick={() => handleRequeue(item.content_type, item.id)}
+                        style={actionBtn()}>Requeue</button>
+                    </>
                   )}
                   {item.content_type !== 'photo' && (
                     <button onClick={() => handleFixDate(item.content_type, item.id)}


### PR DESCRIPTION
## Summary
- Auto-reject news items with future publication dates during moderation sweep
- Show Reject + Requeue buttons on approved items (was only Requeue)
- Pending items keep Approve + Reject (unchanged)

## Test plan
- [x] Verified Reject button appears on approved items in local container
- [ ] Verify future-dated news gets auto-rejected on next collection run

🤖 Generated with [Claude Code](https://claude.com/claude-code)