### PR TITLE
Add feedback form with GitHub Issue creation

### DIFF
--- a/.specify/specs/009-feedback-form/plan.md
+++ b/.specify/specs/009-feedback-form/plan.md
@@ -1,0 +1,196 @@
+# Implementation Plan: Feedback Form with GitHub Issue Creation
+
+> **Spec ID:** 009-feedback-form
+> **Status:** Planning
+> **Last Updated:** 2026-05-10
+> **Estimated Effort:** S
+
+## Summary
+
+Add a public-facing feedback form modal and a backend API endpoint that creates GitHub Issues. No database changes required — all data flows directly to GitHub.
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+User fills form → POST /api/feedback → Server validates → GitHub API → Issue created → 201 response
+```
+
+### Component Diagram
+
+```
+┌──────────────────────────────┐
+│         Frontend             │
+│                              │
+│   ┌──────────────────────┐   │
+│   │   FeedbackForm.jsx   │   │
+│   │   (modal component)  │   │
+│   └──────────┬───────────┘   │
+│              │ POST          │
+└──────────────┼───────────────┘
+               │
+┌──────────────▼───────────────┐
+│         Backend              │
+│                              │
+│   ┌──────────────────────┐   │
+│   │  routes/feedback.js  │   │
+│   │  (validation + rate  │   │
+│   │   limit + GitHub API)│   │
+│   └──────────┬───────────┘   │
+│              │               │
+└──────────────┼───────────────┘
+               │
+               ▼
+       GitHub Issues API
+       (crunchtools/rotv)
+```
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| GitHub API | `fetch` (Node built-in) | No new dependency needed, GitHub REST API is simple |
+| Rate limiting | `express-rate-limit` | Already in the project |
+| Spam prevention | Honeypot field | Simple, no external service needed |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend
+
+- [ ] Create `backend/routes/feedback.js` with POST `/api/feedback` endpoint
+- [ ] Add rate limiter (3 req/hour per IP)
+- [ ] Add input validation (type enum, message length, honeypot check)
+- [ ] Add GitHub issue creation via REST API
+- [ ] Wire route into `server.js`
+- [ ] Add `GITHUB_TOKEN` to `.env.example`
+
+### Phase 2: Frontend
+
+- [ ] Create `frontend/src/components/FeedbackForm.jsx` (modal component)
+- [ ] Add "Feedback" button to the header tab bar in `App.jsx`
+- [ ] Add CSS styles for the modal and form
+- [ ] Handle loading/success/error states
+
+### Phase 3: Testing
+
+- [ ] Add integration test for the feedback endpoint
+- [ ] Manual browser testing of the form
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/routes/feedback.js` | Feedback API endpoint |
+| `frontend/src/components/FeedbackForm.jsx` | Feedback form modal component |
+| `frontend/src/components/FeedbackForm.css` | Styles for the feedback modal |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/server.js` | Import and mount feedback route |
+| `frontend/src/App.jsx` | Add Feedback button to header, import FeedbackForm |
+| `frontend/src/App.css` | Feedback button styling (if not in FeedbackForm.css) |
+| `.env.example` | Add `GITHUB_TOKEN` |
+
+---
+
+## Database Migrations
+
+None required. Feedback goes directly to GitHub.
+
+---
+
+## API Implementation
+
+### Endpoint: `POST /api/feedback`
+
+**Request:**
+```json
+{
+  "type": "bug",
+  "message": "The map doesn't load on my phone",
+  "name": "Jane",
+  "email": "jane@example.com",
+  "hp": ""
+}
+```
+
+**Server-side flow:**
+1. Check honeypot field — reject if non-empty
+2. Validate `type` is one of: `bug`, `feature`, `general`
+3. Validate `message` length (10-1000 chars)
+4. Sanitize all inputs (strip HTML/markdown injection)
+5. Map type to GitHub label: `bug` → `bug`, `feature` → `enhancement`, `general` → `feedback`
+6. Create issue via `POST https://api.github.com/repos/crunchtools/rotv/issues`
+7. Return `{ success: true, issueNumber: N }`
+
+**GitHub Issue Format:**
+```
+Title: [Feedback] <type>: <first 80 chars of message>
+
+Body:
+## User Feedback
+
+**Type:** Bug Report
+
+**Message:**
+<sanitized message>
+
+---
+*Submitted via ROTV feedback form*
+*Name: Jane*
+*Email: jane@example.com*
+```
+
+**Response (201):**
+```json
+{ "success": true, "issueNumber": 218 }
+```
+
+---
+
+## Testing Strategy
+
+### Integration Tests
+
+- [ ] `backend/tests/feedback.test.js` — POST with valid data (mock GitHub API), honeypot rejection, missing fields, rate limiting
+
+### Manual Testing
+
+1. Open ROTV in browser, click Feedback button
+2. Fill form with each feedback type, verify issue created on GitHub
+3. Submit with honeypot filled — verify rejection
+4. Submit 4 times rapidly — verify rate limit kicks in
+5. Submit with empty message — verify validation error
+6. Test on mobile viewport — verify modal is responsive
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| GitHub API rate limit (5000/hr) | Low | User-facing rate limit of 3/hr/IP ensures we never approach this |
+| Spam submissions | Med | Honeypot + rate limiting; can add CAPTCHA later if needed |
+| GitHub token exposure | High | Token is server-side only, never sent to frontend |
+| Markdown injection in issues | Med | Sanitize input before creating issue body |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-10 | Initial plan |

