### PR TITLE
fix: promote date-only values to noon Eastern in moderation rescore

### DIFF
--- a/backend/migrations/040_fix_midnight_publication_dates.sql
+++ b/backend/migrations/040_fix_midnight_publication_dates.sql
@@ -1,0 +1,16 @@
+-- Migration 040: Fix midnight-UTC publication dates
+--
+-- publication_date is TIMESTAMPTZ (since migration 036). Date-only values must
+-- be stored as noon UTC so that Eastern-time display never shifts the calendar day.
+-- The moderation rescore path wrote bare YYYY-MM-DD strings that PostgreSQL
+-- interpreted as midnight UTC, causing off-by-one display in the frontend.
+
+UPDATE poi_news
+SET publication_date = date_trunc('day', publication_date) + interval '12 hours'
+WHERE publication_date IS NOT NULL
+  AND publication_date::time = '00:00:00';
+
+UPDATE poi_events
+SET publication_date = date_trunc('day', publication_date) + interval '12 hours'
+WHERE publication_date IS NOT NULL
+  AND publication_date::time = '00:00:00';

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -346,7 +346,13 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         }
 
         if (consensus.date) {
-          newDate = consensus.date;
+          // Promote date-only to noon Eastern so TIMESTAMPTZ display never shifts the calendar day
+          if (/^\d{4}-\d{2}-\d{2}$/.test(consensus.date)) {
+            const noon = parseDateTime(consensus.date + 'T12:00:00', 'America/New_York');
+            newDate = noon ? noon + 'Z' : consensus.date;
+          } else {
+            newDate = consensus.date;
+          }
           newScore = consensus.score;
           rescoredDate = true;
         }
@@ -771,8 +777,12 @@ export async function fixDate(pool, contentType, contentId) {
     });
   }
 
-  // Update the item
-  const newDate = consensus.date || null;
+  // Update the item — promote date-only to noon Eastern so display never shifts
+  let newDate = consensus.date || null;
+  if (newDate && /^\d{4}-\d{2}-\d{2}$/.test(newDate)) {
+    const noon = parseDateTime(newDate + 'T12:00:00', 'America/New_York');
+    newDate = noon ? noon + 'Z' : newDate;
+  }
   const newScore = consensus.score || 0;
   await pool.query(
     `UPDATE ${table} SET publication_date = $1, date_consensus_score = $2, moderation_processed = true WHERE id = $3`,


### PR DESCRIPTION
## Summary
- Moderation rescore and fixDate paths wrote bare `YYYY-MM-DD` strings to the `TIMESTAMPTZ` `publication_date` column, stored as midnight UTC — shifting to the previous day when displayed in Eastern time
- Promote date-only values to noon Eastern (matching `saveNewsItems`) so display never crosses midnight
- Migration 040 repairs existing midnight-UTC rows

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — no new failures (existing failures are unrelated competitor→blocklist rename)
- [ ] Run migration 040 on production
- [ ] Verify trail conditions article #902 displays as June 20 (not 21)
- [ ] Verify Seiberling shelter #857 displays as April 9 (not 10)
- [ ] Confirm `SELECT COUNT(*) FROM poi_news WHERE publication_date::time = '00:00:00'` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)