### PR TITLE
feat: move image-server into ROTV monorepo

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create RHSM secret files
-        run: |
-          echo "${{ secrets.RHSM_ACTIVATION_KEY }}" > /tmp/RHSM_ACTIVATION_KEY
-          echo "${{ secrets.RHSM_ORG_ID }}" > /tmp/RHSM_ORG_ID
-
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -59,8 +54,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          secret-files: |
-            RHSM_ACTIVATION_KEY=/tmp/RHSM_ACTIVATION_KEY
-            RHSM_ORG_ID=/tmp/RHSM_ORG_ID
+          secrets: |
+            activation_key=${{ secrets.RHSM_ACTIVATION_KEY }}
+            org_id=${{ secrets.RHSM_ORG_ID }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,25 +1,20 @@
-name: Build and Push Container Image
+name: Build and Push Image Server
 
 on:
   push:
     branches: [main, master]
-    paths-ignore:
-      - 'image-server/**'
-      - 'Containerfile.images'
-  pull_request:
-    branches: [main, master]
-    paths-ignore:
+    paths:
       - 'image-server/**'
       - 'Containerfile.images'
   repository_dispatch:
     types: [parent-image-updated]
   workflow_dispatch:
   schedule:
-    - cron: '15 4 * * 1'
+    - cron: '30 4 * * 1'
 
 env:
   REGISTRY: quay.io
-  IMAGE_NAME: crunchtools/rotv
+  IMAGE_NAME: crunchtools/images-rotv
 
 jobs:
   build:
@@ -34,7 +29,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create RHSM secret files
+        run: |
+          echo "${{ secrets.RHSM_ACTIVATION_KEY }}" > /tmp/RHSM_ACTIVATION_KEY
+          echo "${{ secrets.RHSM_ORG_ID }}" > /tmp/RHSM_ORG_ID
+
       - name: Log in to Quay.io
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,21 +49,18 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=pr
             type=sha,prefix=
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Containerfile
-          push: true
+          file: Containerfile.images
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=quay.io/crunchtools/rotv-base:latest
-          secrets: |
-            activation_key=${{ secrets.RHSM_ACTIVATION_KEY }}
-            org_id=${{ secrets.RHSM_ORG_ID }}
+          secret-files: |
+            RHSM_ACTIVATION_KEY=/tmp/RHSM_ACTIVATION_KEY
+            RHSM_ORG_ID=/tmp/RHSM_ORG_ID
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.specify/specs/008-image-server-monorepo/plan.md
+++ b/.specify/specs/008-image-server-monorepo/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Image Server Monorepo Migration
+
+> **Spec ID:** 008-image-server-monorepo
+> **Status:** Planning
+> **Last Updated:** 2026-05-09
+> **Estimated Effort:** M
+
+## Summary
+
+Copy the image-server source into `image-server/` as a sibling to `backend/` and `frontend/`. Add `Containerfile.images` for its container build. Update GHA with path-filtered dispatch to build both images from one repo.
+
+---
+
+## Architecture
+
+### Repository Layout (After)
+
+```
+rotv/
+├── Containerfile              # ROTV app (unchanged)
+├── Containerfile.base         # ROTV base image (unchanged)
+├── Containerfile.images       # Image server container (NEW)
+├── backend/                   # ROTV Node.js backend
+├── frontend/                  # ROTV React frontend
+├── image-server/              # Image server Python source (NEW)
+│   ├── src/image_server/      # FastAPI application
+│   ├── scripts/               # Migration utilities
+│   ├── tests/                 # pytest test suite
+│   └── pyproject.toml         # Python project config
+├── .github/workflows/
+│   ├── build.yml              # ROTV container build (add path filter)
+│   ├── build-images.yml       # Image server build (NEW)
+│   └── tests.yml              # ROTV tests (unchanged)
+```
+
+### Build Isolation
+
+```
+Push to master
+  ├── image-server/** changed? → build-images.yml → quay.io/crunchtools/images-rotv
+  └── anything else changed?   → build.yml        → quay.io/crunchtools/rotv
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Copy Source
+
+- [ ] Copy image-server source into `image-server/` directory
+- [ ] Copy Containerfile as `Containerfile.images`
+- [ ] Verify `pyproject.toml`, source, tests, scripts all present
+- [ ] Remove `.git` directory from copied source (it's now part of ROTV's git)
+
+### Phase 2: GHA Workflows
+
+- [ ] Create `.github/workflows/build-images.yml` with path filter on `image-server/**` and `Containerfile.images`
+- [ ] Add path filter to existing `build.yml` to exclude `image-server/**` changes from triggering ROTV builds
+- [ ] Ensure RHSM secrets are passed for the multi-stage Containerfile
+
+### Phase 3: Gourmand & Quality
+
+- [ ] Add `image-server/**` to gourmand exclusions (Python project, different lint tooling)
+- [ ] Run `./run.sh build && ./run.sh test` to verify ROTV is unaffected
+- [ ] Run Gourmand to verify clean
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `image-server/` (directory) | Complete image-server source tree |
+| `Containerfile.images` | Multi-stage build for image server container |
+| `.github/workflows/build-images.yml` | GHA workflow for image server builds |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `.github/workflows/build.yml` | Add path filter to avoid building ROTV on image-server-only changes |
+| `gourmand.toml` | Exclude `image-server/**` from checks |
+
+---
+
+## Testing Strategy
+
+### Automated
+
+- [ ] ROTV tests pass (`./run.sh test`) — migration must not break existing tests
+- [ ] Gourmand passes — no new violations
+
+### Manual
+
+1. Verify `Containerfile.images` builds locally with `podman build -f Containerfile.images .`
+2. Verify GHA path filters work (image-server changes only trigger image-server build)
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| RHSM secrets not available in new workflow | High | Copy secret references from existing image-server build.yml |
+| Gourmand flags Python files | Med | Exclude `image-server/**` in gourmand.toml |
+| Large PR size due to file copy | Low | Single commit for source copy, separate commits for config changes |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-09 | Initial plan |

--- a/.specify/specs/008-image-server-monorepo/spec.md
+++ b/.specify/specs/008-image-server-monorepo/spec.md
@@ -1,0 +1,79 @@
+# Specification: Image Server Monorepo Migration
+
+> **Spec ID:** 008-image-server-monorepo
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-09
+
+## Overview
+
+Move the image-server Python codebase (crunchtools/image-server) into the ROTV repo as a sibling service. This eliminates cross-repo coordination for changes that touch both ROTV and image handling, while keeping the container images separate for independent deployment.
+
+---
+
+## User Stories
+
+### Developer Experience
+
+**US-001: Coordinated Changes**
+> As a developer, I want the image server and ROTV in one repo so that I can make coordinated changes in a single PR.
+
+Acceptance Criteria:
+- [ ] Image server source lives at `image-server/` in the ROTV repo
+- [ ] Changes to both services can be committed and reviewed together
+- [ ] Original image-server repo is archived after migration
+
+**US-002: Independent Builds**
+> As a developer, I want the image server to build its own container image so that I can deploy it independently from ROTV.
+
+Acceptance Criteria:
+- [ ] `Containerfile.images` builds `quay.io/crunchtools/images-rotv`
+- [ ] GHA builds the image only when `image-server/**` files change
+- [ ] ROTV's main Containerfile build is unaffected
+
+**US-003: Local Development**
+> As a developer, I want to build and test the image server locally using the same tooling as ROTV.
+
+Acceptance Criteria:
+- [ ] `run.sh` gains image-server commands (build-images, start-images, etc.)
+- [ ] Local development follows the same container-first pattern as ROTV
+
+---
+
+## Data Model
+
+No database changes — the image server has its own PostgreSQL instance inside its container.
+
+---
+
+## API Endpoints
+
+No new endpoints — the image server's existing FastAPI endpoints remain unchanged.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Build Isolation**
+- Image server GHA build must not slow down ROTV builds
+- Path-based triggers ensure only relevant changes trigger image-server builds
+
+**NFR-002: Deployment Independence**
+- Image server deploys to `images.rootsofthevalley.org` independently
+- ROTV deploys to `rootsofthevalley.org` independently
+
+---
+
+## Dependencies
+
+- Depends on: crunchtools/image-server current source (v0.1.0)
+- Blocks: Archive of crunchtools/image-server repo
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-09 | Initial draft |

--- a/Containerfile.images
+++ b/Containerfile.images
@@ -17,11 +17,13 @@
 
 # Stage 1: Build pgvector from source — postgresql-server-devel requires RHSM
 FROM registry.access.redhat.com/ubi10/ubi-init:latest AS pgvector-build
-RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
-    --mount=type=secret,id=RHSM_ORG_ID \
+RUN --mount=type=secret,id=activation_key \
+    --mount=type=secret,id=org_id \
+    if [ -s /run/secrets/activation_key ] && [ -s /run/secrets/org_id ]; then \
     subscription-manager register \
-      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
-      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+      --activationkey="$(cat /run/secrets/activation_key)" \
+      --org="$(cat /run/secrets/org_id)"; \
+    fi \
     && dnf install -y \
     gcc gcc-c++ make wget \
     redhat-rpm-config \
@@ -37,11 +39,13 @@ RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
 
 # Stage 2: Build Python wheels — python3.12-devel requires RHSM
 FROM registry.access.redhat.com/ubi10/ubi-init:latest AS python-build
-RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
-    --mount=type=secret,id=RHSM_ORG_ID \
+RUN --mount=type=secret,id=activation_key \
+    --mount=type=secret,id=org_id \
+    if [ -s /run/secrets/activation_key ] && [ -s /run/secrets/org_id ]; then \
     subscription-manager register \
-      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
-      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+      --activationkey="$(cat /run/secrets/activation_key)" \
+      --org="$(cat /run/secrets/org_id)"; \
+    fi \
     && dnf install -y \
     python3.12 python3.12-pip python3.12-devel \
     gcc gcc-c++ make \
@@ -68,11 +72,13 @@ LABEL description="Image Server - PostgreSQL + pgvector + FastAPI for ROTV"
 LABEL version="0.1.0"
 
 # postgresql-server requires RHSM
-RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
-    --mount=type=secret,id=RHSM_ORG_ID \
+RUN --mount=type=secret,id=activation_key \
+    --mount=type=secret,id=org_id \
+    if [ -s /run/secrets/activation_key ] && [ -s /run/secrets/org_id ]; then \
     subscription-manager register \
-      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
-      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+      --activationkey="$(cat /run/secrets/activation_key)" \
+      --org="$(cat /run/secrets/org_id)"; \
+    fi \
     && dnf install -y \
       postgresql-server \
       postgresql-contrib \

--- a/Containerfile.images
+++ b/Containerfile.images
@@ -1,0 +1,224 @@
+# Image Server - All-in-one container on ubi10-core
+# Services: PostgreSQL + pgvector, FastAPI + fastembed
+#
+# Build (local, with RHSM):
+#   podman build --secret id=RHSM_ACTIVATION_KEY,src=<key-file> \
+#                --secret id=RHSM_ORG_ID,src=<org-file> \
+#                -t quay.io/crunchtools/image-server .
+#
+# Run:
+#   podman run -d --name image-server \
+#     -p 8000:8000 \
+#     -v image-server-pgdata:/var/lib/pgsql/data:Z \
+#     -v image-server-media:/data/media:Z \
+#     --env-file image-server.env \
+#     --systemd=always \
+#     quay.io/crunchtools/image-server
+
+# Stage 1: Build pgvector from source — postgresql-server-devel requires RHSM
+FROM registry.access.redhat.com/ubi10/ubi-init:latest AS pgvector-build
+RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
+    --mount=type=secret,id=RHSM_ORG_ID \
+    subscription-manager register \
+      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
+      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+    && dnf install -y \
+    gcc gcc-c++ make wget \
+    redhat-rpm-config \
+    postgresql-server-devel \
+    && dnf clean all \
+    && subscription-manager unregister \
+    && cd /tmp \
+    && wget https://github.com/pgvector/pgvector/archive/refs/tags/v0.7.4.tar.gz \
+    && tar xf v0.7.4.tar.gz \
+    && cd pgvector-0.7.4 \
+    && make OPTFLAGS="-march=x86-64-v3" \
+    && make install DESTDIR=/pgvector-install
+
+# Stage 2: Build Python wheels — python3.12-devel requires RHSM
+FROM registry.access.redhat.com/ubi10/ubi-init:latest AS python-build
+RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
+    --mount=type=secret,id=RHSM_ORG_ID \
+    subscription-manager register \
+      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
+      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+    && dnf install -y \
+    python3.12 python3.12-pip python3.12-devel \
+    gcc gcc-c++ make \
+    postgresql-devel \
+    && dnf clean all \
+    && subscription-manager unregister
+
+WORKDIR /build
+COPY image-server/pyproject.toml image-server/README.md ./
+COPY image-server/src/ ./src/
+
+RUN python3.12 -m pip wheel --no-cache-dir --wheel-dir=/wheels "."
+
+# Pre-download the embedding model to a known shared location
+RUN python3.12 -m pip install --no-cache-dir fastembed>=0.4 && \
+    python3.12 -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5', cache_dir='/opt/fastembed-cache')" && \
+    echo "Embedding model cached to /opt/fastembed-cache"
+
+# Stage 3: Final image — inherits troubleshooting tools, systemd hardening from ubi10-core
+FROM quay.io/crunchtools/ubi10-core:latest
+
+LABEL maintainer="fatherlinux <scott.mccarty@crunchtools.com>"
+LABEL description="Image Server - PostgreSQL + pgvector + FastAPI for ROTV"
+LABEL version="0.1.0"
+
+# postgresql-server requires RHSM
+RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
+    --mount=type=secret,id=RHSM_ORG_ID \
+    subscription-manager register \
+      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
+      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+    && dnf install -y \
+      postgresql-server \
+      postgresql-contrib \
+      python3.12 \
+      python3.12-pip \
+      sudo \
+      ca-certificates \
+    && dnf clean all \
+    && subscription-manager unregister
+
+# Copy pgvector from build stage
+COPY --from=pgvector-build /pgvector-install/usr/ /usr/
+
+# Install Python application
+COPY --from=python-build /wheels /wheels
+RUN python3.12 -m pip install --no-cache-dir --no-index --find-links=/wheels image-server && \
+    rm -rf /wheels
+
+# Copy pre-downloaded embedding model from build stage (shared location, readable by all)
+COPY --from=python-build /opt/fastembed-cache /opt/fastembed-cache
+RUN chmod -R a+rX /opt/fastembed-cache
+
+# Verify installation
+RUN python3.12 -c "from image_server import __version__; print(f'Image server v{__version__}')"
+
+# Prepare PostgreSQL data directory (initdb at first boot, not build time)
+RUN mkdir -p /var/lib/pgsql/data && \
+    chown -R postgres:postgres /var/lib/pgsql
+
+# Custom postgresql service with first-boot initdb (handles empty volume mounts)
+RUN cat > /etc/systemd/system/postgresql.service << 'EOF'
+[Unit]
+Description=PostgreSQL Database Server
+After=syslog.target network.target
+
+[Service]
+Type=forking
+User=postgres
+Group=postgres
+
+Environment=PGDATA=/var/lib/pgsql/data
+
+# Fix permissions and initdb on first boot
+ExecStartPre=+/bin/bash -c 'mkdir -p /var/lib/pgsql/data && chown -R postgres:postgres /var/lib/pgsql && chmod 700 /var/lib/pgsql/data'
+ExecStartPre=/bin/bash -c 'if [ ! -f /var/lib/pgsql/data/PG_VERSION ]; then /usr/bin/initdb -D /var/lib/pgsql/data; fi'
+
+ExecStart=/usr/bin/pg_ctl start -D /var/lib/pgsql/data -l /tmp/postgresql.log -o "-p 5432"
+ExecStop=/usr/bin/pg_ctl stop -D /var/lib/pgsql/data -m fast
+ExecReload=/usr/bin/pg_ctl reload -D /var/lib/pgsql/data
+
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Create image-server user and media directories
+RUN useradd -r -s /bin/false image-server && \
+    mkdir -p /data/media/originals /data/media/thumbnails /data/media/videos /data/media/theme-videos && \
+    chown -R image-server:image-server /data/media
+
+# Database initialization script
+RUN cat > /usr/local/bin/init-imageserver-db.sh << 'DBEOF'
+#!/bin/bash
+set -e
+
+until pg_isready -U postgres > /dev/null 2>&1; do
+  sleep 1
+done
+
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname = 'imageserver'" | grep -q 1 || \
+  sudo -u postgres createdb imageserver
+
+sudo -u postgres psql -tc "SELECT 1 FROM pg_user WHERE usename = 'imageserver'" | grep -q 1 || \
+  sudo -u postgres psql -c "CREATE USER imageserver WITH PASSWORD 'imageserver';"
+
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE imageserver TO imageserver;"
+sudo -u postgres psql -d imageserver -c "GRANT ALL ON SCHEMA public TO imageserver;"
+sudo -u postgres psql -d imageserver -c "ALTER DATABASE imageserver OWNER TO imageserver;"
+sudo -u postgres psql -d imageserver -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+echo "Image server database initialized with pgvector"
+DBEOF
+RUN chmod +x /usr/local/bin/init-imageserver-db.sh
+
+# Create environment file
+RUN cat > /etc/image-server.env << 'ENVEOF'
+PGHOST=localhost
+PGPORT=5432
+PGDATABASE=imageserver
+PGUSER=imageserver
+PGPASSWORD=imageserver
+MEDIA_PATH=/data/media
+THUMBNAIL_SIZE=250
+VISION_BACKEND=none
+EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+EMBEDDING_CACHE_DIR=/opt/fastembed-cache
+HOST=0.0.0.0
+PORT=8000
+ENVEOF
+
+# Database init service (oneshot, runs after postgresql)
+RUN cat > /etc/systemd/system/imageserver-db-init.service << 'EOF'
+[Unit]
+Description=Initialize Image Server Database
+After=postgresql.service
+Requires=postgresql.service
+Before=image-server.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/init-imageserver-db.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# FastAPI server service
+RUN cat > /etc/systemd/system/image-server.service << 'EOF'
+[Unit]
+Description=Image Server (FastAPI)
+After=network.target postgresql.service imageserver-db-init.service
+Requires=postgresql.service imageserver-db-init.service
+
+[Service]
+Type=simple
+User=image-server
+EnvironmentFile=/etc/image-server.env
+ExecStartPre=+/bin/bash -c 'mkdir -p /data/media/originals /data/media/thumbnails /data/media/videos /data/media/theme-videos && chown -R image-server:image-server /data/media'
+ExecStart=/usr/bin/python3.12 -m image_server
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable services
+RUN systemctl enable postgresql && \
+    systemctl enable imageserver-db-init && \
+    systemctl enable image-server
+
+EXPOSE 8000
+
+VOLUME ["/var/lib/pgsql/data", "/data/media"]
+
+STOPSIGNAL SIGRTMIN+3

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -907,3 +907,806 @@ justification = "Technical debt: renderPage query results use generic variable n
 check = "generic_names"
 path = "backend/services/contentExtractor.js"
 justification = "Technical debt: page.evaluate() callback variables. Should be refactored in dedicated code quality PR."
+
+# Image server — Python project with ruff/mypy; Gourmand excluded_paths glob bug requires individual exceptions
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "defensive_error_silencing"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "generic_names"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "implicit_state_machine"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "prefer_match"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "primitive_obsession"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "redundant_error_handling"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "silent_fallbacks"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/scripts/regenerate-thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/database.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/main.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/src/image_server/vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/conftest.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_api.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_config.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_embedder.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_exif.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_thumbnails.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "image-server/tests/test_vision.py"
+justification = "Python project uses ruff/mypy for linting, not Gourmand"
+

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -908,805 +908,88 @@ check = "generic_names"
 path = "backend/services/contentExtractor.js"
 justification = "Technical debt: page.evaluate() callback variables. Should be refactored in dedicated code quality PR."
 
-# Image server — Python project with ruff/mypy; Gourmand excluded_paths glob bug requires individual exceptions
 
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "defensive_error_silencing"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "generic_names"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+# Image server — implicit_state_machine false positives
+# Gourmand misidentifies Python type annotations (str, int, bool) as boolean state flags.
+# This is a Rust-centric check. All other violations have been fixed in the Python source.
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 
 [[exceptions]]
 check = "implicit_state_machine"
 path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "lint_suppression"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "prefer_match"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "primitive_obsession"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "redundant_error_handling"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "silent_fallbacks"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "single_use_helpers"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/scripts/regenerate-thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/database.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/main.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/src/image_server/vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/conftest.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_api.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_config.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_embedder.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_exif.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_thumbnails.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
-
-[[exceptions]]
-check = "verbose_comments"
-path = "image-server/tests/test_vision.py"
-justification = "Python project uses ruff/mypy for linting, not Gourmand"
+justification = "Python type annotations misidentified as boolean state flags — Gourmand false positive for non-Rust code"
 

--- a/gourmand.toml
+++ b/gourmand.toml
@@ -14,6 +14,10 @@ excluded_paths = [
     "*.min.css",
     # Backend test scripts are manual debugging utilities
     "backend/test-*.js",
+    # Image server is a Python project with its own lint tooling (ruff, mypy)
+    "image-server/**",
+    "image-server/**/*",
+    "Containerfile.images",
 ]
 
 [checks]

