### PR TITLE
feat: add sort controls to moderation queue

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -3891,7 +3891,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   // Get paginated moderation queue
   router.get('/moderation/queue', isAdmin, async (req, res) => {
     try {
-      const { page = 1, limit = 20, type, status = 'pending', source, search, id } = req.query;
+      const { page = 1, limit = 20, type, status = 'pending', source, search, id, sort } = req.query;
       const result = await getModerationQueue(pool, {
         page: parseInt(page),
         limit: parseInt(limit),
@@ -3899,7 +3899,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         status,
         contentSource: source || null,
         search: search || null,
-        id: id || null
+        id: id || null,
+        sort: sort || 'collected_desc'
       });
       res.json(result);
     } catch (error) {

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -810,7 +810,7 @@ export async function fixDate(pool, contentType, contentId) {
   };
 }
 
-export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null, search = null, id = null } = {}) {
+export async function getQueue(pool, { page = 1, limit = 20, contentType = null, status = 'pending', contentSource = null, search = null, id = null, sort = 'collected_desc' } = {}) {
   const offset = (page - 1) * limit;
   const statusList = status === 'all'
     ? ['pending', 'published', 'auto_approved', 'rejected']
@@ -892,9 +892,15 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
 
   const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
 
-  const orderBy = status === 'approved'
-    ? 'ORDER BY COALESCE(publication_date, created_at) DESC, created_at DESC'
-    : 'ORDER BY created_at DESC';
+  const sortMap = {
+    collected_desc: 'ORDER BY created_at DESC',
+    collected_asc: 'ORDER BY created_at ASC',
+    date_asc: 'ORDER BY COALESCE(start_date, publication_date, created_at) ASC',
+    date_desc: 'ORDER BY COALESCE(start_date, publication_date, created_at) DESC',
+    poi_asc: 'ORDER BY poi_name ASC NULLS LAST, created_at DESC',
+    poi_desc: 'ORDER BY poi_name DESC NULLS LAST, created_at DESC',
+  };
+  const orderBy = sortMap[sort] || sortMap.collected_desc;
   const wrappedQuery = `SELECT * FROM (${baseQuery}) AS q ${whereClause} ${orderBy} LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
   const countQuery = `SELECT COUNT(*) FROM (${baseQuery}) AS q ${whereClause}`;
 

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -52,6 +52,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
   const [createFields, setCreateFields] = useState({});
   const [pois, setPois] = useState([]);
   const [sourceFilter, setSourceFilter] = useState(null);
+  const [sortOrder, setSortOrder] = useState('collected_desc');
   const [iaDateItem, setIaDateItem] = useState(null);
   const [mergingItem, setMergingItem] = useState(null); // { type, id, poiId }
   const [mergeCandidates, setMergeCandidates] = useState([]);
@@ -103,7 +104,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
   const fetchQueue = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams({ page: 1, limit: LIMIT, status: statusFilter });
+      const params = new URLSearchParams({ page: 1, limit: LIMIT, status: statusFilter, sort: sortOrder });
       if (filter) params.set('type', filter);
       if (sourceFilter) params.set('source', sourceFilter);
       if (idFilter) {
@@ -124,7 +125,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     } finally {
       setLoading(false);
     }
-  }, [filter, statusFilter, sourceFilter, searchQuery, idFilter]);
+  }, [filter, statusFilter, sourceFilter, searchQuery, idFilter, sortOrder]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
 
@@ -743,7 +744,11 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
             { label: 'Events', value: 'event' },
             { label: 'Photos', value: 'photo' },
           ].map(f => (
-            <button key={f.label} onClick={() => { setFilter(f.value);}}
+            <button key={f.label} onClick={() => {
+              setFilter(f.value);
+              if (f.value === 'event') setSortOrder('date_asc');
+              else if (f.value !== filter) setSortOrder('collected_desc');
+            }}
               style={filterBtn(filter === f.value)}>
               {f.label}
             </button>
@@ -773,6 +778,22 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
           ].map(f => (
             <button key={f.value} onClick={() => { setStatusFilter(f.value);setSelectedItems(new Set()); }}
               style={filterBtn(statusFilter === f.value)}>
+              {f.label}
+            </button>
+          ))}
+        </div>
+        {/* Row 4: Sort order */}
+        <div style={{ display: 'flex', gap: '3px' }}>
+          {[
+            { label: 'Collected \u2193', value: 'collected_desc' },
+            { label: 'Collected \u2191', value: 'collected_asc' },
+            { label: 'Date \u2191', value: 'date_asc' },
+            { label: 'Date \u2193', value: 'date_desc' },
+            { label: 'POI A\u2192Z', value: 'poi_asc' },
+            { label: 'POI Z\u2192A', value: 'poi_desc' },
+          ].map(f => (
+            <button key={f.value} onClick={() => setSortOrder(f.value)}
+              style={filterBtn(sortOrder === f.value)}>
               {f.label}
             </button>
           ))}


### PR DESCRIPTION
## Summary
- Adds 6 sort options to moderation queue: collected date (asc/desc), content date (asc/desc), POI name (A-Z/Z-A)
- Events filter auto-defaults to date ascending (oldest start_date first) for chronological triage
- Sort is a new 4th filter row using existing button style

## Test plan
- [x] Verified locally: Events filter auto-switches to Date ↑
- [x] Verified locally: POI A→Z sorts alphabetically by POI name
- [x] Verified locally: All sort buttons toggle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)