### PR TITLE
feat: deterministic link extraction replaces Gemini link selection

### DIFF
--- a/backend/migrations/046_add_trusted_event_paths.sql
+++ b/backend/migrations/046_add_trusted_event_paths.sql
@@ -1,0 +1,6 @@
+-- Add default trusted event paths for the events crawler.
+-- These path patterns bypass the basePath filter, allowing the crawler
+-- to follow detail links even when listing and detail pages use different paths.
+INSERT INTO admin_settings (key, value) VALUES
+  ('trusted_event_paths', '["/event","/events","/program","/programs","iteminfo.html","/store/p"]')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -488,7 +488,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'page_delay_ms',
       'news_collection_excluded_pois',
       'blocklist_urls',
-      'moderation_trusted_domains'
+      'moderation_trusted_domains',
+      'trusted_event_paths'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -252,9 +252,118 @@ export async function findIncompleteJobs(pool) {
   return result.rows;
 }
 
+// Calendar/view navigation suffixes — links ending with these are view selectors, not detail pages
+const CALENDAR_VIEW_SUFFIXES = ['/list/', '/list', '/month/', '/month', '/today/', '/today',
+  '/week/', '/week', '/day/', '/day', '/map/', '/map', '/photo/', '/photo',
+  '/summary/', '/summary', '/calendar/', '/calendar'];
+
+// Single-segment nav paths — pages that are never content detail pages
+const NAV_PATHS = [
+  '/login', '/signin', '/signup', '/register',
+  '/cart', '/checkout', '/account', '/household',
+  '/contact', '/contactus', '/contact-us',
+  '/about', '/about-us', '/aboutus',
+  '/privacy', '/terms', '/cookie', '/accessibility',
+  '/search', '/subscribe', '/newsletter',
+  '/donate', '/give', '/membership',
+  '/splash', '/faq', '/help',
+  '/become-a-member', '/get-involved', '/volunteer'
+];
+
+// WebTrac navigation files — sibling HTML files that aren't event detail pages
+const WEBTRAC_NAV_FILES = ['splash.html', 'contactus.html', 'cart.html', 'login.html',
+  'household.html', 'register.html', 'forgotpassword.html', 'wishlist.html', 'addtocart.html'];
+
+/**
+ * Test whether a URL is a known non-detail pattern (noise link).
+ * Used by deterministic link extraction to filter calendar nav, pagination,
+ * images, forms, and other links that look like content but aren't detail pages.
+ *
+ * @param {string} url - The link URL to test
+ * @param {string} sourceUrl - The page the link was found on
+ * @returns {boolean} - true if the link is noise (should be excluded)
+ */
+function isNoiseLink(url, sourceUrl) {
+  let parsed;
+  try { parsed = new URL(url); } catch { return true; }
+
+  const path = parsed.pathname.toLowerCase();
+  const search = parsed.search.toLowerCase();
+
+  // Non-page resources (images, docs, stylesheets)
+  if (/\.(png|jpe?g|gif|svg|webp|pdf|css|js|ico|woff2?|mp[34]|zip|ics)$/i.test(path)) return true;
+
+  // Hash-only link (same page anchor)
+  try {
+    const source = new URL(sourceUrl);
+    if (parsed.origin === source.origin && parsed.pathname === source.pathname && parsed.hash) return true;
+  } catch { /* ignore */ }
+
+  // Homepage / site root
+  if (path === '/' || path === '') return true;
+
+  // Calendar view selectors
+  for (const suffix of CALENDAR_VIEW_SUFFIXES) {
+    if (path.endsWith(suffix)) return true;
+  }
+
+  // Past events / archive views
+  if (search.includes('eventdisplay=past') || search.includes('display=past')) return true;
+
+  // iCal / feed exports
+  if (search.includes('ical=1') || search.includes('outlook-ical') || path.endsWith('.ics')) return true;
+
+  // Pagination links
+  if (/\/page\/\d+\/?$/.test(path)) return true;
+  if (/[?&]page=\d+/.test(search)) return true;
+
+  // Common non-content pages (only single-segment paths like /about, not /about/news)
+  const pathSegments = path.replace(/\/$/, '').split('/').filter(Boolean);
+  if (pathSegments.length <= 1) {
+    const simplePath = '/' + (pathSegments[0] || '');
+    if (NAV_PATHS.includes(simplePath)) return true;
+  }
+
+  // WebTrac-specific nav pages
+  const filename = path.split('/').pop();
+  if (WEBTRAC_NAV_FILES.includes(filename)) return true;
+
+  // Request/submission forms
+  const lastSegment = path.replace(/\/$/, '').split('/').pop() || '';
+  if (/\brequest|submit|apply|form\b/i.test(lastSegment)) return true;
+
+  return false;
+}
+
+/**
+ * Deduplicate URLs by keeping the shortest when one is a prefix of another.
+ * Handles WebTrac sub-tab URLs: iteminfo.html?FMID=123&option=fees is longer
+ * than iteminfo.html?FMID=123, so the shorter base event URL wins.
+ *
+ * @param {Array} urls - Array of URL strings
+ * @returns {Array} - Deduplicated URLs
+ */
+function shortestUrlDedup(urls) {
+  const byUrl = new Map();
+  for (const url of urls) {
+    let dominated = false;
+    for (const [existing] of byUrl) {
+      if (url.startsWith(existing + '&') || url.startsWith(existing + '%')) {
+        dominated = true;
+        break;
+      }
+      if (existing.startsWith(url + '&') || existing.startsWith(url + '%')) {
+        byUrl.delete(existing);
+      }
+    }
+    if (!dominated) byUrl.set(url, true);
+  }
+  return [...byUrl.keys()];
+}
+
 /**
  * Classify a web page as LISTING or DETAIL using Gemini.
- * Sends first 3000 chars of markdown + first 20 links, returns classification.
+ * Gemini classifies only — link extraction is fully deterministic.
  *
  * @param {Pool} pool - Database connection pool
  * @param {string} markdown - Page markdown content
@@ -262,9 +371,10 @@ export async function findIncompleteJobs(pool) {
  * @param {string} url - The page URL
  * @param {string} contentType - 'event' or 'news'
  * @param {Object} sheets - Optional sheets client for API key restore
+ * @param {Array} trustedEventPaths - URL path patterns that bypass basePath (e.g., /event, iteminfo.html)
  * @returns {Object} - { pageType, detailLinks, reasoning }
  */