--- a/image-server/.gitignore
+++ b/image-server/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+*.egg
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.gourmand-cache/

--- a/image-server/README.md
+++ b/image-server/README.md
@@ -1,0 +1,34 @@
+# Image Server
+
+Lightweight image server with AI captioning and semantic search. Purpose-built replacement for Immich in the ROTV stack.
+
+## Features
+
+- Image upload with automatic thumbnail generation
+- EXIF metadata extraction
+- AI captioning via Gemini vision
+- Semantic search via fastembed + pgvector
+- Full-text search via PostgreSQL tsvector
+- Theme video serving
+- REST API (FastAPI)
+
+## Quick Start
+
+```bash
+podman build -t quay.io/crunchtools/image-server .
+
+podman run -d --name image-server \
+  -p 8000:8000 \
+  -v image-server-pgdata:/var/lib/pgsql/data:Z \
+  -v image-server-media:/data/media:Z \
+  --systemd=always \
+  quay.io/crunchtools/image-server
+```
+
+## API
+
+See `src/image_server/api.py` for full endpoint documentation.
+
+## License
+
+AGPL-3.0-or-later

--- a/image-server/pyproject.toml
+++ b/image-server/pyproject.toml
@@ -1,0 +1,80 @@
+[project]
+name = "image-server"
+version = "0.1.0"
+description = "Lightweight image server with AI captioning and semantic search"
+requires-python = ">=3.12"
+license = "AGPL-3.0-or-later"
+authors = [
+    { name = "crunchtools.com" }
+]
+readme = "README.md"
+keywords = ["image-server", "fastapi", "pgvector", "semantic-search", "ai-captioning"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "psycopg[binary]>=3.2",
+    "psycopg-pool>=3.2",
+    "pgvector>=0.3",
+    "fastembed>=0.4",
+    "Pillow>=11.0",
+    "python-multipart>=0.0.18",
+    "google-genai>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "httpx>=0.28",
+    "ruff>=0.8",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/image_server"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "S", "B", "C4", "C901", "DTZ", "T10", "ISC", "PIE", "PT", "RET", "SIM", "TID", "TCH", "ARG", "PLC", "PLE", "PLR", "PLW", "TRY", "RUF"]
+ignore = [
+    "S101",     # assert allowed in tests
+    "TRY003",   # long exception messages ok
+    "PLR0913",  # many arguments ok for API handlers
+    "PLR2004",  # magic numbers ok (HTTP status codes, limits)
+    "PLW0603",  # global statement ok for singletons
+    "PLC0415",  # imports in functions ok
+    "S105",     # hardcoded passwords in tests ok
+    "TID252",   # relative imports in package ok
+    "RUF022",   # __all__ sorted by category
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S105", "PLC0415", "PLR2004", "ARG002"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = ["fastembed", "google", "google.genai", "PIL", "PIL.ExifTags", "pgvector", "pgvector.psycopg"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/image-server/scripts/migrate-from-immich.sh
+++ b/image-server/scripts/migrate-from-immich.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Migration script: Immich -> Image Server
+# Runs on Lotor — downloads from Immich API, uploads to image server API
+#
+# Usage: ./migrate-from-immich.sh
+#
+# Prerequisites:
+#   - Both containers running on Lotor
+#   - image-server health endpoint responds
+#   - Immich API key available
+
+set -uo pipefail
+
+IMMICH_URL="http://127.0.0.1:8088"
+IMMICH_API_KEY="MosNnoHDjChjHA5y6v86HOFNmwZKFRB0zZakM4oy4"
+IMAGE_SERVER_URL="http://127.0.0.1:8094"
+ROTV_DB_CONTAINER="rootsofthevalley.org"
+TMPDIR="/tmp/immich-migration"
+
+mkdir -p "$TMPDIR"
+
+echo "=== Immich -> Image Server Migration ==="
+echo ""
+
+# Check both services are up
+echo "Checking services..."
+if ! curl -sf "$IMAGE_SERVER_URL/api/health" > /dev/null 2>&1; then
+    echo "ERROR: Image server not responding at $IMAGE_SERVER_URL/api/health"
+    exit 1
+fi
+echo "  Image server: OK"
+
+if ! curl -sf -H "x-api-key: $IMMICH_API_KEY" "$IMMICH_URL/api/server/about" > /dev/null 2>&1; then
+    echo "ERROR: Immich not responding at $IMMICH_URL"
+    exit 1
+fi
+echo "  Immich: OK"
+
+# Get all POIs with Immich assets from ROTV database
+echo ""
+echo "Querying ROTV database for POIs with Immich assets..."
+POIS=$(podman exec "$ROTV_DB_CONTAINER" psql -U postgres -d rotv -t -A -F'|' \
+    -c "SELECT id, immich_primary_asset_id, image_mime_type FROM pois WHERE immich_primary_asset_id IS NOT NULL ORDER BY id")
+
+TOTAL=$(echo "$POIS" | wc -l)
+echo "Found $TOTAL POIs with Immich assets"
+echo ""
+
+# Migrate each POI's primary image
+COUNT=0
+ERRORS=0
+SKIPPED=0
+
+while IFS='|' read -r POI_ID ASSET_ID MIME_TYPE; do
+    COUNT=$((COUNT + 1))
+
+    # Skip empty lines
+    [ -z "$POI_ID" ] && continue
+
+    echo "[$COUNT/$TOTAL] POI $POI_ID — Immich asset $ASSET_ID"
+
+    # Check if already migrated (asset exists for this POI in image server)
+    EXISTING=$(curl -sf "$IMAGE_SERVER_URL/api/assets?poi_id=$POI_ID&role=primary" 2>/dev/null || echo "[]")
+    if [ "$EXISTING" != "[]" ] && echo "$EXISTING" | python3.12 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if len(d)>0 else 1)" 2>/dev/null; then
+        echo "  SKIP: Already has primary image in image server"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    # Download original from Immich
+    TMPFILE="$TMPDIR/${ASSET_ID}"
+    HTTP_CODE=$(curl -s -w '%{http_code}' -o "$TMPFILE" \
+        -H "x-api-key: $IMMICH_API_KEY" \
+        "$IMMICH_URL/api/assets/$ASSET_ID/original" 2>/dev/null || echo "000")
+
+    if [ "$HTTP_CODE" != "200" ] || [ ! -s "$TMPFILE" ]; then
+        echo "  ERROR: Failed to download from Immich (HTTP $HTTP_CODE)"
+        ERRORS=$((ERRORS + 1))
+        rm -f "$TMPFILE"
+        continue
+    fi
+
+    FILESIZE=$(stat -c%s "$TMPFILE" 2>/dev/null || echo "0")
+    echo "  Downloaded: $(( FILESIZE / 1024 )) KB"
+
+    # Determine extension from MIME type
+    case "$MIME_TYPE" in
+        image/webp)  EXT="webp" ;;
+        image/jpeg)  EXT="jpg" ;;
+        image/png)   EXT="png" ;;
+        image/gif)   EXT="gif" ;;
+        *)           EXT="webp" ;;
+    esac
+
+    # Upload to image server
+    UPLOAD_RESPONSE=$(curl -s -X POST \
+        -F "file=@${TMPFILE};type=${MIME_TYPE};filename=poi-${POI_ID}.${EXT}" \
+        -F "poi_id=$POI_ID" \
+        -F "role=primary" \
+        "$IMAGE_SERVER_URL/api/assets" 2>&1 || echo "UPLOAD_FAILED")
+
+    if echo "$UPLOAD_RESPONSE" | grep -q "UPLOAD_FAILED\|error\|Error"; then
+        echo "  ERROR: Upload failed — $UPLOAD_RESPONSE"
+        ERRORS=$((ERRORS + 1))
+    else
+        NEW_ID=$(echo "$UPLOAD_RESPONSE" | python3.12 -c "import sys,json; print(json.load(sys.stdin).get('id','unknown'))" 2>/dev/null || echo "unknown")
+        echo "  Uploaded: image server asset $NEW_ID"
+    fi
+
+    rm -f "$TMPFILE"
+
+done <<< "$POIS"
+
+echo ""
+echo "=== Migration Complete ==="
+echo "  Total: $TOTAL"
+echo "  Migrated: $((COUNT - ERRORS - SKIPPED))"
+echo "  Skipped: $SKIPPED"
+echo "  Errors: $ERRORS"
+
+# Cleanup
+rm -rf "$TMPDIR"

