### PR TITLE
fix: stagger news collection schedules

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2720,8 +2720,8 @@ async function start() {
     // Register and schedule tiered news collection (daily/weekly/monthly)
     for (const { tier, cron } of [
       { tier: 'daily',   cron: '0 6 * * *' },     // Every day at 6 AM Eastern
-      { tier: 'weekly',  cron: '0 6 * * 1' },     // Monday at 6 AM Eastern
-      { tier: 'monthly', cron: '0 6 1 * *' },     // 1st of month at 6 AM Eastern
+      { tier: 'weekly',  cron: '0 5 * * 4' },     // Thursday at 5 AM Eastern
+      { tier: 'monthly', cron: '0 1 1 * *' },     // 1st of month at 1 AM Eastern
     ]) {
       await registerTierNewsCollectionHandler(tier, withJitter(async () => {
         console.log(`Running scheduled ${tier} news collection...`);

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -10,8 +10,8 @@ let boss = null;
 const JOB_NAMES = {
   NEWS_COLLECTION: 'news-collection',           // Legacy (kept for admin batch + unschedule)
   NEWS_COLLECTION_DAILY: 'news-collection-daily',     // Tier: daily at 6 AM
-  NEWS_COLLECTION_WEEKLY: 'news-collection-weekly',   // Tier: weekly Monday 6 AM
-  NEWS_COLLECTION_MONTHLY: 'news-collection-monthly', // Tier: monthly 1st 6 AM
+  NEWS_COLLECTION_WEEKLY: 'news-collection-weekly',   // Tier: weekly Thursday 5 AM
+  NEWS_COLLECTION_MONTHLY: 'news-collection-monthly', // Tier: monthly 1st 1 AM
   NEWS_COLLECTION_POI: 'news-collection-poi',   // Individual POI processing
   NEWS_BATCH: 'news-batch-collection',          // Admin-triggered batch collection
   TRAIL_STATUS_COLLECTION: 'trail-status-collection',  // Scheduled trail status collection


### PR DESCRIPTION
## Summary
- Move weekly news collection from Monday 6AM to Thursday 5AM Eastern
- Move monthly news collection from 1st-at-6AM to 1st-at-1AM Eastern
- Prevents all three tiers from firing simultaneously

## Test plan
- [ ] Verify container builds successfully
- [ ] Confirm service starts on lotor
- [ ] Check pg-boss schedules registered in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)