### PR TITLE
fix: widen moderation relevance prompt scope

### DIFF
--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -188,7 +188,7 @@ async function attemptDeepCrawl(pool, contentType, contentId, row, scoring) {
  */
 async function runContentRelevanceVotes(pool, { title, description, poiName, contentType }, numVotes = 3) {
   const typeLabel = contentType === 'event' ? 'event' : 'news article or announcement';
-  const prompt = `You are evaluating content for "Roots of The Valley," a guide to Cuyahoga Valley National Park.
+  const prompt = `You are evaluating content for "Roots of The Valley," a guide to Cuyahoga Valley National Park and the surrounding region including Cleveland Metroparks, Summit Metro Parks, and other nearby parks, trails, and outdoor recreation areas.
 
 Title: "${title}"
 Summary: "${description || '(none)'}"
@@ -200,6 +200,7 @@ Is this a real ${typeLabel}, NOT a static reference page?
 APPROVE if the content:
 - Reports on something that happened or will happen (article, announcement, press release)
 - Describes a specific event with dates
+- Scheduled recreational excursions, tours, or rides with specific dates (e.g., scenic train rides, guided hikes, boat tours) — even if they run regularly
 - The TOPIC is directly related to: nature, trails, hiking, biking, paddling, outdoor recreation,
   conservation, ecology, wildlife, park operations, land management, environmental education,
   local history of the Cuyahoga Valley, or outdoor arts/music events hosted by a park or nature organization


### PR DESCRIPTION
## Summary
- Expanded geographic scope in the AI moderation relevance prompt from "CVNP only" to include Cleveland Metroparks, Summit Metro Parks, and surrounding parks/trails
- Added explicit approval rule for scheduled recreational excursions (scenic train rides, guided hikes, boat tours) that run regularly but have specific dates

## Context
The AI moderator was rejecting valid content:
- **2026 Trail Challenge** (Cleveland Metroparks) — rejected 0/3 because "not CVNP"
- **Classic Scenic Train Ride** (CVSR) — rejected 0/3 as a "permanent attraction/service"

## Test plan
- [ ] Requeue the two rejected events and verify they pass moderation
- [ ] Monitor next collection run for false negatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)