### PR TITLE
feat: auto-reject excluded POIs, simplify moderation pipeline

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -33,8 +33,6 @@ import {
   getUpcomingEvents,
   getLatestJobStatus,
   getJobStatus,
-  cleanupOldNews,
-  cleanupPastEvents,
   collectPoi,
   saveNewsItems,
   saveEventItems,
@@ -45,7 +43,7 @@ import {
   getAllActiveProgress,
   getDisplaySlots as getNewsDisplaySlots
 } from '../services/newsService.js';
-import { submitBatchNewsJob, queueModerationJob, getJobScheduler, JOB_NAMES, updateSchedule } from '../services/jobScheduler.js';
+import { submitBatchNewsJob, getJobScheduler, JOB_NAMES, updateSchedule } from '../services/jobScheduler.js';
 import {
   getQueue as getModerationQueue,
   getPendingCount as getModerationPendingCount,
@@ -58,7 +56,6 @@ import {
   requeueItem,
   fixDate,
   createItem,
-  purgeRejected,
   processItem,
   mergeItems,
   getMergeCandidates,
@@ -3069,23 +3066,6 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
   });
 
-  // Cleanup old news and past events
-  router.post('/news/cleanup', isAdmin, async (req, res) => {
-    try {
-      const newsDeleted = await cleanupOldNews(pool, 90);
-      const eventsDeleted = await cleanupPastEvents(pool, 30);
-      console.log(`Admin ${req.user.email} cleaned up ${newsDeleted} old news items and ${eventsDeleted} past events`);
-      res.json({
-        success: true,
-        newsDeleted,
-        eventsDeleted
-      });
-    } catch (error) {
-      console.error('Error cleaning up news/events:', error);
-      res.status(500).json({ error: 'Failed to cleanup' });
-    }
-  });
-
   // POI Associations CRUD endpoints (admin only)
   router.post('/poi-associations', isAdmin, async (req, res) => {
     try {
@@ -4035,8 +4015,6 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         return res.status(400).json({ error: 'type and id are required' });
       }
       await requeueItem(pool, type, id);
-      // Queue a new moderation job
-      await queueModerationJob(type, id);
       res.json({ success: true });
     } catch (error) {
       console.error('Error requeuing item:', error);
@@ -4103,18 +4081,6 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     } catch (error) {
       console.error('Error fixing date:', error);
       res.status(500).json({ error: error.message || 'Failed to fix date' });
-    }
-  });
-
-  // Purge all rejected items
-  router.post('/moderation/purge-rejected', isAdmin, async (req, res) => {
-    try {
-      const { type } = req.body;
-      const result = await purgeRejected(pool, type || null);
-      res.json(result);
-    } catch (error) {
-      console.error('Error purging rejected items:', error);
-      res.status(500).json({ error: 'Failed to purge rejected items' });
     }
   });
 
