### PR TITLE
fix: use app timezone for event date comparisons

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1990,7 +1990,7 @@ app.get('/api/pois/:id/events', async (req, res) => {
         AND e.moderation_status IN ('published', 'auto_approved')
     `;
     if (upcomingOnly) {
-      query += ` AND e.start_date >= (CURRENT_TIMESTAMP AT TIME ZONE $3)::date`;
+      query += ` AND (e.start_date AT TIME ZONE $3)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $3)::date`;
     }
     query += ` GROUP BY e.id ORDER BY e.start_date ASC LIMIT $2`;
 
@@ -2203,7 +2203,7 @@ app.get('/api/events/upcoming', async (req, res) => {
       JOIN pois p ON e.poi_id = p.id
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
-        AND e.start_date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
+        AND (e.start_date AT TIME ZONE $1)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       GROUP BY e.id, p.id, p.name, p.poi_roles
       ORDER BY e.start_date ASC
@@ -2228,7 +2228,7 @@ app.get('/api/events/past', async (req, res) => {
       JOIN pois p ON e.poi_id = p.id
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
-        AND e.start_date < (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
+        AND (e.start_date AT TIME ZONE $2)::date < (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       GROUP BY e.id, p.id, p.name, p.poi_roles
       ORDER BY e.start_date DESC

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -2094,8 +2094,9 @@ export async function getNewsForPoi(pool, poiId, limit = 10) {
  * @param {Pool} pool - Database connection pool
  * @param {number} poiId - POI ID
  * @param {boolean} upcomingOnly - Only return future events
+ * @param {string} tz - IANA timezone for date comparison
  */
-export async function getEventsForPoi(pool, poiId, upcomingOnly = true) {
+export async function getEventsForPoi(pool, poiId, upcomingOnly = true, tz = 'America/New_York') {
   let query = `
     SELECT id, title, description, start_date, end_date, event_type, location_details, source_url, collection_date
     FROM poi_events
@@ -2104,12 +2105,12 @@ export async function getEventsForPoi(pool, poiId, upcomingOnly = true) {
   `;
 
   if (upcomingOnly) {
-    query += ` AND start_date >= CURRENT_DATE`;
+    query += ` AND (start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date`;
   }
 
   query += ` ORDER BY start_date ASC`;
 
-  const result = await pool.query(query, [poiId]);
+  const result = await pool.query(query, upcomingOnly ? [poiId, tz] : [poiId]);
   return result.rows;
 }
 
@@ -2136,18 +2137,19 @@ export async function getRecentNews(pool, limit = 20) {
  * Get all upcoming events across all POIs
  * @param {Pool} pool - Database connection pool
  * @param {number} daysAhead - How many days ahead to look
+ * @param {string} tz - IANA timezone for date comparison
  */
-export async function getUpcomingEvents(pool, daysAhead = 30) {
+export async function getUpcomingEvents(pool, daysAhead = 30, tz = 'America/New_York') {
   const result = await pool.query(`
     SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
            e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_events e
     JOIN pois p ON e.poi_id = p.id
-    WHERE e.start_date >= CURRENT_DATE
-      AND e.start_date <= CURRENT_DATE + INTERVAL '1 day' * $1
+    WHERE (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
+      AND (e.start_date AT TIME ZONE $2)::date <= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date + $1
       AND e.moderation_status IN ('published', 'auto_approved')
     ORDER BY e.start_date ASC
-  `, [daysAhead]);
+  `, [daysAhead, tz]);
 
   return result.rows;
 }

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -3,17 +3,18 @@ import { sendEmail } from './buttondownClient.js';
 /**
  * Generate HTML digest content for weekly newsletter
  * @param {Pool} pool - Database connection pool
+ * @param {string} tz - IANA timezone for date comparison
  * @returns {Promise<string>} HTML digest content
  */
-export async function generateDigest(pool) {
+export async function generateDigest(pool, tz = 'America/New_York') {
   // Get events happening Friday-Sunday (next 3 days from Friday)
   const eventsQuery = `
     SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
            e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_events e
     JOIN pois p ON e.poi_id = p.id
-    WHERE e.start_date >= CURRENT_DATE
-      AND e.start_date <= CURRENT_DATE + INTERVAL '2 days'
+    WHERE (e.start_date AT TIME ZONE $1)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
+      AND (e.start_date AT TIME ZONE $1)::date <= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date + 2
       AND e.moderation_status IN ('published', 'auto_approved')
     ORDER BY e.start_date ASC
     LIMIT 10
@@ -32,7 +33,7 @@ export async function generateDigest(pool) {
   `;
 
   const [eventsResult, newsResult] = await Promise.all([
-    pool.query(eventsQuery),
+    pool.query(eventsQuery, [tz]),
     pool.query(newsQuery)
   ]);
 

--- a/frontend/src/components/NewsEvents.jsx
+++ b/frontend/src/components/NewsEvents.jsx
@@ -17,9 +17,12 @@ function NewsEvents({ poiId, isAdmin }) {
       setError(null);
 
       try {
+        const tz = localStorage.getItem('app-timezone')
+          || Intl.DateTimeFormat().resolvedOptions().timeZone
+          || 'America/New_York';
         const [newsRes, eventsRes] = await Promise.all([
           fetch(`/api/pois/${poiId}/news?limit=10`),
-          fetch(`/api/pois/${poiId}/events`)
+          fetch(`/api/pois/${poiId}/events?tz=${encodeURIComponent(tz)}`)
         ]);
 
         if (newsRes.ok) {

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -44,7 +44,9 @@ function ParkEvents({ isAdmin, onSelectPoi, filteredDestinations, filteredLinear
     setLoading(true);
     setError(null);
     try {
-      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const tz = localStorage.getItem('app-timezone')
+        || Intl.DateTimeFormat().resolvedOptions().timeZone
+        || 'America/New_York';
       const response = await fetch(`/api/events/upcoming?tz=${encodeURIComponent(tz)}`);
       if (response.ok) {
         const data = await response.json();

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1382,7 +1382,10 @@ function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectE
     if (!poiId) return;
     setLoading(true);
     try {
-      const response = await fetch(`/api/pois/${poiId}/events?limit=50`);
+      const tz = localStorage.getItem('app-timezone')
+        || Intl.DateTimeFormat().resolvedOptions().timeZone
+        || 'America/New_York';
+      const response = await fetch(`/api/pois/${poiId}/events?limit=50&tz=${encodeURIComponent(tz)}`);
       if (response.ok) {
         const data = await response.json();
         setEvents(data);


### PR DESCRIPTION
## Summary
- Fix TIMESTAMPTZ-vs-DATE comparison bug that caused yesterday's evening events to appear as "upcoming" (PostgreSQL cast DATE to midnight UTC, not Eastern)
- Frontend now reads user's app timezone setting (Settings > General > Timezone) instead of only using browser Intl API
- All event date queries now compare both sides in the user's timezone: `(e.start_date AT TIME ZONE $tz)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $tz)::date`
- Timezone priority: app setting → browser detection → hardcoded America/New_York

## Files Changed
- `backend/server.js` — 3 endpoint queries fixed
- `backend/services/newsService.js` — `getEventsForPoi()` and `getUpcomingEvents()` now accept tz param
- `backend/services/newsletterDigestService.js` — `generateDigest()` now accepts tz param
- `frontend/src/components/ParkEvents.jsx` — read app-timezone from localStorage
- `frontend/src/components/NewsEvents.jsx` — pass tz to POI events API
- `frontend/src/components/Sidebar.jsx` — pass tz to POI events API

## Test plan
- [x] `./run.sh build` passes
- [x] `./run.sh test` passes (pre-existing failures only)
- [x] Verified in browser: May 8th events no longer show on May 9th
- [x] Gatehouse critical finding reviewed — false positive (conditional param binding is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)