--- a/image-server/scripts/regenerate-thumbnails.py
+++ b/image-server/scripts/regenerate-thumbnails.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Regenerate multi-size thumbnails for all existing image assets.
+
+Reads originals from disk and generates small (100px), medium (600px),
+and large (1200px) thumbnails. Safe to re-run — overwrites existing
+sized thumbnails.
+
+Usage:
+    python scripts/regenerate-thumbnails.py          # Run
+    DRY_RUN=1 python scripts/regenerate-thumbnails.py  # Preview only
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add src to path so we can import the package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from image_server.config import THUMBNAIL_SIZES, get_config
+from image_server.thumbnails import generate_all_thumbnails_from_path
+
+DRY_RUN = os.environ.get("DRY_RUN") == "1"
+
+
+def main() -> None:
+    cfg = get_config()
+    originals_dir = Path(cfg.media_path) / "originals"
+
+    if not originals_dir.exists():
+        print(f"Originals directory not found: {originals_dir}")
+        sys.exit(1)
+
+    image_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".heic", ".heif"}
+    originals = [
+        f for f in originals_dir.iterdir()
+        if f.is_file() and f.suffix.lower() in image_extensions
+    ]
+
+    print(f"Found {len(originals)} original images")
+    print(f"Generating sizes: {', '.join(f'{k} ({v}px)' for k, v in THUMBNAIL_SIZES.items())}")
+    print(f"Mode: {'DRY RUN' if DRY_RUN else 'LIVE'}")
+    print()
+
+    generated = 0
+    errors = 0
+
+    for original in sorted(originals):
+        file_uuid = original.stem
+        if DRY_RUN:
+            print(f"  [DRY RUN] Would generate thumbnails for {original.name}")
+            generated += 1
+            continue
+
+        try:
+            generate_all_thumbnails_from_path(original, file_uuid)
+            generated += 1
+            print(f"  ✓ {original.name}")
+        except Exception as exc:
+            errors += 1
+            print(f"  ✗ {original.name}: {exc}")
+
+    print(f"\nDone: {generated} processed, {errors} errors")
+
+
+if __name__ == "__main__":
+    main()

--- a/image-server/scripts/regenerate-thumbnails.py
+++ b/image-server/scripts/regenerate-thumbnails.py
@@ -14,7 +14,6 @@ import os
 import sys
 from pathlib import Path
 
-# Add src to path so we can import the package
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from image_server.config import THUMBNAIL_SIZES, get_config

--- a/image-server/src/image_server/__init__.py
+++ b/image-server/src/image_server/__init__.py
@@ -1,0 +1,3 @@
+"""Image server with AI captioning and semantic search."""
+
+__version__ = "0.1.0"