-async function classifyPage(pool, markdown, links, url, contentType, sheets) {
+async function classifyPage(pool, markdown, links, url, contentType, sheets, trustedEventPaths = []) {
   // Prioritize content links over navigation — "Read More", article-pattern URLs, etc.
   // Navigation links (menus, footers) dominate the first positions in DOM order,
   // burying the actual article links the classifier needs to see.
@@ -282,53 +392,101 @@ async function classifyPage(pool, markdown, links, url, contentType, sheets) {
       const linkPath = new URL(l.url).pathname;
       if (sourceOrigin.length > 1 && linkPath.startsWith(sourceOrigin) && linkPath !== sourceOrigin && linkPath !== sourceOrigin + '/') return true;
     } catch { /* ignore */ }
+    // Links to a different page in the same directory (sibling files)
+    // e.g., /webtrac/web/search.html → /webtrac/web/iteminfo.html
+    try {
+      const linkPath = new URL(l.url).pathname;
+      const sourceDir = sourceOrigin.replace(/\/[^/]+\.[^/]+$/, '');
+      if (sourceDir && sourceDir !== sourceOrigin && linkPath.startsWith(sourceDir + '/') && linkPath !== sourceOrigin) return true;
+    } catch { /* ignore */ }
+    // Links matching trusted event path patterns (e.g., /event, /events, iteminfo.html)
+    if (trustedEventPaths.length > 0) {
+      try {
+        const linkPath = new URL(l.url).pathname;
+        if (trustedEventPaths.some(pattern => linkPath.includes(pattern))) return true;
+      } catch { /* ignore */ }
+    }
     return false;
   });
+  // Filter out links pointing to the same page (same pathname, different query params).
+  // e.g., search.html?category=Golf is a filtered view of search.html, not a detail page.
+  let sourcePathname;
+  try { sourcePathname = new URL(url).pathname; } catch { sourcePathname = null; }
+  const notSelfRef = l => {
+    if (!sourcePathname) return true;
+    try { return new URL(l.url).pathname !== sourcePathname; } catch { return true; }
+  };
+  // Deduplicate by URL — same event may appear multiple times with different anchor text
+  // (e.g., "Archery for Beginners", "Fee Details", "Share" all link to the same iteminfo.html).
+  // Keep the first occurrence, which is typically the event title.
+  const dedup = (arr) => {
+    const urlSeen = new Set();
+    return arr.filter(l => {
+      if (urlSeen.has(l.url)) return false;
+      urlSeen.add(l.url);
+      return true;
+    });
+  };
   // Use content links first, then fill with remaining links up to 30