@@ -4250,9 +4216,6 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
          VALUES ($1, $2, $3, $4, $5) RETURNING id`,
         [parseInt(poi_id), uploadResult.assetId, req.file.originalname, req.user.id, caption || null]
       );
-
-      // Queue moderation job
-      await queueModerationJob('photo', result.rows[0].id);
 
       res.json({ success: true, submissionId: result.rows[0].id });
     } catch (error) {
@@ -4415,8 +4378,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         [JOB_NAMES.NEWS_BATCH]: { label: 'News & Events (Manual)', description: 'Admin-triggered batch collection from Data Collection tab' },
         [JOB_NAMES.TRAIL_STATUS_COLLECTION]: { label: 'Trail Status Check', description: 'Checks MTB trail conditions via status URLs (every 30 min)' },
         [JOB_NAMES.TRAIL_STATUS_BATCH]: { label: 'Trail Status (Manual)', description: 'Admin-triggered trail status collection' },
-        [JOB_NAMES.CONTENT_MODERATION]: { label: 'AI Moderation', description: 'Scores new content with Gemini when inserted' },
-        [JOB_NAMES.CONTENT_MODERATION_SWEEP]: { label: 'Moderation Sweep', description: 'Re-checks unscored items missed by per-item queue (every 15 min)' },
+        [JOB_NAMES.CONTENT_MODERATION_SWEEP]: { label: 'Content Moderation', description: 'Scores pending content with Gemini (every 15 min)' },
         [JOB_NAMES.NEWSLETTER_PROCESS]: { label: 'Email Ingestion', description: 'Extracts news and events from inbound newsletters' },
         [JOB_NAMES.IMAGE_BACKUP]: { label: 'Image Server Backup', description: 'Syncs image server media files to Google Drive (2 AM daily)' },
         [JOB_NAMES.DATABASE_BACKUP]: { label: 'Database Backup', description: 'Uploads PostgreSQL dump to Google Drive (3 AM daily)' }

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,7 +28,6 @@ import {
   scheduleTrailStatusCollection,
   registerTrailStatusHandler,
   registerBatchTrailStatusHandler,
-  registerModerationHandler,
   registerModerationSweepHandler,
   scheduleModerationSweep,
   registerNewsletterHandler,
@@ -2768,12 +2767,7 @@ async function start() {
     const trailStatusInterval = '*/30 * * * *';
     await scheduleTrailStatusCollection(trailStatusInterval);
 
-    // Register content moderation handler (processes individual items)
-    await registerModerationHandler(async (contentType, contentId) => {
-      await processItem(pool, contentType, contentId);
-    });
-
-    // Register moderation sweep handler (catches unprocessed items)
+    // Register moderation sweep handler (processes all unprocessed items every 15 min)
     await registerModerationSweepHandler(withJitter(async () => {
       await processPendingItems(pool);
       // Retention: purge job logs older than 30 days

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -75,8 +75,8 @@ export const COLLECTION_TYPES = [
   },
   {
     id: 'moderation_sweep',
-    label: 'Moderation Sweep',
-    description: 'Re-checks unscored items missed by per-item queue',
+    label: 'Content Moderation',
+    description: 'Scores pending content with Gemini (every 15 min)',
     icon: '\u{1F50D}',
     promptKeys: [],
     scheduleJobName: 'content-moderation-sweep',
@@ -144,20 +144,6 @@ export const COLLECTION_TYPES = [
     hasPrompt: false
   },
   {
-    id: 'moderation_item',
-    label: 'AI Moderation',
-    description: 'Scores new content with Gemini when inserted',
-    icon: '\u{2696}',
-    promptKeys: [],
-    scheduleJobName: 'content-moderation',
-    schedule: null,
-    statusTable: null,
-    historyTypes: ['moderation'],
-    triggerEndpoint: null,
-    manualTriggerMethod: null,
-    hasPrompt: false
-  },
-  {
     id: 'research',
     label: 'POI Research',
     description: 'Multi-pass AI research for POI metadata, descriptions, and hero images',
@@ -179,20 +165,6 @@ export const COLLECTION_TYPES = [
     manualTriggerMethod: 'POST',
     hasPrompt: true
   },
-  {
-    id: 'cleanup',
-    label: 'Content Cleanup',
-    description: 'Deletes old news and past events',
-    icon: '\u{1F9F9}',
-    promptKeys: [],
-    scheduleJobName: null,
-    schedule: null,
-    statusTable: null,
-    historyTypes: ['cleanup'],
-    triggerEndpoint: null,
-    manualTriggerMethod: null,
-    hasPrompt: false
-  }
 ];
 
 /**

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -358,57 +358,6 @@ export async function registerBatchTrailStatusHandler(handler) {
 }
 
 /**
- * Register handler for content moderation (individual items)
- * @param {Function} handler - Async function(contentType, contentId) to moderate a single item
- */
-export async function registerModerationHandler(handler) {
-  const scheduler = getJobScheduler();
-
-  try {
-    await scheduler.createQueue(JOB_NAMES.CONTENT_MODERATION);
-    console.log(`Queue '${JOB_NAMES.CONTENT_MODERATION}' created`);
-  } catch (error) {
-    if (!error.message?.includes('already exists')) {
-      console.log(`Queue '${JOB_NAMES.CONTENT_MODERATION}' may already exist`);
-    }
-  }
-
-  await scheduler.work(JOB_NAMES.CONTENT_MODERATION, {
-    teamSize: 3,
-    teamConcurrency: 1
-  }, async (jobs) => {
-    const jobList = Array.isArray(jobs) ? jobs : [jobs];
-    for (const job of jobList) {
-      try {
-        await handler(job.data.contentType, job.data.contentId);
-      } catch (error) {
-        console.error(`[pg-boss] Moderation failed for ${job.data.contentType} #${job.data.contentId}:`, error.message);
-        throw error;
-      }
-    }
-  });
-}
-
-/**
- * Queue a content moderation job for a single item
- * @param {string} contentType - 'news', 'event', or 'photo'
- * @param {number} contentId - ID of the content to moderate
- */
-export async function queueModerationJob(contentType, contentId) {
-  const scheduler = getJobScheduler();
-
-  return scheduler.send(JOB_NAMES.CONTENT_MODERATION, {
-    contentType,
-    contentId,
-    queuedAt: new Date().toISOString()
-  }, {
-    retryLimit: 2,
-    retryDelay: 30,
-    expireInMinutes: 15
-  });
-}
-
-/**
  * Schedule the moderation sweep job (daily at 7 AM after news collection)
  * @param {string} cronExpression - Cron expression
  */

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -23,15 +23,12 @@ import {
   fixDate,
   bulkApprove,
   createItem,
-  editAndPublish,
-  purgeRejected
+  editAndPublish
 } from './moderationService.js';
 
 import {
   getJobStatus as getNewsJobStatus,
   getDisplaySlots as getNewsDisplaySlots,
-  cleanupOldNews,
-  cleanupPastEvents,
   getLatestJobStatus as getLatestNewsJobStatus
 } from './newsService.js';
 