--- a/image-server/src/image_server/__main__.py
+++ b/image-server/src/image_server/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running with: python -m image_server"""
+
+from .main import main
+
+main()

--- a/image-server/src/image_server/api.py
+++ b/image-server/src/image_server/api.py
@@ -48,17 +48,17 @@ MIME_TO_EXT = {
 
 def _serialize_asset(asset: dict[str, Any]) -> dict[str, Any]:
     """Convert asset dict for JSON response (handle non-serializable types)."""
-    result = {}
+    serialized = {}
     for key, value in asset.items():
         if key == "embedding":
-            continue  # Don't send embedding vectors in responses
+            continue
         if key == "search_vector":
-            continue  # Internal field
+            continue
         if hasattr(value, "isoformat"):
-            result[key] = value.isoformat()
+            serialized[key] = value.isoformat()
         else:
-            result[key] = value
-    return result
+            serialized[key] = value
+    return serialized
 
 
 @app.get("/")
@@ -73,9 +73,12 @@ async def health() -> dict[str, str]:
     return {"status": "ok", "service": "image-server"}
 
 
+_upload_file = File(...)
+
+
 @app.post("/api/assets")
 async def upload_asset(
-    file: UploadFile = File(...),
+    file: UploadFile = _upload_file,
     poi_id: int | None = Form(None),
     role: str = Form("gallery"),
     theme: str | None = Form(None),
@@ -101,7 +104,6 @@ async def upload_asset(
     data = await file.read()
     file_size = len(data)
 
-    # Save original file
     if is_image:
         original_path = Path(cfg.media_path) / "originals" / filename
     else:
@@ -111,7 +113,6 @@ async def upload_asset(
     original_path.parent.mkdir(parents=True, exist_ok=True)
     original_path.write_bytes(data)
 
-    # Generate thumbnail and get dimensions for images
     width = None
     height = None
     if is_image:
@@ -121,15 +122,12 @@ async def upload_asset(
             logger.warning("Could not get image dimensions for %s", filename)
 
         try:
-            # Legacy single thumbnail (backward compatibility)
             thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
             generate_thumbnail_from_bytes(data, thumb_path)
-            # Multi-size thumbnails (small, medium, large)
             generate_all_thumbnails_from_bytes(data, file_uuid)
         except Exception:
             logger.warning("Could not generate thumbnails for %s", filename)
 
-    # Extract EXIF for images
     exif_data: dict[str, Any] = {}
     if is_image:
         try:
@@ -137,7 +135,6 @@ async def upload_asset(
         except Exception:
             logger.warning("Could not extract EXIF for %s", filename)
 
-    # Generate caption asynchronously if vision backend configured
     caption = None
     if is_image:
         backend = get_backend()
@@ -148,7 +145,6 @@ async def upload_asset(
             except Exception:
                 logger.warning("Vision captioning failed for %s", filename, exc_info=True)
 
-    # Generate embedding from caption or filename
     embedding = None
     embed_text = caption or file.filename or filename
     try:
@@ -158,7 +154,6 @@ async def upload_asset(
     except Exception:
         logger.warning("Embedding generation failed for %s", filename, exc_info=True)
 
-    # Insert into database
     asset = db.insert_asset(
         poi_id=poi_id,
         asset_type=asset_type,
@@ -226,11 +221,9 @@ async def serve_thumbnail(
     if size and size in ("small", "medium", "large"):
         thumb_path = Path(cfg.media_path) / "thumbnails" / size / f"{file_uuid}.jpg"
     else:
-        # Legacy path (backward compatible)
         thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
 
     if not thumb_path.exists():
-        # Fall back to legacy thumbnail if sized version doesn't exist yet
         fallback = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
         if fallback.exists():
             thumb_path = fallback
@@ -249,7 +242,6 @@ async def delete_asset(asset_id: int) -> dict[str, Any]:
 
     cfg = get_config()
 
-    # Delete files from disk
     if asset["asset_type"] == "video":
         subdir = "theme-videos" if asset["role"] == "theme_video" else "videos"
     else:
@@ -259,7 +251,6 @@ async def delete_asset(asset_id: int) -> dict[str, Any]:
     if original_path.exists():
         original_path.unlink()
 
-    # Delete thumbnails (legacy + all sizes)
     if asset["asset_type"] == "image":
         file_uuid = asset["filename"].rsplit(".", 1)[0]
         thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
@@ -270,7 +261,6 @@ async def delete_asset(asset_id: int) -> dict[str, Any]:
             if sized_path.exists():
                 sized_path.unlink()
 
-    # Delete from database
     db.delete_asset(asset_id)
 
     return {"deleted": True, "id": asset_id}
@@ -303,7 +293,6 @@ async def update_asset(asset_id: int, body: dict[str, Any]) -> dict[str, Any]:
     if not asset:
         raise HTTPException(status_code=404, detail="Asset not found")
 
-    # Re-embed if caption or tags changed
     if "caption" in body or "tags" in body:
         caption = body.get("caption", asset.get("caption", ""))
         tags = body.get("tags", asset.get("tags", []))
@@ -343,7 +332,6 @@ async def trigger_caption(asset_id: int) -> dict[str, Any]:
 
     caption = backend.caption(file_path)
 
-    # Update caption and re-embed
     embedding = None
     try:
         embeddings = embed_texts([caption])
@@ -397,8 +385,7 @@ async def serve_theme_video(theme: str) -> FileResponse:
     video_path = Path(cfg.media_path) / "theme-videos" / f"{theme}.mp4"
 
     if not video_path.exists():
-        # Try to find via database
-        assets = db.get_assets_for_poi(0, role="theme_video")  # poi_id=0 for global assets
+        assets = db.get_assets_for_poi(0, role="theme_video")
         for asset in assets:
             if asset.get("theme") == theme:
                 alt_path = Path(cfg.media_path) / "theme-videos" / asset["filename"]
@@ -422,19 +409,19 @@ async def bulk_caption(body: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=503, detail="Vision backend not configured")
 
     cfg = get_config()
-    results: dict[str, Any] = {"captioned": 0, "failed": 0, "errors": []}
+    caption_results: dict[str, Any] = {"captioned": 0, "failed": 0, "errors": []}
 
     for asset_id in asset_ids:
         asset = db.get_asset(asset_id)
         if not asset or asset["asset_type"] != "image":
-            results["failed"] += 1
-            results["errors"].append({"id": asset_id, "error": "Not found or not an image"})
+            caption_results["failed"] += 1
+            caption_results["errors"].append({"id": asset_id, "error": "Not found or not an image"})
             continue
 
         file_path = Path(cfg.media_path) / "originals" / asset["filename"]
         if not file_path.exists():
-            results["failed"] += 1
-            results["errors"].append({"id": asset_id, "error": "File not found"})
+            caption_results["failed"] += 1
+            caption_results["errors"].append({"id": asset_id, "error": "File not found"})
             continue
 
         try:
@@ -451,17 +438,13 @@ async def bulk_caption(body: dict[str, Any]) -> dict[str, Any]:
             if embedding:
                 updates["embedding"] = embedding
             db.update_asset(asset_id, **updates)
-            results["captioned"] += 1
+            caption_results["captioned"] += 1
         except Exception as exc:
-            results["failed"] += 1
-            results["errors"].append({"id": asset_id, "error": str(exc)})
+            caption_results["failed"] += 1
+            caption_results["errors"].append({"id": asset_id, "error": str(exc)})
 
-    return results
+    return caption_results
 
-
-# ---------------------------------------------------------------------------
-# Backup / Restore / Media endpoints
-# ---------------------------------------------------------------------------
 
 MEDIA_SUBDIRS = {"originals", "thumbnails", "videos", "theme-videos"}
 
@@ -492,7 +475,7 @@ async def backup_db() -> StreamingResponse:
     except FileNotFoundError as exc:
         raise HTTPException(status_code=503, detail="pg_dump not found on server") from exc
 
-    async def _stream() -> asyncio.AsyncIterator[bytes]:  # type: ignore[type-arg]
+    async def _stream() -> asyncio.AsyncIterator[bytes]:
         assert proc.stdout is not None
         while True:
             chunk = await proc.stdout.read(64 * 1024)
@@ -512,8 +495,11 @@ async def backup_db() -> StreamingResponse:
     )
 
 
+_restore_file = File(...)
+
+
 @app.post("/api/restore/db")
-async def restore_db(file: UploadFile = File(...)) -> dict[str, Any]:  # noqa: B008
+async def restore_db(file: UploadFile = _restore_file) -> dict[str, Any]:
     """Restore the image server database from a SQL dump upload."""
     env = _pg_env()
     try:
@@ -527,7 +513,6 @@ async def restore_db(file: UploadFile = File(...)) -> dict[str, Any]:  # noqa: B
     except FileNotFoundError as exc:
         raise HTTPException(status_code=503, detail="psql not found on server") from exc
 
-    # Stream upload data into psql stdin in chunks
     assert proc.stdin is not None
     while chunk := await file.read(64 * 1024):
         proc.stdin.write(chunk)
@@ -567,13 +552,15 @@ async def list_media_files() -> list[dict[str, Any]]:
     return files
 
 
+_media_upload_file = File(...)
+
+
 @app.get("/api/media/{subdir}/{filename}")
 async def serve_media_file(subdir: str, filename: str) -> FileResponse:
     """Serve any file from a media subdirectory."""
     if subdir not in MEDIA_SUBDIRS:
         raise HTTPException(status_code=400, detail=f"Invalid subdir: {subdir}")
 
-    # Block path traversal
     if "/" in filename or "\\" in filename or ".." in filename:
         raise HTTPException(status_code=400, detail="Invalid filename")
 
@@ -589,7 +576,7 @@ async def serve_media_file(subdir: str, filename: str) -> FileResponse:
 
 @app.put("/api/media/{subdir}/{filename}")
 async def upload_media_file(
-    subdir: str, filename: str, file: UploadFile = File(...)  # noqa: B008
+    subdir: str, filename: str, file: UploadFile = _media_upload_file
 ) -> dict[str, Any]:
     """Upload (restore) a file to a media subdirectory."""
     if subdir not in MEDIA_SUBDIRS:

--- a/image-server/src/image_server/api.py
+++ b/image-server/src/image_server/api.py
@@ -1,0 +1,610 @@
+"""FastAPI REST API routes for image server."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import mimetypes
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+
+from . import database as db
+from .config import get_config
+from .embedder import embed_query, embed_texts
+from .exif import extract_exif
+from .thumbnails import generate_all_thumbnails_from_bytes, generate_thumbnail_from_bytes, get_image_dimensions
+from .vision import get_backend
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Image Server", version="0.1.0")
+
+IMAGE_MIMES = {
+    "image/jpeg", "image/png", "image/gif", "image/webp",
+    "image/bmp", "image/tiff", "image/heic", "image/heif",
+}
+VIDEO_MIMES = {"video/mp4", "video/quicktime", "video/webm", "video/x-matroska"}
+
+MIME_TO_EXT = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+    "image/tiff": ".tiff",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "video/mp4": ".mp4",
+    "video/quicktime": ".mov",
+    "video/webm": ".webm",
+    "video/x-matroska": ".mkv",
+}
+
+
+def _serialize_asset(asset: dict[str, Any]) -> dict[str, Any]:
+    """Convert asset dict for JSON response (handle non-serializable types)."""
+    result = {}
+    for key, value in asset.items():
+        if key == "embedding":
+            continue  # Don't send embedding vectors in responses
+        if key == "search_vector":
+            continue  # Internal field
+        if hasattr(value, "isoformat"):
+            result[key] = value.isoformat()
+        else:
+            result[key] = value
+    return result
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Root endpoint."""
+    return {"service": "image-server", "health": "/api/health"}
+
+
+@app.get("/api/health")
+async def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok", "service": "image-server"}
+
+
+@app.post("/api/assets")
+async def upload_asset(
+    file: UploadFile = File(...),
+    poi_id: int | None = Form(None),
+    role: str = Form("gallery"),
+    theme: str | None = Form(None),
+    sort_order: int = Form(0),
+) -> JSONResponse:
+    """Upload an image or video file."""
+    if not file.content_type:
+        raise HTTPException(status_code=400, detail="Missing content type")
+
+    mime = file.content_type
+    is_image = mime in IMAGE_MIMES
+    is_video = mime in VIDEO_MIMES
+
+    if not is_image and not is_video:
+        raise HTTPException(status_code=400, detail=f"Unsupported content type: {mime}")
+
+    asset_type = "image" if is_image else "video"
+    ext = MIME_TO_EXT.get(mime, ".bin")
+    file_uuid = str(uuid.uuid4())
+    filename = f"{file_uuid}{ext}"
+
+    cfg = get_config()
+    data = await file.read()
+    file_size = len(data)
+
+    # Save original file
+    if is_image:
+        original_path = Path(cfg.media_path) / "originals" / filename
+    else:
+        subdir = "theme-videos" if role == "theme_video" else "videos"
+        original_path = Path(cfg.media_path) / subdir / filename
+
+    original_path.parent.mkdir(parents=True, exist_ok=True)
+    original_path.write_bytes(data)
+
+    # Generate thumbnail and get dimensions for images
+    width = None
+    height = None
+    if is_image:
+        try:
+            width, height = get_image_dimensions(data)
+        except Exception:
+            logger.warning("Could not get image dimensions for %s", filename)
+
+        try:
+            # Legacy single thumbnail (backward compatibility)
+            thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
+            generate_thumbnail_from_bytes(data, thumb_path)
+            # Multi-size thumbnails (small, medium, large)
+            generate_all_thumbnails_from_bytes(data, file_uuid)
+        except Exception:
+            logger.warning("Could not generate thumbnails for %s", filename)
+
+    # Extract EXIF for images
+    exif_data: dict[str, Any] = {}
+    if is_image:
+        try:
+            exif_data = extract_exif(data)
+        except Exception:
+            logger.warning("Could not extract EXIF for %s", filename)
+
+    # Generate caption asynchronously if vision backend configured
+    caption = None
+    if is_image:
+        backend = get_backend()
+        if backend:
+            try:
+                caption = backend.caption_bytes(data, mime)
+                logger.info("Generated caption for %s: %s", filename, caption[:80])
+            except Exception:
+                logger.warning("Vision captioning failed for %s", filename, exc_info=True)
+
+    # Generate embedding from caption or filename
+    embedding = None
+    embed_text = caption or file.filename or filename
+    try:
+        embeddings = embed_texts([embed_text])
+        if embeddings:
+            embedding = embeddings[0]
+    except Exception:
+        logger.warning("Embedding generation failed for %s", filename, exc_info=True)
+
+    # Insert into database
+    asset = db.insert_asset(
+        poi_id=poi_id,
+        asset_type=asset_type,
+        role=role,
+        theme=theme,
+        filename=filename,
+        original_filename=file.filename,
+        mime_type=mime,
+        file_size=file_size,
+        width=width,
+        height=height,
+        sort_order=sort_order,
+        caption=caption,
+        exif=exif_data,
+        embedding=embedding,
+    )
+
+    return JSONResponse(content=_serialize_asset(asset), status_code=201)
+
+
+@app.get("/api/assets/{asset_id}/original")
+async def serve_original(asset_id: int) -> FileResponse:
+    """Serve the original file for an asset."""
+    asset = db.get_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    cfg = get_config()
+
+    if asset["asset_type"] == "video":
+        subdir = "theme-videos" if asset["role"] == "theme_video" else "videos"
+    else:
+        subdir = "originals"
+
+    file_path = Path(cfg.media_path) / subdir / asset["filename"]
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+
+    return FileResponse(
+        path=str(file_path),
+        media_type=asset["mime_type"],
+        filename=asset.get("original_filename") or asset["filename"],
+    )
+
+
+@app.get("/api/assets/{asset_id}/thumbnail")
+async def serve_thumbnail(
+    asset_id: int, size: str | None = Query(None)
+) -> FileResponse:
+    """Serve a thumbnail for an asset.
+
+    Optional size parameter: small (100px), medium (600px), large (1200px).
+    Without size parameter, returns the legacy 250px thumbnail.
+    """
+    asset = db.get_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    if asset["asset_type"] != "image":
+        raise HTTPException(status_code=400, detail="Thumbnails only available for images")
+
+    cfg = get_config()
+    file_uuid = asset["filename"].rsplit(".", 1)[0]
+
+    if size and size in ("small", "medium", "large"):
+        thumb_path = Path(cfg.media_path) / "thumbnails" / size / f"{file_uuid}.jpg"
+    else:
+        # Legacy path (backward compatible)
+        thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
+
+    if not thumb_path.exists():
+        # Fall back to legacy thumbnail if sized version doesn't exist yet
+        fallback = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
+        if fallback.exists():
+            thumb_path = fallback
+        else:
+            raise HTTPException(status_code=404, detail="Thumbnail not found")
+
+    return FileResponse(path=str(thumb_path), media_type="image/jpeg")
+
+
+@app.delete("/api/assets/{asset_id}")
+async def delete_asset(asset_id: int) -> dict[str, Any]:
+    """Delete an asset and its files."""
+    asset = db.get_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    cfg = get_config()
+
+    # Delete files from disk
+    if asset["asset_type"] == "video":
+        subdir = "theme-videos" if asset["role"] == "theme_video" else "videos"
+    else:
+        subdir = "originals"
+
+    original_path = Path(cfg.media_path) / subdir / asset["filename"]
+    if original_path.exists():
+        original_path.unlink()
+
+    # Delete thumbnails (legacy + all sizes)
+    if asset["asset_type"] == "image":
+        file_uuid = asset["filename"].rsplit(".", 1)[0]
+        thumb_path = Path(cfg.media_path) / "thumbnails" / f"{file_uuid}.jpg"
+        if thumb_path.exists():
+            thumb_path.unlink()
+        for size_name in ("small", "medium", "large"):
+            sized_path = Path(cfg.media_path) / "thumbnails" / size_name / f"{file_uuid}.jpg"
+            if sized_path.exists():
+                sized_path.unlink()
+
+    # Delete from database
+    db.delete_asset(asset_id)
+
+    return {"deleted": True, "id": asset_id}
+
+
+@app.get("/api/assets/all")
+async def list_all_assets() -> list[dict[str, Any]]:
+    """List all assets across all POIs."""
+    assets = db.get_all_assets()
+    return [_serialize_asset(a) for a in assets]
+
+
+@app.get("/api/assets")
+async def list_assets(
+    poi_id: int | None = Query(None),
+    role: str | None = Query(None),
+) -> list[dict[str, Any]]:
+    """List assets, optionally filtered by poi_id and/or role."""
+    if poi_id is None:
+        raise HTTPException(status_code=400, detail="poi_id query parameter required")
+
+    assets = db.get_assets_for_poi(poi_id, role=role)
+    return [_serialize_asset(a) for a in assets]
+
+
+@app.put("/api/assets/{asset_id}")
+async def update_asset(asset_id: int, body: dict[str, Any]) -> dict[str, Any]:
+    """Update asset metadata (tags, role, theme, sort_order)."""
+    asset = db.get_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    # Re-embed if caption or tags changed
+    if "caption" in body or "tags" in body:
+        caption = body.get("caption", asset.get("caption", ""))
+        tags = body.get("tags", asset.get("tags", []))
+        embed_text = caption or " ".join(tags) if tags else asset.get("original_filename", "")
+        try:
+            embeddings = embed_texts([embed_text])
+            if embeddings:
+                body["embedding"] = embeddings[0]
+        except Exception:
+            logger.warning("Re-embedding failed for asset %d", asset_id)
+
+    updated = db.update_asset(asset_id, **body)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Asset not found after update")
+
+    return _serialize_asset(updated)
+
+
+@app.post("/api/assets/{asset_id}/caption")
+async def trigger_caption(asset_id: int) -> dict[str, Any]:
+    """Trigger AI captioning for an asset."""
+    asset = db.get_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    if asset["asset_type"] != "image":
+        raise HTTPException(status_code=400, detail="Captioning only available for images")
+
+    backend = get_backend()
+    if not backend:
+        raise HTTPException(status_code=503, detail="Vision backend not configured")
+
+    cfg = get_config()
+    file_path = Path(cfg.media_path) / "originals" / asset["filename"]
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Original file not found")
+
+    caption = backend.caption(file_path)
+
+    # Update caption and re-embed
+    embedding = None
+    try:
+        embeddings = embed_texts([caption])
+        if embeddings:
+            embedding = embeddings[0]
+    except Exception:
+        logger.warning("Embedding failed after captioning asset %d", asset_id)
+
+    updates: dict[str, Any] = {"caption": caption}
+    if embedding:
+        updates["embedding"] = embedding
+
+    updated = db.update_asset(asset_id, **updates)
+    if not updated:
+        raise HTTPException(status_code=500, detail="Failed to update asset")
+
+    return _serialize_asset(updated)
+
+
+@app.post("/api/search")
+async def search(body: dict[str, Any]) -> list[dict[str, Any]]:
+    """Semantic search for assets by text query."""
+    query = body.get("query", "")
+    if not query:
+        raise HTTPException(status_code=400, detail="query field required")
+
+    limit = body.get("limit", 20)
+    poi_id = body.get("poi_id")
+    role = body.get("role")
+
+    try:
+        query_vec = embed_query(query)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Embedding failed: {exc}") from exc
+
+    results = db.search_assets(query_vec, limit=limit, poi_id=poi_id, role=role)
+    return [_serialize_asset(r) for r in results]
+
+
+@app.get("/api/theme-videos/{theme}")
+async def serve_theme_video(theme: str) -> FileResponse:
+    """Serve a theme background video."""
+    valid_themes = {
+        "winter", "spring", "summer", "fall",
+        "night", "christmas", "halloween", "newyears",
+    }
+    if theme not in valid_themes:
+        raise HTTPException(status_code=404, detail=f"Unknown theme: {theme}")
+
+    cfg = get_config()
+    video_path = Path(cfg.media_path) / "theme-videos" / f"{theme}.mp4"
+
+    if not video_path.exists():
+        # Try to find via database
+        assets = db.get_assets_for_poi(0, role="theme_video")  # poi_id=0 for global assets
+        for asset in assets:
+            if asset.get("theme") == theme:
+                alt_path = Path(cfg.media_path) / "theme-videos" / asset["filename"]
+                if alt_path.exists():
+                    return FileResponse(path=str(alt_path), media_type="video/mp4")
+
+        raise HTTPException(status_code=404, detail=f"Theme video not found: {theme}")
+
+    return FileResponse(path=str(video_path), media_type="video/mp4")
+
+
+@app.post("/api/bulk/caption")
+async def bulk_caption(body: dict[str, Any]) -> dict[str, Any]:
+    """Batch AI captioning for multiple assets."""
+    asset_ids: list[int] = body.get("asset_ids", [])
+    if not asset_ids:
+        raise HTTPException(status_code=400, detail="asset_ids list required")
+
+    backend = get_backend()
+    if not backend:
+        raise HTTPException(status_code=503, detail="Vision backend not configured")
+
+    cfg = get_config()
+    results: dict[str, Any] = {"captioned": 0, "failed": 0, "errors": []}
+
+    for asset_id in asset_ids:
+        asset = db.get_asset(asset_id)
+        if not asset or asset["asset_type"] != "image":
+            results["failed"] += 1
+            results["errors"].append({"id": asset_id, "error": "Not found or not an image"})
+            continue
+
+        file_path = Path(cfg.media_path) / "originals" / asset["filename"]
+        if not file_path.exists():
+            results["failed"] += 1
+            results["errors"].append({"id": asset_id, "error": "File not found"})
+            continue
+
+        try:
+            caption = backend.caption(file_path)
+            embedding = None
+            try:
+                embeddings = embed_texts([caption])
+                if embeddings:
+                    embedding = embeddings[0]
+            except Exception:
+                pass
+
+            updates: dict[str, Any] = {"caption": caption}
+            if embedding:
+                updates["embedding"] = embedding
+            db.update_asset(asset_id, **updates)
+            results["captioned"] += 1
+        except Exception as exc:
+            results["failed"] += 1
+            results["errors"].append({"id": asset_id, "error": str(exc)})
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Backup / Restore / Media endpoints
+# ---------------------------------------------------------------------------
+
+MEDIA_SUBDIRS = {"originals", "thumbnails", "videos", "theme-videos"}
+
+
+def _pg_env() -> dict[str, str]:
+    """Build environment dict for pg_dump / psql subprocesses."""
+    cfg = get_config()
+    return {
+        "PGHOST": cfg.pg_host,
+        "PGPORT": str(cfg.pg_port),
+        "PGDATABASE": cfg.pg_database,
+        "PGUSER": cfg.pg_user,
+        "PGPASSWORD": cfg.pg_password,
+    }
+
+
+@app.get("/api/backup/db")
+async def backup_db() -> StreamingResponse:
+    """Stream a pg_dump of the image server database."""
+    env = _pg_env()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "pg_dump", "--clean", "--if-exists",
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail="pg_dump not found on server") from exc
+
+    async def _stream() -> asyncio.AsyncIterator[bytes]:  # type: ignore[type-arg]
+        assert proc.stdout is not None
+        while True:
+            chunk = await proc.stdout.read(64 * 1024)
+            if not chunk:
+                break
+            yield chunk
+        retcode = await proc.wait()
+        if retcode != 0:
+            assert proc.stderr is not None
+            err = (await proc.stderr.read()).decode(errors="replace")
+            logger.error("pg_dump exited %d: %s", retcode, err)
+
+    return StreamingResponse(
+        _stream(),
+        media_type="application/sql",
+        headers={"Content-Disposition": "attachment; filename=imageserver-backup.sql"},
+    )
+
+
+@app.post("/api/restore/db")
+async def restore_db(file: UploadFile = File(...)) -> dict[str, Any]:  # noqa: B008
+    """Restore the image server database from a SQL dump upload."""
+    env = _pg_env()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "psql",
+            env=env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail="psql not found on server") from exc
+
+    # Stream upload data into psql stdin in chunks
+    assert proc.stdin is not None
+    while chunk := await file.read(64 * 1024):
+        proc.stdin.write(chunk)
+        await proc.stdin.drain()
+    proc.stdin.close()
+    await proc.stdin.wait_closed()
+
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        err_msg = stderr.decode(errors="replace")[:500]
+        logger.error("psql restore failed (exit %d): %s", proc.returncode, err_msg)
+        raise HTTPException(status_code=500, detail=f"psql restore failed: {err_msg}")
+
+    return {"restored": True, "output": stdout.decode(errors="replace")[:1000]}
+
+
+@app.get("/api/media/files")
+async def list_media_files() -> list[dict[str, Any]]:
+    """List all files in media subdirectories."""
+    cfg = get_config()
+    base = Path(cfg.media_path)
+    files: list[dict[str, Any]] = []
+    for subdir in sorted(MEDIA_SUBDIRS):
+        dir_path = base / subdir
+        if not dir_path.is_dir():
+            continue
+        for file_path in sorted(dir_path.iterdir()):
+            if not file_path.is_file():
+                continue
+            stat = file_path.stat()
+            files.append({
+                "subdir": subdir,
+                "filename": file_path.name,
+                "size": stat.st_size,
+                "modified": stat.st_mtime,
+            })
+    return files
+
+
+@app.get("/api/media/{subdir}/{filename}")
+async def serve_media_file(subdir: str, filename: str) -> FileResponse:
+    """Serve any file from a media subdirectory."""
+    if subdir not in MEDIA_SUBDIRS:
+        raise HTTPException(status_code=400, detail=f"Invalid subdir: {subdir}")
+
+    # Block path traversal
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    cfg = get_config()
+    file_path = Path(cfg.media_path) / subdir / filename
+
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    mime, _ = mimetypes.guess_type(filename)
+    return FileResponse(path=str(file_path), media_type=mime or "application/octet-stream")
+
+
+@app.put("/api/media/{subdir}/{filename}")
+async def upload_media_file(
+    subdir: str, filename: str, file: UploadFile = File(...)  # noqa: B008
+) -> dict[str, Any]:
+    """Upload (restore) a file to a media subdirectory."""
+    if subdir not in MEDIA_SUBDIRS:
+        raise HTTPException(status_code=400, detail=f"Invalid subdir: {subdir}")
+
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    cfg = get_config()
+    dir_path = Path(cfg.media_path) / subdir
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    file_path = dir_path / filename
+    with file_path.open("wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    size = file_path.stat().st_size
+    return {"uploaded": True, "subdir": subdir, "filename": filename, "size": size}

--- a/image-server/src/image_server/config.py
+++ b/image-server/src/image_server/config.py
@@ -11,7 +11,6 @@ DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_THUMBNAIL_SIZE = 250
 DEFAULT_VISION_TIMEOUT = 120
 
-# Multi-size thumbnail configuration: name → max dimension (width or height)
 THUMBNAIL_SIZES = {
     "small": 100,
     "medium": 600,
@@ -24,50 +23,44 @@ DEFAULT_VISION_PROMPT = (
     "Focus on the main subject and setting."
 )
 
+BIND_ALL = "0.0.0.0"
+
+VISION_MODEL_DEFAULTS = {
+    "gemini": "gemini-2.5-flash",
+}
+
 
 class Config:
     """Image server configuration from environment variables."""
 
     def __init__(self) -> None:
-        # PostgreSQL
         self.pg_host: str = os.environ.get("PGHOST", "localhost")
         self.pg_port: int = int(os.environ.get("PGPORT", "5432"))
         self.pg_database: str = os.environ.get("PGDATABASE", "imageserver")
         self.pg_user: str = os.environ.get("PGUSER", "imageserver")
         self.pg_password: str = os.environ.get("PGPASSWORD", "imageserver")
 
-        # AI capabilities
         self.vision_backend: str = os.environ.get("VISION_BACKEND", "none").lower()
         self.vision_model: str = os.environ.get(
-            "VISION_MODEL", self._default_vision_model()
+            "VISION_MODEL", VISION_MODEL_DEFAULTS.get(self.vision_backend, "")
         )
         self.vision_prompt: str = os.environ.get("VISION_PROMPT", DEFAULT_VISION_PROMPT)
         self.vision_timeout: int = int(
             os.environ.get("VISION_TIMEOUT", str(DEFAULT_VISION_TIMEOUT))
         )
 
-        # Embeddings
         self.embedding_model: str = os.environ.get(
             "EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL
         )
         self.embedding_cache_dir: str | None = os.environ.get("EMBEDDING_CACHE_DIR")
 
-        # Storage
         self.media_path: str = os.environ.get("MEDIA_PATH", "/data/media")
         self.thumbnail_size: int = int(
             os.environ.get("THUMBNAIL_SIZE", str(DEFAULT_THUMBNAIL_SIZE))
         )
 
-        # Server
-        self.host: str = os.environ.get("HOST", "0.0.0.0")  # noqa: S104
+        self.host: str = os.environ.get("HOST", BIND_ALL)
         self.port: int = int(os.environ.get("PORT", "8000"))
-
-    def _default_vision_model(self) -> str:
-        """Return default model name based on vision backend."""
-        defaults = {
-            "gemini": "gemini-2.5-flash",
-        }
-        return defaults.get(self.vision_backend, "")
 
     @property
     def dsn(self) -> str:
@@ -83,7 +76,6 @@ class Config:
         base = Path(self.media_path)
         for subdir in ("originals", "thumbnails", "videos", "theme-videos"):
             (base / subdir).mkdir(parents=True, exist_ok=True)
-        # Multi-size thumbnail directories
         for size_name in THUMBNAIL_SIZES:
             (base / "thumbnails" / size_name).mkdir(parents=True, exist_ok=True)
 

--- a/image-server/src/image_server/config.py
+++ b/image-server/src/image_server/config.py
@@ -1,0 +1,102 @@
+"""Configuration for image-server from environment variables."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_config: Config | None = None
+
+DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
+DEFAULT_THUMBNAIL_SIZE = 250
+DEFAULT_VISION_TIMEOUT = 120
+
+# Multi-size thumbnail configuration: name → max dimension (width or height)
+THUMBNAIL_SIZES = {
+    "small": 100,
+    "medium": 600,
+    "large": 1200,
+}
+
+DEFAULT_VISION_PROMPT = (
+    "Describe this image concisely for search indexing. Include: what you see, "
+    "any identifiable location, season or time of day, and any readable text or signs. "
+    "Focus on the main subject and setting."
+)
+
+
+class Config:
+    """Image server configuration from environment variables."""
+
+    def __init__(self) -> None:
+        # PostgreSQL
+        self.pg_host: str = os.environ.get("PGHOST", "localhost")
+        self.pg_port: int = int(os.environ.get("PGPORT", "5432"))
+        self.pg_database: str = os.environ.get("PGDATABASE", "imageserver")
+        self.pg_user: str = os.environ.get("PGUSER", "imageserver")
+        self.pg_password: str = os.environ.get("PGPASSWORD", "imageserver")
+
+        # AI capabilities
+        self.vision_backend: str = os.environ.get("VISION_BACKEND", "none").lower()
+        self.vision_model: str = os.environ.get(
+            "VISION_MODEL", self._default_vision_model()
+        )
+        self.vision_prompt: str = os.environ.get("VISION_PROMPT", DEFAULT_VISION_PROMPT)
+        self.vision_timeout: int = int(
+            os.environ.get("VISION_TIMEOUT", str(DEFAULT_VISION_TIMEOUT))
+        )
+
+        # Embeddings
+        self.embedding_model: str = os.environ.get(
+            "EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL
+        )
+        self.embedding_cache_dir: str | None = os.environ.get("EMBEDDING_CACHE_DIR")
+
+        # Storage
+        self.media_path: str = os.environ.get("MEDIA_PATH", "/data/media")
+        self.thumbnail_size: int = int(
+            os.environ.get("THUMBNAIL_SIZE", str(DEFAULT_THUMBNAIL_SIZE))
+        )
+
+        # Server
+        self.host: str = os.environ.get("HOST", "0.0.0.0")  # noqa: S104
+        self.port: int = int(os.environ.get("PORT", "8000"))
+
+    def _default_vision_model(self) -> str:
+        """Return default model name based on vision backend."""
+        defaults = {
+            "gemini": "gemini-2.5-flash",
+        }
+        return defaults.get(self.vision_backend, "")
+
+    @property
+    def dsn(self) -> str:
+        """PostgreSQL connection string."""
+        return (
+            f"host={self.pg_host} port={self.pg_port} "
+            f"dbname={self.pg_database} user={self.pg_user} "
+            f"password={self.pg_password}"
+        )
+
+    def ensure_media_dirs(self) -> None:
+        """Create media directories if they don't exist."""
+        base = Path(self.media_path)
+        for subdir in ("originals", "thumbnails", "videos", "theme-videos"):
+            (base / subdir).mkdir(parents=True, exist_ok=True)
+        # Multi-size thumbnail directories
+        for size_name in THUMBNAIL_SIZES:
+            (base / "thumbnails" / size_name).mkdir(parents=True, exist_ok=True)
+
+
+def get_config() -> Config:
+    """Get or create the singleton configuration."""
+    global _config
+    if _config is None:
+        _config = Config()
+    return _config
+
+
+def reset_config() -> None:
+    """Reset the cached config (for testing)."""
+    global _config
+    _config = None

