### PR TITLE
Add Test button for GitHub token

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -556,6 +556,33 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
   });
 
+  router.post('/settings/github-api-token/test', isAdmin, async (req, res) => {
+    try {
+      const result = await pool.query("SELECT value FROM admin_settings WHERE key = 'github_api_token'");
+      const token = result.rows[0]?.value;
+      if (!token) {
+        return res.json({ success: false, message: 'GitHub token is not configured' });
+      }
+
+      const response = await fetch('https://api.github.com/repos/crunchtools/rotv', {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
+      });
+
+      if (response.ok) {
+        res.json({ success: true, message: 'GitHub token is valid' });
+      } else {
+        res.json({ success: false, message: `GitHub API returned ${response.status}` });
+      }
+    } catch (error) {
+      console.error('Error testing GitHub token:', error);
+      res.status(500).json({ success: false, message: 'Failed to test token', error: error.message });
+    }
+  });
+
   // ============================================
   // AI Content Generation Routes (Gemini)
   // ============================================

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -42,6 +42,7 @@ function DataCollectionSettings() {
   const [githubToken, setGithubToken] = useState('');
   const [githubTokenSet, setGithubTokenSet] = useState(false);
   const [githubSaving, setGithubSaving] = useState(false);
+  const [githubTesting, setGithubTesting] = useState(false);
   const [githubResult, setGithubResult] = useState(null);
 
   // Playwright status state
@@ -323,6 +324,20 @@ function DataCollectionSettings() {
       } else { const error = await response.json(); throw new Error(error.error || 'Failed to save token'); }
     } catch (err) { setGithubResult({ type: 'error', message: `Save failed: ${err.message}` }); }
     finally { setGithubSaving(false); }
+  };
+
+  const handleTestGithubToken = async () => {
+    setGithubTesting(true); setGithubResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/github-api-token/test', { method: 'POST', credentials: 'include' });
+      const data = await response.json();
+      if (data.success) {
+        setGithubResult({ type: 'success', message: 'Test passed' });
+      } else {
+        setGithubResult({ type: 'error', message: data.message || 'Test failed' });
+      }
+    } catch (err) { setGithubResult({ type: 'error', message: `Test failed: ${err.message}` }); }
+    finally { setGithubTesting(false); }
   };
 
   const handleSaveTwitterCredentials = async () => {
@@ -869,7 +884,7 @@ function DataCollectionSettings() {
         </div>
 
         {/* GitHub API Token */}
-        <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid #e0e0e0' }}>
+        <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid #e0e0e0' , paddingBottom: '1.5rem' }}>
           <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>GitHub</h5>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
             <span className={`status-indicator ${githubTokenSet ? 'configured' : 'not-configured'}`}></span>
@@ -905,6 +920,10 @@ function DataCollectionSettings() {
             <button className="action-btn primary" onClick={handleSaveGithubToken} disabled={githubSaving || !githubToken.trim()}
               style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
               {githubSaving ? 'Saving...' : 'Save'}
+            </button>
+            <button className="action-btn secondary" onClick={handleTestGithubToken} disabled={githubTesting || !githubTokenSet}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {githubTesting ? 'Testing...' : 'Test'}
             </button>
           </div>
           <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>


### PR DESCRIPTION
## Summary
- Add Test button for GitHub API token (calls GET /repos/crunchtools/rotv to verify access)
- Match padding/spacing to other API key sections

Relates to #217

## Test plan
- [ ] Save and Test buttons both visible
- [ ] Test button validates token against GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)