-  const seen = new Set(contentLinks.map(l => l.url));
-  const otherLinks = links.filter(l => !seen.has(l.url));
-  const rankedLinks = [...contentLinks, ...otherLinks].slice(0, 30);
+  const filteredContentLinks = dedup(contentLinks.filter(notSelfRef));
+  const seen = new Set(filteredContentLinks.map(l => l.url));
+  const otherLinks = dedup(links.filter(l => !seen.has(l.url)).filter(notSelfRef));
+  const rankedLinks = [...filteredContentLinks, ...otherLinks].slice(0, 30);
 
   const prompt = `Classify this web page. Based on the content, is it:
 A) LISTING — lists multiple ${contentType}s with links to individual pages
 B) DETAIL — describes a single ${contentType} with dates/descriptions/details
+C) NEITHER — not a ${contentType} page at all (e.g., about page, contact form, login, navigation, store/shop, generic info)
 
 PAGE URL: ${url}
 CONTENT (first 3000 chars):
 ${markdown.substring(0, 5000)}
 
-LINKS (${rankedLinks.length} most relevant, content links first):
-${rankedLinks.map(l => `- "${(l.text || '').substring(0, 60)}" → ${l.url}`).join('\n')}
-
 Return ONLY valid JSON:
-{"page_type": "listing|detail", "reasoning": "one sentence", "detail_links": ["url1", "url2"]}
-For LISTING: populate detail_links with URLs to individual ${contentType} pages (max 15).
-For DETAIL: detail_links should be empty.`;
+{"page_type": "listing|detail|neither", "reasoning": "one sentence"}`;
 
-  const result = await generateTextWithCustomPrompt(pool, prompt, { maxOutputTokens: 1024, thinkingBudget: 0 });
+  const result = await generateTextWithCustomPrompt(pool, prompt, { maxOutputTokens: 256, thinkingBudget: 0 });
 
   // Parse JSON from response (handle markdown code blocks)
   const text = result.response || result;
   const jsonMatch = text.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
-    return { pageType: 'listing', detailLinks: links.map(l => l.url).slice(0, 15), reasoning: 'parse failure fallback' };
+    // Parse failure — assume listing and pass all ranked links for deterministic filtering
+    return { pageType: 'listing', detailLinks: rankedLinks.map(l => l.url), reasoning: 'parse failure fallback' };
   }
   try {
     const parsed = JSON.parse(jsonMatch[0]);
-    return { pageType: (parsed.page_type || '').toLowerCase(), detailLinks: parsed.detail_links || [], reasoning: parsed.reasoning };
+    const pageType = (parsed.page_type || '').toLowerCase();
+
+    // Gemini is ONLY a classifier — it does NOT select links.
+    // rankedLinks were built deterministically above (content link heuristics + dedup).
+    // filterDetailLinks() applies noise filtering, basePath, and trusted patterns downstream.
+    if (pageType === 'listing') {
+      return { pageType, detailLinks: rankedLinks.map(l => l.url), reasoning: parsed.reasoning };
+    }
+    if (pageType === 'detail') {
+      return { pageType, detailLinks: [], reasoning: parsed.reasoning };
+    }
+    if (pageType === 'neither') {
+      return { pageType, detailLinks: [], reasoning: parsed.reasoning };
+    }
+    // Unrecognized response — treat as listing (safer than dropping links)
+    return { pageType: 'listing', detailLinks: rankedLinks.map(l => l.url), reasoning: parsed.reasoning || 'unrecognized classification fallback' };
   } catch {
-    return { pageType: 'listing', detailLinks: links.map(l => l.url).slice(0, 15), reasoning: 'parse failure fallback' };
+    return { pageType: 'listing', detailLinks: rankedLinks.map(l => l.url), reasoning: 'parse failure fallback' };
   }
 }
 
 /**
- * Filter detail links to same-origin, deduplicate, and cap at 15.
+ * Filter detail links: noise filter, same-origin, basePath/trusted patterns, deduplicate, cap at 20.
  *
- * @param {Array} detailLinks - URLs returned by the classifier
+ * @param {Array} detailLinks - Ranked URLs from deterministic extraction
  * @param {string} sourceUrl - The page URL that produced these links
+ * @param {string} basePath - Path prefix for scoping (e.g., /excursions)
+ * @param {Array} trustedEventPaths - Patterns that bypass basePath (e.g., /event, iteminfo.html)
  * @returns {Array} - Filtered, deduplicated URLs
  */
-function filterDetailLinks(detailLinks, sourceUrl, basePath = null) {
+function filterDetailLinks(detailLinks, sourceUrl, basePath = null, trustedEventPaths = []) {
   if (!detailLinks?.length) return [];
   let sourceOrigin;
   try { sourceOrigin = new URL(sourceUrl).origin; } catch { return []; }
@@ -340,14 +498,22 @@ function filterDetailLinks(detailLinks, sourceUrl, basePath = null) {
     try {
       const parsed = new URL(link);
       if (parsed.origin !== sourceOrigin) return false;
+      // Noise filter — reject known non-detail patterns (calendar nav, pagination, images, etc.)
+      if (isNoiseLink(link, sourceUrl)) return false;
       // When basePath is set, only follow links under the start URL's path prefix.
       // e.g., crawling /about/news only follows /about/news/... links, not /excursions/...
-      if (basePath && !parsed.pathname.startsWith(basePath)) return false;
+      // Trusted event paths bypass this restriction for known detail-page patterns.
+      if (basePath && !parsed.pathname.startsWith(basePath)) {
+        const matchesTrusted = trustedEventPaths.some(pattern =>
+          parsed.pathname.includes(pattern)
+        );
+        if (!matchesTrusted) return false;
+      }
       if (seen.has(link)) return false;
       seen.add(link);
       return true;
     } catch { return false; }
-  }).slice(0, 15);
+  }).slice(0, 20);
 }
 
 /**
@@ -694,8 +860,34 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
     try {
       const startParsed = new URL(startUrl);
       // Strip trailing slash and hash fragments for consistent matching
-      basePath = startParsed.pathname.replace(/\/$/, '') || '/';
+      let rawPath = startParsed.pathname.replace(/\/$/, '') || '/';
+      // If the path ends with a web filename (e.g., search.html), use the directory instead.
+      // e.g., /webtrac/web/search.html → /webtrac/web
+      // This allows sibling files like iteminfo.html to pass the basePath filter.
+      // Directory-style paths like /excursions are unchanged.
+      // Only matches known web extensions — prevents false positives on paths like /api/v2.0
+      if (/\/[^/]+\.(html?|aspx?|php|jsp|shtml)$/i.test(rawPath)) {
+        const dir = rawPath.replace(/\/[^/]+$/, '');
+        // Don't collapse to root — /events.html stays as /events.html, not /
+        if (dir && dir !== '/') rawPath = dir;
+      }
+      basePath = rawPath;
     } catch { /* leave basePath null if URL is unparseable */ }
+  }
+
+  // Load trusted event paths — patterns that bypass basePath for known detail-page URLs.
+  // e.g., /event, /events, iteminfo.html — allows the events crawler to follow links
+  // to detail pages even when they don't share the listing page's path prefix.
+  let trustedEventPaths = [];
+  if (contentType === 'event') {
+    try {
+      const tepResult = await pool.query(
+        "SELECT value FROM admin_settings WHERE key = 'trusted_event_paths'"
+      );
+      if (tepResult.rows.length) {
+        trustedEventPaths = JSON.parse(tepResult.rows[0].value);
+      }
+    } catch { /* use empty list */ }
   }
 
   async function processLevel(urls, depth) {
@@ -742,13 +934,13 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
         classification = { pageType: extracted.pageType, detailLinks: [], reasoning: 'cached' };
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Cache] Classify skip — already ${extracted.pageType}: ${url}`);
         if (extracted.pageType === 'listing') {
-          classification.detailLinks = filterDetailLinks(
-            (extracted.links || []).map(l => l.url), url, basePath
-          );
+          classification.detailLinks = shortestUrlDedup(filterDetailLinks(
+            (extracted.links || []).map(l => l.url), url, basePath, trustedEventPaths
+          ));
         }
       } else {
         updateProgress(poi.id, { phase: 'classify', message: url });
-        classification = await classifyPage(pool, extracted.markdown, extracted.links || [], url, contentType, sheets);
+        classification = await classifyPage(pool, extracted.markdown, extracted.links || [], url, contentType, sheets, trustedEventPaths);
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Classify] ${url} → ${classification.pageType} (${classification.reasoning})`);
         await setCachePageType(pool, url, classification.pageType);
       }
@@ -756,10 +948,13 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
       if (classification.pageType === 'detail') {
         collectedPages.push({ url, markdown: extracted.markdown, rawText: extracted.rawText, ogDates: extracted.ogDates, title: extracted.title, itemCountNews: extracted.itemCountNews, itemCountEvents: extracted.itemCountEvents });
       } else if (classification.pageType === 'listing') {
-        const validLinks = filterDetailLinks(classification.detailLinks, url, basePath);
+        // shortestUrlDedup removes sub-tab variants (e.g., &option=fees) before they consume slots
+        const validLinks = shortestUrlDedup(filterDetailLinks(classification.detailLinks, url, basePath, trustedEventPaths));
         updateProgress(poi.id, { phase: 'crawl', message: `${validLinks.length} links from ${url}` });
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Crawl] Following ${validLinks.length} detail links from ${url}`);
         await processLevel(validLinks, depth + 1);