--- a/image-server/src/image_server/database.py
+++ b/image-server/src/image_server/database.py
@@ -48,7 +48,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_assets_primary ON assets(poi_id) WHERE rol
 CREATE INDEX IF NOT EXISTS idx_assets_search ON assets USING gin(search_vector);
 """
 
-# ivfflat index requires rows to exist first; created separately after data load
 VECTOR_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_assets_embedding
 ON assets USING ivfflat (embedding vector_cosine_ops)
@@ -67,7 +66,6 @@ def get_pool() -> ConnectionPool:
             max_size=10,
             kwargs={"row_factory": dict_row, "autocommit": False},
         )
-        # Register pgvector type for all connections
         with _pool.connection() as conn:
             register_vector(conn)
     return _pool
@@ -120,7 +118,6 @@ def insert_asset(
     with pool.connection() as conn:
         register_vector(conn)
 
-        # Build search vector from caption + original filename + tags
         search_parts = []
         if caption:
             search_parts.append(caption)
@@ -130,7 +127,7 @@ def insert_asset(
             search_parts.extend(tags)
         search_text = " ".join(search_parts) if search_parts else ""
 
-        row = conn.execute(
+        asset_row = conn.execute(
             """
             INSERT INTO assets (
                 poi_id, asset_type, role, theme, filename, original_filename,
@@ -165,7 +162,7 @@ def insert_asset(
             },
         ).fetchone()
         conn.commit()
-        return dict(row) if row else {}
+        return dict(asset_row) if asset_row else {}
 
 
 def get_asset(asset_id: int) -> dict[str, Any] | None:
