### PR TITLE
fix: cap trail status dates to prevent future date hallucinations

### DIFF
--- a/backend/migrations/040_cap_future_trail_status_dates.sql
+++ b/backend/migrations/040_cap_future_trail_status_dates.sql
@@ -1,0 +1,5 @@
+-- Cap any trail_status last_updated dates that are in the future back to created_at
+-- These occur when Gemini misinterprets phrases like "opening the week of May 24th" as the status date
+UPDATE trail_status
+SET last_updated = created_at
+WHERE last_updated > NOW();

--- a/backend/services/trailStatusService.js
+++ b/backend/services/trailStatusService.js
@@ -403,6 +403,17 @@ async function saveTrailStatus(pool, poiId, status) {
       }
     }
 
+    // Cap last_updated at current time — Gemini sometimes hallucinates future dates
+    // from phrases like "anticipating opening the week of May 24th"
+    let lastUpdated = status.last_updated;
+    if (lastUpdated) {
+      const parsedDate = new Date(lastUpdated);
+      if (!isNaN(parsedDate) && parsedDate > new Date()) {
+        console.log(`[Trail Status] Capping future last_updated ${lastUpdated} to now`);
+        lastUpdated = new Date().toISOString();
+      }
+    }
+
     // Insert new status
     await pool.query(`
       INSERT INTO trail_status (
@@ -419,7 +430,7 @@ async function saveTrailStatus(pool, poiId, status) {
       poiId,
       status.status,
       status.conditions,
-      status.last_updated,
+      lastUpdated,
       status.source_name,
       status.source_url,
       status.weather_impact,


### PR DESCRIPTION
## Summary
- Gemini sometimes interprets phrases like "anticipating opening the week of May 24th" as the `last_updated` date, setting it weeks in the future
- Since the mtb-trails API sorts by `last_updated DESC LIMIT 1`, these future-dated records permanently override correct statuses (e.g., East Rim showed "closed" even though the latest tweet said "open")
- Adds a guard in `saveTrailStatus()` that caps `last_updated` at the current time
- Adds migration 040 to fix 3 existing bad records in production

## Test plan
- [ ] Deploy and verify East Rim shows "open" on the MTB Trail Status tab
- [ ] Verify other trails unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)