### PR TITLE
feat: add About page and interactive guided tour (#212)

### DIFF
--- a/.specify/specs/010-onboarding-tour/plan.md
+++ b/.specify/specs/010-onboarding-tour/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: New User Onboarding — About Page & Interactive Tour
+
+> **Spec ID:** 010-onboarding-tour
+> **Status:** Planning
+> **Last Updated:** 2026-05-10
+> **Estimated Effort:** M
+
+## Summary
+
+Add an About tab to the main navigation and a custom guided tour overlay. Pure frontend — no backend or database changes. Three new React components, modifications to App.jsx for the tab and tour state, and CSS for the spotlight overlay effect.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌──────────────────────────────────────────┐
+│                App.jsx                    │
+│                                          │
+│   ┌──────────────────────────────────┐   │
+│   │  Header Nav (tabs)               │   │
+│   │  Map | Results | News | Events   │   │
+│   │  [About] | Login                 │   │
+│   └──────────────────────────────────┘   │
+│                                          │
+│   ┌──────────────────────────────────┐   │
+│   │  AboutPage (when activeTab =     │   │
+│   │  'about')                        │   │
+│   └──────────────────────────────────┘   │
+│                                          │
+│   ┌──────────────────────────────────┐   │
+│   │  GuidedTour (overlay, when       │   │
+│   │  tourActive = true)              │   │
+│   └──────────────────────────────────┘   │
+│                                          │
+│   ┌──────────────────────────────────┐   │
+│   │  TourPrompt (first visit only)   │   │
+│   └──────────────────────────────────┘   │
+└──────────────────────────────────────────┘
+```
+
+### Data Flow
+
+1. App.jsx checks localStorage for `rotv-tour-seen` on mount
+2. If not set → show TourPrompt modal
+3. User clicks "Take a Tour" → set tourActive state, dismiss prompt, set localStorage flag
+4. GuidedTour renders overlay with spotlight on current step's target element
+5. Steps 1-4 highlight map-related elements (map, zoom, overlays, POI sidebar tabs)
+6. Steps 5-8 highlight header nav tabs (Results, News, Events, Login)
+7. User clicks Next/End → advance or dismiss tour
+8. About tab click → render AboutPage with "Take a Tour" button (re-triggers tour)
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Tour positioning | getBoundingClientRect() | No library needed, target elements already exist |
+| Spotlight effect | CSS box-shadow on overlay | Single-div approach, performant |
+| State persistence | localStorage | Simple, no backend needed |
+| Tour steps config | Static array in GuidedTour | Easy to modify, no DB dependency |
+
+---
+
+## Implementation Steps
+
+### Phase 1: About Page
+
+- [ ] Create `AboutPage.jsx` component with ROTV description and feature list
+- [ ] Add "About" tab button to header nav in App.jsx (after Events, before Login)
+- [ ] Add `activeTab === 'about'` rendering block in App.jsx
+- [ ] Add route handling for `/about` path
+- [ ] Add About link to both login dropdown and user dropdown
+- [ ] Style the About page (CSS in App.css)
+
+### Phase 2: Tour Prompt
+
+- [ ] Create `TourPrompt.jsx` — modal overlay with "Take a Tour" / "Skip" buttons
+- [ ] Add localStorage check in App.jsx on mount
+- [ ] Wire prompt buttons to tour state and localStorage flag
+
+### Phase 3: Guided Tour
+
+- [ ] Create `GuidedTour.jsx` — overlay with spotlight and step pop-up
+- [ ] Define tour steps array with target selectors, titles, descriptions
+- [ ] Implement spotlight positioning using getBoundingClientRect()
+- [ ] Add Next/End Tour navigation
+- [ ] Handle window resize (reposition spotlight)
+- [ ] Add keyboard navigation (Escape to end, Enter for Next)
+- [ ] Add mobile-responsive positioning
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/components/AboutPage.jsx` | About page content and "Take a Tour" button |
+| `frontend/src/components/GuidedTour.jsx` | Tour overlay with spotlight and step navigation |
+| `frontend/src/components/TourPrompt.jsx` | First-visit modal offering the tour |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/App.jsx` | Add About tab, tour state, TourPrompt/GuidedTour rendering, localStorage check, /about route |
+| `frontend/src/App.css` | Styles for About page, tour overlay, spotlight, tour prompt modal |
+
+---
+
+## Database Migrations
+
+None required.
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Open app in incognito → verify tour prompt appears
+2. Click "Take a Tour" → verify all 8 steps highlight correct elements
+3. Click "End Tour" mid-way → verify tour dismisses
+4. Refresh → verify tour prompt does NOT reappear
+5. Navigate to About tab → verify content renders
+6. Click "Take a Tour" from About page → verify tour re-launches
+7. Test on mobile viewport (375px wide) → verify responsive layout
+8. Test keyboard navigation (Tab, Enter, Escape)
+
+---
+
+## Rollback Plan
+
+If issues are discovered:
+1. Revert the commits (pure frontend, no DB changes)
+2. No data migration needed
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Tour positioning broken on mobile | Med | Test multiple viewport sizes, use viewport-aware positioning |
+| Tour steps break if tab structure changes | Low | Steps reference stable class names/selectors |
+| Performance impact of overlay | Low | Use CSS-only spotlight (no canvas), lazy-load tour components |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-10 | Initial plan |

--- a/.specify/specs/010-onboarding-tour/spec.md
+++ b/.specify/specs/010-onboarding-tour/spec.md
@@ -1,0 +1,124 @@
+# Specification: New User Onboarding — About Page & Interactive Tour
+
+> **Spec ID:** 010-onboarding-tour
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-10
+
+## Overview
+
+First-time visitors to ROTV don't discover the interactive features (login, settings, trail status, news/events filtering). This spec adds two complementary onboarding mechanisms: a persistent "About" tab in the main navigation that explains what ROTV offers, and an optional guided tour that walks new users through each major section with numbered pop-ups.
+
+Source: Robbie Schneider feedback (April 11, 2026 email thread) — GitHub Issue #212.
+
+---
+
+## User Stories
+
+### Discovery
+
+**US-010-1: About Page**
+> As a new visitor, I want to read what ROTV is and what features are available so that I can understand the app before exploring.
+
+Acceptance Criteria:
+- [ ] "About" tab appears in main navigation (between Events and Settings/Login)
+- [ ] About page describes ROTV's purpose, key features, and how to get started
+- [ ] About page includes a "Take a Tour" button that launches the guided tour
+- [ ] About page is accessible without login
+
+**US-010-2: First-Visit Tour Prompt**
+> As a first-time visitor, I want to be offered a guided tour so that I can quickly learn what ROTV offers.
+
+Acceptance Criteria:
+- [ ] First-time visitors (no localStorage flag) see a tour prompt overlay
+- [ ] Prompt offers "Take a Tour" and "Skip" options
+- [ ] Dismissing the prompt sets a localStorage flag so it doesn't reappear
+- [ ] Tour can be re-triggered from the About page
+
+**US-010-3: Interactive Guided Tour**
+> As a visitor taking the tour, I want numbered pop-ups highlighting each major feature so that I understand how to use the app.
+
+Acceptance Criteria:
+- [ ] Tour highlights these areas in order: (1) Map interaction, (2) Zoom controls, (3) Results tab, (4) News tab, (5) Events tab, (6) POI & Boundary Overlays, (7) POI sidebar tabs (Info/News/Events/History/Associations), (8) Login/Settings, (9) Newsletter signup under Settings → General
+- [ ] Each step shows a numbered indicator, title, and brief description
+- [ ] "Next" button advances to the next step
+- [ ] "End Tour" button exits at any point
+- [ ] Tour automatically ends after the last step
+- [ ] Highlighted area is visually emphasized (spotlight/overlay effect)
+
+---
+
+## Data Model
+
+No database changes required. Tour state is stored in the browser via localStorage.
+
+---
+
+## API Endpoints
+
+No new API endpoints required. This is a purely frontend feature.
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `AboutPage` — Full-page content describing ROTV, with "Take a Tour" CTA
+- `GuidedTour` — Overlay component with step-by-step pop-ups and spotlight effect
+- `TourPrompt` — Modal shown to first-time visitors offering the tour
+
+### Tour Steps
+
+| Step | Target | Title | Description |
+|------|--------|-------|-------------|
+| 1 | Map area | Interactive Map | Pan, zoom, and click any point of interest to explore Cuyahoga Valley's history |
+| 2 | Zoom controls | Zoom In & Out | Use these controls to zoom the map and discover more detail |
+| 3 | Results tab | Browse Results | Results update as you zoom — see all points of interest in the current map view |
+| 4 | News tab | Park News | News updates with the map too — AI-curated from local sources about the valley |
+| 5 | Events tab | Upcoming Events | Events also follow the map — concerts, hikes, programs in your current view |
+| 6 | Map legend/overlays | POIs & Boundaries | Toggle point of interest types and boundary overlays to customize your view |
+| 7 | POI sidebar tabs | Explore a Place | When you click a POI, browse its Info, News, Events, History, and Associations |
+| 8 | Login button | Sign In | Log in to access settings, edit mode, and personalization |
+| 9 | Settings → General (newsletter) | Newsletter | Sign up for a weekly digest of news and events delivered to your inbox |
+
+### Design Constraints
+
+- Tour overlay must work on both desktop and mobile
+- Pop-ups should not obscure the element they're highlighting
+- Use existing ROTV color scheme and typography
+- No external tour library dependencies — keep it lightweight and custom
+
+---
+
+## Non-Functional Requirements
+
+**NFR-010-1: Performance**
+- Tour components should lazy-load (not in initial bundle for returning visitors)
+- localStorage check should happen synchronously to avoid flash
+
+**NFR-010-2: Accessibility**
+- Tour pop-ups must be keyboard-navigable (Tab, Enter, Escape to dismiss)
+- ARIA labels on tour elements
+
+---
+
+## Dependencies
+
+- None (purely frontend, no backend changes)
+
+---
+
+## Open Questions
+
+1. Should the About tab replace a tab position or be added as a new tab? (Recommend: add between Events and Login)
+2. Should the tour include the sidebar POI detail view? (Recommend: no, keep it to top-level navigation for v1)
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-10 | Initial draft |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13705,3 +13705,302 @@ button.feedback-link-inline {
     font-size: 1.4rem;
   }
 }
+
+/* ===========================================
+   About Page
+   =========================================== */
+
+.about-page {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.about-content h2 {
+  color: #2d6a4f;
+  font-size: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.about-tagline {
+  font-size: 1.1rem;
+  color: #555;
+  margin-bottom: 2rem;
+  font-style: italic;
+}
+
+.about-section {
+  margin-bottom: 2rem;
+}
+
+.about-section h3 {
+  color: #333;
+  font-size: 1.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.about-section p {
+  color: #444;
+  line-height: 1.6;
+}
+
+.about-features-list {
+  list-style: none;
+  padding: 0;
+}
+
+.about-features-list li {
+  padding: 0.5rem 0;
+  color: #444;
+  line-height: 1.5;
+  border-bottom: 1px solid #eee;
+}
+
+.about-features-list li:last-child {
+  border-bottom: none;
+}
+
+.about-features-list li strong {
+  color: #2d6a4f;
+}
+
+.about-tour-btn {
+  background: #2d6a4f;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.about-tour-btn:hover {
+  background: #1b4332;
+}
+
+.about-credits {
+  border-top: 1px solid #ddd;
+  padding-top: 1.5rem;
+}
+
+.about-credits a {
+  color: #2d6a4f;
+  text-decoration: none;
+}
+
+.about-credits a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .about-page {
+    padding: 1.5rem;
+  }
+
+  .about-content h2 {
+    font-size: 1.3rem;
+  }
+}
+
+/* ===========================================
+   Tour Prompt Modal
+   =========================================== */
+
+.tour-prompt-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10003;
+}
+
+.tour-prompt-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.tour-prompt-modal h3 {
+  color: #2d6a4f;
+  font-size: 1.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.tour-prompt-modal p {
+  color: #555;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.tour-prompt-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.tour-prompt-btn {
+  padding: 0.6rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: none;
+}
+
+.tour-prompt-start {
+  background: #2d6a4f;
+  color: white;
+}
+
+.tour-prompt-start:hover {
+  background: #1b4332;
+}
+
+.tour-prompt-skip {
+  background: #e9ecef;
+  color: #555;
+}
+
+.tour-prompt-skip:hover {
+  background: #dee2e6;
+}
+
+/* ===========================================
+   Guided Tour Overlay
+   =========================================== */
+
+.guided-tour-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10002;
+  pointer-events: all;
+}
+
+.guided-tour-backdrop {
+  pointer-events: none;
+}
+
+.guided-tour-backdrop-full {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  animation: tourFadeIn 0.9s ease-out;
+}
+
+.guided-tour-tooltip {
+  position: fixed;
+  background: white;
+  border-radius: 10px;
+  padding: 1.25rem;
+  width: 300px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  pointer-events: all;
+  z-index: 10003;
+  transition: top 0.3s ease-out, left 0.3s ease-out;
+}
+
+.guided-tour-tooltip.tour-hidden {
+  opacity: 0;
+  pointer-events: none;
+  transition: none;
+}
+
+.guided-tour-tooltip.tour-visible {
+  animation: tourFadeIn 0.9s ease-out;
+}
+
+@keyframes tourFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.guided-tour-step-indicator {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+}
+
+.guided-tour-title {
+  color: #2d6a4f;
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.guided-tour-description {
+  color: #444;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 1rem 0;
+}
+
+.guided-tour-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.guided-tour-btn {
+  padding: 0.4rem 0.9rem;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: none;
+}
+
+.guided-tour-next {
+  background: #2d6a4f;
+  color: white;
+}
+
+.guided-tour-next:hover {
+  background: #1b4332;
+}
+
+.guided-tour-end {
+  background: #e9ecef;
+  color: #555;
+}
+
+.guided-tour-end:hover {
+  background: #dee2e6;
+}
+
+.guided-tour-back {
+  background: transparent;
+  color: #888;
+}
+
+.guided-tour-back:hover {
+  color: #555;
+}
+
+@media (max-width: 768px) {
+  .guided-tour-tooltip {
+    width: calc(100vw - 40px);
+    max-width: 300px;
+    left: 50% !important;
+    transform: translateX(-50%) !important;
+    bottom: 20px !important;
+    top: auto !important;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,9 @@ import NewsPermalink from './components/NewsPermalink';
 import EventPermalink from './components/EventPermalink';
 import PrivacyPolicy from './components/PrivacyPolicy';
 import FeedbackForm from './components/FeedbackForm';
+import AboutPage from './components/AboutPage';
+import GuidedTour from './components/GuidedTour';
+import TourPrompt from './components/TourPrompt';
 
 // Default icon type IDs for initializing the filter
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'mtb-trailhead', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default', 'lighthouse', 'cemetery']);
@@ -132,6 +135,11 @@ function AppContent() {
   const [showUserDropdown, setShowUserDropdown] = useState(false);
   const [profileImageError, setProfileImageError] = useState(false);
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
+
+  // Tour state
+  const [showTourPrompt, setShowTourPrompt] = useState(false);
+  const [tourActive, setTourActive] = useState(false);
+  const [tourStep, setTourStep] = useState(0);
 
   // Router hooks
   const location = useLocation();
@@ -242,6 +250,66 @@ function AppContent() {
   // Known main tab paths — used to distinguish tab URLs from POI slugs
   const MAIN_TAB_PATHS = new Set(['results', 'news', 'events', 'settings', 'privacy']);
   const SIDEBAR_SUB_TABS = new Set(['info', 'news', 'events', 'history', 'associations']);
+
+  // Tour handlers
+  const startTour = useCallback(() => {
+    setShowTourPrompt(false);
+    setTourStep(0);
+    setTourActive(true);
+    localStorage.setItem('rotv-tour-seen', 'true');
+    // Switch to map view for tour start
+    setActiveTab('view');
+    setSelectedDestination(null);
+    setSelectedLinearFeature(null);
+    isProgrammaticNavigationRef.current = true;
+    navigate('/');
+  }, [navigate]);
+
+  const endTour = useCallback(() => {
+    setTourActive(false);
+    setTourStep(0);
+    // Return to map view
+    setActiveTab('view');
+    setSelectedDestination(null);
+    setSelectedLinearFeature(null);
+    isProgrammaticNavigationRef.current = true;
+    navigate('/');
+  }, [navigate]);
+
+  const handleTourStepAction = useCallback((action) => {
+    switch (action) {
+      case 'selectVisitorCenter': {
+        // Select Boston Mill Visitor Center to show sidebar tabs
+        setActiveTab('view');
+        const visitorCenter = destinations.find(d => d.name === 'Boston Mill Visitor Center');
+        if (visitorCenter) {
+          setSelectedDestination(visitorCenter);
+        }
+        break;
+      }
+      case 'showMapView': {
+        // Return to map view, clear POI selection
+        setActiveTab('view');
+        setSelectedDestination(null);
+        setSelectedLinearFeature(null);
+        isProgrammaticNavigationRef.current = true;
+        navigate('/');
+        break;
+      }
+      case 'showNewsletter': {
+        // Navigate to Settings -> Newsletter tab
+        if (isAuthenticated) {
+          setActiveTab('settings');
+          if (isAdmin) {
+            setSettingsTab('newsletter');
+          }
+          isProgrammaticNavigationRef.current = true;
+          navigate('/settings');
+        }
+        break;
+      }
+    }
+  }, [destinations, isAuthenticated, isAdmin, navigate]);
 
   // Helper to handle tab changes and clear MTB mode if needed
   const handleTabChange = useCallback((newTab) => {
@@ -432,7 +500,7 @@ function AppContent() {
     let poiSlug = null;
     const pathParts = window.location.pathname.split('/').filter(Boolean);
 
-    const mainTabPaths = ['results', 'news', 'events', 'settings'];
+    const mainTabPaths = ['results', 'news', 'events', 'settings', 'about'];
     const sidebarSubTabs = ['info', 'news', 'events', 'history', 'associations'];
 
     if (pathParts.length === 3 && (pathParts[1] === 'news' || pathParts[1] === 'events')) {
@@ -566,7 +634,7 @@ function AppContent() {
     const pathParts = location.pathname.split('/').filter(Boolean);
 
     // Handle main tab paths: /results, /news, /events, /settings
-    const mainTabPaths = ['results', 'news', 'events', 'settings'];
+    const mainTabPaths = ['results', 'news', 'events', 'settings', 'about'];
     if (pathParts.length === 1 && mainTabPaths.includes(pathParts[0])) {
       setActiveTab(pathParts[0]);
       if (selectedDestination || selectedLinearFeature) {
@@ -856,6 +924,27 @@ function AppContent() {
   useEffect(() => {
     refreshAllData();
   }, [refreshAllData]);
+
+  // Show tour prompt for first-time visitors
+  useEffect(() => {
+    if (!localStorage.getItem('rotv-tour-seen')) {
+      setShowTourPrompt(true);
+    }
+  }, []);
+
+  // Handle /tutorial/stepN URLs for testing
+  useEffect(() => {
+    const match = location.pathname.match(/^\/tutorial\/step(\d+)$/);
+    if (match && !tourActive) {
+      const stepNum = parseInt(match[1], 10) - 1;
+      if (stepNum >= 0 && stepNum <= 8) {
+        setTourStep(stepNum);
+        setTourActive(true);
+        setShowTourPrompt(false);
+        localStorage.setItem('rotv-tour-seen', 'true');
+      }
+    }
+  }, [location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Initialize visibleTypes from iconConfig ONCE after it loads from database
   // Use a ref to ensure this only runs once, not every time iconConfig changes
@@ -1575,6 +1664,8 @@ function AppContent() {
     return <PrivacyPolicy />;
   }
 
+
+
   return (
     <div className="app">
       <header className={`header ${activeTheme ? `theme-${activeTheme}` : ''} ${isNightMode ? 'theme-night' : ''}`}>
@@ -1620,6 +1711,12 @@ function AppContent() {
           >
             Events
           </button>
+          <button
+            className={`tab-btn ${activeTab === 'about' ? 'active' : ''}`}
+            onClick={() => handleTabChange('about')}
+          >
+            About
+          </button>
           {isAuthenticated && (
             <button
               className={`tab-btn ${activeTab === 'settings' ? 'active' : ''}`}
@@ -1659,6 +1756,12 @@ function AppContent() {
                       <span className="user-email-inline">{user?.email}</span>
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
+                    <button
+                      className="dropdown-item-inline privacy-link-inline"
+                      onClick={() => { setShowUserDropdown(false); handleTabChange('about'); }}
+                    >
+                      About
+                    </button>
                     <a
                       className="dropdown-item-inline privacy-link-inline"
                       href="https://buttondown.com/rotv/rss"
@@ -1734,6 +1837,12 @@ function AppContent() {
                         <path fill="#1877F2" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
                       </svg>
                       Continue with Facebook
+                    </button>
+                    <button
+                      className="privacy-link-inline"
+                      onClick={() => { setShowLoginDropdown(false); handleTabChange('about'); }}
+                    >
+                      About
                     </button>
                     <a
                       className="privacy-link-inline"
@@ -1849,6 +1958,12 @@ function AppContent() {
         </main>
       )}
 
+      {/* About tab content */}
+      {activeTab === 'about' && (
+        <main className="main-content-full">
+          <AboutPage onStartTour={startTour} />
+        </main>
+      )}
 
       {activeTab === 'settings' && (
         <main className="settings-content">
@@ -2145,6 +2260,27 @@ function AppContent() {
       </main>
       {showFeedbackForm && (
         <FeedbackForm onClose={() => setShowFeedbackForm(false)} />
+      )}
+
+      {/* Tour prompt for first-time visitors */}
+      {showTourPrompt && (
+        <TourPrompt
+          onStartTour={startTour}
+          onDismiss={() => {
+            setShowTourPrompt(false);
+            localStorage.setItem('rotv-tour-seen', 'true');
+          }}
+        />
+      )}
+
+      {/* Guided tour overlay */}
+      {tourActive && (
+        <GuidedTour
+          onEnd={endTour}
+          currentStep={tourStep}
+          setCurrentStep={setTourStep}
+          onStepAction={handleTourStepAction}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/AboutPage.jsx
+++ b/frontend/src/components/AboutPage.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+function AboutPage({ onStartTour }) {
+  return (
+    <main className="about-page">
+      <div className="about-content">
+        <h2>About Roots of The Valley</h2>
+        <p className="about-tagline">
+          An interactive map exploring the history, nature, and community of Cuyahoga Valley National Park.
+        </p>
+
+        <section className="about-section">
+          <h3>What is ROTV?</h3>
+          <p>
+            Roots of The Valley is a discovery engine for Cuyahoga Valley National Park and the surrounding area.
+            We aggregate news, events, trail conditions, and historical information from dozens of local sources
+            so you can find what&apos;s happening without searching everywhere yourself.
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h3>Features</h3>
+          <ul className="about-features-list">
+            <li>
+              <strong>Interactive Map</strong> &mdash; Browse 200+ points of interest including trails, historic sites, waterfalls, and more
+            </li>
+            <li>
+              <strong>Dynamic Results</strong> &mdash; The results list updates as you zoom and pan the map
+            </li>
+            <li>
+              <strong>Park News</strong> &mdash; AI-curated news from local sources, filtered to your map view
+            </li>
+            <li>
+              <strong>Events</strong> &mdash; Concerts, hikes, programs, and community events happening near you
+            </li>
+            <li>
+              <strong>POI & Boundary Overlays</strong> &mdash; Toggle point of interest types and park boundaries
+            </li>
+            <li>
+              <strong>Place Details</strong> &mdash; Click any POI for Info, News, Events, History, and Associations
+            </li>
+            <li>
+              <strong>Newsletter</strong> &mdash; Sign up for a weekly digest of news and events (requires login)
+            </li>
+          </ul>
+        </section>
+
+        <section className="about-section">
+          <h3>Get Started</h3>
+          <p>
+            New here? Take a quick guided tour to learn how ROTV works.
+          </p>
+          <button className="about-tour-btn" onClick={onStartTour}>
+            Take a Tour
+          </button>
+        </section>
+
+        <section className="about-section about-credits">
+          <h3>Credits</h3>
+          <p>
+            Built by <a href="https://crunchtools.com" target="_blank" rel="noopener noreferrer">Crunchtools</a>.
+            Feedback welcome &mdash; use the Send Feedback option in the menu.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default AboutPage;

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -1,0 +1,326 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+const TOUR_STEPS = [
+  {
+    selector: '.leaflet-container',
+    title: 'Interactive Map',
+    description: 'Pan, zoom, and click any point of interest to explore Cuyahoga Valley\'s history.',
+    position: 'center'
+  },
+  {
+    selector: '.zoom-locate-control',
+    title: 'Zoom In & Out',
+    description: 'Use these controls to zoom the map and discover more detail.',
+    position: 'right'
+  },
+  {
+    selector: '.header-tabs .tab-btn:nth-child(2)',
+    title: 'Browse Results',
+    description: 'Results update as you zoom \u2014 see all points of interest in the current map view.',
+    position: 'bottom',
+    padding: 2
+  },
+  {
+    selector: '.tab-btn:nth-child(3)',
+    title: 'Park News',
+    description: 'News updates with the map too \u2014 curated from local sources about the valley.',
+    position: 'bottom',
+    padding: 2
+  },
+  {
+    selector: '.tab-btn:nth-child(4)',
+    title: 'Upcoming Events',
+    description: 'Events also follow the map \u2014 concerts, hikes, programs in your current view.',
+    position: 'bottom',
+    padding: 2
+  },
+  {
+    selector: '.legend',
+    title: 'POIs & Boundaries',
+    description: 'Toggle point of interest types and boundary overlays to customize your view.',
+    position: 'right'
+  },
+  {
+    selector: '.sidebar-tabs .sidebar-tab',
+    title: 'Explore a Place',
+    description: 'When you click a POI, browse its Info, News, Events, History, and Associations.',
+    position: 'left',
+    action: 'selectVisitorCenter',
+    delay: 400,
+    spotlightSelector: '.sidebar-tabs'
+  },
+  {
+    selector: '.tab-account-container',
+    title: 'Sign In',
+    description: 'Log in to access settings, edit mode, and personalization.',
+    position: 'bottom-left',
+    action: 'showMapView'
+  },
+  {
+    selector: '.newsletter-form .save-settings-btn',
+    title: 'Newsletter',
+    description: 'Sign up for a weekly digest of news and events delivered to your inbox.',
+    position: 'right',
+    action: 'showNewsletter',
+    delay: 100
+  }
+];
+
+// Pure function — compute spotlight rect and tooltip position from a step and its DOM element
+function computePosition(step, el) {
+  if (!el) {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    return {
+      spotlightRect: null,
+      tooltipStyle: { top: `${vh / 2 - 90}px`, left: `${vw / 2 - 150}px` }
+    };
+  }
+
+  // Scroll into view if needed (only for non-map elements like settings forms)
+  const elRect = el.getBoundingClientRect();
+  const isOffScreen = elRect.top < 0 || elRect.bottom > window.innerHeight;
+  const isInSettingsPanel = el.closest('.settings-content');
+  if (isOffScreen && isInSettingsPanel) {
+    el.scrollIntoView({ behavior: 'instant', block: 'center' });
+  }
+
+  const rect = el.getBoundingClientRect();
+  const padding = step.padding !== undefined ? step.padding : 8;
+  const spotlight = {
+    top: rect.top - padding,
+    left: rect.left - padding,
+    width: rect.width + padding * 2,
+    height: rect.height + padding * 2
+  };
+
+  if (step.position === 'center') {
+    const cvw = window.innerWidth;
+    const cvh = window.innerHeight;
+    return {
+      spotlightRect: spotlight,
+      tooltipStyle: { top: `${cvh / 2 - 90}px`, left: `${cvw / 2 - 150}px` }
+    };
+  }
+
+  const tooltipWidth = 300;
+  const tooltipHeight = 180;
+  const gap = 16;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let top, left;
+
+  switch (step.position) {
+    case 'bottom':
+      top = spotlight.top + spotlight.height + gap;
+      left = spotlight.left + spotlight.width / 2 - tooltipWidth / 2;
+      break;
+    case 'bottom-right':
+      top = spotlight.top + spotlight.height + gap;
+      left = Math.min(spotlight.left + spotlight.width / 2, vw - tooltipWidth - 20);
+      break;
+    case 'bottom-left':
+      top = spotlight.top + spotlight.height + gap;
+      left = Math.max(20, spotlight.left + spotlight.width / 2 - tooltipWidth);
+      break;
+    case 'top':
+      top = spotlight.top - tooltipHeight - gap;
+      left = spotlight.left + spotlight.width / 2 - tooltipWidth / 2;
+      break;
+    case 'left':
+      top = spotlight.top + spotlight.height / 2 - tooltipHeight / 2;
+      left = spotlight.left - tooltipWidth - gap;
+      break;
+    case 'right':
+      top = spotlight.top + spotlight.height / 2 - tooltipHeight / 2;
+      left = spotlight.left + spotlight.width + gap;
+      break;
+    default:
+      top = spotlight.top + spotlight.height + gap;
+      left = spotlight.left;
+  }
+
+  // Clamp to viewport
+  if (top + tooltipHeight > vh - 20) {
+    top = Math.min(spotlight.top + spotlight.height - tooltipHeight - gap, vh - tooltipHeight - 20);
+    top = Math.max(20, top);
+  }
+  if (top < 20) top = 20;
+  if (left + tooltipWidth > vw - 20) left = vw - tooltipWidth - 20;
+  if (left < 20) left = 20;
+
+  return { spotlightRect: spotlight, tooltipStyle: { top: `${top}px`, left: `${left}px` } };
+}
+
+function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction }) {
+  const [spotlightRect, setSpotlightRect] = useState(null);
+  const [tooltipStyle, setTooltipStyle] = useState({});
+  const [stepReady, setStepReady] = useState(true);
+  const resizeRef = useRef(null);
+  const prevStepRef = useRef(-1);
+
+  const step = TOUR_STEPS[currentStep];
+
+  // Apply positioning from a step
+  const applyPosition = useCallback((s) => {
+    const spotlightEl = s.spotlightSelector ? document.querySelector(s.spotlightSelector) : null;
+    const el = spotlightEl || document.querySelector(s.selector);
+    const result = computePosition(s, el);
+    setSpotlightRect(result.spotlightRect);
+    setTooltipStyle(result.tooltipStyle);
+  }, []);
+
+  // Single effect for step transitions — handles actions, delays, and positioning
+  useEffect(() => {
+    if (!step) return;
+    let cancelled = false;
+    const timers = [];
+
+    // Fire action on step entry (only once per step)
+    if (prevStepRef.current !== currentStep) {
+      prevStepRef.current = currentStep;
+
+      if (step.action && onStepAction) {
+        onStepAction(step.action);
+      }
+    }
+
+    if (step.delay) {
+      // Hide everything until element is found and layout is stable
+      setStepReady(false);
+      setSpotlightRect(null);
+
+      // Poll until element appears and position is stable
+      let retryCount = 0;
+      let lastTop = null;
+      let stableCount = 0;
+      const poll = () => {
+        if (cancelled) return;
+        const targetSelector = step.spotlightSelector || step.selector;
+        const el = document.querySelector(targetSelector);
+        if (el) {
+          const rect = el.getBoundingClientRect();
+          // Wait until the element position is stable (not moving from animations)
+          if (lastTop !== null && Math.abs(rect.top - lastTop) < 2) {
+            stableCount++;
+          } else {
+            stableCount = 0;
+          }
+          lastTop = rect.top;
+          if (stableCount >= 2) {
+            applyPosition(step);
+            setStepReady(true);
+            return;
+          }
+          timers.push(setTimeout(poll, 80));
+        } else if (retryCount < 30) {
+          retryCount++;
+          timers.push(setTimeout(poll, 50));
+        } else {
+          applyPosition(step);
+          setStepReady(true);
+        }
+      };
+      timers.push(setTimeout(poll, step.delay));
+    } else {
+      // Immediate positioning
+      setStepReady(true);
+      applyPosition(step);
+    }
+
+    // Resize handler
+    const handleResize = () => {
+      if (resizeRef.current) cancelAnimationFrame(resizeRef.current);
+      resizeRef.current = requestAnimationFrame(() => applyPosition(step));
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelled = true;
+      timers.forEach(t => clearTimeout(t));
+      window.removeEventListener('resize', handleResize);
+      if (resizeRef.current) cancelAnimationFrame(resizeRef.current);
+    };
+  }, [currentStep, step, onStepAction, applyPosition]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onEnd();
+      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        if (currentStep < TOUR_STEPS.length - 1) {
+          setCurrentStep(currentStep + 1);
+        } else {
+          onEnd();
+        }
+      } else if (e.key === 'ArrowLeft' && currentStep > 0) {
+        setCurrentStep(currentStep - 1);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [currentStep, setCurrentStep, onEnd]);
+
+  if (!step) return null;
+
+  const isLastStep = currentStep === TOUR_STEPS.length - 1;
+
+  return (
+    <div className="guided-tour-overlay" aria-label="Guided tour" role="dialog">
+      {spotlightRect && stepReady && (
+        <div
+          className="guided-tour-backdrop"
+          style={{
+            boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 0 2px rgba(255, 255, 255, 0.3) inset',
+            position: 'fixed',
+            top: `${spotlightRect.top}px`,
+            left: `${spotlightRect.left}px`,
+            width: `${spotlightRect.width}px`,
+            height: `${spotlightRect.height}px`,
+            borderRadius: '8px',
+            pointerEvents: 'none',
+            zIndex: 10002
+          }}
+        />
+      )}
+      {!spotlightRect && stepReady && (
+        <div className="guided-tour-backdrop-full" />
+      )}
+
+      <div
+        className={`guided-tour-tooltip ${stepReady ? 'tour-visible' : 'tour-hidden'}`}
+        style={tooltipStyle}
+        role="alertdialog"
+        aria-label={step.title}
+      >
+        <div className="guided-tour-step-indicator">
+          {currentStep + 1} of {TOUR_STEPS.length}
+        </div>
+        <h4 className="guided-tour-title">{step.title}</h4>
+        <p className="guided-tour-description">{step.description}</p>
+        <div className="guided-tour-actions">
+          {currentStep > 0 && (
+            <button className="guided-tour-btn guided-tour-back" onClick={() => setCurrentStep(currentStep - 1)}>
+              Back
+            </button>
+          )}
+          <button className="guided-tour-btn guided-tour-end" onClick={onEnd}>
+            End Tour
+          </button>
+          {!isLastStep ? (
+            <button className="guided-tour-btn guided-tour-next" onClick={() => setCurrentStep(currentStep + 1)}>
+              Next
+            </button>
+          ) : (
+            <button className="guided-tour-btn guided-tour-next" onClick={onEnd}>
+              Finish
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GuidedTour;

--- a/frontend/src/components/TourPrompt.jsx
+++ b/frontend/src/components/TourPrompt.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+function TourPrompt({ onStartTour, onDismiss }) {
+  return (
+    <div className="tour-prompt-overlay">
+      <div className="tour-prompt-modal">
+        <h3>Welcome to Roots of The Valley!</h3>
+        <p>
+          Would you like a quick tour to learn how the app works?
+        </p>
+        <div className="tour-prompt-actions">
+          <button className="tour-prompt-btn tour-prompt-start" onClick={onStartTour}>
+            Take a Tour
+          </button>
+          <button className="tour-prompt-btn tour-prompt-skip" onClick={onDismiss}>
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TourPrompt;


### PR DESCRIPTION
## Summary
- Adds persistent **About** tab in main navigation with ROTV description and feature list
- Adds **9-step interactive guided tour** with spotlight overlay for first-time visitors
- Tour steps: Interactive Map → Zoom → Results → News → Events → POIs & Boundaries → Explore a Place (auto-selects Boston Mill Visitor Center) → Sign In → Newsletter signup
- First-visit tour prompt via localStorage detection
- Tour re-triggerable from About page
- Keyboard navigation (Enter/Arrow/Escape)
- Smooth CSS transitions between steps, fade-in for delayed steps
- `/tutorial/stepN` URLs for testing individual steps

Closes #212

## Test plan
- [ ] Open in incognito — tour prompt appears
- [ ] Click "Take a Tour" — all 9 steps work with correct spotlight positioning
- [ ] Step 7 auto-selects Boston Mill Visitor Center and highlights sidebar tabs
- [ ] Step 9 navigates to Settings → Newsletter (when logged in)
- [ ] Click "Skip" — prompt dismissed, doesn't reappear on refresh
- [ ] About tab renders with feature list and "Take a Tour" button
- [ ] Tour works on mobile viewport
- [ ] Keyboard nav: Enter=Next, Arrow keys, Escape=End

🤖 Generated with [Claude Code](https://claude.com/claude-code)