--- a/.specify/specs/009-feedback-form/spec.md
+++ b/.specify/specs/009-feedback-form/spec.md
@@ -1,0 +1,136 @@
+# Specification: Feedback Form with GitHub Issue Creation
+
+> **Spec ID:** 009-feedback-form
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-10
+
+## Overview
+
+Add a public feedback form to ROTV that lets any visitor submit feedback, bug reports, or feature suggestions. Submissions are automatically created as GitHub Issues in the `crunchtools/rotv` repository, giving the community a direct voice without requiring them to have a GitHub account.
+
+---
+
+## User Stories
+
+### Public Feedback
+
+**US-001: Submit Feedback**
+> As a park visitor using ROTV, I want to submit feedback or report a problem so that the development team can improve the site.
+
+Acceptance Criteria:
+- [ ] A "Feedback" button is accessible from every page (header or footer)
+- [ ] The form works without requiring login
+- [ ] Form collects: feedback type, message, and optional name/email
+- [ ] Submitting creates a GitHub Issue in `crunchtools/rotv`
+- [ ] User sees a success confirmation after submission
+- [ ] Form is protected against spam (rate limiting + honeypot)
+
+**US-002: Categorized Issues**
+> As a project maintainer, I want feedback submissions labeled by type so that I can triage them efficiently.
+
+Acceptance Criteria:
+- [ ] Issues are created with labels matching the feedback type (bug, feature-request, feedback)
+- [ ] Issue body includes the submitter's message and optional contact info
+- [ ] Issues are tagged with a `user-submitted` label for easy filtering
+
+---
+
+## API Endpoints
+
+### New Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/feedback` | Submit feedback, creates GitHub Issue | No (public, rate-limited) |
+
+### POST `/api/feedback`
+
+**Request Body:**
+```json
+{
+  "type": "bug | feature | general",
+  "message": "Description of the feedback",
+  "name": "Optional name",
+  "email": "Optional email",
+  "hp": ""
+}
+```
+
+**Response (201):**
+```json
+{
+  "success": true,
+  "issueNumber": 218
+}
+```
+
+**Response (429):**
+```json
+{
+  "error": "Too many submissions. Please try again later."
+}
+```
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `FeedbackForm.jsx` — Modal dialog with the feedback form, accessible from a persistent "Feedback" button
+
+### Design
+
+- Small "Feedback" button in the header tab bar (visible to all users, not just authenticated)
+- Clicking opens a modal overlay (consistent with existing modal patterns like Lightbox)
+- Form fields:
+  - **Type** (required): Radio buttons — Bug Report / Feature Request / General Feedback
+  - **Message** (required): Textarea, 10-1000 characters
+  - **Name** (optional): Text input
+  - **Email** (optional): Text input (in case they want a response)
+  - **Honeypot** (hidden): Empty text field, invisible to users, rejects if filled
+- Submit button with loading state
+- Success message with the issue number
+- Error message on failure
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Spam Prevention**
+- Rate limit: 3 submissions per IP per hour
+- Honeypot field to catch bots
+- Message length validation (10-1000 chars)
+
+**NFR-002: Security**
+- GitHub token stored server-side only (never exposed to frontend)
+- Input sanitization before creating the issue (prevent markdown injection)
+- No PII stored in the database — feedback goes directly to GitHub
+
+**NFR-003: Availability**
+- If GitHub API is unavailable, return a clear error asking the user to try again later
+- Form should degrade gracefully (no blank screens on API failure)
+
+---
+
+## Dependencies
+
+- **GitHub Personal Access Token** — Fine-grained PAT with `issues:write` scope for `crunchtools/rotv`
+- Environment variable: `GITHUB_TOKEN`
+
+---
+
+## Open Questions
+
+1. ~~Should the form require login?~~ No — public form to maximize feedback.
+2. Should we store submissions locally as a backup? (Proposed: No — keep it simple, GitHub is the system of record)
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-10 | Initial draft |

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -489,7 +489,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'news_collection_excluded_pois',
       'blocklist_urls',
       'moderation_trusted_domains',
