### PR TITLE
fix: filter WebTrac PM and FR modules from event crawling

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -328,6 +328,9 @@ function isNoiseLink(url, sourceUrl) {
   const filename = path.split('/').pop();
   if (WEBTRAC_NAV_FILES.includes(filename)) return true;
 
+  // WebTrac non-event modules (PM=passes, FR=facility rentals — not events)
+  if (/[?&]module=(PM|FR)\b/i.test(search)) return true;
+
   // Request/submission forms
   const lastSegment = path.replace(/\/$/, '').split('/').pop() || '';
   if (/\brequest|submit|apply|form\b/i.test(lastSegment)) return true;


### PR DESCRIPTION
## Summary

- WebTrac `module=PM` (Pass Management) and `module=FR` (Facility Rentals) were being crawled as events
- Golf Bonus Round, pool passes, and shelter bookings were making it into the moderation queue
- Added to `isNoiseLink()` so they're filtered deterministically before Gemini classify calls
- `module=AR` (activities) and `module=PST` (programs/tours) still pass through

## Test plan
- [x] `./run.sh build` passes
- [ ] Production deploy — golf/shelter items should stop appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)