### PR TITLE
fix: show times for events starting at midnight UTC

### DIFF
--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -210,8 +210,8 @@ export function EventItemCard({ item, onDelete, deleting, isAdmin }) {
           // Detect non-midnight time in both ISO ('T') and pg space format
           const _hasTime = (s) => { const m = s.match(/[T ](\d{2}:\d{2}:\d{2})/); return m && m[1] !== '00:00:00'; };
           const _toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2').replace(/([+-]\d{2})$/, '$1:00');
-          const startHasTime = _hasTime(startStr);
           const endHasTime = _hasTime(endStr);
+          const startHasTime = _hasTime(startStr) || endHasTime;
           // Compare dates in Eastern time, not UTC — evening events can span midnight UTC
           const _localDate = (s) => new Date(_toISO(s)).toLocaleDateString('en-US', { timeZone: 'America/New_York' });
           const sameDay = endStr ? _localDate(startStr) === _localDate(endStr) : true;
@@ -274,8 +274,9 @@ export function formatEventDateRange(startDate, endDate) {
   };
   // Normalize pg space format to ISO for Date parsing
   const toISO = (s) => s.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/, '$1T$2').replace(/([+-]\d{2})$/, '$1:00');
-  const startHasTime = hasNonMidnightTime(startStr);
   const endHasTime = hasNonMidnightTime(endStr);
+  // If end has a real time, start does too — it just happens to be midnight UTC (e.g. 8 PM EDT)
+  const startHasTime = hasNonMidnightTime(startStr) || endHasTime;
   // Compare dates in Eastern time, not UTC — an evening event (e.g. 9:30 PM–12:30 AM UTC)
   // can span midnight UTC while being same-day in local time
   const localDate = (s) => new Date(toISO(s)).toLocaleDateString('en-US', { timeZone: 'America/New_York' });


### PR DESCRIPTION
## Summary
- Events at 8 PM Eastern are stored as 00:00:00 UTC, which hasNonMidnightTime treated as date-only
- Now infers start has a real time if end_date has a non-midnight time
- Fixes David Mayfield Parade showing "Fri, 05/08/2026" instead of "Fri, May 8, 2026, 8:00 PM – 10:00 PM"

## Test plan
- [x] Verified David Mayfield events (00:00:00+00 to 02:00:00+00) would display with times

🤖 Generated with [Claude Code](https://claude.com/claude-code)