### PR TITLE
fix: strip leading "The" from title dedup

### DIFF
--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -9,7 +9,7 @@ import { renderPage } from './renderPage.js';
 import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 import { parseDate, parseDateTime, localToUTC, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
-import { scoreDate, normalizeRenderUrl } from './newsService.js';
+import { scoreDate, normalizeRenderUrl, normalizeTitle } from './newsService.js';
 
 const TABLE_MAP = {
   news: 'poi_news',
@@ -275,13 +275,16 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     if (!itemQuery.rows.length) return;
     const row = itemQuery.rows[0];
 
-    // Duplicate check (cheap DB query)
+    // Duplicate check (cheap DB query) — strip leading "The" so
+    // "The David Mayfield Parade" matches "David Mayfield Parade"
+    const titleNorm = `TRIM(LOWER(REGEXP_REPLACE(title, '^[Tt]he\\s+', '')))`;
+    const paramNorm = normalizeTitle(row.title);
     const dupWhere = contentType === 'news'
-      ? `LOWER(title) = LOWER($1) AND id != $2`
-      : `LOWER(title) = LOWER($1) AND start_date = $3 AND id != $2`;
+      ? `${titleNorm} = $1 AND id != $2`
+      : `${titleNorm} = $1 AND start_date = $3 AND id != $2`;
     const dupParams = contentType === 'news'
-      ? [row.title, contentId]
-      : [row.title, contentId, row.start_date];
+      ? [paramNorm, contentId]
+      : [paramNorm, contentId, row.start_date];
     const dupCheck = await pool.query(
       `SELECT id FROM ${table} WHERE ${dupWhere}
        AND moderation_status IN ('published', 'auto_approved') LIMIT 1`,

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1069,8 +1069,8 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
           for (const itemsOrError of phase2Results) {
             if (!itemsOrError || itemsOrError instanceof Error) continue;
             const newNews = itemsOrError.filter(item => {
-              const titleLower = item.title.toLowerCase().trim();
-              return !allNews.some(n => n.title.toLowerCase().trim() === titleLower);
+              const norm = normalizeTitle(item.title);
+              return !allNews.some(n => normalizeTitle(n.title) === norm);
             });
             if (newNews.length > 0) {
               logInfo(jobId, jobType, poi.id, poi.name, `Phase II: Adding ${newNews.length} unique items`);
@@ -1277,6 +1277,20 @@ async function resolveRedirectUrl(url) {
 }
 
 /**
+ * Normalize a title for duplicate detection by stripping leading articles.
+ * "The David Mayfield Parade" and "David Mayfield Parade" → same normalized form.
+ * @param {string} title - Original title
+ * @returns {string} - Normalized title (lowercased, article-stripped)
+ */
+export function normalizeTitle(title) {
+  if (!title) return '';
+  return title.toLowerCase().replace(/^the\s+/i, '').trim();
+}
+
+// SQL expression matching normalizeTitle() — strip leading "The", lowercase, trim
+const SQL_NORMALIZE_TITLE = `TRIM(LOWER(REGEXP_REPLACE(title, '^[Tt]he\\s+', '')))`;
+
+/**
  * Normalize a news title for duplicate detection
  * Strips date suffixes like "| January 30" or "| 2026-01-30"
  * @param {string} title - Original title
@@ -1358,14 +1372,15 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
       const normalizedTitle = normalizeNewsTitle(item.title);
 
       const normalizedUrl = normalizeUrl(resolvedUrl);
+      const normalizedTitleNoArticle = normalizeTitle(item.title);
       const existing = await pool.query(
         `SELECT id, title, source_url, poi_id FROM poi_news
          WHERE (
            ($1::text IS NOT NULL AND LOWER(REGEXP_REPLACE(source_url, '/+$', '')) = $1::text)
-           OR (poi_id = $2 AND title = $3)
-           OR (poi_id = $2 AND REGEXP_REPLACE(title, '\\s*\\|\\s*(\\d{4}-\\d{2}-\\d{2}|[A-Z][a-z]+\\s+\\d{1,2}(,\\s*\\d{4})?)\\s*$', '', 'i') = $4)
+           OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3)
+           OR (poi_id = $2 AND TRIM(LOWER(REGEXP_REPLACE(REGEXP_REPLACE(title, '\\s*\\|\\s*(\\d{4}-\\d{2}-\\d{2}|[A-Z][a-z]+\\s+\\d{1,2}(,\\s*\\d{4})?)\\s*$', '', 'i'), '^[Tt]he\\s+', ''))) = $4)
          )`,
-        [normalizedUrl, poiId, item.title, normalizedTitle]
+        [normalizedUrl, poiId, normalizedTitleNoArticle, normalizeTitle(normalizedTitle)]
       );
 
       if (existing.rows.length > 0) {
@@ -1475,13 +1490,14 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
       }
 
       const normalizedEventUrl = normalizeUrl(resolvedUrl);
+      const normalizedEventTitle = normalizeTitle(item.title);
       const existing = await pool.query(
         `SELECT id, title, source_url, poi_id FROM poi_events
          WHERE (
            ($1::text IS NOT NULL AND LOWER(REGEXP_REPLACE(source_url, '/+$', '')) = $1::text)
-           OR (poi_id = $2 AND title = $3 AND start_date = $4)
+           OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3 AND start_date = $4)
          )`,
-        [normalizedEventUrl, poiId, item.title, item.start_date]
+        [normalizedEventUrl, poiId, normalizedEventTitle, item.start_date]
       );
 
       if (existing.rows.length > 0) {


### PR DESCRIPTION
## Summary
- Adds `normalizeTitle()` helper that lowercases and strips leading "The " from titles
- Applies normalization at all 4 dedup layers: in-memory Phase II merge, news save-time DB, event save-time DB, and moderation-time DB
- "The David Mayfield Parade" and "David Mayfield Parade" with the same date/POI now correctly dedup

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` — no new failures (all failures match master)
- [ ] Deploy and requeue known duplicates to verify dedup catches them

🤖 Generated with [Claude Code](https://claude.com/claude-code)