### PR TITLE
fix: tiered collection UI — dashboard + edit form

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -26,6 +26,7 @@ import {
   runBatchNewsCollection,
   createNewsCollectionJob,
   getAllPoisForCollection,
+  getPoisForTierCollection,
   getNewsForPoi,
   getEventsForPoi,
   getRecentNews,
@@ -2565,7 +2566,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   // Trigger news collection job manually (all POIs) - starts job and returns immediately
   router.post('/news/collect', isAdmin, async (req, res) => {
     try {
-      console.log(`Admin ${req.user.email} triggered full news collection`);
+      const tier = req.query.tier; // optional: 'daily', 'weekly', 'monthly'
+      const tierLabel = tier ? `${tier} tier` : 'all POIs';
+      console.log(`Admin ${req.user.email} triggered news collection for ${tierLabel}`);
 
       // Check if a job is already running
       const runningJobCheck = await pool.query(`
@@ -2581,22 +2584,25 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         });
       }
 
-      // Use the same function as the scheduled collection so filters stay in sync
-      const poiIds = await getAllPoisForCollection(pool);
+      // Get POIs — tier-filtered or all
+      const poiIds = tier
+        ? await getPoisForTierCollection(pool, tier)
+        : await getAllPoisForCollection(pool);
 
       if (poiIds.length === 0) {
-        return res.status(400).json({ error: 'No POIs found to process' });
+        return res.status(400).json({ error: `No POIs found for ${tierLabel}` });
       }
 
       // Create the job record first
-      const { jobId, totalPois } = await createNewsCollectionJob(pool, poiIds, 'manual');
+      const source = tier ? `manual-${tier}` : 'manual';
+      const { jobId, totalPois } = await createNewsCollectionJob(pool, poiIds, source);
 
       // Submit to pg-boss for crash-recoverable processing
       await submitBatchNewsJob({ jobId, poiIds });
 
       res.json({
         success: true,
-        message: 'News & events collection started for all POIs (pg-boss)',
+        message: `News & events collection started for ${tierLabel} (${totalPois} POIs)`,
         jobId,
         totalPois
       });

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -10,22 +10,50 @@
 
 export const COLLECTION_TYPES = [
   {
-    id: 'news',
-    label: 'News & Events',
-    description: 'AI-powered news and event discovery for POIs',
+    id: 'news_daily',
+    label: 'News & Events (Daily)',
+    description: 'Daily collection for POIs with dedicated URLs + high-value POIs',
     icon: '\u{1F4F0}',
     promptKeys: [{
       key: 'news_collection_prompt',
       label: 'News Collection Prompt',
       placeholders: ['{{name}}', '{{poi_roles}}', '{{timezone}}', '{{website}}', '{{eventsUrl}}', '{{newsUrl}}']
     }],
-    scheduleJobName: 'news-collection',
+    scheduleJobName: 'news-collection-daily',
     schedule: '0 6 * * *',
     statusTable: 'news_job_status',
     historyTypes: ['news', 'news_single', 'events_single'],
-    triggerEndpoint: '/api/admin/news/collect',
+    triggerEndpoint: '/api/admin/news/collect?tier=daily',
     manualTriggerMethod: 'POST',
     hasPrompt: true
+  },
+  {
+    id: 'news_weekly',
+    label: 'News & Events (Weekly)',
+    description: 'Weekly collection for active parks, landmarks, and organizations',
+    icon: '\u{1F4F0}',
+    promptKeys: [],
+    scheduleJobName: 'news-collection-weekly',
+    schedule: '0 6 * * 1',
+    statusTable: 'news_job_status',
+    historyTypes: ['news'],
+    triggerEndpoint: '/api/admin/news/collect?tier=weekly',
+    manualTriggerMethod: 'POST',
+    hasPrompt: false
+  },
+  {
+    id: 'news_monthly',
+    label: 'News & Events (Monthly)',
+    description: 'Monthly collection for low-activity and static POIs',
+    icon: '\u{1F4F0}',
+    promptKeys: [],
+    scheduleJobName: 'news-collection-monthly',
+    schedule: '0 6 1 * *',
+    statusTable: 'news_job_status',
+    historyTypes: ['news'],
+    triggerEndpoint: '/api/admin/news/collect?tier=monthly',
+    manualTriggerMethod: 'POST',
+    hasPrompt: false
   },
   {
     id: 'trail_status',

--- a/frontend/src/components/JobsDashboard.jsx
+++ b/frontend/src/components/JobsDashboard.jsx
@@ -71,6 +71,8 @@ function formatCronHuman(cron) {
   if (cron === '0 6 * * *') return 'Daily at 6:00 AM';
   if (cron === '0 2 * * *') return 'Daily at 2:00 AM';
   if (cron === '0 3 * * *') return 'Daily at 3:00 AM';
+  if (cron === '0 6 * * 1') return 'Mondays at 6:00 AM';
+  if (cron === '0 6 1 * *') return '1st of month at 6:00 AM';
   if (cron.startsWith('*/')) return `Every ${min.slice(2)} minutes`;
   if (hour !== '*' && min !== '*' && dom === '*') return `Daily at ${hour}:${min.padStart(2, '0')}`;
   return cron;
@@ -333,7 +335,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
     if (expandedRun.jobType !== 'news_single' && expandedRun.jobType !== 'events_single') return;
     const hasCompleted = runLogs.some(l => l.details?.completed === true);
     if (hasCompleted) {
-      setJobHistory(prev => { const next = { ...prev }; delete next['news']; return next; });
+      setJobHistory(prev => { const next = { ...prev }; delete next['news_daily']; return next; });
     }
   }, [expandedRun, runLogs]);
 
@@ -368,7 +370,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
     if (urlJobId && urlJobType && !scheduledLoading) {
       // For single-POI jobs, expand the News & Events card and the specific run
       if (urlJobType === 'news_single' || urlJobType === 'events_single') {
-        setExpandedScheduled('news');
+        setExpandedScheduled('news_daily');
         setExpandedRun({ jobType: urlJobType, runId: urlJobId, poiId: urlPoiId || urlJobId });
 
         // Clear URL params so this effect doesn't re-fire
@@ -509,7 +511,7 @@ export default function JobsDashboard({ expandTarget, onExpandTargetConsumed }) 
     const stats = aiStats[job.id];
 
     // Progress values
-    const isNews = job.id === 'news';
+    const isNews = job.id.startsWith('news');
     const processed = isNews ? (info.pois_processed || 0) : (info.trails_processed || 0);
     const total = isNews ? (info.total_pois || 0) : (info.total_trails || 0);
     const pct = total > 0 ? (processed / total) * 100 : 0;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -988,6 +988,21 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
         </small>
       </div>
 
+      <div className="edit-section">
+        <label>News Collection Tier</label>
+        <select
+          value={editedData.collection_tier || 'weekly'}
+          onChange={(e) => handleChange('collection_tier', e.target.value)}
+        >
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+        <small style={{ color: '#666', display: 'block', marginTop: '0.5rem' }}>
+          How often this POI is included in scheduled news collection
+        </small>
+      </div>
+
 
       </div>
 


### PR DESCRIPTION
## Summary

- Jobs dashboard now shows three separate News & Events jobs (Daily, Weekly, Monthly) instead of one
- POI Edit form has a "News Collection Tier" dropdown (daily/weekly/monthly)
- "Run Now" button on each tier job only collects POIs in that tier
- Fixes cron display for weekly (Mondays at 6:00 AM) and monthly (1st of month at 6:00 AM)

Follow-up to PR #312 which added the backend tiering but missed the frontend.

## Test plan
- [ ] Jobs dashboard shows three News & Events entries with correct schedules
- [ ] Edit a POI — collection_tier dropdown is visible and saves correctly
- [ ] "Run Now" on Daily tier only collects daily-tier POIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)