### PR TITLE
fix: comprehensive timezone handling for dates and datetimes

### DIFF
--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -52,18 +52,25 @@ export function parseDateTime(raw, timezone = 'America/New_York') {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
-  // chrono-node handles both cases:
-  //   - Bare strings ("2026-04-28T18:00", "April 28 at 6pm") → interpreted in `timezone`
-  //   - Explicit offsets ("2026-04-28T18:00:00-04:00", "...Z") → offset honored as-is
-  // start.date() returns a UTC-correct JS Date in both cases.
+  // Bare ISO strings ("2026-04-22T10:30", "2026-04-22T10:30:00") — no Z, no ±offset.
+  // chrono-node ignores the timezone parameter for these and treats them as UTC.
+  // Use localToUTC instead, which correctly interprets them in the given timezone.
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(trimmed) &&
+      !/[Zz]/.test(trimmed) &&
+      !/[+-]\d{2}(:\d{2})?$/.test(trimmed)) {
+    return localToUTC(trimmed, timezone);
+  }
+
+  // Everything else: natural language ("April 28 at 6pm"), explicit offsets
+  // ("2026-04-28T18:00:00-04:00"), Z-terminated ("...Z"). chrono handles correctly.
   let parsedDates;
   try {
     parsedDates = chrono.parse(trimmed, { instant: new Date(), timezone });
   } catch { return null; }
   if (parsedDates.length === 0) return null;
 
-  const d = parsedDates[0].start.date(); // UTC-correct JS Date
-  return d.toISOString().substring(0, 19); // "YYYY-MM-DDTHH:MM:SS" in UTC
+  const d = parsedDates[0].start.date();
+  return d.toISOString().substring(0, 19);
 }
 
 /**
@@ -331,4 +338,27 @@ export function findEventDates(text, title, timezone = 'America/New_York') {
   }
 
   return eventDates;
+}
+
+/**
+ * Convert a datetime-local string (no offset) from a given IANA timezone to UTC ISO.
+ * Unlike parseDateTime, this correctly handles ISO-format strings (chrono-node
+ * ignores the timezone parameter for ISO strings and treats them as UTC).
+ *
+ * @param {string} localStr - "YYYY-MM-DDTHH:MM" (datetime-local input value)
+ * @param {string} timezone - IANA timezone the value is expressed in (default: America/New_York)
+ * @returns {string|null} "YYYY-MM-DDTHH:MM:SS" in UTC, or null
+ */
+export function localToUTC(localStr, timezone = 'America/New_York') {
+  if (!localStr || !localStr.includes('T')) return null;
+  // Eastern is either -04:00 (EDT) or -05:00 (EST). Try both, verify with round-trip.
+  for (const offset of ['-04:00', '-05:00']) {
+    const d = new Date(localStr + ':00' + offset);
+    if (isNaN(d.getTime())) continue;
+    const rt = d.toLocaleString('sv-SE', { timeZone: timezone }).replace(' ', 'T').substring(0, 16);
+    if (rt === localStr.substring(0, 16)) {
+      return d.toISOString().substring(0, 19);
+    }
+  }
+  return null;
 }

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -8,7 +8,7 @@ import { moderateContent, moderatePhoto, generateTextWithCustomPrompt } from './
 import { renderPage } from './renderPage.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