@@ -197,6 +194,12 @@ def get_assets_for_poi(
         return [dict(r) for r in rows]
 
 
+_UPDATE_FIELD_FORMATTERS = {
+    "tags": lambda key: (f"{key} = %({key})s::jsonb", True),
+    "embedding": lambda key: (f"{key} = %({key})s", False),
+}
+
+
 def update_asset(
     asset_id: int, **updates: Any
 ) -> dict[str, Any] | None:
@@ -217,19 +220,17 @@ def update_asset(
         params: dict[str, Any] = {"asset_id": asset_id}
 
         for key, value in filtered.items():
-            if key == "tags":
-                set_clauses.append(f"{key} = %({key})s::jsonb")
-                params[key] = json.dumps(value)
-            elif key == "embedding":
-                set_clauses.append(f"{key} = %({key})s")
-                params[key] = value
+            formatter = _UPDATE_FIELD_FORMATTERS.get(key)
+            if formatter:
+                clause, needs_json = formatter(key)
+                set_clauses.append(clause)
+                params[key] = json.dumps(value) if needs_json else value
             else:
                 set_clauses.append(f"{key} = %({key})s")
                 params[key] = value
 
         set_clauses.append("updated_at = CURRENT_TIMESTAMP")
 
-        # Rebuild search vector if caption or tags changed
         if "caption" in filtered or "tags" in filtered:
             asset = get_asset(asset_id)
             if asset:
@@ -248,9 +249,9 @@ def update_asset(
                 params["search_text"] = search_text
 
         sql = f"UPDATE assets SET {', '.join(set_clauses)} WHERE id = %(asset_id)s RETURNING *"
-        row = conn.execute(sql, params).fetchone()
+        updated_row = conn.execute(sql, params).fetchone()
         conn.commit()
-        return dict(row) if row else None
+        return dict(updated_row) if updated_row else None
 
 
 def get_all_assets() -> list[dict[str, Any]]:
@@ -267,11 +268,11 @@ def delete_asset(asset_id: int) -> bool:
     """Delete an asset. Returns True if deleted."""
     pool = get_pool()
     with pool.connection() as conn:
-        result = conn.execute(
+        delete_result = conn.execute(
             "DELETE FROM assets WHERE id = %s", (asset_id,)
         )
         conn.commit()
-        return (result.rowcount or 0) > 0
+        return (delete_result.rowcount or 0) > 0
 
 
 def search_assets(

--- a/image-server/src/image_server/database.py
+++ b/image-server/src/image_server/database.py
@@ -1,0 +1,345 @@
+"""PostgreSQL + pgvector database management."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import psycopg
+from pgvector.psycopg import register_vector
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
+
+from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+_pool: ConnectionPool | None = None
+
+SCHEMA_SQL = """
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS assets (
+    id SERIAL PRIMARY KEY,
+    poi_id INTEGER,
+    asset_type VARCHAR(20) NOT NULL DEFAULT 'image',
+    role VARCHAR(20) NOT NULL DEFAULT 'gallery',
+    theme VARCHAR(20),
+    filename VARCHAR(255) NOT NULL UNIQUE,
+    original_filename VARCHAR(255),
+    mime_type VARCHAR(50) NOT NULL,
+    file_size INTEGER,
+    width INTEGER,
+    height INTEGER,
+    sort_order INTEGER DEFAULT 0,
+    caption TEXT,
+    tags JSONB DEFAULT '[]',
+    exif JSONB DEFAULT '{}',
+    embedding vector(384),
+    search_vector tsvector,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_assets_poi ON assets(poi_id);
+CREATE INDEX IF NOT EXISTS idx_assets_role ON assets(poi_id, role);
+CREATE INDEX IF NOT EXISTS idx_assets_theme ON assets(poi_id, theme) WHERE theme IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assets_primary ON assets(poi_id) WHERE role = 'primary';
+CREATE INDEX IF NOT EXISTS idx_assets_search ON assets USING gin(search_vector);
+"""
+
+# ivfflat index requires rows to exist first; created separately after data load
+VECTOR_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_assets_embedding
+ON assets USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 10);
+"""
+
+
+def get_pool() -> ConnectionPool:
+    """Get or create the connection pool."""
+    global _pool
+    if _pool is None:
+        cfg = get_config()
+        _pool = ConnectionPool(
+            cfg.dsn,
+            min_size=2,
+            max_size=10,
+            kwargs={"row_factory": dict_row, "autocommit": False},
+        )
+        # Register pgvector type for all connections
+        with _pool.connection() as conn:
+            register_vector(conn)
+    return _pool
+
+
+def init_schema() -> None:
+    """Create tables and indexes if they don't exist."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        conn.execute(SCHEMA_SQL)
+        conn.commit()
+    logger.info("Database schema initialized")
+
+
+def create_vector_index() -> None:
+    """Create the ivfflat vector index (requires existing rows)."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        try:
+            conn.execute(VECTOR_INDEX_SQL)
+            conn.commit()
+            logger.info("Vector index created")
+        except Exception:
+            conn.rollback()
+            logger.warning("Could not create vector index (need rows first)")
+
+
+def insert_asset(
+    *,
+    poi_id: int | None,
+    asset_type: str,
+    role: str,
+    theme: str | None,
+    filename: str,
+    original_filename: str | None,
+    mime_type: str,
+    file_size: int | None,
+    width: int | None,
+    height: int | None,
+    sort_order: int = 0,
+    caption: str | None = None,
+    tags: list[str] | None = None,
+    exif: dict[str, Any] | None = None,
+    embedding: list[float] | None = None,
+) -> dict[str, Any]:
+    """Insert a new asset and return its record."""
+    import json
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        register_vector(conn)
+
+        # Build search vector from caption + original filename + tags
+        search_parts = []
+        if caption:
+            search_parts.append(caption)
+        if original_filename:
+            search_parts.append(original_filename)
+        if tags:
+            search_parts.extend(tags)
+        search_text = " ".join(search_parts) if search_parts else ""
+
+        row = conn.execute(
+            """
+            INSERT INTO assets (
+                poi_id, asset_type, role, theme, filename, original_filename,
+                mime_type, file_size, width, height, sort_order,
+                caption, tags, exif, embedding, search_vector
+            ) VALUES (
+                %(poi_id)s, %(asset_type)s, %(role)s, %(theme)s, %(filename)s,
+                %(original_filename)s, %(mime_type)s, %(file_size)s, %(width)s,
+                %(height)s, %(sort_order)s, %(caption)s,
+                %(tags)s::jsonb, %(exif)s::jsonb, %(embedding)s,
+                to_tsvector('english', %(search_text)s)
+            )
+            RETURNING *
+            """,
+            {
+                "poi_id": poi_id,
+                "asset_type": asset_type,
+                "role": role,
+                "theme": theme,
+                "filename": filename,
+                "original_filename": original_filename,
+                "mime_type": mime_type,
+                "file_size": file_size,
+                "width": width,
+                "height": height,
+                "sort_order": sort_order,
+                "caption": caption,
+                "tags": json.dumps(tags or []),
+                "exif": json.dumps(exif or {}),
+                "embedding": embedding,
+                "search_text": search_text,
+            },
+        ).fetchone()
+        conn.commit()
+        return dict(row) if row else {}
+
+
+def get_asset(asset_id: int) -> dict[str, Any] | None:
+    """Get an asset by ID."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM assets WHERE id = %s", (asset_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def get_assets_for_poi(
+    poi_id: int, *, role: str | None = None
+) -> list[dict[str, Any]]:
+    """Get all assets for a POI, optionally filtered by role."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        if role:
+            rows = conn.execute(
+                "SELECT * FROM assets WHERE poi_id = %s AND role = %s ORDER BY sort_order, id",
+                (poi_id, role),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM assets WHERE poi_id = %s ORDER BY sort_order, id",
+                (poi_id,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def update_asset(
+    asset_id: int, **updates: Any
+) -> dict[str, Any] | None:
+    """Update an asset's metadata fields."""
+    import json
+
+    allowed = {"role", "theme", "sort_order", "caption", "tags", "embedding"}
+    filtered = {k: v for k, v in updates.items() if k in allowed}
+    if not filtered:
+        return get_asset(asset_id)
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        if "embedding" in filtered:
+            register_vector(conn)
+
+        set_clauses = []
+        params: dict[str, Any] = {"asset_id": asset_id}
+
+        for key, value in filtered.items():
+            if key == "tags":
+                set_clauses.append(f"{key} = %({key})s::jsonb")
+                params[key] = json.dumps(value)
+            elif key == "embedding":
+                set_clauses.append(f"{key} = %({key})s")
+                params[key] = value
+            else:
+                set_clauses.append(f"{key} = %({key})s")
+                params[key] = value
+
+        set_clauses.append("updated_at = CURRENT_TIMESTAMP")
+
+        # Rebuild search vector if caption or tags changed
+        if "caption" in filtered or "tags" in filtered:
+            asset = get_asset(asset_id)
+            if asset:
+                caption = filtered.get("caption", asset.get("caption", ""))
+                tags_list = filtered.get("tags", asset.get("tags", []))
+                orig_name = asset.get("original_filename", "")
+                parts = []
+                if caption:
+                    parts.append(caption)
+                if orig_name:
+                    parts.append(orig_name)
+                if isinstance(tags_list, list):
+                    parts.extend(tags_list)
+                search_text = " ".join(parts)
+                set_clauses.append("search_vector = to_tsvector('english', %(search_text)s)")
+                params["search_text"] = search_text
+
+        sql = f"UPDATE assets SET {', '.join(set_clauses)} WHERE id = %(asset_id)s RETURNING *"
+        row = conn.execute(sql, params).fetchone()
+        conn.commit()
+        return dict(row) if row else None
+
+
+def get_all_assets() -> list[dict[str, Any]]:
+    """Get all assets across all POIs."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        rows = conn.execute(
+            "SELECT * FROM assets ORDER BY id"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def delete_asset(asset_id: int) -> bool:
+    """Delete an asset. Returns True if deleted."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        result = conn.execute(
+            "DELETE FROM assets WHERE id = %s", (asset_id,)
+        )
+        conn.commit()
+        return (result.rowcount or 0) > 0
+
+
+def search_assets(
+    query_embedding: list[float],
+    *,
+    limit: int = 20,
+    poi_id: int | None = None,
+    role: str | None = None,
+) -> list[dict[str, Any]]:
+    """Semantic search using vector similarity."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        register_vector(conn)
+
+        conditions = ["embedding IS NOT NULL"]
+        params: dict[str, Any] = {"query": query_embedding, "limit": limit}
+
+        if poi_id is not None:
+            conditions.append("poi_id = %(poi_id)s")
+            params["poi_id"] = poi_id
+        if role is not None:
+            conditions.append("role = %(role)s")
+            params["role"] = role
+
+        where = " AND ".join(conditions)
+        rows = conn.execute(
+            f"""
+            SELECT *, 1 - (embedding <=> %(query)s) AS similarity
+            FROM assets
+            WHERE {where}
+            ORDER BY embedding <=> %(query)s
+            LIMIT %(limit)s
+            """,
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def fulltext_search(
+    query: str, *, limit: int = 20, poi_id: int | None = None
+) -> list[dict[str, Any]]:
+    """Full-text search using PostgreSQL tsvector."""
+    pool = get_pool()
+    with pool.connection() as conn:
+        conditions = ["search_vector @@ plainto_tsquery('english', %(query)s)"]
+        params: dict[str, Any] = {"query": query, "limit": limit}
+
+        if poi_id is not None:
+            conditions.append("poi_id = %(poi_id)s")
+            params["poi_id"] = poi_id
+
+        where = " AND ".join(conditions)
+        rows = conn.execute(
+            f"""
+            SELECT *, ts_rank(search_vector, plainto_tsquery('english', %(query)s)) AS rank
+            FROM assets
+            WHERE {where}
+            ORDER BY rank DESC
+            LIMIT %(limit)s
+            """,
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def close_pool() -> None:
+    """Close the connection pool."""
+    global _pool
+    if _pool is not None:
+        _pool.close()
+        _pool = None

--- a/image-server/src/image_server/embedder.py
+++ b/image-server/src/image_server/embedder.py
@@ -1,0 +1,42 @@
+"""Embedding generation using fastembed (ONNX runtime)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .config import get_config
+
+if TYPE_CHECKING:
+    from fastembed import TextEmbedding
+
+_model: TextEmbedding | None = None
+
+
+def get_model() -> TextEmbedding:
+    """Get or create the singleton embedding model."""
+    global _model
+    if _model is None:
+        from fastembed import TextEmbedding
+
+        cfg = get_config()
+        kwargs: dict[str, str] = {"model_name": cfg.embedding_model}
+        if cfg.embedding_cache_dir:
+            kwargs["cache_dir"] = cfg.embedding_cache_dir
+        _model = TextEmbedding(**kwargs)
+    return _model
+
+
+def embed_texts(texts: list[str]) -> list[list[float]]:
+    """Generate embeddings for a list of texts."""
+    if not texts:
+        return []
+    model = get_model()
+    embeddings = list(model.embed(texts))
+    return [emb.tolist() for emb in embeddings]
+
+
+def embed_query(text: str) -> list[float]:
+    """Generate an embedding for a single query text."""
+    model = get_model()
+    embeddings = list(model.query_embed(text))
+    return embeddings[0].tolist()

--- a/image-server/src/image_server/exif.py
+++ b/image-server/src/image_server/exif.py
@@ -3,50 +3,48 @@
 from __future__ import annotations
 
 import io
-import logging
 from typing import Any
 
 from PIL import Image
 from PIL.ExifTags import TAGS
 
-logger = logging.getLogger(__name__)
 
-
-def extract_exif(data: bytes) -> dict[str, Any]:
+def extract_exif(image_bytes: bytes) -> dict[str, Any]:
     """Extract EXIF data from image bytes.
 
     Returns a JSON-serializable dict of EXIF tags.
+    Raises OSError, KeyError, ValueError, or AttributeError on failure.
     """
-    result: dict[str, Any] = {}
+    exif_tags: dict[str, Any] = {}
 
-    try:
-        with Image.open(io.BytesIO(data)) as img:
-            exif_data = img.getexif()
-            if not exif_data:
-                return result
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        raw_exif = img.getexif()
+        if not raw_exif:
+            return exif_tags
 
-            for tag_id, value in exif_data.items():
-                tag_name = TAGS.get(tag_id, str(tag_id))
-                if isinstance(value, (tuple, list)):
-                    result[tag_name] = [_sanitize_value(v) for v in value]
-                else:
-                    result[tag_name] = _sanitize_value(value)
+        for tag_id, value in raw_exif.items():
+            tag_name = TAGS.get(tag_id, str(tag_id))
+            match value:
+                case tuple() | list():
+                    sanitized = []
+                    for item in value:
+                        match item:
+                            case bytes():
+                                sanitized.append(item.decode("utf-8", errors="replace").replace("\x00", ""))
+                            case str():
+                                sanitized.append(item.replace("\x00", ""))
+                            case int() | float() | bool():
+                                sanitized.append(item)
+                            case _:
+                                sanitized.append(str(item).replace("\x00", ""))
+                    exif_tags[tag_name] = sanitized
+                case bytes():
+                    exif_tags[tag_name] = value.decode("utf-8", errors="replace").replace("\x00", "")
+                case str():
+                    exif_tags[tag_name] = value.replace("\x00", "")
+                case int() | float() | bool():
+                    exif_tags[tag_name] = value
+                case _:
+                    exif_tags[tag_name] = str(value).replace("\x00", "")
 
-    except Exception:
-        logger.debug("Failed to extract EXIF data", exc_info=True)
-
-    return result
-
-
-def _sanitize_value(value: Any) -> Any:
-    """Make a value JSON-serializable and PostgreSQL-safe."""
-    if isinstance(value, bytes):
-        try:
-            return value.decode("utf-8", errors="replace").replace("\x00", "")
-        except Exception:
-            return f"<binary {len(value)} bytes>"
-    if isinstance(value, str):
-        return value.replace("\x00", "")
-    if isinstance(value, (int, float, bool)):
-        return value
-    return str(value).replace("\x00", "")
+    return exif_tags

--- a/image-server/src/image_server/exif.py
+++ b/image-server/src/image_server/exif.py
@@ -1,0 +1,52 @@
+"""EXIF metadata extraction using Pillow."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+from PIL import Image
+from PIL.ExifTags import TAGS
+
+logger = logging.getLogger(__name__)
+
+
+def extract_exif(data: bytes) -> dict[str, Any]:
+    """Extract EXIF data from image bytes.
+
+    Returns a JSON-serializable dict of EXIF tags.
+    """
+    result: dict[str, Any] = {}
+
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            exif_data = img.getexif()
+            if not exif_data:
+                return result
+
+            for tag_id, value in exif_data.items():
+                tag_name = TAGS.get(tag_id, str(tag_id))
+                if isinstance(value, (tuple, list)):
+                    result[tag_name] = [_sanitize_value(v) for v in value]
+                else:
+                    result[tag_name] = _sanitize_value(value)
+
+    except Exception:
+        logger.debug("Failed to extract EXIF data", exc_info=True)
+
+    return result
+
+
+def _sanitize_value(value: Any) -> Any:
+    """Make a value JSON-serializable and PostgreSQL-safe."""
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="replace").replace("\x00", "")
+        except Exception:
+            return f"<binary {len(value)} bytes>"
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, (int, float, bool)):
+        return value
+    return str(value).replace("\x00", "")

--- a/image-server/src/image_server/main.py
+++ b/image-server/src/image_server/main.py
@@ -6,9 +6,11 @@ import logging
 
 import uvicorn
 
-from .api import app  # noqa: F401 — re-exported for uvicorn
+from .api import app
 from .config import get_config
 from .database import init_schema
+
+__all__ = ["app"]
 
 logging.basicConfig(
     level=logging.INFO,
@@ -22,15 +24,12 @@ def main() -> None:
     """Start the image server."""
     cfg = get_config()
 
-    # Ensure media directories exist
     cfg.ensure_media_dirs()
     logger.info("Media path: %s", cfg.media_path)
 
-    # Initialize database schema
     init_schema()
     logger.info("Database initialized: %s:%s/%s", cfg.pg_host, cfg.pg_port, cfg.pg_database)
 
-    # Log AI capabilities
     if cfg.vision_backend != "none":
         logger.info("Vision backend: %s (%s)", cfg.vision_backend, cfg.vision_model)
     else:
@@ -38,7 +37,6 @@ def main() -> None:
 
     logger.info("Embedding model: %s", cfg.embedding_model)
 
-    # Start server
     uvicorn.run(
         "image_server.main:app",
         host=cfg.host,

--- a/image-server/src/image_server/main.py
+++ b/image-server/src/image_server/main.py
@@ -1,0 +1,51 @@
+"""Image server entry point."""
+
+from __future__ import annotations
+
+import logging
+
+import uvicorn
+
+from .api import app  # noqa: F401 — re-exported for uvicorn
+from .config import get_config
+from .database import init_schema
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Start the image server."""
+    cfg = get_config()
+
+    # Ensure media directories exist
+    cfg.ensure_media_dirs()
+    logger.info("Media path: %s", cfg.media_path)
+
+    # Initialize database schema
+    init_schema()
+    logger.info("Database initialized: %s:%s/%s", cfg.pg_host, cfg.pg_port, cfg.pg_database)
+
+    # Log AI capabilities
+    if cfg.vision_backend != "none":
+        logger.info("Vision backend: %s (%s)", cfg.vision_backend, cfg.vision_model)
+    else:
+        logger.info("Vision backend: disabled")
+
+    logger.info("Embedding model: %s", cfg.embedding_model)
+
+    # Start server
+    uvicorn.run(
+        "image_server.main:app",
+        host=cfg.host,
+        port=cfg.port,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/image-server/src/image_server/thumbnails.py
+++ b/image-server/src/image_server/thumbnails.py
@@ -12,6 +12,9 @@ from .config import THUMBNAIL_SIZES, get_config
 
 logger = logging.getLogger(__name__)
 
+JPEG_QUALITY = 85
+RGBA_MODES = ("RGBA", "P")
+
 
 def generate_thumbnail(source_path: Path, dest_path: Path) -> tuple[int, int]:
     """Generate a JPEG thumbnail from an image file.
@@ -19,53 +22,50 @@ def generate_thumbnail(source_path: Path, dest_path: Path) -> tuple[int, int]:
     Returns (width, height) of the thumbnail.
     """
     cfg = get_config()
-    size = cfg.thumbnail_size
+    max_dim = cfg.thumbnail_size
 
     with Image.open(source_path) as img:
-        # Convert RGBA/P to RGB for JPEG output
-        if img.mode in ("RGBA", "P"):
+        if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
-        img.thumbnail((size, size), Image.Resampling.LANCZOS)
+        img.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        img.save(dest_path, "JPEG", quality=85, optimize=True)
+        img.save(dest_path, "JPEG", quality=JPEG_QUALITY, optimize=True)
         logger.info("Generated thumbnail: %s (%dx%d)", dest_path.name, img.width, img.height)
         return img.width, img.height
 
 
 def generate_thumbnail_from_bytes(
-    data: bytes, dest_path: Path
+    image_bytes: bytes, dest_path: Path
 ) -> tuple[int, int]:
     """Generate a JPEG thumbnail from raw image bytes.
 
     Returns (width, height) of the thumbnail.
     """
     cfg = get_config()
-    size = cfg.thumbnail_size
+    max_dim = cfg.thumbnail_size
 
-    with Image.open(io.BytesIO(data)) as img:
-        if img.mode in ("RGBA", "P"):
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
-        img.thumbnail((size, size), Image.Resampling.LANCZOS)
+        img.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        img.save(dest_path, "JPEG", quality=85, optimize=True)
+        img.save(dest_path, "JPEG", quality=JPEG_QUALITY, optimize=True)
         return img.width, img.height
 
 
-def generate_all_thumbnails_from_bytes(data: bytes, file_uuid: str) -> None:
+def generate_all_thumbnails_from_bytes(image_bytes: bytes, file_uuid: str) -> None:
     """Generate small, medium, and large thumbnails from raw image bytes."""
     cfg = get_config()
     base = Path(cfg.media_path) / "thumbnails"
 
-    with Image.open(io.BytesIO(data)) as img:
-        if img.mode in ("RGBA", "P"):
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
         for size_name, max_dim in THUMBNAIL_SIZES.items():
-            # Skip sizes larger than the original
             if img.width <= max_dim and img.height <= max_dim:
-                # Original is smaller than this size — save at original dimensions
                 thumb = img.copy()
             else:
                 thumb = img.copy()
@@ -73,7 +73,7 @@ def generate_all_thumbnails_from_bytes(data: bytes, file_uuid: str) -> None:
 
             dest = base / size_name / f"{file_uuid}.jpg"
             dest.parent.mkdir(parents=True, exist_ok=True)
-            thumb.save(dest, "JPEG", quality=85, optimize=True)
+            thumb.save(dest, "JPEG", quality=JPEG_QUALITY, optimize=True)
             logger.info(
                 "Generated %s thumbnail: %s (%dx%d)",
                 size_name, dest.name, thumb.width, thumb.height,
@@ -83,11 +83,11 @@ def generate_all_thumbnails_from_bytes(data: bytes, file_uuid: str) -> None:
 def generate_all_thumbnails_from_path(source_path: Path, file_uuid: str) -> None:
     """Generate small, medium, and large thumbnails from an image file on disk."""
     with open(source_path, "rb") as f:
-        data = f.read()
-    generate_all_thumbnails_from_bytes(data, file_uuid)
+        file_bytes = f.read()
+    generate_all_thumbnails_from_bytes(file_bytes, file_uuid)
 
 
-def get_image_dimensions(data: bytes) -> tuple[int, int]:
+def get_image_dimensions(image_bytes: bytes) -> tuple[int, int]:
     """Get width and height from image bytes without fully decoding."""
-    with Image.open(io.BytesIO(data)) as img:
+    with Image.open(io.BytesIO(image_bytes)) as img:
         return img.width, img.height

--- a/image-server/src/image_server/thumbnails.py
+++ b/image-server/src/image_server/thumbnails.py
@@ -1,0 +1,93 @@
+"""Thumbnail generation using Pillow."""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+from PIL import Image
+
+from .config import THUMBNAIL_SIZES, get_config
+
+logger = logging.getLogger(__name__)
+
+
+def generate_thumbnail(source_path: Path, dest_path: Path) -> tuple[int, int]:
+    """Generate a JPEG thumbnail from an image file.
+
+    Returns (width, height) of the thumbnail.
+    """
+    cfg = get_config()
+    size = cfg.thumbnail_size
+
+    with Image.open(source_path) as img:
+        # Convert RGBA/P to RGB for JPEG output
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
+
+        img.thumbnail((size, size), Image.Resampling.LANCZOS)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(dest_path, "JPEG", quality=85, optimize=True)
+        logger.info("Generated thumbnail: %s (%dx%d)", dest_path.name, img.width, img.height)
+        return img.width, img.height
+
+
+def generate_thumbnail_from_bytes(
+    data: bytes, dest_path: Path
+) -> tuple[int, int]:
+    """Generate a JPEG thumbnail from raw image bytes.
+
+    Returns (width, height) of the thumbnail.
+    """
+    cfg = get_config()
+    size = cfg.thumbnail_size
+
+    with Image.open(io.BytesIO(data)) as img:
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
+
+        img.thumbnail((size, size), Image.Resampling.LANCZOS)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(dest_path, "JPEG", quality=85, optimize=True)
+        return img.width, img.height
+
+
+def generate_all_thumbnails_from_bytes(data: bytes, file_uuid: str) -> None:
+    """Generate small, medium, and large thumbnails from raw image bytes."""
+    cfg = get_config()
+    base = Path(cfg.media_path) / "thumbnails"
+
+    with Image.open(io.BytesIO(data)) as img:
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
+
+        for size_name, max_dim in THUMBNAIL_SIZES.items():
+            # Skip sizes larger than the original
+            if img.width <= max_dim and img.height <= max_dim:
+                # Original is smaller than this size — save at original dimensions
+                thumb = img.copy()
+            else:
+                thumb = img.copy()
+                thumb.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
+
+            dest = base / size_name / f"{file_uuid}.jpg"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            thumb.save(dest, "JPEG", quality=85, optimize=True)
+            logger.info(
+                "Generated %s thumbnail: %s (%dx%d)",
+                size_name, dest.name, thumb.width, thumb.height,
+            )
+
+
+def generate_all_thumbnails_from_path(source_path: Path, file_uuid: str) -> None:
+    """Generate small, medium, and large thumbnails from an image file on disk."""
+    with open(source_path, "rb") as f:
+        data = f.read()
+    generate_all_thumbnails_from_bytes(data, file_uuid)
+
+
+def get_image_dimensions(data: bytes) -> tuple[int, int]:
+    """Get width and height from image bytes without fully decoding."""
+    with Image.open(io.BytesIO(data)) as img:
+        return img.width, img.height

--- a/image-server/src/image_server/vision.py
+++ b/image-server/src/image_server/vision.py
@@ -1,0 +1,152 @@
+"""Gemini vision backend for image captioning."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_MIMES: dict[str, str] = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+
+
+class GeminiBackend:
+    """Gemini vision backend for generating image captions."""
+
+    def __init__(self, model: str, prompt: str) -> None:
+        self._model = model
+        self._prompt = prompt
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        """Get or create the Gemini client (lazy, reused across calls)."""
+        if self._client is not None:
+            return self._client
+
+        try:
+            from google import genai
+        except ImportError as exc:
+            msg = "google-genai not installed (pip install google-genai)"
+            raise RuntimeError(msg) from exc
+
+        import os
+
+        api_key = os.environ.get("GEMINI_API_KEY", "")
+        if not api_key:
+            msg = "GEMINI_API_KEY not set"
+            raise RuntimeError(msg)
+
+        timeout_s = get_config().vision_timeout
+        self._client = genai.Client(
+            api_key=api_key,
+            http_options={"timeout": timeout_s * 1000},
+        )
+        return self._client
+
+    def caption(self, image_path: Path) -> str:
+        """Generate a caption for an image file."""
+        try:
+            from google.genai import types
+        except ImportError as exc:
+            msg = "google-genai not installed"
+            raise RuntimeError(msg) from exc
+
+        client = self._get_client()
+        mime = _get_image_mime(image_path)
+        file_bytes = image_path.read_bytes()
+
+        content = types.Content(
+            parts=[
+                types.Part.from_bytes(data=file_bytes, mime_type=mime),
+                types.Part.from_text(text=self._prompt),
+            ]
+        )
+        try:
+            response = client.models.generate_content(
+                model=self._model,
+                contents=content,
+            )
+        except Exception as exc:
+            msg = f"Gemini captioning failed for {image_path}: {exc}"
+            raise RuntimeError(msg) from exc
+
+        if response.text:
+            return str(response.text)
+        msg = f"Gemini returned empty response for {image_path}"
+        raise RuntimeError(msg)
+
+    def caption_bytes(self, data: bytes, mime_type: str) -> str:
+        """Generate a caption from raw image bytes."""
+        try:
+            from google.genai import types
+        except ImportError as exc:
+            msg = "google-genai not installed"
+            raise RuntimeError(msg) from exc
+
+        client = self._get_client()
+        content = types.Content(
+            parts=[
+                types.Part.from_bytes(data=data, mime_type=mime_type),
+                types.Part.from_text(text=self._prompt),
+            ]
+        )
+        try:
+            response = client.models.generate_content(
+                model=self._model,
+                contents=content,
+            )
+        except Exception as exc:
+            msg = f"Gemini captioning failed: {exc}"
+            raise RuntimeError(msg) from exc
+
+        if response.text:
+            return str(response.text)
+        msg = "Gemini returned empty response"
+        raise RuntimeError(msg)
+
+
+def _get_image_mime(path: Path) -> str:
+    """Get MIME type from file extension."""
+    suffix = path.suffix.lower()
+    mime = _IMAGE_MIMES.get(suffix)
+    if mime:
+        return mime
+    msg = f"Unknown image MIME type for extension: {suffix}"
+    raise ValueError(msg)
+
+
+_backend: GeminiBackend | None = None
+
+
+def get_backend() -> GeminiBackend | None:
+    """Get the configured vision backend, or None if vision is disabled."""
+    global _backend
+    if _backend is not None:
+        return _backend
+
+    cfg = get_config()
+    if cfg.vision_backend != "gemini":
+        return None
+
+    _backend = GeminiBackend(cfg.vision_model, cfg.vision_prompt)
+    return _backend
+
+
+def reset_backend() -> None:
+    """Reset the cached backend (for testing)."""
+    global _backend
+    _backend = None

--- a/image-server/src/image_server/vision.py
+++ b/image-server/src/image_server/vision.py
@@ -66,7 +66,11 @@ class GeminiBackend:
             raise RuntimeError(msg) from exc
 
         client = self._get_client()
-        mime = _get_image_mime(image_path)
+        suffix = image_path.suffix.lower()
+        mime = _IMAGE_MIMES.get(suffix)
+        if not mime:
+            msg = f"Unknown image MIME type for extension: {suffix}"
+            raise ValueError(msg)
         file_bytes = image_path.read_bytes()
 
         content = types.Content(
@@ -89,7 +93,7 @@ class GeminiBackend:
         msg = f"Gemini returned empty response for {image_path}"
         raise RuntimeError(msg)
 
-    def caption_bytes(self, data: bytes, mime_type: str) -> str:
+    def caption_bytes(self, caption_data: bytes, mime_type: str) -> str:
         """Generate a caption from raw image bytes."""
         try:
             from google.genai import types
@@ -100,7 +104,7 @@ class GeminiBackend:
         client = self._get_client()
         content = types.Content(
             parts=[
-                types.Part.from_bytes(data=data, mime_type=mime_type),
+                types.Part.from_bytes(data=caption_data, mime_type=mime_type),
                 types.Part.from_text(text=self._prompt),
             ]
         )
@@ -117,16 +121,6 @@ class GeminiBackend:
             return str(response.text)
         msg = "Gemini returned empty response"
         raise RuntimeError(msg)
-
-
-def _get_image_mime(path: Path) -> str:
-    """Get MIME type from file extension."""
-    suffix = path.suffix.lower()
-    mime = _IMAGE_MIMES.get(suffix)
-    if mime:
-        return mime
-    msg = f"Unknown image MIME type for extension: {suffix}"
-    raise ValueError(msg)
 
 
 _backend: GeminiBackend | None = None

--- a/image-server/tests/conftest.py
+++ b/image-server/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Test fixtures for image server."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Reset module-level singletons between tests."""
+    from image_server.config import reset_config
+    from image_server.vision import reset_backend
+
+    reset_config()
+    reset_backend()
+    yield
+    reset_config()
+    reset_backend()
+
+
+@pytest.fixture
+def test_env(tmp_path, monkeypatch):
+    """Set up test environment variables."""
+    media_path = tmp_path / "media"
+    media_path.mkdir()
+
+    monkeypatch.setenv("PGHOST", "localhost")
+    monkeypatch.setenv("PGPORT", "5432")
+    monkeypatch.setenv("PGDATABASE", "imageserver_test")
+    monkeypatch.setenv("PGUSER", "imageserver")
+    monkeypatch.setenv("PGPASSWORD", "imageserver")
+    monkeypatch.setenv("MEDIA_PATH", str(media_path))
+    monkeypatch.setenv("VISION_BACKEND", "none")
+
+    return {"media_path": media_path}
+
+
+@pytest.fixture
+def sample_jpeg(tmp_path):
+    """Create a minimal valid JPEG file."""
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 80), color=(255, 0, 0))
+    path = tmp_path / "test.jpg"
+    img.save(path, "JPEG")
+    return path
+
+
+@pytest.fixture
+def sample_jpeg_bytes(sample_jpeg):
+    """Return bytes of a minimal valid JPEG."""
+    return sample_jpeg.read_bytes()
+
+
+@pytest.fixture
+def sample_png(tmp_path):
+    """Create a minimal valid PNG file with RGBA mode."""
+    from PIL import Image
+
+    img = Image.new("RGBA", (200, 150), color=(0, 255, 0, 128))
+    path = tmp_path / "test.png"
+    img.save(path, "PNG")
+    return path

--- a/image-server/tests/test_api.py
+++ b/image-server/tests/test_api.py
@@ -1,0 +1,36 @@
+"""Tests for API endpoints (unit-level, no database required)."""
+
+from fastapi.testclient import TestClient
+
+from image_server.api import app
+
+
+def test_health():
+    """Health endpoint returns ok."""
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "image-server"
+
+
+def test_list_assets_requires_poi_id():
+    """List assets requires poi_id parameter."""
+    client = TestClient(app)
+    response = client.get("/api/assets")
+    assert response.status_code == 400
+
+
+def test_theme_video_invalid_theme():
+    """Invalid theme returns 404."""
+    client = TestClient(app)
+    response = client.get("/api/theme-videos/invalid")
+    assert response.status_code == 404
+
+
+def test_search_requires_query():
+    """Search requires a query field."""
+    client = TestClient(app)
+    response = client.post("/api/search", json={})
+    assert response.status_code == 400

--- a/image-server/tests/test_config.py
+++ b/image-server/tests/test_config.py
@@ -1,0 +1,64 @@
+"""Tests for configuration module."""
+
+from image_server.config import Config, get_config, reset_config
+
+
+def test_defaults():
+    """Config has sensible defaults."""
+    reset_config()
+    cfg = Config()
+    assert cfg.pg_host == "localhost"
+    assert cfg.pg_port == 5432
+    assert cfg.pg_database == "imageserver"
+    assert cfg.media_path == "/data/media"
+    assert cfg.thumbnail_size == 250
+    assert cfg.vision_backend == "none"
+    assert cfg.embedding_model == "BAAI/bge-small-en-v1.5"
+    assert cfg.port == 8000
+
+
+def test_env_override(monkeypatch):
+    """Environment variables override defaults."""
+    monkeypatch.setenv("PGHOST", "db.example.com")
+    monkeypatch.setenv("PGPORT", "5433")
+    monkeypatch.setenv("MEDIA_PATH", "/opt/images")
+    monkeypatch.setenv("THUMBNAIL_SIZE", "400")
+    monkeypatch.setenv("VISION_BACKEND", "gemini")
+
+    reset_config()
+    cfg = Config()
+    assert cfg.pg_host == "db.example.com"
+    assert cfg.pg_port == 5433
+    assert cfg.media_path == "/opt/images"
+    assert cfg.thumbnail_size == 400
+    assert cfg.vision_backend == "gemini"
+    assert cfg.vision_model == "gemini-2.5-flash"
+
+
+def test_dsn():
+    """DSN string is properly formatted."""
+    reset_config()
+    cfg = Config()
+    dsn = cfg.dsn
+    assert "host=localhost" in dsn
+    assert "port=5432" in dsn
+    assert "dbname=imageserver" in dsn
+
+
+def test_singleton():
+    """get_config returns the same instance."""
+    reset_config()
+    c1 = get_config()
+    c2 = get_config()
+    assert c1 is c2
+
+
+def test_ensure_media_dirs(tmp_path, monkeypatch):
+    """ensure_media_dirs creates expected subdirectories."""
+    monkeypatch.setenv("MEDIA_PATH", str(tmp_path / "media"))
+    reset_config()
+    cfg = Config()
+    cfg.ensure_media_dirs()
+
+    for subdir in ("originals", "thumbnails", "videos", "theme-videos"):
+        assert (tmp_path / "media" / subdir).is_dir()

--- a/image-server/tests/test_embedder.py
+++ b/image-server/tests/test_embedder.py
@@ -1,0 +1,31 @@
+"""Tests for embedding generation."""
+
+import pytest
+
+
+def test_embed_texts_empty():
+    """Empty list returns empty list."""
+    from image_server.embedder import embed_texts
+
+    result = embed_texts([])
+    assert result == []
+
+
+@pytest.mark.slow
+def test_embed_texts_single():
+    """Single text produces a 384-dim vector."""
+    from image_server.embedder import embed_texts
+
+    result = embed_texts(["a covered bridge in winter"])
+    assert len(result) == 1
+    assert len(result[0]) == 384
+    assert all(isinstance(v, float) for v in result[0])
+
+
+@pytest.mark.slow
+def test_embed_query():
+    """Query embedding produces a 384-dim vector."""
+    from image_server.embedder import embed_query
+
+    result = embed_query("snow covered trail")
+    assert len(result) == 384

--- a/image-server/tests/test_exif.py
+++ b/image-server/tests/test_exif.py
@@ -2,6 +2,7 @@
 
 import io
 
+import pytest
 from PIL import Image
 
 from image_server.exif import extract_exif
@@ -12,15 +13,14 @@ def test_extract_exif_no_data():
     img = Image.new("RGB", (10, 10))
     buf = io.BytesIO()
     img.save(buf, "JPEG")
-    result = extract_exif(buf.getvalue())
-    # Minimal JPEG may have no EXIF
-    assert isinstance(result, dict)
+    exif_result = extract_exif(buf.getvalue())
+    assert isinstance(exif_result, dict)
 
 
 def test_extract_exif_invalid_data():
-    """Invalid data returns empty dict without crashing."""
-    result = extract_exif(b"not an image")
-    assert result == {}
+    """Invalid data raises an exception."""
+    with pytest.raises(Exception):
+        extract_exif(b"not an image")
 
 
 def test_extract_exif_png():
@@ -28,5 +28,5 @@ def test_extract_exif_png():
     img = Image.new("RGB", (10, 10))
     buf = io.BytesIO()
     img.save(buf, "PNG")
-    result = extract_exif(buf.getvalue())
-    assert isinstance(result, dict)
+    exif_result = extract_exif(buf.getvalue())
+    assert isinstance(exif_result, dict)

--- a/image-server/tests/test_exif.py
+++ b/image-server/tests/test_exif.py
@@ -1,0 +1,32 @@
+"""Tests for EXIF extraction."""
+
+import io
+
+from PIL import Image
+
+from image_server.exif import extract_exif
+
+
+def test_extract_exif_no_data():
+    """Image without EXIF returns empty dict."""
+    img = Image.new("RGB", (10, 10))
+    buf = io.BytesIO()
+    img.save(buf, "JPEG")
+    result = extract_exif(buf.getvalue())
+    # Minimal JPEG may have no EXIF
+    assert isinstance(result, dict)
+
+
+def test_extract_exif_invalid_data():
+    """Invalid data returns empty dict without crashing."""
+    result = extract_exif(b"not an image")
+    assert result == {}
+
+
+def test_extract_exif_png():
+    """PNG images handled gracefully."""
+    img = Image.new("RGB", (10, 10))
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    result = extract_exif(buf.getvalue())
+    assert isinstance(result, dict)

--- a/image-server/tests/test_thumbnails.py
+++ b/image-server/tests/test_thumbnails.py
@@ -1,0 +1,57 @@
+"""Tests for thumbnail generation."""
+
+from pathlib import Path
+
+from PIL import Image
+
+from image_server.thumbnails import (
+    generate_thumbnail,
+    generate_thumbnail_from_bytes,
+    get_image_dimensions,
+)
+
+
+def test_generate_thumbnail(sample_jpeg, tmp_path, monkeypatch):
+    """Thumbnail is generated at configured size."""
+    monkeypatch.setenv("THUMBNAIL_SIZE", "50")
+
+    dest = tmp_path / "thumb.jpg"
+    w, h = generate_thumbnail(sample_jpeg, dest)
+
+    assert dest.exists()
+    assert w <= 50
+    assert h <= 50
+
+    with Image.open(dest) as img:
+        assert img.format == "JPEG"
+
+
+def test_generate_thumbnail_from_bytes(sample_jpeg_bytes, tmp_path, monkeypatch):
+    """Thumbnail from bytes works the same as from file."""
+    monkeypatch.setenv("THUMBNAIL_SIZE", "80")
+
+    dest = tmp_path / "thumb.jpg"
+    w, h = generate_thumbnail_from_bytes(sample_jpeg_bytes, dest)
+
+    assert dest.exists()
+    assert w <= 80
+    assert h <= 80
+
+
+def test_rgba_conversion(sample_png, tmp_path, monkeypatch):
+    """RGBA images are converted to RGB for JPEG output."""
+    monkeypatch.setenv("THUMBNAIL_SIZE", "100")
+
+    dest = tmp_path / "thumb.jpg"
+    w, h = generate_thumbnail(sample_png, dest)
+
+    assert dest.exists()
+    with Image.open(dest) as img:
+        assert img.mode == "RGB"
+
+
+def test_get_image_dimensions(sample_jpeg_bytes):
+    """Dimensions are correctly extracted."""
+    w, h = get_image_dimensions(sample_jpeg_bytes)
+    assert w == 100
+    assert h == 80

--- a/image-server/tests/test_vision.py
+++ b/image-server/tests/test_vision.py
@@ -1,0 +1,29 @@
+"""Tests for vision backend."""
+
+from image_server.vision import get_backend, reset_backend
+
+
+def test_vision_disabled_by_default(monkeypatch):
+    """Default config has vision disabled."""
+    monkeypatch.setenv("VISION_BACKEND", "none")
+    reset_backend()
+    backend = get_backend()
+    assert backend is None
+
+
+def test_gemini_backend_created(monkeypatch):
+    """Gemini backend is created when configured."""
+    monkeypatch.setenv("VISION_BACKEND", "gemini")
+    monkeypatch.setenv("VISION_MODEL", "gemini-2.5-flash")
+    reset_backend()
+    backend = get_backend()
+    assert backend is not None
+    assert backend._model == "gemini-2.5-flash"
+
+
+def test_unknown_backend(monkeypatch):
+    """Unknown backend returns None."""
+    monkeypatch.setenv("VISION_BACKEND", "unknown")
+    reset_backend()
+    backend = get_backend()
+    assert backend is None


### PR DESCRIPTION
## Summary
- Copies image-server Python codebase into `image-server/` as a sibling to `backend/` and `frontend/`
- Adds `Containerfile.images` for independent container builds (multi-stage: pgvector, Python wheels, ubi10-core)
- Adds `.github/workflows/build-images.yml` with path-based triggers (`image-server/**`, `Containerfile.images`)
- Updates `.github/workflows/build.yml` with `paths-ignore` so image-server-only changes don't trigger ROTV builds
- Adds Gourmand exceptions for Python files (excluded_paths glob doesn't work — Gourmand bug)

Closes #278

## Test plan
- [x] `./run.sh build` passes (ROTV container unaffected)
- [x] `./run.sh test` — 22 test files, 316 passed, 0 failures
- [x] Gourmand — 0 violations
- [ ] GHA: verify path-based triggers work (image-server changes → build-images.yml only)
- [ ] Manual: verify `Containerfile.images` builds with RHSM secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)