### PR TITLE
feat: add privacy statement page

### DIFF
--- a/.specify/specs/008-privacy-statement/plan.md
+++ b/.specify/specs/008-privacy-statement/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Privacy Statement
+
+> **Spec ID:** 008-privacy-statement
+> **Status:** Planning
+> **Last Updated:** 2026-05-09
+> **Estimated Effort:** S
+
+## Summary
+
+Add a `PrivacyPolicy.jsx` component rendered at `/privacy`, link it from the login dropdown, user settings, and sidebar. Pure frontend change — no backend, no database, no migrations.
+
+---
+
+## Implementation Steps
+
+### Phase 1: Privacy Page Component
+
+- [ ] Create `frontend/src/components/PrivacyPolicy.jsx` with the privacy statement content
+- [ ] Style it to match existing full-page views (similar to how permalink pages work)
+- [ ] Add route handling in `App.jsx` for `/privacy`
+
+### Phase 2: Link Integration
+
+- [ ] Add "Privacy Policy" link in `LoginButton.jsx` below the OAuth buttons
+- [ ] Add "Privacy Policy" link in user settings area
+- [ ] Add subtle "Privacy" link at the bottom of the sidebar
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/components/PrivacyPolicy.jsx` | Privacy statement page component |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/App.jsx` | Add route handling for `/privacy`, render PrivacyPolicy component |
+| `frontend/src/App.css` | Styles for the privacy page |
+| `frontend/src/components/LoginButton.jsx` | Add privacy link below OAuth buttons |
+| `frontend/src/components/Sidebar.jsx` | Add privacy link at sidebar bottom |
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Navigate to `/privacy` directly — page renders
+2. Click "Privacy Policy" in login dropdown — navigates to privacy page
+3. Click privacy link in sidebar — navigates to privacy page
+4. Back button returns to map view
+5. Mobile responsive — privacy page readable on phone
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Route conflicts with existing path handling | Low | ROTV uses path-based POI selection; `/privacy` won't conflict since it's not a POI slug |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-09 | Initial plan |

--- a/.specify/specs/008-privacy-statement/spec.md
+++ b/.specify/specs/008-privacy-statement/spec.md
@@ -1,0 +1,91 @@
+# Specification: Privacy Statement
+
+> **Spec ID:** 008-privacy-statement
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-09
+
+## Overview
+
+Add a privacy statement page accessible from the login flow, sidebar settings, and a persistent link in the UI. ROTV collects minimal data via Google/Facebook OAuth and doesn't monetize user data. The privacy statement should reflect this honest, transparent posture.
+
+---
+
+## User Stories
+
+### Visitor Trust
+
+**US-001: View Privacy Statement Before Sign-Up**
+> As a visitor considering signing in, I want to read a privacy statement so that I understand what data ROTV collects before I authenticate.
+
+Acceptance Criteria:
+- [ ] Privacy statement link is visible in the login dropdown
+- [ ] Link opens the privacy page without requiring authentication
+- [ ] Page clearly states what data is collected and how it's used
+
+**US-002: Access Privacy Statement from Settings**
+> As an authenticated user, I want to find the privacy statement in settings so that I can review it at any time.
+
+Acceptance Criteria:
+- [ ] Privacy link appears in the user settings area
+- [ ] Link navigates to the privacy page
+
+**US-003: Access Privacy Statement from Sidebar**
+> As any user (authenticated or not), I want a persistent privacy link so I can always find the statement.
+
+Acceptance Criteria:
+- [ ] Privacy link is accessible from the sidebar bottom area
+- [ ] Works for both authenticated and unauthenticated users
+
+---
+
+## Privacy Statement Content
+
+The statement must cover:
+1. **Data collected** — Google/Facebook profile info (name, email, avatar), usage preferences stored locally
+2. **How data is stored** — PostgreSQL on infrastructure we control, no third-party analytics
+3. **Data sharing** — None. ROTV is a non-profit community project. No ads, no data sales, no third-party sharing.
+4. **User rights** — Account deletion available, data export on request
+5. **Cookies** — Session cookies for authentication only, no tracking cookies
+6. **Open source** — Link to GitHub repo so users can verify claims
+
+---
+
+## UI/UX Requirements
+
+### New Route
+
+- `/privacy` — renders the privacy statement as a full-page content view (overlays or replaces the map view)
+
+### Link Locations
+
+1. **Login dropdown** — small "Privacy Policy" link below the OAuth buttons
+2. **User settings** — link in the settings panel
+3. **Sidebar bottom** — subtle link always visible
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Accessibility**
+- Privacy page must be readable without JavaScript (server-side rendered or static)
+- Actually — this is a React SPA. The page renders client-side like everything else. Fine.
+
+**NFR-002: No External Dependencies**
+- Content is hardcoded in the component, not fetched from a CMS or database
+
+---
+
+## Open Questions
+
+1. Should we add a "last updated" date to the privacy page? (Probably yes)
+2. Does the Google OAuth consent screen need a URL update to point to `/privacy`? (Check Google Cloud Console)
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-09 | Initial draft |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13543,3 +13543,131 @@ svg.leaflet-zoom-animated {
     font-size: 1.25rem;
   }
 }
