### PR TITLE
feat: add RSS feed link to dropdowns

### DIFF
--- a/backend/services/newsletterService.js
+++ b/backend/services/newsletterService.js
@@ -442,7 +442,6 @@ export function startSmtpServer(pool) {
           const raw = Buffer.concat(chunks);
           const recipient = session.envelope.rcptTo[0]?.address?.toLowerCase();
 
-          // Forward admin@ emails to personal Gmail via Gmail MX
           if (recipient === 'admin@rootsofthevalley.org') {
             const transporter = nodemailer.createTransport({
               host: 'gmail-smtp-in.l.google.com',
@@ -467,7 +466,6 @@ export function startSmtpServer(pool) {
             return;
           }
 
-          // Newsletter processing
           const parsed = await simpleParser(raw);
 
           const from = parsed.from?.text || 'unknown';

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1677,6 +1677,14 @@ function AppContent() {
                     </div>
                     <a
                       className="dropdown-item-inline privacy-link-inline"
+                      href="https://buttondown.com/rotv/rss"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      RSS Feed
+                    </a>
+                    <a
+                      className="dropdown-item-inline privacy-link-inline"
                       href="/privacy"
                       onClick={(e) => { e.preventDefault(); setShowUserDropdown(false); navigate('/privacy'); }}
                     >
@@ -1722,6 +1730,14 @@ function AppContent() {
                       </svg>
                       Continue with Facebook
                     </button>
+                    <a
+                      className="privacy-link-inline"
+                      href="https://buttondown.com/rotv/rss"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      RSS Feed
+                    </a>
                     <a
                       className="privacy-link-inline"
                       href="/privacy"


### PR DESCRIPTION
## Summary
- Adds Buttondown newsletter RSS feed link above Privacy Policy in both login and user dropdowns
- Links to https://buttondown.com/rotv/rss

Closes #219

## Test plan
- [x] Verified on localhost — link appears in both dropdowns
- [x] Opens in new tab with correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)