### PR TITLE
fix: normalize datetime sources to UTC, Eastern as default

### DIFF
--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -40,36 +40,30 @@ export function parseDate(raw, timezone = 'America/New_York') {
 }
 
 /**
- * Normalize a datetime string to YYYY-MM-DDTHH:MM:SS.
+ * Normalize a datetime string to a UTC ISO string (YYYY-MM-DDTHH:MM:SS).
+ * Bare strings (no explicit offset) are interpreted in `timezone` (default: Eastern).
+ * Strings with explicit offsets (Z, +HH:MM, -HH:MM) are honored as-is.
  * @param {string|null} raw - Raw datetime string
- * @param {string} timezone - IANA timezone
- * @returns {string|null} 'YYYY-MM-DDTHH:MM:SS' or null
+ * @param {string} timezone - IANA timezone for bare strings (default: America/New_York)
+ * @returns {string|null} 'YYYY-MM-DDTHH:MM:SS' in UTC, or null
  */
 export function parseDateTime(raw, timezone = 'America/New_York') {
   if (!raw || typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
-  const isoMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)$/);
-  if (isoMatch) return `${isoMatch[1]}T${isoMatch[2].length === 5 ? isoMatch[2] + ':00' : isoMatch[2]}`;
-
+  // chrono-node handles both cases:
+  //   - Bare strings ("2026-04-28T18:00", "April 28 at 6pm") → interpreted in `timezone`
+  //   - Explicit offsets ("2026-04-28T18:00:00-04:00", "...Z") → offset honored as-is
+  // start.date() returns a UTC-correct JS Date in both cases.
   let parsedDates;
   try {
     parsedDates = chrono.parse(trimmed, { instant: new Date(), timezone });
   } catch { return null; }
   if (parsedDates.length === 0) return null;
 
-  const d = parsedDates[0].start;
-  const year = d.get('year');
-  const month = d.get('month');
-  const day = d.get('day');
-  if (!year || !month || !day) return null;
-
-  const hour = d.get('hour') ?? 0;
-  const minute = d.get('minute') ?? 0;
-  const second = d.get('second') ?? 0;
-
-  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`;
+  const d = parsedDates[0].start.date(); // UTC-correct JS Date
+  return d.toISOString().substring(0, 19); // "YYYY-MM-DDTHH:MM:SS" in UTC
 }
 
 /**

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -105,7 +105,12 @@ export async function scoreDate(pool, { title, description, pageContent, sources
     : []);
 
   const normalizedSources = normalizeDateSources(sources, timezone, mode);
-  const consensus = scoreDateConsensus(normalizedSources, votes);
+  // For datetime mode, normalize LLM votes to UTC so they match normalized sources.
+  // In date mode, votes are already YYYY-MM-DD strings with no timezone concern.
+  const normalizedVotes = (mode === 'datetime')
+    ? votes.map(v => v ? parseDateTime(v, timezone)?.substring(0, 16) : null).filter(Boolean)
+    : votes;
+  const consensus = scoreDateConsensus(normalizedSources, normalizedVotes);
 
   return {
     ...consensus,
@@ -114,7 +119,7 @@ export async function scoreDate(pool, { title, description, pageContent, sources
       meta: normalizedSources.meta || [],
       timeTags: normalizedSources.timeTags || [],
       url: normalizedSources.url || null,
-      llmVotes: votes
+      llmVotes: normalizedVotes
     }
   };
 }
@@ -1262,12 +1267,12 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 
   for (const item of newsItems) {
     try {
-      // Normalize dates. Full ISO timestamps are preserved; bare dates are promoted to
-      // noon UTC (YYYY-MM-DDT12:00:00Z) so timezone conversion never shifts the calendar date.
+      // Normalize dates. Full ISO timestamps are converted to UTC via parseDateTime
+      // (bare strings assumed Eastern; explicit offsets honored). Bare dates are promoted
+      // to noon UTC (YYYY-MM-DDT12:00:00Z) so timezone conversion never shifts the calendar date.
       if (item.published_date && item.published_date.includes('T')) {
-        // Already a full timestamp — keep as-is (validated below)
-        const ts = new Date(item.published_date);
-        item.published_date = isNaN(ts) ? null : ts.toISOString();
+        const normalized = parseDateTime(item.published_date, 'America/New_York');
+        item.published_date = normalized ? normalized + 'Z' : null;
       } else {
         const d = parseDate(item.published_date);
         item.published_date = d ? `${d}T12:00:00Z` : null;


### PR DESCRIPTION
## Summary

- **`parseDateTime`** (`dateExtractor.js`): replaced fast-path regex + `d.get('hour')` component assembly with `chrono-node`'s `start.date()` — bare strings (no offset) are interpreted as Eastern, explicit offsets (Z, ±HH:MM) are honored as-is. All paths return a UTC `"YYYY-MM-DDTHH:MM:SS"` string.
- **`scoreDate`** (`newsService.js`): LLM votes in `datetime` mode are now normalized through `parseDateTime` before `scoreDateConsensus`, so they match UTC-normalized deterministic sources. Normalized votes are also stored in `rawSignals` for cache consistency.
- **`saveNewsItems`** (`newsService.js`): full-timestamp `published_date` now goes through `parseDateTime` instead of bare `new Date()`, applying the same Eastern-default rule.

## Why

Events stored as `"18:00 UTC"` when the source said `"6:00 PM Eastern"` — displayed as 2:00 PM. Root cause: `parseDateTime` returned local-time strings that PostgreSQL `TIMESTAMPTZ` interpreted as UTC.

## Follow-up required

After merge and deploy: truncate `poi_events` and `poi_news` and trigger a full re-collection to clear pre-existing rows with wrong UTC offsets. No user-submitted content exists (beta).

## Test plan
- [x] `./run.sh test` — no new failures (4 pre-existing failures unchanged)
- [ ] After deploy: re-collect a known 6 PM Eastern event, confirm `start_date` is `22:00:00+00` in DB
- [ ] Confirm `date_consensus_score` ≥ 4 (LLM votes and JSON-LD now agree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)