### PR TITLE
fix: event datetime display and timezone migration

### DIFF
--- a/backend/migrations/043_fix_event_times_local_as_utc.sql
+++ b/backend/migrations/043_fix_event_times_local_as_utc.sql
@@ -1,0 +1,35 @@
+-- Migration 043: Fix event times stored as local Eastern instead of UTC
+--
+-- Events collected before 2026-04-29 (commit 595f9a3) had a bug where
+-- parseDateTime() extracted hour/minute/second components from chrono-node
+-- without converting to UTC. Local Eastern times were stored as-is with
+-- a +00 offset, making them display 4-5 hours early.
+--
+-- Fix: shift start_date and end_date forward by the correct UTC offset.
+-- PostgreSQL's AT TIME ZONE handles EDT/EST automatically based on the
+-- date, so we don't need to hardcode offsets.
+--
+-- The trick: the stored timestamp IS the local time with a wrong +00 offset.
+-- To fix: interpret the stored value as if it were Eastern (strip UTC, treat
+-- as local), then convert back to UTC properly.
+--
+-- Example: stored 2026-05-07 15:00:00+00 (meant 3 PM Eastern)
+--   → strip offset: 2026-05-07 15:00:00 (bare timestamp)
+--   → interpret as Eastern: 2026-05-07 15:00:00 America/New_York
+--   → convert to UTC: 2026-05-07 19:00:00+00 (EDT, +4h)
+
+-- Fix start_date
+UPDATE poi_events
+SET start_date = (start_date AT TIME ZONE 'UTC') AT TIME ZONE 'America/New_York'
+WHERE collection_date < '2026-04-29'
+  AND start_date IS NOT NULL
+  AND EXTRACT(HOUR FROM start_date) != 0
+  AND EXTRACT(HOUR FROM start_date) != 12;
+
+-- Fix end_date
+UPDATE poi_events
+SET end_date = (end_date AT TIME ZONE 'UTC') AT TIME ZONE 'America/New_York'
+WHERE collection_date < '2026-04-29'
+  AND end_date IS NOT NULL
+  AND EXTRACT(HOUR FROM end_date) != 0
+  AND EXTRACT(HOUR FROM end_date) != 12;

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -211,7 +211,7 @@ export function EventItemCard({ item, onDelete, deleting, isAdmin }) {
           const endDateOnly = endStr.substring(0, 10);
           // Detect non-midnight time in both ISO ('T') and pg space format
           const _hasTime = (s) => { const m = s.match(/[T ](\d{2}:\d{2}:\d{2})/); return m && m[1] !== '00:00:00'; };
-          const _toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2');
+          const _toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2').replace(/([+-]\d{2})$/, '$1:00');
           const startHasTime = _hasTime(startStr);
           const endHasTime = _hasTime(endStr);
           const sameDay = endDateOnly === startDateOnly;
@@ -275,7 +275,7 @@ export function formatEventDateRange(startDate, endDate) {
     return m && m[1] !== '00:00:00';
   };
   // Normalize pg space format to ISO for Date parsing
-  const toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2');
+  const toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2').replace(/([+-]\d{2})$/, '$1:00');
   const startHasTime = hasNonMidnightTime(startStr);
   const endHasTime = hasNonMidnightTime(endStr);
   const sameDay = endDateOnly === startDateOnly;


### PR DESCRIPTION
## Summary
- Fix "Invalid Date" display for events with PG-format timestamps — `toISO` helper was converting `+00` offsets into invalid ISO strings (needs `+00:00` with colon)
- Migration 043 fixes 35 events collected April 19 (before timezone fix on April 29) that had local Eastern times stored as UTC, displaying 4-5 hours early

## Test plan
- [x] Verified Senior Bike Ride and Tinkers Creek Aqueduct events display correct times in dev
- [x] Dry-ran migration and confirmed EDT (+4h) and EST (+5h) corrections via PostgreSQL AT TIME ZONE
- [x] Confirmed date-only events (midnight/noon UTC) are excluded from migration (not affected by bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)