-      'trusted_event_paths'
+      'trusted_event_paths',
+      'github_api_token'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });

--- a/backend/routes/feedback.js
+++ b/backend/routes/feedback.js
@@ -1,0 +1,117 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+
+const router = express.Router();
+
+const feedbackLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 3,
+  message: { error: 'Too many submissions. Please try again later.' },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+function sanitizeForMarkdown(text) {
+  if (!text) return '';
+  return text
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]');
+}
+
+const TYPE_LABELS = {
+  bug: 'bug',
+  feature: 'enhancement',
+  general: 'feedback'
+};
+
+const TYPE_DISPLAY = {
+  bug: 'Bug Report',
+  feature: 'Feature Request',
+  general: 'General Feedback'
+};
+
+export function createFeedbackRouter(pool) {
+  router.post('/', feedbackLimiter, async (req, res) => {
+    const { type, message, name, email, hp } = req.body;
+
+    if (hp) {
+      return res.status(201).json({ success: true, issueNumber: 0 });
+    }
+
+    if (!type || !TYPE_LABELS[type]) {
+      return res.status(400).json({ error: 'Invalid feedback type. Must be: bug, feature, or general.' });
+    }
+
+    if (!message || typeof message !== 'string') {
+      return res.status(400).json({ error: 'Message is required.' });
+    }
+
+    const trimmed = message.trim();
+    if (trimmed.length < 10) {
+      return res.status(400).json({ error: 'Message must be at least 10 characters.' });
+    }
+    if (trimmed.length > 1000) {
+      return res.status(400).json({ error: 'Message must be 1000 characters or fewer.' });
+    }
+
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return res.status(400).json({ error: 'Invalid email format.' });
+    }
+
+    let token;
+    try {
+      const result = await pool.query("SELECT value FROM admin_settings WHERE key = 'github_api_token'");
+      token = result.rows[0]?.value;
+    } catch (err) {
+      console.error('Failed to read GitHub token from admin_settings:', err.message);
+    }
+    token = token || process.env.GITHUB_TOKEN;
+
+    if (!token) {
+      console.error('GitHub token not configured — cannot create feedback issue');
+      return res.status(503).json({ error: 'Feedback service is temporarily unavailable. Please try again later.' });
+    }
+
+    const titlePreview = trimmed.length > 80 ? trimmed.substring(0, 77) + '...' : trimmed;
+    const title = `[Feedback] ${TYPE_DISPLAY[type]}: ${titlePreview}`;
+
+    let body = `## User Feedback\n\n**Type:** ${TYPE_DISPLAY[type]}\n\n**Message:**\n${sanitizeForMarkdown(trimmed)}\n\n---\n*Submitted via ROTV feedback form*`;
+    if (name) {
+      body += `\n*Name: ${sanitizeForMarkdown(name.trim().substring(0, 100))}*`;
+    }
+    if (email) {
+      body += `\n*Email: ${sanitizeForMarkdown(email.trim())}*`;
+    }
+
+    const labels = [TYPE_LABELS[type], 'user-submitted'];
+
+    try {
+      const response = await fetch('https://api.github.com/repos/crunchtools/rotv/issues', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ title, body, labels })
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(`GitHub API error (${response.status}): ${errorBody}`);
+        return res.status(502).json({ error: 'Failed to submit feedback. Please try again later.' });
+      }
+
+      const issue = await response.json();
+      res.status(201).json({ success: true, issueNumber: issue.number });
+    } catch (err) {
+      console.error('GitHub API request failed:', err.message);
+      res.status(502).json({ error: 'Failed to submit feedback. Please try again later.' });
+    }
+  });
+
+  return router;
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ import { configurePassport } from './config/passport.js';
 import authRoutes from './routes/auth.js';
 import { createAdminRouter } from './routes/admin.js';
 import { createNewsletterRouter } from './routes/newsletter.js';
