### PR TITLE
fix: localToUTC double-seconds bug causing 2-day date drift

### DIFF
--- a/backend/migrations/042_fix_corrupted_dates_from_migration_drift.sql
+++ b/backend/migrations/042_fix_corrupted_dates_from_migration_drift.sql
@@ -1,0 +1,24 @@
+-- Migration 042: Fix dates corrupted by localToUTC bug + migration 036 compounding
+--
+-- The localToUTC() function had a double-seconds bug that caused noon-Eastern
+-- promotion to fail, writing bare date strings as midnight UTC. Migration 036
+-- then added +12h on each container restart (before PR #306 fixed idempotency),
+-- shifting dates forward by up to 2+ days.
+--
+-- This re-derives publication_date from date_signals.llmVotes where the LLM
+-- votes unanimously agree but the stored date doesn't match.
+
+UPDATE poi_news
+SET publication_date = (
+  (date_signals->'llmVotes'->>0)::date + interval '12 hours'
+)
+WHERE date_signals IS NOT NULL
+  AND date_signals->'llmVotes' IS NOT NULL
+  AND jsonb_array_length(date_signals->'llmVotes') >= 3
+  AND (date_signals->'llmVotes'->>0) IS NOT NULL
+  AND (date_signals->'llmVotes'->>0) = (date_signals->'llmVotes'->>1)
+  AND (date_signals->'llmVotes'->>0) = (date_signals->'llmVotes'->>2)
+  AND publication_date::date != (date_signals->'llmVotes'->>0)::date
+  -- Only fix small drifts (1-5 days) caused by migration compounding.
+  -- Larger mismatches may be LLM errors, not migration damage.
+  AND ABS(publication_date::date - (date_signals->'llmVotes'->>0)::date) BETWEEN 1 AND 5;

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -353,7 +353,8 @@ export function localToUTC(localStr, timezone = 'America/New_York') {
   if (!localStr || !localStr.includes('T')) return null;
   // Eastern is either -04:00 (EDT) or -05:00 (EST). Try both, verify with round-trip.
   for (const offset of ['-04:00', '-05:00']) {
-    const d = new Date(localStr + ':00' + offset);
+    const needsSeconds = (localStr.match(/:/g) || []).length < 2;
+    const d = new Date(localStr + (needsSeconds ? ':00' : '') + offset);
     if (isNaN(d.getTime())) continue;
     const rt = d.toLocaleString('sv-SE', { timeZone: timezone }).replace(' ', 'T').substring(0, 16);
     if (rt === localStr.substring(0, 16)) {


### PR DESCRIPTION
## Summary
- `localToUTC()` appended `:00` to inputs that already had seconds, creating invalid dates
- This caused noon-Eastern promotion to fail, writing bare dates as midnight UTC
- Combined with non-idempotent migration 036 compounding +12h per restart, dates drifted 2+ days
- Migration 042 repairs 90 affected records using unanimous LLM vote consensus

## Test plan
- [ ] Verify news #929 (Boston Store) shows April 9
- [ ] Spot-check other Facebook-sourced news dates
- [ ] New date extractions produce correct noon-Eastern timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)