### PR TITLE
feat: per-POI score thresholds for news/events moderation

### DIFF
--- a/backend/migrations/045_add_poi_score_thresholds.sql
+++ b/backend/migrations/045_add_poi_score_thresholds.sql
@@ -1,0 +1,8 @@
+-- Migration 045: Add per-POI score thresholds for news/events moderation
+-- NULL = use global default (from admin_settings moderation_news_date_threshold)
+-- When set, applies only to items whose source_url matches the POI's
+-- configured news_url or events_url origin. Serper-sourced items still
+-- use the global threshold.
+
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS news_score_threshold INTEGER;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS events_score_threshold INTEGER;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -170,7 +170,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'research_context',
       'length_miles', 'difficulty', 'boundary_type', 'boundary_color',
-      'collection_tier'
+      'collection_tier', 'news_score_threshold', 'events_score_threshold'
     ];
     const updates = {};
     const values = [];
@@ -227,7 +227,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'name', 'latitude', 'longitude', 'property_owner', 'owner_id', 'brief_description',
       'era', 'era_id', 'historical_description', 'primary_activities', 'surface',
       'pets', 'cell_signal', 'more_info_link', 'events_url', 'news_url', 'research_context', 'status_url',
-      'collection_tier'
+      'collection_tier', 'news_score_threshold', 'events_score_threshold'
     ];
     const updates = {};
     const values = [];
@@ -300,7 +300,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'property_owner', 'owner_id', 'brief_description', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'status_url',
-      'collection_tier'
+      'collection_tier', 'news_score_threshold', 'events_score_threshold'
     ];
 
     const fields = ['name', 'latitude', 'longitude'];
@@ -367,7 +367,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'poi_roles', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
       'historical_description', 'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'has_primary_image',
-      'collection_tier'
+      'collection_tier', 'news_score_threshold', 'events_score_threshold'
     ];
 
     const fields = ['name', 'poi_roles'];
@@ -2103,7 +2103,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         'era_id', 'historical_description', 'primary_activities', 'surface', 'pets',
         'cell_signal', 'more_info_link', 'length_miles', 'difficulty',
         'boundary_type', 'boundary_color', 'status_url', 'news_url', 'events_url',
-        'collection_tier'
+        'collection_tier', 'news_score_threshold', 'events_score_threshold'
       ];
 
       const updates = [];

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -299,15 +299,7 @@ export function scoreDateConsensus(deterministicSources = {}, llmResults = []) {
     return { date: sorted[0][0], score: 0, sourceMap };
   }
 