+      } else if (classification.pageType === 'neither') {
+        logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Skip] Not a ${contentType} page: ${url} (${classification.reasoning})`);
       }
     }), 3, 2000);
   }

--- a/backend/tests/deterministicLinks.experiment.js
+++ b/backend/tests/deterministicLinks.experiment.js
@@ -1,0 +1,376 @@
+/**
+ * Experiment v2: Deterministic link extraction with noise filters
+ *
+ * Tests whether deterministic extraction + exclusion patterns can replace
+ * Gemini's link selection for event/news crawling.
+ *
+ * Usage: node backend/tests/deterministicLinks.experiment.js
+ */
+
+import pg from 'pg';
+const { Pool } = pg;
+
+const DB_URL = process.env.DATABASE_URL || 'postgresql://postgres@localhost:5432/rotv';
+const pool = new Pool({ connectionString: DB_URL });
+
+// --- Trusted event paths (same defaults as migration 046) ---
+const TRUSTED_EVENT_PATHS = ['/event', '/events', '/program', '/programs', 'iteminfo.html', '/store/p'];
+
+// --- NOISE FILTERS: patterns that look like content links but aren't detail pages ---
+
+// Calendar view selectors (The Events Calendar plugin, generic calendar UIs)
+const CALENDAR_VIEW_SUFFIXES = ['/list/', '/list', '/month/', '/month', '/today/', '/today',
+  '/week/', '/week', '/day/', '/day', '/map/', '/map', '/photo/', '/photo',
+  '/summary/', '/summary', '/calendar/', '/calendar'];
+
+function isNoiseLink(url, sourceUrl) {
+  let parsed;
+  try { parsed = new URL(url); } catch { return true; }
+
+  const path = parsed.pathname.toLowerCase();
+  const search = parsed.search.toLowerCase();
+
+  // 1. Non-page resources (images, docs, stylesheets)
+  if (/\.(png|jpe?g|gif|svg|webp|pdf|css|js|ico|woff2?|mp[34]|zip|ics)$/i.test(path)) return true;
+
+  // 2. Hash-only link (same page anchor)
+  try {
+    const source = new URL(sourceUrl);
+    if (parsed.origin === source.origin && parsed.pathname === source.pathname && parsed.hash) return true;
+  } catch { /* ignore */ }
+
+  // 3. Homepage / site root
+  if (path === '/' || path === '') return true;
+
+  // 4. Calendar view selectors
+  for (const suffix of CALENDAR_VIEW_SUFFIXES) {
+    if (path.endsWith(suffix)) return true;
+  }
+
+  // 5. Past events / archive views
+  if (search.includes('eventdisplay=past') || search.includes('display=past')) return true;
+
+  // 6. iCal / feed exports
+  if (search.includes('ical=1') || search.includes('outlook-ical') || path.endsWith('.ics')) return true;
+
+  // 7. Pagination links
+  if (/\/page\/\d+\/?$/.test(path)) return true;
+  if (/[?&]page=\d+/.test(search)) return true;
+
+  // 8. Common non-content pages (nav chrome)
+  const navPatterns = [
+    '/login', '/signin', '/signup', '/register',
+    '/cart', '/checkout', '/account', '/household',
+    '/contact', '/contactus', '/contact-us',
+    '/about', '/about-us', '/aboutus',
+    '/privacy', '/terms', '/cookie', '/accessibility',
+    '/search', '/subscribe', '/newsletter',
+    '/donate', '/give', '/membership',
+    '/splash', '/faq', '/help',
+    '/become-a-member', '/get-involved', '/volunteer'
+  ];
+  // Only match if the path IS one of these (not a subpath like /about/news)
+  const pathSegments = path.replace(/\/$/, '').split('/').filter(Boolean);
+  if (pathSegments.length <= 1) {
+    const simplePath = '/' + (pathSegments[0] || '');
+    if (navPatterns.includes(simplePath)) return true;
+  }
+
+  // 9. WebTrac-specific nav pages (sibling files that aren't events)
+  const filename = path.split('/').pop();
+  const webTracNav = ['splash.html', 'contactus.html', 'cart.html', 'login.html',
+    'household.html', 'register.html', 'forgotpassword.html', 'wishlist.html'];
+  if (webTracNav.includes(filename)) return true;
+
+  // 10. Request/submission forms (not content pages)
+  const lastSegment = path.replace(/\/$/, '').split('/').pop() || '';
+  if (/\brequest|submit|apply|form\b/i.test(lastSegment)) return true;
+
+  return false;
+}
+
+// --- Content link ranking (mirrors classifyPage logic) ---
+function rankLinks(links, sourceUrl) {
+  let sourcePathname;
+  try { sourcePathname = new URL(sourceUrl).pathname; } catch { sourcePathname = ''; }
+
+  const contentLinks = (links || []).filter(l => {
+    const text = (l.text || '').toLowerCase();
+    if (/read\s*more|continue|full\s*(article|story)|learn\s*more|details/i.test(text)) return true;
+    if (/\b(article|post|news|event|card|entry|blog)\b/i.test(l.parentClassName || '')) return true;
+    if (/\b(article|post|news|event|card|entry|blog)\b/i.test(l.className || '')) return true;
+    try {
+      const linkPath = new URL(l.url).pathname;
+      if (sourcePathname.length > 1 && linkPath.startsWith(sourcePathname) && linkPath !== sourcePathname && linkPath !== sourcePathname + '/') return true;
+    } catch { /* ignore */ }
+    // Sibling-file rule
+    try {
+      const linkPath = new URL(l.url).pathname;
+      const sourceDir = sourcePathname.replace(/\/[^/]+\.[^/]+$/, '');
+      if (sourceDir && sourceDir !== sourcePathname && linkPath.startsWith(sourceDir + '/') && linkPath !== sourcePathname) return true;
+    } catch { /* ignore */ }
+    // Trusted event path boost
+    try {
+      const linkPath = new URL(l.url).pathname;
+      if (TRUSTED_EVENT_PATHS.some(p => linkPath.includes(p))) return true;
+    } catch { /* ignore */ }
+    return false;
+  });
+
+  // Self-referencing filter (same pathname = same page with different query params)
+  const notSelfRef = l => {
+    if (!sourcePathname) return true;
+    try { return new URL(l.url).pathname !== sourcePathname; } catch { return true; }
+  };
+
+  const dedup = (arr) => {
+    const seen = new Set();
+    return arr.filter(l => {
+      if (seen.has(l.url)) return false;
+      seen.add(l.url);
+      return true;
+    });
+  };
+
+  const filteredContent = dedup(contentLinks.filter(notSelfRef));
+  const seen = new Set(filteredContent.map(l => l.url));
+  const otherLinks = dedup(links.filter(l => !seen.has(l.url)).filter(notSelfRef));
+  return { contentLinks: filteredContent, otherLinks, all: [...filteredContent, ...otherLinks] };
+}
+
+// --- basePath computation ---
+function computeBasePath(startUrl) {
+  try {
+    const parsed = new URL(startUrl);
+    let rawPath = parsed.pathname.replace(/\/$/, '') || '/';
+    // Only strip filename if result isn't root — /events.html → keep /events.html
+    if (/\/[^/]+\.(html?|aspx?|php|jsp|shtml)$/i.test(rawPath)) {
+      const dir = rawPath.replace(/\/[^/]+$/, '');
+      if (dir && dir !== '/') {
+        rawPath = dir;
+      }
+      // If dir would be "/" or empty, keep the original path as basePath
+      // This prevents basePath collapse on root-level files like /events.html
+    }
+    return rawPath;
+  } catch { return null; }
+}
+
+// --- filterDetailLinks with noise filter ---
+function filterDetailLinks(detailLinks, sourceUrl, basePath, trustedPaths = [], cap = 15) {
+  if (!detailLinks?.length) return [];
+  let sourceOrigin;
+  try { sourceOrigin = new URL(sourceUrl).origin; } catch { return []; }
+  const seen = new Set();
+  return detailLinks.map(link => {
+    try { const u = new URL(link); u.hash = ''; return u.toString(); } catch { return link; }
+  }).filter(link => {
+    try {
+      const parsed = new URL(link);
+      if (parsed.origin !== sourceOrigin) return false;
+      // Noise filter — reject known non-detail patterns
+      if (isNoiseLink(link, sourceUrl)) return false;
+      // basePath + trusted pattern bypass
+      if (basePath && !parsed.pathname.startsWith(basePath)) {
+        const matchesTrusted = trustedPaths.some(p => parsed.pathname.includes(p));
+        if (!matchesTrusted) return false;
+      }
+      if (seen.has(link)) return false;
+      seen.add(link);
+      return true;
+    } catch { return false; }
+  }).slice(0, cap);
+}
+
+// --- Shortest-URL dedup ---
+function shortestUrlDedup(urls) {
+  const byUrl = new Map();
+  for (const url of urls) {
+    let dominated = false;
+    for (const [existing] of byUrl) {
+      if (url.startsWith(existing + '&') || url.startsWith(existing + '%')) {
+        dominated = true;
+        break;
+      }
+      if (existing.startsWith(url + '&') || existing.startsWith(url + '%')) {
+        byUrl.delete(existing);
+      }
+    }
+    if (!dominated) byUrl.set(url, true);
+  }
+  return [...byUrl.keys()];
+}
+
+// --- Main experiment ---
+async function run() {
+  const poisResult = await pool.query(`
+    SELECT id, name, events_url, news_url
+    FROM pois
+    WHERE (events_url IS NOT NULL AND events_url != 'No dedicated events page')
+       OR (news_url IS NOT NULL AND news_url != 'No dedicated news page')
+    ORDER BY name
+  `);
+
+  const detailCache = await pool.query(`SELECT url FROM rendered_page_cache WHERE page_type = 'detail'`);
+  const detailUrlSet = new Set(detailCache.rows.map(r => r.url.toLowerCase().replace(/\/+$/, '')));
+
+  const savedEvents = await pool.query(`SELECT source_url FROM poi_events WHERE source_url IS NOT NULL`);
+  const savedUrlSet = new Set(savedEvents.rows.map(r => r.source_url.toLowerCase().replace(/\/+$/, '')));
+
+  const savedNews = await pool.query(`SELECT source_url FROM poi_news WHERE source_url IS NOT NULL`);
+  const savedNewsSet = new Set(savedNews.rows.map(r => r.source_url.toLowerCase().replace(/\/+$/, '')));
+
+  const normUrl = u => u.toLowerCase().replace(/\/+$/, '');
+
+  // Aggregate stats
+  let totalSelected = 0, totalHits = 0, totalNoise = 0;
+  let totalNewsSelected = 0, totalNewsHits = 0;
+
+  console.log(`\n${'='.repeat(100)}`);
+  console.log(`EXPERIMENT v2: Deterministic Extraction + Noise Filters`);
+  console.log(`${'='.repeat(100)}`);
+  console.log(`Detail pages in cache: ${detailUrlSet.size} | Saved events: ${savedUrlSet.size} | Saved news: ${savedNewsSet.size}\n`);
+
+  // ======================== EVENTS ========================
+  console.log(`${'─'.repeat(100)}`);
+  console.log(`EVENTS`);
+  console.log(`${'─'.repeat(100)}`);
+
+  for (const poi of poisResult.rows) {
+    const eventsUrl = poi.events_url;
+    if (!eventsUrl || eventsUrl === 'No dedicated events page') continue;
+
+    const basePath = computeBasePath(eventsUrl);
+
+    let cacheResult = await pool.query(
+      `SELECT url, links, page_type FROM rendered_page_cache
+       WHERE url = $1 AND links IS NOT NULL`, [eventsUrl]
+    );
+    if (cacheResult.rows.length === 0) {
+      try {
+        const parsed = new URL(eventsUrl);
+        const pathPrefix = parsed.origin + parsed.pathname;
+        cacheResult = await pool.query(
+          `SELECT url, links, page_type FROM rendered_page_cache
+           WHERE url LIKE $1 AND page_type = 'listing' AND links IS NOT NULL
+           ORDER BY rendered_at DESC LIMIT 1`, [pathPrefix + '%']
+        );
+      } catch { /* skip */ }
+    }
+    if (cacheResult.rows.length === 0 || (cacheResult.rows[0].links || []).length === 0) continue;
+
+    const cached = cacheResult.rows[0];
+    const links = cached.links;
+
+    const ranked = rankLinks(links, cached.url);
+    const allUrls = ranked.all.map(l => l.url);
+
+    // Apply noise filter + basePath + trusted patterns — NO cap yet (dedup first)
+    const filtered = filterDetailLinks(allUrls, cached.url, basePath, TRUSTED_EVENT_PATHS, 999);
+
+    // Shortest-URL dedup BEFORE cap — so sub-tab variants don't consume slots
+    const dedupedFiltered = shortestUrlDedup(filtered);
+
+    // Now cap at 20
+    const final = dedupedFiltered.slice(0, 20);
+
+    const hits = final.filter(u => detailUrlSet.has(normUrl(u)) || savedUrlSet.has(normUrl(u)));
+
+    // Count what the noise filter removed
+    const allBeforeNoise = ranked.all.map(l => l.url).filter(u => {
+      try { const p = new URL(u); return p.origin === new URL(cached.url).origin; } catch { return false; }
+    });
+    const noiseRemoved = allBeforeNoise.filter(u => isNoiseLink(u, cached.url));
+
+    totalSelected += final.length;
+    totalHits += hits.length;
+    totalNoise += noiseRemoved.length;
+
+    const hitRate = final.length > 0 ? Math.round(hits.length / final.length * 100) : 0;
+
+    console.log(`\n  ${poi.name}`);
+    console.log(`    URL: ${eventsUrl.substring(0, 80)}${eventsUrl.length > 80 ? '...' : ''}`);
+    console.log(`    basePath: ${basePath} | total links: ${links.length} | T1: ${ranked.contentLinks.length} | noise removed: ${noiseRemoved.length}`);
+    console.log(`    Selected: ${final.length} | Hits: ${hits.length} | Rate: ${hitRate}%`);
+
+    for (const u of final) {
+      const hit = detailUrlSet.has(normUrl(u)) ? '✓cache' : savedUrlSet.has(normUrl(u)) ? '✓saved' : '○ new ';
+      const shortUrl = u.length > 85 ? u.substring(0, 82) + '...' : u;
+      console.log(`      [${hit}] ${shortUrl}`);
+    }
+  }
+
+  // ======================== NEWS ========================
+  console.log(`\n${'─'.repeat(100)}`);
+  console.log(`NEWS`);
+  console.log(`${'─'.repeat(100)}`);
+
+  for (const poi of poisResult.rows) {
+    const newsUrl = poi.news_url;
+    if (!newsUrl || newsUrl === 'No dedicated news page') continue;
+
+    const basePath = computeBasePath(newsUrl);
+
+    let cacheResult = await pool.query(
+      `SELECT url, links, page_type FROM rendered_page_cache
+       WHERE url = $1 AND links IS NOT NULL`, [newsUrl]
+    );
+    if (cacheResult.rows.length === 0) {
+      try {
+        const parsed = new URL(newsUrl);
+        const pathPrefix = parsed.origin + parsed.pathname;
+        cacheResult = await pool.query(
+          `SELECT url, links, page_type FROM rendered_page_cache
+           WHERE url LIKE $1 AND page_type = 'listing' AND links IS NOT NULL
+           ORDER BY rendered_at DESC LIMIT 1`, [pathPrefix + '%']
+        );
+      } catch { /* skip */ }
+    }
+    if (cacheResult.rows.length === 0 || (cacheResult.rows[0].links || []).length === 0) continue;
+
+    const cached = cacheResult.rows[0];
+    const links = cached.links;
+
+    const ranked = rankLinks(links, cached.url);
+    const allUrls = ranked.all.map(l => l.url);
+    // No trusted patterns for news — pure basePath
+    const filtered = filterDetailLinks(allUrls, cached.url, basePath, [], 20);
+    const hits = filtered.filter(u => detailUrlSet.has(normUrl(u)) || savedNewsSet.has(normUrl(u)));
+
+    const noiseRemoved = ranked.all.map(l => l.url).filter(u => {
+      try { const p = new URL(u); return p.origin === new URL(cached.url).origin; } catch { return false; }
+    }).filter(u => isNoiseLink(u, cached.url));
+
+    totalNewsSelected += filtered.length;
+    totalNewsHits += hits.length;
+
+    const hitRate = filtered.length > 0 ? Math.round(hits.length / filtered.length * 100) : 0;
+
+    console.log(`\n  ${poi.name}`);
+    console.log(`    URL: ${newsUrl}`);
+    console.log(`    basePath: ${basePath} | total links: ${links.length} | T1: ${ranked.contentLinks.length} | noise removed: ${noiseRemoved.length}`);
+    console.log(`    Selected: ${filtered.length} | Hits: ${hits.length} | Rate: ${hitRate}%`);
+
+    for (const u of filtered.slice(0, 8)) {
+      const hit = detailUrlSet.has(normUrl(u)) ? '✓cache' : savedNewsSet.has(normUrl(u)) ? '✓saved' : '○ new ';
+      const shortUrl = u.length > 85 ? u.substring(0, 82) + '...' : u;
+      console.log(`      [${hit}] ${shortUrl}`);
+    }
+    if (filtered.length > 8) console.log(`      ... and ${filtered.length - 8} more`);
+  }
+
+  // ======================== SUMMARY ========================
+  console.log(`\n${'='.repeat(100)}`);
+  console.log(`SUMMARY`);
+  console.log(`${'='.repeat(100)}`);
+  console.log(`Events: ${totalSelected} selected, ${totalHits} hits (${totalSelected > 0 ? Math.round(totalHits/totalSelected*100) : 0}%), ${totalNoise} noise links removed`);
+  console.log(`News:   ${totalNewsSelected} selected, ${totalNewsHits} hits (${totalNewsSelected > 0 ? Math.round(totalNewsHits/totalNewsSelected*100) : 0}%)`);
+  console.log(`${'='.repeat(100)}\n`);
+
+  await pool.end();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -57,6 +57,8 @@ function DataCollectionSettings() {
   const [domainListsSaving, setDomainListsSaving] = useState(false);
   const [newTrustedDomain, setNewTrustedDomain] = useState('');
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
+  const [trustedEventPaths, setTrustedEventPaths] = useState([]);
+  const [newTrustedEventPath, setNewTrustedEventPath] = useState('');
 
   // Excluded POIs state
   const [excludedPois, setExcludedPois] = useState([]); // [{id, name}]
@@ -374,13 +376,16 @@ function DataCollectionSettings() {
         const settings = await response.json();
         const trusted = settings.moderation_trusted_domains?.value || '[]';
         const blocklist = settings.blocklist_urls?.value || '[]';
+        const eventPaths = settings.trusted_event_paths?.value || '[]';
         try {
           const parsedTrusted = JSON.parse(trusted);
           const parsedBlocklist = JSON.parse(blocklist);
+          const parsedEventPaths = JSON.parse(eventPaths);
           setDomainLists({
             trusted: Array.isArray(parsedTrusted) ? parsedTrusted.filter(d => typeof d === 'string') : [],
             competitor: Array.isArray(parsedBlocklist) ? parsedBlocklist.filter(d => typeof d === 'string') : []
           });
+          setTrustedEventPaths(Array.isArray(parsedEventPaths) ? parsedEventPaths.filter(d => typeof d === 'string') : []);
           if (!Array.isArray(parsedTrusted) || !Array.isArray(parsedBlocklist)) {
             setResult({ type: 'error', message: 'Domain lists configuration error - invalid format' });
           }
@@ -398,7 +403,8 @@ function DataCollectionSettings() {
     try {
       const settings = [
         { key: 'moderation_trusted_domains', value: JSON.stringify(domainLists.trusted) },
-        { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) }
+        { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) },
+        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) }
       ];
       // Note: N+1 pattern - acceptable for 2 settings, batch endpoint would be better for scale
       for (const setting of settings) {
@@ -449,6 +455,19 @@ function DataCollectionSettings() {
 
   const handleRemoveCompetitorDomain = (domain) => {
     setDomainLists({ ...domainLists, competitor: domainLists.competitor.filter(d => d !== domain) });
+  };
+
+  const handleAddTrustedEventPath = () => {
+    const path = newTrustedEventPath.trim().toLowerCase();
+    if (!path) return;
+    if (!trustedEventPaths.includes(path)) {
+      setTrustedEventPaths([...trustedEventPaths, path]);
+      setNewTrustedEventPath('');
+    }
+  };
+
+  const handleRemoveTrustedEventPath = (path) => {
+    setTrustedEventPaths(trustedEventPaths.filter(p => p !== path));
   };
 
   const fetchExcludedPois = async () => {
@@ -1019,6 +1038,49 @@ function DataCollectionSettings() {
                   disabled={domainListsSaving}
                 />
                 <button className="action-btn secondary" onClick={handleAddCompetitorDomain} disabled={domainListsSaving || !newCompetitorDomain.trim()}>Add</button>
+              </div>
+            </div>
+
+            <div style={{ marginBottom: '1.5rem' }}>
+              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#17a2b8' }}>Trusted Event Paths</h5>
+              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>URL path patterns the events crawler can follow beyond the listing page path (e.g., /event, /events, iteminfo.html).</p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
+                {trustedEventPaths.map(path => (
+                  <span key={path} style={{
+                    padding: '0.25rem 0.5rem',
+                    backgroundColor: '#d1ecf1',
+                    color: '#0c5460',
+                    borderRadius: '4px',
+                    fontSize: '0.85rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem'
+                  }}>
+                    {path}
+                    <button onClick={() => handleRemoveTrustedEventPath(path)}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        color: '#0c5460',
+                        cursor: 'pointer',
+                        padding: '0',
+                        fontSize: '1rem',
+                        lineHeight: '1'
+                      }}>×</button>
+                  </span>
+                ))}
+              </div>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={newTrustedEventPath}
+                  onChange={e => setNewTrustedEventPath(e.target.value)}
+                  onKeyPress={e => e.key === 'Enter' && handleAddTrustedEventPath()}
+                  placeholder="/event"
+                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
+                  disabled={domainListsSaving}
+                />
+                <button className="action-btn secondary" onClick={handleAddTrustedEventPath} disabled={domainListsSaving || !newTrustedEventPath.trim()}>Add</button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Gemini now classifies pages only (listing/detail/neither) — all link extraction is deterministic
- `isNoiseLink()` filters calendar nav, pagination, images, forms, WebTrac nav pages
- `shortestUrlDedup()` prevents WebTrac sub-tab variants (`&option=fees`) from consuming link slots
- Configurable Trusted Event Paths (admin UI + migration) bypass basePath for known detail-page patterns
- `neither` classification catches false positives that slip past the noise filter (FAQ, addtocart, Eventbrite marketing)
- Link cap increased from 15 to 20, dedup runs before cap

## Results (tested against production cache + live on localhost)

| Site | Before | After |
|------|--------|-------|
| Stan Hywet | **0 events** | **15 events** |
| Cleveland Metroparks | 4 events | **20 events** |
| Conservancy CVNP | **0 events** | **10 events** |
| Appalachian ADV | 0 events | **8 events** |
| CVSR | 15 | 20 |
| Blossom Music Center | 15 | 20 |
| Peninsula Foundation | ~4 | 13 |
| News (all sites) | No regressions | Same or better |

## Test plan
- [x] `./run.sh build` passes
- [x] Live test on localhost — 27 events saved across 8 POIs
- [x] `neither` classification fired correctly 6+ times (FAQ, addtocart, Eventbrite, empty search)
- [x] No false positives through moderation
- [x] Stan Hywet collected events for the first time
- [x] Cleveland Metroparks WebTrac pipeline end-to-end
- [ ] Production deployment and overnight collection run

🤖 Generated with [Claude Code](https://claude.com/claude-code)