+import { createFeedbackRouter } from './routes/feedback.js';
 import { isAuthenticated } from './middleware/auth.js';
 import {
   initJobScheduler,
@@ -179,6 +180,9 @@ app.use('/api/admin', createAdminRouter(pool, invalidateMosaicCache));
 
 // Mount newsletter routes
 app.use('/api/newsletter', createNewsletterRouter(pool));
+
+// Mount feedback routes
+app.use('/api/feedback', createFeedbackRouter(pool));
 
 // Import trails and rivers from GeoJSON files into unified pois table
 async function importGeoJSONFeatures(client) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13651,6 +13651,18 @@ svg.leaflet-zoom-animated {
   border-top: 1px solid #eee;
 }
 
+/* Feedback link in dropdowns (button reset to match privacy-link-inline) */
+button.feedback-link-inline {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  width: 100%;
+  margin-top: 0;
+  border-top: none;
+  padding-top: 4px;
+}
+
 /* Settings link style */
 .settings-link {
   color: #2d6a4f;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import ResultsTab from './components/ResultsTab';
 import NewsPermalink from './components/NewsPermalink';
 import EventPermalink from './components/EventPermalink';
 import PrivacyPolicy from './components/PrivacyPolicy';
+import FeedbackForm from './components/FeedbackForm';
 
 // Default icon type IDs for initializing the filter
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'mtb-trailhead', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default', 'lighthouse', 'cemetery']);
@@ -130,6 +131,7 @@ function AppContent() {
   const [showLoginDropdown, setShowLoginDropdown] = useState(false);
   const [showUserDropdown, setShowUserDropdown] = useState(false);
   const [profileImageError, setProfileImageError] = useState(false);
+  const [showFeedbackForm, setShowFeedbackForm] = useState(false);
 
   // Router hooks
   const location = useLocation();
@@ -1683,6 +1685,12 @@ function AppContent() {
                       Privacy Policy
                     </a>
                     <button
+                      className="dropdown-item-inline privacy-link-inline feedback-link-inline"
+                      onClick={() => { setShowUserDropdown(false); setShowFeedbackForm(true); }}
+                    >
+                      Send Feedback
+                    </button>
+                    <button
                       className="dropdown-item-inline"
                       onClick={() => {
                         setShowUserDropdown(false);
@@ -1729,6 +1737,12 @@ function AppContent() {
                     >
                       Privacy Policy
                     </a>
+                    <button
+                      className="privacy-link-inline feedback-link-inline"
+                      onClick={() => { setShowLoginDropdown(false); setShowFeedbackForm(true); }}
+                    >
+                      Send Feedback
+                    </button>
                   </div>
                 </>
               )}
@@ -2116,6 +2130,9 @@ function AppContent() {
           onSidebarTabChange={(tab) => setInitialSidebarTab(null)}
         />
       </main>
+      {showFeedbackForm && (
+        <FeedbackForm onClose={() => setShowFeedbackForm(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -39,6 +39,11 @@ function DataCollectionSettings() {
   const [serperSaving, setSerperSaving] = useState(false);
   const [serperTesting, setSerperTesting] = useState(false);
 
+  const [githubToken, setGithubToken] = useState('');
+  const [githubTokenSet, setGithubTokenSet] = useState(false);
+  const [githubSaving, setGithubSaving] = useState(false);
+  const [githubResult, setGithubResult] = useState(null);
+
   // Playwright status state
   const [playwrightStatus, setPlaywrightStatus] = useState(null);
   const [playwrightLoading, setPlaywrightLoading] = useState(true);
@@ -126,6 +131,7 @@ function DataCollectionSettings() {
     fetchGeminiStatus();
     fetchApifyStatus();
     fetchSerperStatus();
+    fetchGithubStatus();
     fetchPlaywrightStatus();
     fetchModerationConfig();
     fetchDomainLists();
@@ -292,6 +298,31 @@ function DataCollectionSettings() {
       }
     } catch (err) { setSerperResult({ type: 'error', message: `Test failed: ${err.message}` }); }
     finally { setSerperTesting(false); }
+  };
+
+  const fetchGithubStatus = async () => {
+    try {
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
+      if (response.ok) { const settings = await response.json(); setGithubTokenSet(settings.github_api_token?.isSet || false); }
+    } catch (err) { console.error('Error fetching GitHub status:', err); }
+  };
+
+  const handleSaveGithubToken = async () => {
+    if (!githubToken.trim()) { setGithubResult({ type: 'error', message: 'Token cannot be empty' }); return; }
+    setGithubSaving(true); setGithubResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/github_api_token', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: githubToken })
+      });
+      if (response.ok) {
+        setGithubResult({ type: 'success', message: 'Saved successfully' });
+        setGithubToken('');
+        setGithubTokenSet(true);
+        await fetchGithubStatus();
+      } else { const error = await response.json(); throw new Error(error.error || 'Failed to save token'); }
+    } catch (err) { setGithubResult({ type: 'error', message: `Save failed: ${err.message}` }); }
+    finally { setGithubSaving(false); }
   };
 
   const handleSaveTwitterCredentials = async () => {
@@ -834,6 +865,50 @@ function DataCollectionSettings() {
           </div>
           <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
             Twitter/X and Facebook scraping. Get token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
+          </p>
+        </div>
+
+        {/* GitHub API Token */}
+        <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid #e0e0e0' }}>
+          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>GitHub</h5>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
+            <span className={`status-indicator ${githubTokenSet ? 'configured' : 'not-configured'}`}></span>
+            <span style={{ fontSize: '0.9rem' }}>{githubTokenSet ? 'Configured' : 'Not configured'}</span>
+            {githubResult && (
+              <span
+                style={{
+                  marginLeft: '12px',
+                  padding: '4px 10px',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  fontWeight: '500',
+                  backgroundColor: githubResult.type === 'success' ? '#d4edda' : '#f8d7da',
+                  color: githubResult.type === 'success' ? '#155724' : '#721c24',
+                  cursor: 'pointer'
+                }}
+                onClick={() => setGithubResult(null)}
+                title="Click to dismiss"
+              >
+                {githubResult.message}
+              </span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch', marginBottom: '0.5rem' }}>
+            <input
+              type="password"
+              value={githubToken || (githubTokenSet ? '••••••••••••••••••••••••' : '')}
+              onChange={e => setGithubToken(e.target.value)}
+              placeholder="Enter GitHub token..."
+              disabled={githubSaving}
+              style={{ flex: 1, padding: '8px', fontSize: '0.9rem', border: '1px solid #ccc', borderRadius: '4px', minWidth: 0 }}
+            />
+            <button className="action-btn primary" onClick={handleSaveGithubToken} disabled={githubSaving || !githubToken.trim()}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {githubSaving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+          <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
+            Feedback form creates GitHub Issues. Use a fine-grained PAT with <code>issues:write</code> scope for <code>crunchtools/rotv</code>.
           </p>
         </div>
       </div>

--- a/frontend/src/components/FeedbackForm.css
+++ b/frontend/src/components/FeedbackForm.css
@@ -1,0 +1,253 @@
+/* Feedback Modal Overlay */
+.feedback-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: feedbackFadeIn 0.2s ease-in-out;
+}
+
+@keyframes feedbackFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Modal Container */
+.feedback-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  width: 90%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.feedback-modal h2 {
+  margin: 0 0 0.25rem 0;
+  color: #2d5016;
+  font-size: 1.4rem;
+}
+
+.feedback-modal .feedback-subtitle {
+  color: #666;
+  font-size: 0.9rem;
+  margin: 0 0 1.5rem 0;
+}
+
+/* Close Button */
+.feedback-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #999;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+
+.feedback-close:hover {
+  background: #f0f0f0;
+  color: #333;
+}
+
+/* Form Elements */
+.feedback-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.feedback-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.feedback-field label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.feedback-field .field-optional {
+  font-weight: 400;
+  color: #999;
+  font-size: 0.8rem;
+}
+
+/* Radio Group */
+.feedback-radio-group {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.feedback-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.15s;
+  user-select: none;
+}
+
+.feedback-radio-label:hover {
+  border-color: #4a7c2e;
+}
+
+.feedback-radio-label.selected {
+  border-color: #2d5016;
+  background: #f0f7eb;
+}
+
+.feedback-radio-label input[type="radio"] {
+  accent-color: #2d5016;
+}
+
+/* Text Inputs */
+.feedback-form input[type="text"],
+.feedback-form input[type="email"],
+.feedback-form textarea {
+  padding: 0.6rem 0.75rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+
+.feedback-form input[type="text"]:focus,
+.feedback-form input[type="email"]:focus,
+.feedback-form textarea:focus {
+  outline: none;
+  border-color: #4a7c2e;
+}
+
+.feedback-form textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.feedback-char-count {
+  font-size: 0.75rem;
+  color: #999;
+  text-align: right;
+}
+
+.feedback-char-count.near-limit {
+  color: #c0392b;
+}
+
+/* Honeypot — visually hidden */
+.feedback-hp {
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  overflow: hidden;
+}
+
+/* Submit Button */
+.feedback-submit {
+  padding: 0.75rem 1.5rem;
+  background: #2d5016;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.feedback-submit:hover:not(:disabled) {
+  background: #3a6a1e;
+}
+
+.feedback-submit:disabled {
+  background: #999;
+  cursor: not-allowed;
+}
+
+/* Error Message */
+.feedback-error {
+  background: #fef2f2;
+  color: #c0392b;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  border: 1px solid #fecaca;
+}
+
+/* Success State */
+.feedback-success {
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.feedback-success .success-icon {
+  font-size: 3rem;
+  margin-bottom: 0.75rem;
+}
+
+.feedback-success h3 {
+  color: #2d5016;
+  margin: 0 0 0.5rem 0;
+}
+
+.feedback-success p {
+  color: #666;
+  font-size: 0.9rem;
+  margin: 0 0 1.5rem 0;
+}
+
+.feedback-success .feedback-done-btn {
+  padding: 0.6rem 2rem;
+  background: #2d5016;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.feedback-success .feedback-done-btn:hover {
+  background: #3a6a1e;
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+  .feedback-modal {
+    width: 95%;
+    padding: 1.5rem;
+  }
+
+  .feedback-radio-group {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/components/FeedbackForm.jsx
+++ b/frontend/src/components/FeedbackForm.jsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import './FeedbackForm.css';
+
+const TYPES = [
+  { value: 'bug', label: 'Bug Report' },
+  { value: 'feature', label: 'Feature Request' },
+  { value: 'general', label: 'General Feedback' }
+];
+
+function FeedbackForm({ onClose }) {
+  const [type, setType] = useState('general');
+  const [message, setMessage] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [hp, setHp] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'auto';
+    };
+  }, [onClose]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmed = message.trim();
+    if (trimmed.length < 10) {
+      setError('Message must be at least 10 characters.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type,
+          message: trimmed,
+          name: name.trim() || undefined,
+          email: email.trim() || undefined,
+          hp
+        })
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Something went wrong. Please try again.');
+        return;
+      }
+
+      setSuccess(data.issueNumber);
+    } catch {
+      setError('Network error. Please check your connection and try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div className="feedback-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="feedback-modal">
+        <button className="feedback-close" onClick={onClose}>&times;</button>
+
+        {success ? (
+          <div className="feedback-success">
+            <div className="success-icon">&#10003;</div>
+            <h3>Thank you for your feedback!</h3>
+            <p>Your submission has been recorded as issue #{success}.</p>
+            <button className="feedback-done-btn" onClick={onClose}>Close</button>
+          </div>
+        ) : (
+          <>
+            <h2>Send Feedback</h2>
+            <p className="feedback-subtitle">Help us improve Roots of the Valley</p>
+
+            <form className="feedback-form" onSubmit={handleSubmit}>
+              <div className="feedback-field">
+                <label>What kind of feedback?</label>
+                <div className="feedback-radio-group">
+                  {TYPES.map((t) => (
+                    <label key={t.value} className={`feedback-radio-label ${type === t.value ? 'selected' : ''}`}>
+                      <input
+                        type="radio"
+                        name="feedback-type"
+                        value={t.value}
+                        checked={type === t.value}
+                        onChange={() => setType(t.value)}
+                      />
+                      {t.label}
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="feedback-field">
+                <label htmlFor="feedback-message">Message</label>
+                <textarea
+                  id="feedback-message"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Tell us what's on your mind..."
+                  maxLength={1000}
+                  required
+                />
+                <span className={`feedback-char-count ${message.length > 900 ? 'near-limit' : ''}`}>
+                  {message.length}/1000
+                </span>
+              </div>
+
+              <div className="feedback-field">
+                <label htmlFor="feedback-name">Name <span className="field-optional">(optional)</span></label>
+                <input
+                  type="text"
+                  id="feedback-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Your name"
+                  maxLength={100}
+                />
+              </div>
+
+              <div className="feedback-field">
+                <label htmlFor="feedback-email">Email <span className="field-optional">(optional, if you'd like a response)</span></label>
+                <input
+                  type="email"
+                  id="feedback-email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                />
+              </div>
+
+              {/* Honeypot */}
+              <div className="feedback-hp" aria-hidden="true">
+                <input
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  value={hp}
+                  onChange={(e) => setHp(e.target.value)}
+                />
+              </div>
+
+              {error && <div className="feedback-error">{error}</div>}
+
+              <button type="submit" className="feedback-submit" disabled={submitting}>
+                {submitting ? 'Submitting...' : 'Send Feedback'}
+              </button>
+            </form>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default FeedbackForm;


### PR DESCRIPTION
## Summary
- Public feedback form accessible from Login/Account dropdown (no auth required)
- Submits bug reports, feature requests, and general feedback as GitHub Issues
- GitHub token configurable in Settings > Data Collection alongside other API keys
- Spam prevention: honeypot field + rate limiting (3/hr/IP)
- Issues auto-labeled (`bug`/`enhancement`/`feedback` + `user-submitted`)

Closes #217

## Test plan
- [x] Build passes
- [x] Feedback form opens from Login dropdown
- [x] Feedback form opens from Account dropdown (authenticated)
- [x] GitHub token saves in Data Collection settings
- [x] Submission creates labeled GitHub Issue (#340)
- [ ] Honeypot rejection
- [ ] Rate limiting
- [ ] Mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)