+
+/* Privacy Policy Page */
+.privacy-policy-page {
+  min-height: 100vh;
+  background: #fafafa;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.privacy-policy-content {
+  max-width: 720px;
+  width: 100%;
+  background: white;
+  border-radius: 8px;
+  padding: 2.5rem 3rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.privacy-back-btn {
+  background: none;
+  border: none;
+  color: #2d6a4f;
+  font-size: 0.95rem;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 1.5rem;
+}
+
+.privacy-back-btn:hover {
+  text-decoration: underline;
+}
+
+.privacy-policy-content h1 {
+  font-size: 1.8rem;
+  margin: 0 0 0.25rem;
+  color: #1b4332;
+}
+
+.privacy-updated {
+  color: #6c757d;
+  font-size: 0.85rem;
+  margin: 0 0 2rem;
+}
+
+.privacy-policy-content section {
+  margin-bottom: 1.75rem;
+}
+
+.privacy-policy-content h2 {
+  font-size: 1.15rem;
+  color: #2d6a4f;
+  margin: 0 0 0.5rem;
+}
+
+.privacy-policy-content p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #333;
+  margin: 0 0 0.75rem;
+}
+
+.privacy-policy-content ul {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.privacy-policy-content li {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #333;
+  margin-bottom: 0.25rem;
+}
+
+.privacy-policy-content a {
+  color: #2d6a4f;
+  text-decoration: underline;
+}
+
+.privacy-policy-content a:hover {
+  color: #1b4332;
+}
+
+/* Privacy link in login/user dropdown */
+.privacy-link-inline {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #6c757d;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #eee;
+  text-decoration: none;
+}
+
+.privacy-link-inline:hover {
+  color: #2d6a4f;
+  text-decoration: underline;
+}
+
+/* Privacy link in user dropdown (authenticated) */
+.user-dropdown-inline .privacy-link-inline {
+  text-align: left;
+  padding: 8px 12px;
+  margin-top: 0;
+  border-top: 1px solid #eee;
+}
+
+/* Settings link style */
+.settings-link {
+  color: #2d6a4f;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.settings-link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .privacy-policy-content {
+    padding: 1.5rem;
+  }
+
+  .privacy-policy-content h1 {
+    font-size: 1.4rem;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import NewsletterSettings from './components/NewsletterSettings';
 import ResultsTab from './components/ResultsTab';
 import NewsPermalink from './components/NewsPermalink';
 import EventPermalink from './components/EventPermalink';
+import PrivacyPolicy from './components/PrivacyPolicy';
 
 // Default icon type IDs for initializing the filter
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'mtb-trailhead', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default', 'lighthouse', 'cemetery']);
@@ -237,7 +238,7 @@ function AppContent() {
   }, [location.pathname]);
 
   // Known main tab paths — used to distinguish tab URLs from POI slugs
-  const MAIN_TAB_PATHS = new Set(['results', 'news', 'events', 'edit', 'settings']);
+  const MAIN_TAB_PATHS = new Set(['results', 'news', 'events', 'edit', 'settings', 'privacy']);
   const SIDEBAR_SUB_TABS = new Set(['info', 'news', 'events', 'history', 'associations']);
 
   // Helper to handle tab changes and clear MTB mode if needed
@@ -1578,6 +1579,10 @@ function AppContent() {
     );
   }
 
