### PR TITLE
fix: default empty poi_roles to point

### DIFF
--- a/backend/migrations/041_default_empty_poi_roles.sql
+++ b/backend/migrations/041_default_empty_poi_roles.sql
@@ -1,0 +1,7 @@
+-- Fix any POIs with empty poi_roles — they are invisible to both
+-- /api/destinations (requires 'point') and /api/linear-features (requires trail/river/boundary)
+UPDATE pois SET poi_roles = ARRAY['point']
+WHERE poi_roles = '{}' AND (deleted IS NULL OR deleted = FALSE);
+
+-- Set a default so future inserts without explicit roles get 'point'
+ALTER TABLE pois ALTER COLUMN poi_roles SET DEFAULT ARRAY['point']::text[];


### PR DESCRIPTION
## Summary
- POIs with empty `poi_roles` are invisible — not returned by `/api/destinations` or `/api/linear-features`
- Adds migration to fix existing empty-role POIs and sets DB default to `['point']`
- Schneider Park and Northampton Point already fixed on production

## Test plan
- [ ] Search for "Schneider" and "Northampton" in Results tab
- [ ] Create a new POI without specifying roles — should default to `['point']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)