@@ -411,36 +408,6 @@ function registerTools(server, pool, boss) {
     async ({ items }) => {
       const result = await bulkApprove(pool, items, MCP_ADMIN_USER_ID);
       return { content: [{ type: 'text', text: `Approved ${result.approved} items` }] };
-    }
-  );
-
-  server.tool(
-    'content_cleanup',
-    'Remove old news (>N days) or past events (>N days)',
-    {
-      type: z.enum(['news', 'events']).describe('What to clean up'),
-      days_old: z.number().optional().describe('Delete items older than this many days (default: 90 for news, 30 for events)')
-    },
-    async ({ type, days_old }) => {
-      let deleted;
-      if (type === 'news') {
-        deleted = await cleanupOldNews(pool, days_old || 90);
-      } else {
-        deleted = await cleanupPastEvents(pool, days_old || 30);
-      }
-      return { content: [{ type: 'text', text: `Cleaned up ${deleted} old ${type}` }] };
-    }
-  );
-
-  server.tool(
-    'content_purge_rejected',
-    'Delete all rejected content items (news, events, photos)',
-    {
-      content_type: z.enum(['news', 'event', 'photo']).optional().describe('Purge only this type (omit for all)')
-    },
-    async ({ content_type }) => {
-      const result = await purgeRejected(pool, content_type || null);
-      return { content: [{ type: 'text', text: `Purged ${result.deleted} rejected items${content_type ? ` (${content_type})` : ''}` }] };
     }
   );
 

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -266,7 +266,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     const extraFields = contentType === 'event' ? ', t.start_date, t.content_source' : '';
 
     const itemQuery = await pool.query(
-      `SELECT t.id, t.title, t.${descField} AS description, t.source_url, t.publication_date,
+      `SELECT t.id, t.poi_id, t.title, t.${descField} AS description, t.source_url, t.publication_date,
               t.date_consensus_score, t.rendered_content, t.date_signals, p.name as poi_name${extraFields}
        FROM ${table} t
        LEFT JOIN pois p ON t.poi_id = p.id
@@ -310,6 +310,27 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       console.log(`[Moderation] ${contentType} #${contentId}: rejected (no source URL)`);
       logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: no source URL`, { completed: true });
       return;
+    }
+
+    // Excluded POI check
+    const excludedSetting = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
+    );
+    if (excludedSetting.rows.length > 0 && excludedSetting.rows[0].value) {
+      try {
+        const excludedIds = JSON.parse(excludedSetting.rows[0].value);
+        if (Array.isArray(excludedIds) && excludedIds.includes(row.poi_id)) {
+          await pool.query(
+            `UPDATE ${table} SET moderation_processed = true, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
+            [`Rejected: POI is on the excluded list`, contentId]
+          );
+          console.log(`[Moderation] ${contentType} #${contentId}: rejected (excluded POI ${row.poi_id})`);
+          logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: excluded POI ${row.poi_id}`, { completed: true });
+          return;
+        }
+      } catch (e) {
+        console.error('[Moderation] Failed to parse news_collection_excluded_pois:', e.message);
+      }
     }
 
     let dateScore = row.date_consensus_score || 0;

--- a/backend/services/newsletterService.js
+++ b/backend/services/newsletterService.js
@@ -10,7 +10,7 @@ import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { GEMINI_MODEL } from './geminiService.js';
-import { queueModerationJob, queueNewsletterJob } from './jobScheduler.js';
+import { queueNewsletterJob } from './jobScheduler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 
 const turndown = new TurndownService({
@@ -322,12 +322,6 @@ IMPORTANT:
           item.news_type || 'general', item.published_date || null
         ]);
 
-        try {
-          await queueModerationJob('news', newsInsert.rows[0].id);
-        } catch (modErr) {
-          console.error(`[Newsletter] Failed to queue moderation for news #${newsInsert.rows[0].id}:`, modErr.message);
-        }
-
         newsInserted++;
       } catch (err) {
         console.error(`[Newsletter] Failed to insert news "${item.title}":`, err.message);
@@ -349,12 +343,6 @@ IMPORTANT:
           item.event_type || null, item.location_details || null,
           item.source_url || null
         ]);