-  // Penalise purely LLM-voted dates: no structured source (JSON-LD, meta, time tag, URL)
-  // means the LLM had nothing to anchor against and may have defaulted to today's date.
-  // Subtract 2 so LLM-only scores can never reach the auto-approval threshold (4).
-  const hasDeterministicSource =
-    (deterministicSources.jsonLd?.length > 0) || (deterministicSources.meta?.length > 0) ||
-    (deterministicSources.timeTags?.length > 0) || !!deterministicSources.url;
-  const finalScore = hasDeterministicSource ? sorted[0][1] : Math.max(0, sorted[0][1] - 2);
-
-  return { date: sorted[0][0], score: finalScore, sourceMap };
+  return { date: sorted[0][0], score: sorted[0][1], sourceMap };
 }
 
 /**

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -11,6 +11,11 @@ import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 import { parseDate, parseDateTime, localToUTC, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
 import { scoreDate, normalizeRenderUrl, normalizeTitle } from './newsService.js';
 
+function sameOrigin(urlA, urlB) {
+  try { return new URL(urlA).origin === new URL(urlB).origin; }
+  catch { return false; }
+}
+
 const TABLE_MAP = {
   news: 'poi_news',
   event: 'poi_events',
@@ -267,7 +272,8 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
 
     const itemQuery = await pool.query(
       `SELECT t.id, t.poi_id, t.title, t.${descField} AS description, t.source_url, t.publication_date,
-              t.date_consensus_score, t.rendered_content, t.date_signals, p.name as poi_name${extraFields}
+              t.date_consensus_score, t.rendered_content, t.date_signals, p.name as poi_name,
+              p.news_score_threshold, p.events_score_threshold, p.news_url, p.events_url${extraFields}
        FROM ${table} t
        LEFT JOIN pois p ON t.poi_id = p.id
        WHERE t.id = $1`, [contentId]
@@ -333,14 +339,20 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       }
     }
 
+    // Per-POI threshold override: applies only when item came from the POI's configured URL
+    const poiConfigUrl = contentType === 'news' ? row.news_url : row.events_url;
+    const poiThreshold = contentType === 'news' ? row.news_score_threshold : row.events_score_threshold;
+    const fromConfiguredUrl = row.source_url && poiConfigUrl && sameOrigin(row.source_url, poiConfigUrl);
+    const effectiveThreshold = (fromConfiguredUrl && poiThreshold != null) ? poiThreshold : newsDateThreshold;
+
     let dateScore = row.date_consensus_score || 0;
     let newScore = dateScore;
     let newDate = null;        // only set if a rescore actually produces a date
     let rescoredDate = false;  // track whether we ran a rescore
 
     // --- Step 1: Date scoring (rescore from cached signals or full extraction) ---
-    if (dateScore < newsDateThreshold || forceStatus) {
-      console.log(`[Moderation] ${contentType} #${contentId}: rescoring (current score=${dateScore}, threshold=${newsDateThreshold})`);
+    if (dateScore < effectiveThreshold || forceStatus) {
+      console.log(`[Moderation] ${contentType} #${contentId}: rescoring (current score=${dateScore}, threshold=${effectiveThreshold})`);
       logInfo(itemRunId, 'moderation', null, row.title, `Rescoring ${contentType} #${contentId} (score=${dateScore})`);
 
       try {
@@ -439,12 +451,12 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     } else if (unanimousNo) {
       resolvedStatus = 'rejected';
       reasoning = `Rejected: relevance vote unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})`;
-    } else if (unanimousYes && newScore >= newsDateThreshold && effectiveDate) {
+    } else if (unanimousYes && newScore >= effectiveThreshold && effectiveDate) {
       resolvedStatus = 'published';
-      reasoning = `Published: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${newsDateThreshold}`;
+      reasoning = `Published: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${effectiveThreshold}`;
     } else {
       resolvedStatus = 'pending';
-      reasoning = `Pending: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${newsDateThreshold}`;
+      reasoning = `Pending: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${effectiveThreshold}`;
     }
 
     scoring = { confidence_score: newScore / 8.0, reasoning };

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -113,46 +113,46 @@ describe('scoreDateConsensus', () => {
     expect(result.score).toBe(5);
   });
 
-  it('5 unanimous LLM votes score 3 pts (penalised -2 for no structured source)', () => {
+  it('3 unanimous LLM votes score 3 pts (no penalty, but still below auto-approve threshold of 4)', () => {
     const result = scoreDateConsensus(
       {},
-      ['2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01']
+      ['2024-06-01', '2024-06-01', '2024-06-01']
     );
     expect(result.date).toBe('2024-06-01');
-    expect(result.score).toBe(3); // 5 LLM votes - 2 penalty = 3 (below auto-approve threshold)
+    expect(result.score).toBe(3);
   });
 
-  it('LLM votes + agreeing JSON-LD scores 9 pts', () => {
+  it('LLM votes + agreeing JSON-LD scores 7 pts', () => {
     const result = scoreDateConsensus(
       { jsonLd: ['2024-06-01'] },
-      ['2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01', '2024-06-01']
+      ['2024-06-01', '2024-06-01', '2024-06-01']
     );
     expect(result.date).toBe('2024-06-01');
-    expect(result.score).toBe(9);  // 4 (json-ld) + 5 (llm votes)
+    expect(result.score).toBe(7);  // 4 (json-ld) + 3 (llm votes)
   });
 
   it('LLM votes beat disagreeing time-tags when they have more points', () => {
     const result = scoreDateConsensus(
-      { timeTags: ['2024-03-31', '2024-03-31', '2024-03-31'] },
-      ['2024-04-05', '2024-04-05', '2024-04-05', '2024-04-05', '2024-04-05']
+      { timeTags: ['2024-03-31'] },
+      ['2024-04-05', '2024-04-05', '2024-04-05']
     );
     expect(result.date).toBe('2024-04-05');
-    expect(result.score).toBe(5);  // 5 LLM votes > 3 time-tags
+    expect(result.score).toBe(3);  // 3 LLM votes > 1 time-tag
   });
 
   it('LLM votes add to matching deterministic source', () => {
     const result = scoreDateConsensus(
       { timeTags: ['2024-03-15'] },
-      ['2024-03-15', '2024-03-15', '2024-03-15', '2024-03-16', '2024-03-16']
+      ['2024-03-15', '2024-03-15', '2024-03-16']
     );
     expect(result.date).toBe('2024-03-15');
-    expect(result.score).toBe(4);  // 1 (time-tag) + 3 (llm votes)
+    expect(result.score).toBe(3);  // 1 (time-tag) + 2 (llm votes)
   });
 
   it('includes llm-vote in sourceMap', () => {
     const result = scoreDateConsensus(
       { jsonLd: ['2024-03-15'] },
-      ['2024-03-15', '2024-03-15', '2024-03-15', '2024-03-15', '2024-03-15']
+      ['2024-03-15', '2024-03-15', '2024-03-15']
     );
     expect(result.sourceMap['2024-03-15']).toContain('json-ld');
     expect(result.sourceMap['2024-03-15']).toContain('llm-vote');
@@ -168,16 +168,16 @@ describe('scoreDateConsensus', () => {
   it('LLM votes break JSON-LD ties', () => {
     const result = scoreDateConsensus(
       { jsonLd: ['2024-01-14', '2024-01-15', '2024-04-13', '2024-04-17'] },
-      ['2024-01-14', '2024-01-14', '2024-01-14', '2024-01-14', '2024-01-14']
+      ['2024-01-14', '2024-01-14', '2024-01-14']
     );
     expect(result.date).toBe('2024-01-14');
-    expect(result.score).toBe(9);  // 4 (json-ld) + 5 (llm votes)
+    expect(result.score).toBe(7);  // 4 (json-ld) + 3 (llm votes)
   });
 
   it('handles all null LLM votes gracefully', () => {
     const result = scoreDateConsensus(
       { jsonLd: ['2024-05-20'] },
-      [null, null, null, null, null]
+      [null, null, null]
     );
     expect(result.date).toBe('2024-05-20');
     expect(result.score).toBe(4);

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -681,18 +681,18 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       </div>
 
       <div className="edit-section">
-        <label>Research Context <span className="field-hint">(optional notes for AI)</span></label>
+        <label title="Optional notes to guide AI research (e.g., 'This is a historic gristmill built in 1810, focus on canal era connections')">Research Context</label>
         <textarea
           value={editedData.research_context || ''}
           onChange={(e) => handleChange('research_context', e.target.value)}
-          placeholder="Add context to guide AI research (e.g., 'This is a historic gristmill built in 1810, focus on canal era connections')"
+          placeholder="Optional notes to guide AI research..."
           rows={2}
           style={{ resize: 'vertical' }}
         />
       </div>
 
       <div className="edit-section">
-        <label>Name *</label>
+        <label title="The display name for this location">Name *</label>
         <input
           type="text"
           value={editedData.name || ''}
@@ -702,7 +702,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       </div>
 
       <div className="edit-section">
-        <label>Overview</label>
+        <label title="A short public-facing description of this location">Overview</label>
         <textarea
           value={editedData.brief_description || ''}
           onChange={(e) => {
@@ -725,7 +725,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
         <>
           <div className="edit-row">
             <div className="edit-section half">
-              <label>Era</label>
+              <label title="Historical era this location is associated with">Era</label>
               <select
                 value={editedData.era_id || ''}
                 onChange={(e) => {
@@ -746,7 +746,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
               </select>
             </div>
             <div className="edit-section half">
-              <label>Property Owner</label>
+              <label title="Organization that owns or manages this property">Property Owner</label>
               <select
                 value={editedData.owner_id || ''}
                 onChange={(e) => {
@@ -768,7 +768,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
           </div>
 
           <div className="edit-section">
-            <label>Primary Activities</label>
+            <label title="Activities available at this location (hiking, biking, fishing, etc.)">Primary Activities</label>
             <div className="activities-selector">
               <div
                 className="activities-toggle"
@@ -804,7 +804,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
 
           <div className="edit-row">
             <div className="edit-section half">
-              <label>Surface</label>
+              <label title="Trail or path surface type">Surface</label>
               <select
                 value={editedData.surface || ''}
                 onChange={(e) => handleChange('surface', e.target.value)}
@@ -818,7 +818,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
               </select>
             </div>
             <div className="edit-section half">
-              <label>Pets Allowed</label>
+              <label title="Whether pets are allowed at this location">Pets Allowed</label>
               <select
                 value={editedData.pets || ''}
                 onChange={(e) => handleChange('pets', e.target.value)}
@@ -833,7 +833,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
 
           <div className="edit-row">
             <div className="edit-section half">
-              <label>Cell Signal</label>
+              <label title="Typical cell signal strength at this location">Cell Signal</label>
               <EditableCellSignal
                 level={editedData.cell_signal}
                 onChange={(val) => handleChange('cell_signal', val)}
@@ -848,7 +848,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
         <>
           <div className="edit-row">
             <div className="edit-section half">
-              <label>Feature Type</label>
+              <label title="Type of linear feature (trail, river, boundary)">Feature Type</label>
               <select
                 value={editedData.feature_type || 'trail'}
                 onChange={(e) => handleChange('feature_type', e.target.value)}
@@ -857,7 +857,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
               </select>
             </div>
             <div className="edit-section half">
-              <label>Difficulty</label>
+              <label title="Trail difficulty rating">Difficulty</label>
               <select
                 value={editedData.difficulty || ''}
                 onChange={(e) => handleChange('difficulty', e.target.value)}
@@ -870,7 +870,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
             </div>
           </div>
           <div className="edit-section">
-            <label>Length (miles)</label>
+            <label title="Total length of the trail in miles">Length (miles)</label>
             <input
               type="number"
               step="0.1"
@@ -885,7 +885,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       {/* Boundary color picker */}
       {isLinearFeature && editedData.feature_type === 'boundary' && (
         <div className="edit-section">
-          <label>Boundary Color</label>
+          <label title="Color used to display this boundary on the map">Boundary Color</label>
           <div className="boundary-color-palette">
             {[
               '#228B22', // Forest Green
@@ -925,7 +925,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       {!isLinearFeature && !destination?.poi_roles?.includes('organization') && (
         <div className="edit-row">
           <div className="edit-section half">
-            <label>Latitude</label>
+            <label title="GPS latitude coordinate">Latitude</label>
             <input
               type="number"
               step="0.000001"
@@ -934,7 +934,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
             />
           </div>
           <div className="edit-section half">
-            <label>Longitude</label>
+            <label title="GPS longitude coordinate">Longitude</label>
             <input
               type="number"
               step="0.000001"
@@ -946,7 +946,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       )}
 
       <div className="edit-section">
-        <label>More Info Link</label>
+        <label title="Primary website or information page for this location">More Info Link</label>
         <input
           type="text"
           value={editedData.more_info_link || ''}
@@ -956,17 +956,7 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       </div>
 
       <div className="edit-section">
-        <label>Events Page URL (for AI Research)</label>
-        <input
-          type="text"
-          value={editedData.events_url || ''}
-          onChange={(e) => handleChange('events_url', e.target.value)}
-          placeholder="https://example.com/events or /adventures"
-        />
-      </div>
-
-      <div className="edit-section">
-        <label>News Page URL (for AI Research)</label>
+        <label title="URL of the news or blog page to crawl for this POI">News Page URL</label>
         <input
           type="text"
           value={editedData.news_url || ''}
@@ -976,20 +966,51 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
       </div>
 
       <div className="edit-section">
-        <label>MTB Trail Status URL (for AI status collection)</label>
+        <label title="Auto-approve score for news from this URL. Blank uses global default (4). Only applies to items from the News Page URL, not Serper results.">News Score Threshold</label>
+        <input
+          type="number"
+          min="1"
+          max="8"
+          value={editedData.news_score_threshold ?? ''}
+          onChange={(e) => handleChange('news_score_threshold', e.target.value ? parseInt(e.target.value) : null)}
+          placeholder="Default: 4"
+        />
+      </div>
+
+      <div className="edit-section">
+        <label title="URL of the events or calendar page to crawl for this POI">Events Page URL</label>
+        <input
+          type="text"
+          value={editedData.events_url || ''}
+          onChange={(e) => handleChange('events_url', e.target.value)}
+          placeholder="https://example.com/events or /adventures"
+        />
+      </div>
+
+      <div className="edit-section">
+        <label title="Auto-approve score for events from this URL. Blank uses global default (4). Only applies to items from the Events Page URL, not Serper results.">Events Score Threshold</label>
+        <input
+          type="number"
+          min="1"
+          max="8"
+          value={editedData.events_score_threshold ?? ''}
+          onChange={(e) => handleChange('events_score_threshold', e.target.value ? parseInt(e.target.value) : null)}
+          placeholder="Default: 4"
+        />
+      </div>
+
+      <div className="edit-section">
+        <label title="Trail status page URL. If set, this trail will appear in MTB status collection.">MTB Trail Status URL</label>
         <input
           type="text"
           value={editedData.status_url || ''}
           onChange={(e) => handleChange('status_url', e.target.value)}
-          placeholder="https://example.com/trail-status (leave empty if not an MTB trail)"
+          placeholder="https://example.com/trail-status"
         />
-        <small style={{ color: '#666', display: 'block', marginTop: '0.5rem' }}>
-          If a trail status URL is provided, this trail will appear in MTB status collection
-        </small>
       </div>
 
       <div className="edit-section">
-        <label>News Collection Tier</label>
+        <label title="How often this POI is included in scheduled news and events collection">Collection Tier</label>
         <select
           value={editedData.collection_tier || 'weekly'}
           onChange={(e) => handleChange('collection_tier', e.target.value)}
@@ -998,9 +1019,6 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
           <option value="weekly">Weekly</option>
           <option value="monthly">Monthly</option>
         </select>
-        <small style={{ color: '#666', display: 'block', marginTop: '0.5rem' }}>
-          How often this POI is included in scheduled news collection
-        </small>
       </div>
 
 


### PR DESCRIPTION
## Summary
- Add per-POI `news_score_threshold` and `events_score_threshold` columns to override the global auto-approve threshold for trusted URLs
- Thresholds only apply when the item's source_url matches the POI's configured news_url/events_url origin — Serper results still use global default
- Remove the -2 LLM-only penalty from date consensus scoring (obsolete now that LLM votes are capped at 3)
- Clean up sidebar edit mode: remove "(for AI Research)" labels, add tooltips to all fields, remove inline helper text

## Test plan
- [x] Set CVSR events_score_threshold to 3, reset events to pending, run moderation — score-3 events from cvsr.org auto-published, score-1/0 stayed pending
- [x] Relevance voting still gates auto-approval (Digital Membership Cards had score 3 but only 2/3 relevance → stayed pending)
- [x] All dateExtractor unit tests pass (46/46)
- [x] Sidebar tooltips display on hover for all fields in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)