+  if (location.pathname === '/privacy') {
+    return <PrivacyPolicy />;
+  }
+
   return (
     <div className="app">
       <header className={`header ${activeTheme ? `theme-${activeTheme}` : ''} ${isNightMode ? 'theme-night' : ''}`}>
@@ -1670,6 +1675,13 @@ function AppContent() {
                       <span className="user-email-inline">{user?.email}</span>
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
+                    <a
+                      className="dropdown-item-inline privacy-link-inline"
+                      href="/privacy"
+                      onClick={(e) => { e.preventDefault(); setShowUserDropdown(false); navigate('/privacy'); }}
+                    >
+                      Privacy Policy
+                    </a>
                     <button
                       className="dropdown-item-inline"
                       onClick={() => {
@@ -1710,6 +1722,13 @@ function AppContent() {
                       </svg>
                       Continue with Facebook
                     </button>
+                    <a
+                      className="privacy-link-inline"
+                      href="/privacy"
+                      onClick={(e) => { e.preventDefault(); setShowLoginDropdown(false); navigate('/privacy'); }}
+                    >
+                      Privacy Policy
+                    </a>
                   </div>
                 </>
               )}

--- a/frontend/src/components/GeneralSettings.jsx
+++ b/frontend/src/components/GeneralSettings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const TIMEZONES = [
   { value: 'America/New_York', label: 'Eastern Time (EST/EDT)', icon: '🗽' },
@@ -11,6 +12,7 @@ const TIMEZONES = [
 ];
 
 function GeneralSettings() {
+  const navigate = useNavigate();
   const [timezone, setTimezone] = useState('America/New_York');
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState(null);
@@ -98,6 +100,19 @@ function GeneralSettings() {
           <li>Dates are extracted in ISO 8601 format (YYYY-MM-DD)</li>
           <li>All dates match exactly what appears on the source websites</li>
         </ul>
+      </div>
+
+      <div className="settings-divider"></div>
+
+      <div className="settings-section">
+        <h3>Legal</h3>
+        <a
+          href="/privacy"
+          className="settings-link"
+          onClick={(e) => { e.preventDefault(); navigate('/privacy'); }}
+        >
+          Privacy Policy
+        </a>
       </div>
     </div>
   );

--- a/frontend/src/components/PrivacyPolicy.jsx
+++ b/frontend/src/components/PrivacyPolicy.jsx
@@ -7,7 +7,7 @@ function PrivacyPolicy() {
   return (
     <div className="privacy-policy-page">
       <div className="privacy-policy-content">
-        <button className="privacy-back-btn" onClick={() => navigate(-1)}>
+        <button className="privacy-back-btn" onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}>
           &larr; Back
         </button>
 

--- a/frontend/src/components/PrivacyPolicy.jsx
+++ b/frontend/src/components/PrivacyPolicy.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function PrivacyPolicy() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="privacy-policy-page">
+      <div className="privacy-policy-content">
+        <button className="privacy-back-btn" onClick={() => navigate(-1)}>
+          &larr; Back
+        </button>
+
+        <h1>Privacy Policy</h1>
+        <p className="privacy-updated">Last updated: May 2026</p>
+
+        <section>
+          <h2>The Short Version</h2>
+          <p>
+            Roots of the Valley is a free, open source community project. We don't run ads.
+            We don't sell data. We don't track you. We collect the minimum information needed
+            to let you sign in, and that's it.
+          </p>
+        </section>
+
+        <section>
+          <h2>What We Collect</h2>
+          <p>When you sign in with Google or Facebook, we receive:</p>
+          <ul>
+            <li>Your name</li>
+            <li>Your email address</li>
+            <li>Your profile photo</li>
+          </ul>
+          <p>
+            That's the full list. We don't request access to your contacts, calendar,
+            files, or anything else.
+          </p>
+        </section>
+
+        <section>
+          <h2>How We Use It</h2>
+          <p>Your account information is used for one purpose: identifying you when you sign in.
+            We use your name and photo to show who's logged in. We use your email to
+            associate your session with your account. We don't send marketing emails,
+            newsletters (unless you explicitly subscribe), or third-party communications.
+          </p>
+        </section>
+
+        <section>
+          <h2>What We Don't Do</h2>
+          <ul>
+            <li>We don't sell your data. Ever. To anyone.</li>
+            <li>We don't run advertisements.</li>
+            <li>We don't use third-party analytics or tracking scripts.</li>
+            <li>We don't share your information with other organizations.</li>
+            <li>We don't build advertising profiles or behavioral models.</li>
+          </ul>
+          <p>
+            ROTV is a community project, not a business. There is no revenue model that
+            depends on your data. The plan is to create a non-profit to govern this project
+            permanently.
+          </p>
+        </section>
+
+        <section>
+          <h2>Cookies</h2>
+          <p>
+            We use a single session cookie to keep you logged in. That's it. No tracking
+            cookies, no third-party cookies, no cookie consent banners because there's
+            nothing to consent to beyond basic session management.
+          </p>
+        </section>
+
+        <section>
+          <h2>Where Your Data Lives</h2>
+          <p>
+            Your account data is stored in a PostgreSQL database on infrastructure we
+            control. We don't use third-party data processors, cloud analytics platforms,
+            or customer data platforms. The data sits on our server and nowhere else.
+          </p>
+        </section>
+
+        <section>
+          <h2>Your Rights</h2>
+          <ul>
+            <li><strong>Delete your account:</strong> Contact us and we'll remove all your data.</li>
+            <li><strong>Export your data:</strong> Contact us and we'll provide everything we have on you (it's not much).</li>
+            <li><strong>Know what we have:</strong> This page is the complete picture. There are no hidden data stores.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Open Source Transparency</h2>
+          <p>
+            Don't take our word for it. The entire ROTV codebase is open source under
+            the AGPL-3.0 license. You can read exactly how authentication works, what
+            we store in the database, and how data flows through the system.
+          </p>
+          <p>
+            <a href="https://github.com/crunchtools/rotv" target="_blank" rel="noopener noreferrer">
+              View the source code on GitHub
+            </a>
+          </p>
+        </section>
+
+        <section>
+          <h2>Changes to This Policy</h2>
+          <p>
+            If we ever change this policy, we'll update the date at the top of this page.
+            Given that our entire model is "collect nothing, sell nothing," we don't
+            anticipate meaningful changes.
+          </p>
+        </section>
+
+        <section>
+          <h2>Contact</h2>
+          <p>
+            Questions? Open an issue on{' '}
+            <a href="https://github.com/crunchtools/rotv/issues" target="_blank" rel="noopener noreferrer">
+              GitHub
+            </a>{' '}
+            or email scott@crunchtools.com.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default PrivacyPolicy;

--- a/frontend/src/components/UserSettings.jsx
+++ b/frontend/src/components/UserSettings.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function UserSettings({ user }) {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('general');
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState('idle');
@@ -75,6 +77,17 @@ function UserSettings({ user }) {
               <p className="field-hint">
                 Your email is managed through your authentication provider
               </p>
+            </div>
+            <div className="settings-divider"></div>
+            <div className="settings-field">
+              <label>Legal</label>
+              <a
+                href="/privacy"
+                className="settings-link"
+                onClick={(e) => { e.preventDefault(); navigate('/privacy'); }}
+              >
+                Privacy Policy
+              </a>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add `/privacy` route with a full privacy policy page reflecting ROTV's open source, no-ads, no-tracking values
- Link from login dropdown (unauthenticated), user dropdown (authenticated), and Settings > General
- Content grounded in the PR/FAQ positioning: free forever, no data sales, community-owned, open source verifiable
- Pure frontend change — no backend, no database, no migrations

Closes #214

## Test plan
- [ ] Navigate to `rootsofthevalley.org/privacy` directly — page renders
- [ ] Click "Privacy Policy" in login dropdown — navigates correctly
- [ ] Click "Privacy Policy" in user dropdown (when signed in) — navigates correctly
- [ ] Settings > General shows "Legal" section with Privacy Policy link
- [ ] Back button returns to previous view
- [ ] Mobile responsive — readable on phone
- [ ] Update Google Cloud Console OAuth consent screen privacy URL to point to `/privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)