### PR TITLE
fix: drop date_consensus_score range constraints

### DIFF
--- a/backend/migrations/037_drop_date_score_constraints.sql
+++ b/backend/migrations/037_drop_date_score_constraints.sql
@@ -1,0 +1,8 @@
+-- Migration 037: Drop date_consensus_score range constraints
+--
+-- These constraints assumed a maximum score of 12, but pages with multiple
+-- JSON-LD entries (e.g. Signal Akron) produce scores well above that ceiling.
+-- The constraints are never queried against and serve no functional purpose —
+-- they only cause save failures when high-confidence items exceed the cap.
+ALTER TABLE poi_news   DROP CONSTRAINT IF EXISTS chk_news_date_score_range;
+ALTER TABLE poi_events DROP CONSTRAINT IF EXISTS chk_events_date_score_range;


### PR DESCRIPTION
## Summary

- Drops `chk_news_date_score_range` and `chk_events_date_score_range` constraints from `poi_news` and `poi_events`

## Why

Pages with multiple JSON-LD entries (e.g. Signal Akron) produce `date_consensus_score` values of 20+. The constraint ceiling of 12 assumed one JSON-LD block per page. Every violation means a found article fails to save despite Gemini tokens already spent — and gets reprocessed every subsequent run.

The constraints are never queried against and serve no functional purpose. Dropping them entirely is cleaner than raising the ceiling to another arbitrary number.

## Test plan
- [x] `./run.sh test` — 4 pre-existing failures, no regressions
- [ ] After deploy: run migration, confirm `[Save] Error: ...violates check constraint` disappears from job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)