### PR TITLE
feat: IA Date button in moderation — Wayback Machine date lookup

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4052,13 +4052,25 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         return res.status(400).json({ error: 'url query parameter is required' });
       }
       const cdxUrl = `https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(url)}&output=json&fl=timestamp&limit=1`;
-      const response = await fetch(cdxUrl);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+      let response;
+      try {
+        response = await fetch(cdxUrl, { signal: controller.signal });
+      } catch (err) {
+        if (err.name === 'AbortError') {
+          return res.status(504).json({ error: 'Internet Archive request timed out' });
+        }
+        throw err;
+      } finally {
+        clearTimeout(timeoutId);
+      }
       if (!response.ok) {
         return res.status(502).json({ error: 'Internet Archive CDX API unavailable' });
       }
       const data = await response.json();
       // CDX returns [[header], [row]] — first row after header is the earliest snapshot
-      if (data.length < 2) {
+      if (data.length < 2 || !Array.isArray(data[1]) || !data[1][0] || !/^\d{14}$/.test(data[1][0])) {
         return res.json({ date: null, message: 'No snapshots found' });
       }
       const timestamp = data[1][0]; // Format: YYYYMMDDHHmmss

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4044,7 +4044,33 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
   });
 
-  // Fix publication date via AI web search
+  // Look up earliest Internet Archive snapshot date for a URL
+  router.get('/moderation/ia-date', isAdmin, async (req, res) => {
+    try {
+      const { url } = req.query;
+      if (!url) {
+        return res.status(400).json({ error: 'url query parameter is required' });
+      }
+      const cdxUrl = `https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(url)}&output=json&fl=timestamp&limit=1`;
+      const response = await fetch(cdxUrl);
+      if (!response.ok) {
+        return res.status(502).json({ error: 'Internet Archive CDX API unavailable' });
+      }
+      const data = await response.json();
+      // CDX returns [[header], [row]] — first row after header is the earliest snapshot
+      if (data.length < 2) {
+        return res.json({ date: null, message: 'No snapshots found' });
+      }
+      const timestamp = data[1][0]; // Format: YYYYMMDDHHmmss
+      const date = `${timestamp.slice(0, 4)}-${timestamp.slice(4, 6)}-${timestamp.slice(6, 8)}`;
+      res.json({ date, timestamp, message: `Earliest snapshot: ${date}` });
+    } catch (error) {
+      console.error('Error querying Internet Archive:', error);
+      res.status(500).json({ error: 'Failed to query Internet Archive' });
+    }
+  });
+
+  // Fix publication date via AI web search (legacy — kept for backward compatibility)
   router.post('/moderation/fix-date', isAdmin, async (req, res) => {
     try {
       const { type, id } = req.body;

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -52,7 +52,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
   const [createFields, setCreateFields] = useState({});
   const [pois, setPois] = useState([]);
   const [sourceFilter, setSourceFilter] = useState(null);
-  const [fixingDateItem, setFixingDateItem] = useState(null);
+  const [iaDateItem, setIaDateItem] = useState(null);
   const [mergingItem, setMergingItem] = useState(null); // { type, id, poiId }
   const [mergeCandidates, setMergeCandidates] = useState([]);
   const [merging, setMerging] = useState(false);
@@ -303,30 +303,37 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     } catch (err) { notify('error', err.message); }
   };
 
-  const handleFixDate = async (type, id) => {
+  const handleIaDate = async (type, id, sourceUrl) => {
     const itemKey = `${type}:${id}`;
-    setFixingDateItem(itemKey);
+    if (!sourceUrl) { notify('error', 'No source URL for this item'); return; }
+    setIaDateItem(itemKey);
     try {
-      const response = await fetch('/api/admin/moderation/fix-date', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ type, id })
+      const response = await fetch(`/api/admin/moderation/ia-date?url=${encodeURIComponent(sourceUrl)}`, {
+        credentials: 'include'
       });
       if (response.ok) {
         const data = await response.json();
-        if (data.date_updated) {
-          const parts = [`${type} #${id} — date set: ${data.publication_date} (score=${data.date_consensus_score})`];
-          if (data.start_date) parts.push(`event: ${data.start_date}${data.end_date ? ' — ' + data.end_date : ''}`);
-          notify('success', parts.join(', '));
+        if (data.date) {
+          // Update the item's publication date with the Wayback date
+          const saveResponse = await fetch('/api/admin/moderation/save', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            credentials: 'include', body: JSON.stringify({ type, id, edits: { publication_date: data.date } })
+          });
+          if (saveResponse.ok) {
+            notify('success', `${type} #${id} — date set to ${data.date} (earliest IA snapshot)`);
+            fetchQueue();
+          } else {
+            notify('error', 'IA date found but failed to update item');
+          }
         } else {
-          notify('success', `${type} #${id} — could not determine date`);
+          notify('error', `No Internet Archive snapshots found for this URL`);
         }
-        fetchQueue();
       } else {
         const err = await response.json();
-        notify('error', err.error || 'Fix Date failed');
+        notify('error', err.error || 'IA Date lookup failed');
       }
     } catch (err) { notify('error', err.message); }
-    finally { setFixingDateItem(null); }
+    finally { setIaDateItem(null); }
   };
 
   const startMerge = async (item) => {
@@ -987,12 +994,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
                       onChange={() => toggleSelect(item.content_type, item.id)}
                       style={{ marginRight: '4px' }} />
                   )}