-import { parseDate, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
+import { parseDate, parseDateTime, localToUTC, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
 import { scoreDate, normalizeRenderUrl } from './newsService.js';
 
 const TABLE_MAP = {
@@ -590,8 +590,21 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
   for (const field of allowedFields) {
     if (edits[field] !== undefined) {
       setClauses.push(`${field} = $${idx}`);
-      // Coerce empty strings to null for date/timestamp columns
-      values.push(DATE_FIELDS.includes(field) && edits[field] === '' ? null : edits[field]);
+      if (DATE_FIELDS.includes(field)) {
+        if (!edits[field] || edits[field] === '') {
+          values.push(null);
+        } else if (edits[field].includes('T')) {
+          // datetime-local value — admin entered in Eastern, convert to UTC
+          const utc = localToUTC(edits[field], 'America/New_York');
+          values.push(utc ? utc + 'Z' : edits[field]);
+        } else {
+          // date-only fallback — noon Eastern
+          const utc = parseDateTime(edits[field] + 'T12:00:00', 'America/New_York');
+          values.push(utc ? utc + 'Z' : edits[field]);
+        }
+      } else {
+        values.push(edits[field]);
+      }
       idx++;
     }
   }

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1284,15 +1284,15 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 
   for (const item of newsItems) {
     try {
-      // Normalize dates. Full ISO timestamps are converted to UTC via parseDateTime
-      // (bare strings assumed Eastern; explicit offsets honored). Bare dates are promoted
-      // to noon UTC (YYYY-MM-DDT12:00:00Z) so timezone conversion never shifts the calendar date.
+      // Normalize dates: bare strings assumed Eastern, explicit offsets honored.
+      // Date-only values promoted to noon Eastern so display never shifts the calendar day.
       if (item.published_date && item.published_date.includes('T')) {
         const normalized = parseDateTime(item.published_date, 'America/New_York');
         item.published_date = normalized ? normalized + 'Z' : null;
       } else {
         const d = parseDate(item.published_date);
-        item.published_date = d ? `${d}T12:00:00Z` : null;
+        const noon = d ? parseDateTime(d + 'T12:00:00', 'America/New_York') : null;
+        item.published_date = noon ? noon + 'Z' : null;
       }
 
       // Resolve redirect URLs to final destination URLs
@@ -1387,9 +1387,23 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
 
   for (const item of eventItems) {
     try {
-      // Normalize event dates — preserve datetimes if present, fall back to date-only
-      item.start_date = parseDateTime(item.start_date) || parseDate(item.start_date) || item.start_date;
-      item.end_date = parseDateTime(item.end_date) || parseDate(item.end_date) || null;
+      // Format event dates for DB storage. Values from the scoring pipeline are already
+      // UTC — do NOT re-parse them (would double-convert Eastern→UTC). Just append Z.
+      // Date-only values get promoted to noon Eastern.
+      const noonEastern = (raw) => {
+        const d = parseDate(raw);
+        if (!d) return null;
+        const utc = parseDateTime(d + 'T12:00:00', 'America/New_York');
+        return utc ? utc + 'Z' : null;
+      };
+      const formatForDb = (val) => {
+        if (!val) return null;
+        if (/[Zz]$/.test(val) || /[+-]\d{2}(:\d{2})?$/.test(val)) return val;
+        if (val.includes('T')) return val + 'Z';  // bare UTC from scoring pipeline
+        return noonEastern(val);                   // date-only fallback
+      };
+      item.start_date = formatForDb(item.start_date) || item.start_date;
+      item.end_date = formatForDb(item.end_date) || null;
 
       // Default end time: if start has a time component but end is NULL, assume 60 minutes
       if (item.start_date && !item.end_date && item.start_date.includes('T')) {

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -214,28 +214,28 @@ describe('normalizeRenderUrl', () => {
 });
 
 describe('normalizeDateSources datetime mode', () => {
-  it('normalizes to minute precision (drops seconds)', () => {
+  it('bare ISO treated as Eastern → converted to UTC (Apr = EDT, +4h)', () => {
     const result = normalizeDateSources({ jsonLd: ['2026-04-22T10:30'] }, 'America/New_York', 'datetime');
-    expect(result.jsonLd).toContain('2026-04-22T10:30');
+    expect(result.jsonLd).toContain('2026-04-22T14:30');
   });
 
-  it('parses datetime strings with timezone offsets to minute precision', () => {
+  it('explicit offset honored as-is', () => {
     const result = normalizeDateSources({ jsonLd: ['2026-04-22T10:30-04:00'] }, 'America/New_York', 'datetime');
     expect(result.jsonLd.length).toBe(1);
-    expect(result.jsonLd[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    expect(result.jsonLd[0]).toBe('2026-04-22T14:30');
   });
 
-  it('handles date-only strings by adding T00:00', () => {
+  it('handles date-only strings (produces a datetime)', () => {
     const result = normalizeDateSources({ jsonLd: ['2026-04-22'] }, 'America/New_York', 'datetime');
     expect(result.jsonLd.length).toBe(1);
     expect(result.jsonLd[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
   });
 
-  it('makes "10:30" and "10:30:00" match after normalization', () => {
+  it('bare "10:30" and "10:30:00" match after normalization', () => {
     const a = normalizeDateSources({ jsonLd: ['2026-04-22T10:30'] }, 'America/New_York', 'datetime');
     const b = normalizeDateSources({ jsonLd: ['2026-04-22T10:30:00'] }, 'America/New_York', 'datetime');
-    expect(a.jsonLd[0]).toBe('2026-04-22T10:30');
-    expect(b.jsonLd[0]).toBe('2026-04-22T10:30');
+    expect(a.jsonLd[0]).toBe(b.jsonLd[0]);
+    expect(a.jsonLd[0]).toBe('2026-04-22T14:30');
   });
 
   it('discards unparseable strings', () => {

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -2,24 +2,27 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Lightbox from './Lightbox';
 import { NewsCardBody, EventCardBody, formatPublicationDate } from './NewsEventsShared';
 
+// Eastern timezone abbreviation (EST or EDT) for datetime labels
+const TZ_ABBR = new Date().toLocaleTimeString('en-US', { timeZone: 'America/New_York', timeZoneName: 'short' }).split(' ').pop();
+
 const FIELD_CONFIGS = {
   news: [
     { key: 'title', label: 'Title', type: 'text', required: true },
     { key: 'summary', label: 'Summary', type: 'textarea' },
     { key: 'source_name', label: 'Source Name', type: 'text' },
     { key: 'news_type', label: 'Type', type: 'select', options: ['general', 'closure', 'seasonal', 'maintenance', 'wildlife'] },
-    { key: 'publication_date', label: 'Publication Date', type: 'date' },
+    { key: 'publication_date', label: `Publication Date (${TZ_ABBR})`, type: 'datetime-local' },
     { key: 'poi_id', label: 'POI', type: 'poi' },
     { key: 'source_url', label: 'Primary URL', type: 'text' },
   ],
   event: [
     { key: 'title', label: 'Title', type: 'text', required: true },
     { key: 'description', label: 'Description', type: 'textarea' },
-    { key: 'start_date', label: 'Start Date/Time', type: 'datetime-local', required: true },
-    { key: 'end_date', label: 'End Date/Time', type: 'datetime-local' },
+    { key: 'start_date', label: `Start Date/Time (${TZ_ABBR})`, type: 'datetime-local', required: true },
+    { key: 'end_date', label: `End Date/Time (${TZ_ABBR})`, type: 'datetime-local' },
     { key: 'event_type', label: 'Event Type', type: 'text' },
     { key: 'location_details', label: 'Location Details', type: 'text' },
-    { key: 'publication_date', label: 'Publication Date', type: 'date' },
+    { key: 'publication_date', label: `Publication Date (${TZ_ABBR})`, type: 'datetime-local' },
     { key: 'poi_id', label: 'POI', type: 'poi' },
     { key: 'source_url', label: 'Primary URL', type: 'text' },
   ],
@@ -442,12 +445,15 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
         for (const fc of fieldConfigs) {
           if (fc.type === 'datetime-local' && detail[fc.key]) {
             const raw = String(detail[fc.key]);
-            const match = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
-            fields[fc.key] = match ? `${match[1]}T${match[2]}` : raw.slice(0, 16);
-          } else if (fc.type === 'date' && detail[fc.key]) {
-            const raw = String(detail[fc.key]);
-            const match = raw.match(/^(\d{4}-\d{2}-\d{2})/);
-            fields[fc.key] = match ? match[1] : raw.slice(0, 10);
+            // Convert UTC/pg timestamp to Eastern for display in datetime-local input
+            const utcDate = new Date(raw.replace(' ', 'T').replace(/\+\d{2}$/, 'Z'));
+            if (!isNaN(utcDate.getTime())) {
+              const eastern = utcDate.toLocaleString('sv-SE', { timeZone: 'America/New_York' });
+              fields[fc.key] = eastern.replace(' ', 'T').substring(0, 16);
+            } else {
+              const match = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
+              fields[fc.key] = match ? `${match[1]}T${match[2]}` : raw.slice(0, 16);
+            }
           } else {
             fields[fc.key] = detail[fc.key] || '';
           }

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -197,13 +197,16 @@ export function EventItemCard({ item, onDelete, deleting, isAdmin }) {
           const endStr = String(item.end_date || '');
           const startDateOnly = startStr.substring(0, 10);
           const endDateOnly = endStr.substring(0, 10);
-          const startHasTime = startStr.includes('T') && !startStr.endsWith('T00:00:00');
-          const endHasTime = endStr.includes('T') && !endStr.endsWith('T00:00:00');
+          // Detect non-midnight time in both ISO ('T') and pg space format
+          const _hasTime = (s) => { const m = s.match(/[T ](\d{2}:\d{2}:\d{2})/); return m && m[1] !== '00:00:00'; };
+          const _toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2');
+          const startHasTime = _hasTime(startStr);
+          const endHasTime = _hasTime(endStr);
           const sameDay = endDateOnly === startDateOnly;
 
           if (sameDay && startHasTime) {
             // Same-day event with times: "Sun, Apr 19, 2026, 10:30 AM – 12:00 PM"
-            const startDate = new Date(startStr);
+            const startDate = new Date(_toISO(startStr));
             const dateLabel = startDate.toLocaleDateString('en-US', {
               weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'America/New_York'
             });
@@ -211,7 +214,7 @@ export function EventItemCard({ item, onDelete, deleting, isAdmin }) {
               hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York'
             });
             if (endHasTime) {
-              const endTime = new Date(endStr).toLocaleTimeString('en-US', {
+              const endTime = new Date(_toISO(endStr)).toLocaleTimeString('en-US', {
                 hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York'
               });
               return `${dateLabel}, ${startTime} – ${endTime}`;
@@ -254,13 +257,20 @@ export function formatEventDateRange(startDate, endDate) {
   if (!startStr) return '';
   const startDateOnly = startStr.substring(0, 10);
   const endDateOnly = endStr.substring(0, 10);
-  const startHasTime = startStr.includes('T') && !startStr.endsWith('T00:00:00');
-  const endHasTime = endStr.includes('T') && !endStr.endsWith('T00:00:00');
+  // Detect non-midnight time in both ISO ('T') and pg space format ("2026-04-22 18:30:00+00")
+  const hasNonMidnightTime = (s) => {
+    const m = s.match(/[T ](\d{2}:\d{2}:\d{2})/);
+    return m && m[1] !== '00:00:00';
+  };
+  // Normalize pg space format to ISO for Date parsing
+  const toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2');
+  const startHasTime = hasNonMidnightTime(startStr);
+  const endHasTime = hasNonMidnightTime(endStr);
   const sameDay = endDateOnly === startDateOnly;
-  const fmtTime = (s) => new Date(s).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' });
+  const fmtTime = (s) => new Date(toISO(s)).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' });
 
   if (sameDay && startHasTime) {
-    const d = new Date(startStr);
+    const d = new Date(toISO(startStr));
     const dateLabel = d.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'America/New_York' });
     const startTime = fmtTime(startStr);
     if (endHasTime) return `${dateLabel}, ${startTime} – ${fmtTime(endStr)}`;


### PR DESCRIPTION
## Summary
- **parseDateTime** now correctly treats bare ISO strings (e.g., `2026-04-22T10:30`) as Eastern time instead of UTC — chrono-node silently ignored the timezone parameter for these
- Added `localToUTC` helper for reliable Eastern→UTC conversion without chrono-node
- Fixed `saveEventItems` to stop re-parsing already-UTC values from the scoring pipeline (prevented double-conversion)
- Admin edit form now shows datetime-local for publication dates with EDT/EST label, converts UTC↔Eastern correctly
- Fixed event display to detect times in pg space-format timestamps (`"2026-04-22 18:30:00+00"`)
- Date-only values now stored as noon Eastern (not noon UTC)

## Test plan
- [x] `./run.sh test` — 303 passed, 13 failed (all pre-existing)
- [x] `./run.sh gourmand` — 2 violations in serperService.js (pre-existing)
- [x] `./run.sh gatehouse` — no issues
- [x] `./run.sh build` — successful
- [ ] Admin edit round-trip: set time in Eastern → save → reload → same time displayed
- [ ] Trigger collection → verify event times match source pages
- [ ] Verify news publication dates display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)