### PR TITLE
fix: penalise LLM-only date scores to prevent auto-approval

### DIFF
--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -292,7 +292,15 @@ export function scoreDateConsensus(deterministicSources = {}, llmResults = []) {
     return { date: sorted[0][0], score: 0, sourceMap };
   }
 
-  return { date: sorted[0][0], score: sorted[0][1], sourceMap };
+  // Penalise purely LLM-voted dates: no structured source (JSON-LD, meta, time tag, URL)
+  // means the LLM had nothing to anchor against and may have defaulted to today's date.
+  // Subtract 2 so LLM-only scores can never reach the auto-approval threshold (4).
+  const hasDeterministicSource =
+    (deterministicSources.jsonLd?.length > 0) || (deterministicSources.meta?.length > 0) ||
+    (deterministicSources.timeTags?.length > 0) || !!deterministicSources.url;
+  const finalScore = hasDeterministicSource ? sorted[0][1] : Math.max(0, sorted[0][1] - 2);
+
+  return { date: sorted[0][0], score: finalScore, sourceMap };
 }
 
 /**

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -113,13 +113,13 @@ describe('scoreDateConsensus', () => {
     expect(result.score).toBe(5);
   });
 
-  it('5 unanimous LLM votes score 5 pts', () => {
+  it('5 unanimous LLM votes score 3 pts (penalised -2 for no structured source)', () => {
     const result = scoreDateConsensus(
       {},
       ['2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01']
     );
     expect(result.date).toBe('2024-06-01');
-    expect(result.score).toBe(5);
+    expect(result.score).toBe(3); // 5 LLM votes - 2 penalty = 3 (below auto-approve threshold)
   });
 
   it('LLM votes + agreeing JSON-LD scores 9 pts', () => {


### PR DESCRIPTION
## Summary

Subtracts 2 from `date_consensus_score` when no structured data sources (JSON-LD, meta tags, time tags, URL) contributed to the date. This prevents pure LLM-voted dates from reaching the auto-approval threshold of 4.

## Why

Facebook posts and similar JS-heavy pages expose no parseable date metadata. The LLM sees a relative date ("4 days ago") or nothing, and with "Today's date is YYYY-MM-DD" seeded in the prompt, all 5 votes default to the collection date. Score of 5 → auto-approved with the wrong date.

After this fix: 5 LLM votes, no structured source → score 3 → pending for human review.

Items with any structured source (JSON-LD, meta, time tag, URL) are unaffected.

## Test plan
- [x] `./run.sh test` — 4 pre-existing failures, no regressions
- [x] Updated `dateExtractor.unit.test.js` to reflect new expected score (3, not 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)