-                  <button onClick={() => startEditing(item)}
-                    style={actionBtn()}>Edit</button>
-                  {item.content_type !== 'photo' && (
-                    <button onClick={() => startMerge(item)}
-                      style={actionBtn()}>Merge</button>
-                  )}
+                  {/* Approve / Reject / Requeue */}
                   {isPending && (
                     <>
                       <button onClick={() => handleApprove(item.content_type, item.id)}
@@ -1009,13 +1011,24 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
                         style={actionBtn()}>Requeue</button>
                     </>
                   )}
+                  {/* IA Date */}
                   {item.content_type !== 'photo' && (
-                    <button onClick={() => handleFixDate(item.content_type, item.id)}
-                      disabled={fixingDateItem === itemKey}
-                      style={actionBtn(fixingDateItem === itemKey)}>
-                      {fixingDateItem === itemKey ? 'Finding...' : 'Fix Date'}
+                    <button onClick={() => handleIaDate(item.content_type, item.id, item.source_url)}
+                      disabled={iaDateItem === itemKey}
+                      title="Look up earliest Internet Archive snapshot date for this URL"
+                      style={actionBtn(iaDateItem === itemKey)}>
+                      {iaDateItem === itemKey ? 'Looking up...' : 'IA Date'}
                     </button>
                   )}
+                  {/* Edit */}
+                  <button onClick={() => startEditing(item)}
+                    style={actionBtn()}>Edit</button>
+                  {/* Merge */}
+                  {item.content_type !== 'photo' && (
+                    <button onClick={() => startMerge(item)}
+                      style={actionBtn()}>Merge</button>
+                  )}
+                  {/* Delete */}
                   {item.content_type !== 'photo' && (
                     confirmDelete === itemKey ? (
                       <>


### PR DESCRIPTION
## Summary

- Replaces "Fix Date" button with "IA Date" — queries Internet Archive Wayback Machine CDX API for the earliest snapshot date of the item's source URL
- New backend endpoint `GET /api/admin/moderation/ia-date?url=<url>` — hits CDX API, returns earliest snapshot date
- On click: looks up date, then saves it as the item's publication_date via the existing save endpoint
- Button has tooltip: "Look up earliest Internet Archive snapshot date for this URL"
- Reorders moderation buttons: Approve, Reject, IA Date, Edit, Merge, Delete

## Test plan
- [ ] Click "IA Date" on an item with a source URL — verify it looks up and sets the date
- [ ] Click "IA Date" on an item with no source URL — verify error notification
- [ ] Verify button order: Approve, Reject, IA Date, Edit, Merge, Delete
- [ ] Verify tooltip appears on hover over "IA Date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)