-
-        try {
-          await queueModerationJob('event', eventInsert.rows[0].id);
-        } catch (modErr) {
-          console.error(`[Newsletter] Failed to queue moderation for event #${eventInsert.rows[0].id}:`, modErr.message);
-        }
 
         eventsInserted++;
       } catch (err) {

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -1031,8 +1031,8 @@ function DataCollectionSettings() {
 
       {/* Excluded POIs from News Collection */}
       <div className="ai-config-section">
-        <h4>Excluded POIs from News Collection</h4>
-        <p className="settings-description">POIs in this list are skipped entirely during automated news collection. Use for broad geographic entities (e.g. Cuyahoga County, Cleveland) whose news feeds pull in irrelevant content.</p>
+        <h4>Excluded POIs from News and Events</h4>
+        <p className="settings-description">POIs in this list are skipped during automated news collection, and any news or events from these POIs are automatically rejected during moderation. Use for broad geographic entities (e.g. Cuyahoga County, Cleveland) whose feeds pull in irrelevant content.</p>
         {excludedPoisLoading ? <p>Loading...</p> : (
           <>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -100,8 +100,8 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [expandedItem]);
 
-  const fetchQueue = useCallback(async () => {
-    setLoading(true);
+  const fetchQueue = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
     try {
       const params = new URLSearchParams({ page: 1, limit: LIMIT, status: statusFilter });
       if (filter) params.set('type', filter);
@@ -122,11 +122,17 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     } catch (err) {
       console.error('Error fetching moderation queue:', err);
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }, [filter, statusFilter, sourceFilter, searchQuery, idFilter]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
+
+  // Auto-poll every 5 seconds to pick up background sweep changes
+  useEffect(() => {
+    const interval = setInterval(() => fetchQueue({ silent: true }), 5000);
+    return () => clearInterval(interval);
+  }, [fetchQueue]);
 
   useEffect(() => {
     if (!notification) return;
@@ -657,29 +663,6 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
         <h3 style={{ margin: 0 }}>Moderation Queue</h3>
         <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-          {/* Purge rejected button */}
-          {statusFilter === 'rejected' && total > 0 && (
-            <button
-              onClick={async () => {
-                const typeLabel = filter ? filter + 's' : 'items';
-                if (!window.confirm(`Delete all ${total} rejected ${typeLabel}? This cannot be undone.`)) return;
-                try {
-                  const response = await fetch('/api/admin/moderation/purge-rejected', {
-                    method: 'POST', headers: { 'Content-Type': 'application/json' },
-                    credentials: 'include', body: JSON.stringify({ type: filter || null })
-                  });
-                  if (response.ok) {
-                    const data = await response.json();
-                    notify('success', `Purged ${data.deleted} rejected items`);
-                    fetchQueue();
-                  }
-                } catch (err) { notify('error', err.message); }
-              }}
-              style={btnStyle('#b71c1c')}
-            >
-              Purge Rejected
-            </button>
-          )}
           {/* Reject All visible pending items */}
           {statusFilter === 'pending' && queue.length > 0 && (
             <button

--- a/frontend/src/components/NewsSettings.jsx
+++ b/frontend/src/components/NewsSettings.jsx
@@ -5,7 +5,6 @@ function NewsSettings() {
   const [jobStatus, setJobStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const [collecting, setCollecting] = useState(false);
-  const [cleaningUp, setCleaningUp] = useState(false);
   const [result, setResult] = useState(null);
   const [liveProgress, setLiveProgress] = useState(null);
   const [activeJobId, setActiveJobId] = useState(null);
@@ -171,43 +170,6 @@ function NewsSettings() {
     }
   };
 
-  const handleCleanup = async () => {
-    if (!confirm('Delete old news (>90 days) and past events (>30 days)?')) {
-      return;
-    }
-
-    setCleaningUp(true);
-    setResult(null);
-
-    try {
-      const response = await fetch('/api/admin/news/cleanup', {
-        method: 'POST',
-        credentials: 'include'
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setResult({
-          type: 'success',
-          message: `Cleaned up ${data.newsDeleted} old news items and ${data.eventsDeleted} past events`
-        });
-      } else {
-        const error = await response.json();
-        setResult({
-          type: 'error',
-          message: error.error || 'Cleanup failed'
-        });
-      }
-    } catch (err) {
-      setResult({
-        type: 'error',
-        message: err.message
-      });
-    } finally {
-      setCleaningUp(false);
-    }
-  };
-
   return (
     <div className="news-settings-revamped">
       <h3>News & Events Collection</h3>
@@ -319,25 +281,12 @@ function NewsSettings() {
           <button
             className="action-btn primary"
             onClick={handleCollectNews}
-            disabled={collecting || cleaningUp}
+            disabled={collecting}
           >
             {collecting ? 'Collecting...' : 'Start Collection'}
           </button>
         </div>
 
-        <div className="action-card">
-          <div className="action-info">
-            <strong>Cleanup Old Data</strong>
-            <p>Remove news older than 90 days and events that have already passed (more than 30 days ago).</p>
-          </div>
-          <button
-            className="action-btn secondary"
-            onClick={handleCleanup}
-            disabled={collecting || cleaningUp}
-          >
-            {cleaningUp ? 'Cleaning...' : 'Run Cleanup'}
-          </button>
-        </div>
       </div>
 
       {/* Result message */}

--- a/run.sh
+++ b/run.sh
@@ -451,10 +451,21 @@ ENVFILE
         if [ $? -eq 0 ]; then
             SEED_SIZE=$(du -h "$SEED_DATA_FILE" | cut -f1)
             echo "✓ Production data saved to $SEED_DATA_FILE ($SEED_SIZE)"
-            echo ""
-            echo "Next steps:"
-            echo "  ./run.sh start   # Start with this data"
-            echo "  ./run.sh test    # Run tests with this data"
+
+            # If container is running, import seed data directly
+            if podman ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+                echo ""
+                echo "Importing seed data into running container..."
+                podman cp "$SEED_DATA_FILE" "$CONTAINER_NAME:/tmp/seed-data.sql"
+                podman exec "$CONTAINER_NAME" psql -U postgres -d rotv -f /tmp/seed-data.sql 2>&1 | grep -c "^COPY" | xargs echo "Imported rows from tables:"
+                podman exec "$CONTAINER_NAME" sh -c 'for m in /app/migrations/[0-9]*.sql; do [ -f "$m" ] && psql -U postgres -d rotv -f "$m"; done' 2>&1 | grep -i "notice\|error" || true
+                echo "✓ Seed data imported into running container"
+            else
+                echo ""
+                echo "Next steps:"
+                echo "  ./run.sh start   # Start with this data"
+                echo "  ./run.sh test    # Run tests with this data"
+            fi
         else
             echo "❌ Failed to pull production data"
             rm -f "$SEED_DATA_FILE"


### PR DESCRIPTION
## Summary
- Rename "Excluded POIs from News Collection" → "Excluded POIs from News and Events" in Data Collection settings
- Auto-reject news/events from excluded POIs during moderation, before LLM calls (saves Gemini API costs)
- Remove redundant per-item moderation queue (`content-moderation`); the sweep job handles everything
- Remove content cleanup and purge-rejected functionality — rejected items serve as a dedup shield against re-collection
- Add 5-second silent auto-polling to moderation inbox so background sweep results appear in real time
- Fix `run.sh seed` to import data directly into a running container with persistent storage
- Consolidate Jobs UI: single "Content Moderation" entry replaces two redundant entries

## Test plan
- [x] Verified excluded POI auto-rejection: 10 events from excluded POIs rejected instantly
- [x] Verified moderation inbox title updated
- [x] Verified "Purge Rejected" button removed from moderation inbox
- [x] Verified "Content Cleanup" removed from Jobs dashboard
- [x] Verified single "Content Moderation" job entry in Jobs dashboard
- [x] Verified "Cleanup Old Data" button removed from News & Events Collection page
- [x] Build passes, no test regressions (pre-existing failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)