### PR TITLE
fix: prevent duplicate newsletter on pg-boss retry

### DIFF
--- a/backend/migrations/load-county-state-boundaries.js
+++ b/backend/migrations/load-county-state-boundaries.js
@@ -38,7 +38,6 @@ console.log('Loading county/state boundary geometries...\n');
 
 for (const boundary of boundaries) {
   try {
-    // Check if the POI exists and needs geometry
     const existing = await pool.query(
       "SELECT id, boundary_geom IS NOT NULL as has_geom FROM pois WHERE name = $1 AND 'boundary' = ANY(poi_roles)",
       [boundary.name]
@@ -54,7 +53,6 @@ for (const boundary of boundaries) {
       continue;
     }
 
-    // Read and parse GeoJSON
     const dataDir = join(__dirname, '..', 'data', 'boundaries');
     const filePath = join(dataDir, boundary.file);
     const geojson = JSON.parse(readFileSync(filePath, 'utf-8'));
@@ -67,7 +65,6 @@ for (const boundary of boundaries) {
     const feature = geojson.features[0];
     const geometryJson = JSON.stringify(feature.geometry);
 
-    // Update both the JSONB geometry column and the PostGIS boundary_geom column
     await pool.query(`
       UPDATE pois
       SET geometry = $1::jsonb,
@@ -81,7 +78,6 @@ for (const boundary of boundaries) {
   }
 }
 
-// Verify grounding now works for Liberty Park
 const verify = await pool.query(`
   WITH poi_point AS (
     SELECT id, name, geom as point_geom

--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -181,29 +181,45 @@ export async function getSubscriberCount(pool = null) {
  * @param {string} subject - Email subject line
  * @param {string} htmlBody - HTML email body
  * @param {Pool} pool - Database connection pool
+ * @param {object} [options] - Options
+ * @param {string} [options.existingEmailId] - Resume scheduling a previously created draft
+ * @param {Function} [options.onDraftCreated] - Callback with (emailId) after draft creation, before scheduling
  * @returns {Promise<Object>} Email object from Buttondown
  */
-export async function sendEmail(subject, htmlBody, pool = null) {
+export async function sendEmail(subject, htmlBody, pool = null, { existingEmailId, onDraftCreated } = {}) {
   const apiKey = await getApiKey(pool);
 
-  // Step 1: Create draft email (outside retry to avoid duplicate drafts)
-  console.log(`📧 Creating draft email: "${subject}"`);
+  let emailId;
 
-  let createResponse;
-  try {
-    const draftClient = createClient(apiKey);
-    createResponse = await draftClient.post('/v1/emails', {
-      subject,
-      body: htmlBody,
-      email_type: 'public'
-    });
-  } catch (error) {
-    console.error(`❌ Draft creation failed:`, error.response?.status, error.response?.data);
-    throw error;
+  if (existingEmailId) {
+    // Resume: skip draft creation, go straight to scheduling
+    emailId = existingEmailId;
+    console.log(`📧 Resuming with existing draft: ${emailId}`);
+  } else {
+    // Step 1: Create draft email (outside retry to avoid duplicate drafts)
+    console.log(`📧 Creating draft email: "${subject}"`);
+
+    let createResponse;
+    try {
+      const draftClient = createClient(apiKey);
+      createResponse = await draftClient.post('/v1/emails', {
+        subject,
+        body: htmlBody,
+        email_type: 'public'
+      });
+    } catch (error) {
+      console.error(`❌ Draft creation failed:`, error.response?.status, error.response?.data);
+      throw error;
+    }
+
+    emailId = createResponse.data.id;
+    console.log(`✓ Created email draft: ${emailId}`);
+
+    // Notify caller of the draft ID so it can be persisted for retry recovery
+    if (onDraftCreated) {
+      await onDraftCreated(emailId);
+    }
   }
-
-  const emailId = createResponse.data.id;
-  console.log(`✓ Created email draft: ${emailId}`);
 
   // Step 2: Schedule for immediate sending (with retry)
   return retryRequest(async () => {

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -316,8 +316,7 @@ export async function sendWeeklyDigest(pool, pgBossJobId = null) {
       console.log(`Found existing draft from earlier attempt: ${existingEmailId}`);
     }
 
-    // Wrap sendEmail to log the draft ID before scheduling attempts
-    const result = await sendEmail(subject, digestHtml, pool, {
+    await sendEmail(subject, digestHtml, pool, {
       existingEmailId,
       onDraftCreated: async (emailId) => {
         if (jobId > 0) {

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -297,7 +297,39 @@ export async function sendWeeklyDigest(pool, pgBossJobId = null) {
       ? `What's Happening in the Valley This Weekend - ${dateStr} @ ${sendDate.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}`
       : `What's Happening in the Valley This Weekend - ${dateStr}`;
 
-    await sendEmail(subject, digestHtml, pool);
+    // Check for an existing draft from a previous failed attempt today.
+    // If the draft was created but scheduling failed (e.g., slug_uniqueness),
+    // pg-boss retries the whole job — reuse the draft instead of creating a duplicate.
+    let existingEmailId = null;
+    const draftCheck = await pool.query(
+      `SELECT details->>'buttondownEmailId' as email_id FROM job_logs
+       WHERE job_type = $1
+         AND level = 'info'
+         AND message = 'Draft created in Buttondown'
+         AND created_at::date = $2::date
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [jobType, today]
+    );
+    if (draftCheck.rows.length > 0 && draftCheck.rows[0].email_id) {
+      existingEmailId = draftCheck.rows[0].email_id;
+      console.log(`Found existing draft from earlier attempt: ${existingEmailId}`);
+    }
+
+    // Wrap sendEmail to log the draft ID before scheduling attempts
+    const result = await sendEmail(subject, digestHtml, pool, {
+      existingEmailId,
+      onDraftCreated: async (emailId) => {
+        if (jobId > 0) {
+          await pool.query(
+            `INSERT INTO job_logs (job_id, job_type, level, message, details)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [jobId, jobType, 'info', 'Draft created in Buttondown',
+             JSON.stringify({ buttondownEmailId: emailId })]
+          );
+        }
+      }
+    });
 
     console.log('Weekly digest sent successfully');
 


### PR DESCRIPTION
## Summary
- When Buttondown PATCH to schedule a draft failed (slug_uniqueness constraint), pg-boss retried the entire job and created a second draft — two newsletters sent with slightly different content
- Fix: log the Buttondown draft email ID to `job_logs` after creation; on retry, check for an existing draft and resume scheduling it instead of creating a new one
- Added `existingEmailId` and `onDraftCreated` options to `sendEmail()` in buttondownClient.js

## Root cause
2026-05-08 production logs show:
1. 12:00:06 — Draft `em_3bn9s2xv3286etv8b2g6ydmytj` created, PATCH failed with `slug_uniqueness`
2. 12:00:15 — pg-boss retry created a second draft, PATCH succeeded
3. Both drafts sent → Scott received two newsletters

## Test plan
- [x] Build passes
- [x] All test failures are pre-existing
- [ ] Next Friday digest sends only once (verify in job_logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)