### PR TITLE
fix: small interface bugs (#346)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4748,7 +4748,8 @@ body {
 
 .main-content-full .park-news-tab,
 .main-content-full .park-events-tab,
-.main-content-full .results-tab-wrapper {
+.main-content-full .results-tab-wrapper,
+.main-content-full .about-page {
   flex: 0 0 auto; /* Allow content to grow naturally for scrolling */
   min-height: min-content;
   width: 100%;
@@ -4769,7 +4770,8 @@ body {
 
   .main-content-full .park-news-tab,
   .main-content-full .park-events-tab,
-  .main-content-full .results-tab-wrapper {
+  .main-content-full .results-tab-wrapper,
+  .main-content-full .about-page {
     padding: 1rem;
     border-radius: 8px;
   }
@@ -13746,11 +13748,7 @@ button.feedback-link-inline {
    =========================================== */
 
 .about-page {
-  max-width: 700px;
-  margin: 0 auto;
-  padding: 0;
   overflow-y: auto;
-  flex: 1;
 }
 
 .about-content h2 {
@@ -13831,10 +13829,6 @@ button.feedback-link-inline {
 }
 
 @media (max-width: 768px) {
-  .about-page {
-    padding: 1.5rem;
-  }
-
   .about-content h2 {
     font-size: 1.3rem;
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -74,7 +74,6 @@ function AppContent() {
   const visiblePoiCount = visiblePoiIds.length;
 
   // Layer visibility states (lifted from Map component for unified control)
-  const [showNpsMap, setShowNpsMap] = useState(false);
   const [showTrails, setShowTrails] = useState(true);
   const [showRivers, setShowRivers] = useState(true);
   const [visibleBoundaries, setVisibleBoundaries] = useState(new Set()); // Set of boundary IDs
@@ -1845,12 +1844,6 @@ function AppContent() {
                       <span className="user-email-inline">{user?.email}</span>
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
-                    <button
-                      className="dropdown-item-inline privacy-link-inline"
-                      onClick={() => { setShowUserDropdown(false); handleTabChange('about'); }}
-                    >
-                      About
-                    </button>
                     <a
                       className="dropdown-item-inline privacy-link-inline"
                       href="https://buttondown.com/rotv/rss"
@@ -1938,12 +1931,6 @@ function AppContent() {
                         <path fill="#1877F2" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
                       </svg>
                       Continue with Facebook
-                    </button>
-                    <button
-                      className="privacy-link-inline"
-                      onClick={() => { setShowLoginDropdown(false); handleTabChange('about'); }}
-                    >
-                      About
                     </button>
                     <a
                       className="privacy-link-inline"
@@ -2245,8 +2232,6 @@ function AppContent() {
           onVisibleTypesChange={setVisibleTypes}
           onVisiblePoisChange={setVisiblePoiIds}
           onMapStateChange={setMapState}
-          showNpsMap={showNpsMap}
-          onToggleNpsMap={setShowNpsMap}
           showTrails={showTrails}
           onToggleTrails={setShowTrails}
           showRivers={showRivers}
@@ -2262,7 +2247,7 @@ function AppContent() {
             return next;
           })}
           onShowAllBoundaries={() => {
-            const boundaryIds = linearFeatures.filter(f => f.feature_type === 'boundary').map(f => f.id);
+            const boundaryIds = linearFeatures.filter(f => f.poi_roles?.includes('boundary') && !['county', 'state'].includes(f.boundary_type)).map(f => f.id);
             setVisibleBoundaries(new Set(boundaryIds));
           }}
           onHideAllBoundaries={() => setVisibleBoundaries(new Set())}
@@ -2368,8 +2353,6 @@ function AppContent() {
           onSelectLinearFeature={handleSelectLinearFeature}
           onAssociationsChanged={refreshAllData}
           onStartDrawingAssociations={handleStartDrawingAssociations}
-          showNpsMap={showNpsMap}
-          onToggleNpsMap={setShowNpsMap}
           permalinkInfo={permalinkInfo}
           onSetPermalink={setPermalinkInfo}
           onClearPermalink={() => setPermalinkInfo(null)}

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { MapContainer, TileLayer, Marker, Tooltip, useMap, ImageOverlay, GeoJSON, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
-import MapAdmin from './MapAdmin';
 import VirtualPoiCreator from './VirtualPoiCreator';
 import { getDestinationIconTypeFromConfig } from '../utils/iconUtils';
 
@@ -47,7 +46,6 @@ const DEFAULT_ZOOM = 11;
 
 function Legend({
   // Layer toggles
-  showNpsMap, onToggleNpsMap,
   showTrails, onToggleTrails,
   showRivers, onToggleRivers,
   // Boundary controls - individual toggles
@@ -188,15 +186,6 @@ function Legend({
           )}
         </div>
         <div className="boundary-chips">
-          {/* NPS Map overlay chip */}
-          <button
-            className={`boundary-chip nps-map-chip ${showNpsMap ? 'active' : 'inactive'}`}
-            onClick={() => onToggleNpsMap(!showNpsMap)}
-            title="NPS Park Map Overlay"
-          >
-            <span className="boundary-chip-icon">🗺️</span>
-            <span className="boundary-chip-name">NPS Map</span>
-          </button>
           {/* Individual boundary chips */}
           {boundaries && boundaries.map(boundary => (
             <button
@@ -477,7 +466,7 @@ function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, 
             isLayerVisible = showTrails;
           } else if (feature.feature_type === 'river') {
             isLayerVisible = showRivers;
-          } else if (feature.feature_type === 'boundary') {
+          } else if (feature.poi_roles?.includes('boundary')) {
             isLayerVisible = visibleBoundaries.has(feature.id);
           }
 
@@ -937,22 +926,11 @@ function CoordinateConfirmDialog({ destination, newLat, newLng, onConfirm, onCan
   );
 }
 
-// NPS Park Map overlay default bounds for cropped image (legend removed)
-// Manually calibrated to align Boston Mill Visitor Center and Route 8
-// These coordinates define the corners of the map image: [[south, west], [north, east]]
-const DEFAULT_NPS_MAP_BOUNDS = [
-  [41.1390, -81.6654],  // Southwest corner
-  [41.4226, -81.4706]   // Northeast corner
-];
-
 // Default icon type IDs for initializing the filter (before config loads)
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default']);
 
-function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, selectedLinearFeature, onSelectLinearFeature, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showNpsMap, onToggleNpsMap, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowAllBoundaries, onHideAllBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, visiblePoiCount, iconConfig }) {
-  const [showAdmin, setShowAdmin] = useState(false);
+function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, selectedLinearFeature, onSelectLinearFeature, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowAllBoundaries, onHideAllBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, visiblePoiCount, iconConfig }) {
   const [isLegendExpanded, setIsLegendExpanded] = useState(false);
-  const [mapBounds, setMapBounds] = useState(DEFAULT_NPS_MAP_BOUNDS);
-  const [overlayOpacity, setOverlayOpacity] = useState(1.0);
   const [useSatellite, setUseSatellite] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState(null); // Just for UI display
   const [importType, setImportType] = useState('trail');
@@ -1178,7 +1156,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         opacity: isSelected ? 1 : 0.8,
         color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#1E90FF'
       };
-    } else if (feature.feature_type === 'boundary') {
+    } else if (feature.poi_roles?.includes('boundary')) {
       // Park boundaries - use per-boundary color from database
       // Note: invisible hit area layer handles click detection, so stroke can be thin
       const boundaryColor = feature.boundary_color || '#228B22';
@@ -1235,22 +1213,13 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
           />
         )}
 
-        {/* NPS Park Map overlay - rendered first so markers appear on top */}
-        {showNpsMap && (
-          <ImageOverlay
-            url="/data/cvnp-map-cropped.jpg"
-            bounds={mapBounds}
-            opacity={overlayOpacity}
-            zIndex={100}
-          />
-        )}
 
         {/* Clickable linear features - split by type for independent toggle control */}
         {linearFeatures && linearFeatures.map(feature => {
           // Check visibility based on feature type
           const isVisible = (feature.feature_type === 'trail' && showTrails) ||
                            (feature.feature_type === 'river' && showRivers) ||
-                           (feature.feature_type === 'boundary' && visibleBoundaries.has(feature.id));
+                           (feature.poi_roles?.includes('boundary') && visibleBoundaries.has(feature.id));
           if (!isVisible) return null;
 
           const isSelected = selectedLinearFeature?.id === feature.id;
@@ -1261,7 +1230,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
           };
 
           // For boundaries, render TWO layers: invisible hit area + visible styled line
-          if (feature.feature_type === 'boundary') {
+          if (feature.poi_roles?.includes('boundary')) {
             return (
               <React.Fragment key={`boundary-${feature.id}-${isSelected}-${editMode}-${hasAnySelection}-${feature.updated_at}`}>
                 {/* Invisible wide hit area for click/hover detection - stroke only */}
@@ -1553,8 +1522,6 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
       />
 
       <Legend
-        showNpsMap={showNpsMap}
-        onToggleNpsMap={onToggleNpsMap}
         showTrails={showTrails}
         onToggleTrails={onToggleTrails}
         showRivers={showRivers}
@@ -1563,7 +1530,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         onToggleBoundary={onToggleBoundary}
         onShowAllBoundaries={onShowAllBoundaries}
         onHideAllBoundaries={onHideAllBoundaries}
-        boundaries={linearFeatures.filter(f => f.feature_type === 'boundary')}
+        boundaries={linearFeatures.filter(f => f.poi_roles?.includes('boundary') && !['county', 'state'].includes(f.boundary_type))}
         visibleTypes={visibleTypes}
         onToggleType={handleToggleType}
         onShowAll={handleShowAll}
@@ -1575,7 +1542,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         editMode={editMode}
         activeTab={activeTab}
         iconConfig={iconConfig}
-        onOpenAdmin={() => setShowAdmin(true)}
+        onOpenAdmin={() => {}}
         onFileSelect={handleFileSelect}
         selectedFileName={selectedFileName}
         importType={importType}
@@ -1585,20 +1552,6 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         importMessage={importMessage}
         onDismissMessage={handleDismissMessage}
       />
-      {showAdmin && (
-        <MapAdmin
-          bounds={{
-            south: mapBounds[0][0],
-            west: mapBounds[0][1],
-            north: mapBounds[1][0],
-            east: mapBounds[1][1]
-          }}
-          onBoundsChange={setMapBounds}
-          onClose={() => setShowAdmin(false)}
-          opacity={overlayOpacity}
-          onOpacityChange={setOverlayOpacity}
-        />
-      )}
       {pendingUpdate && (
         <CoordinateConfirmDialog
           destination={pendingUpdate.destination}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -210,7 +210,7 @@ function EditableCellSignal({ level, onChange }) {
 }
 
 // Read-only view component - works for both destinations and linear features
-function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, _showNpsMap, _onToggleNpsMap, onCollectStatus }) {
+function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, onCollectStatus }) {
   return (
     <div className="view-container">
       <div className="view-scroll">
@@ -2405,7 +2405,7 @@ function TrailStatus({ poiId, _poiName, isAdmin, editMode, _selectedFromMtbList,
   );
 }
 
-function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, onClose, isAdmin, user, editMode, onDestinationUpdate, onDestinationDelete, onSaveNewPOI, onCancelNewPOI, onSaveNewOrganization, onCancelNewOrganization, previewCoords, onPreviewCoordsChange, linearFeature, onLinearFeatureUpdate, onLinearFeatureDelete, onNavigate, currentIndex, totalCount, poiNavigationList, associations, allDestinations, allLinearFeatures, allVirtualPois, onSelectDestination, onSelectLinearFeature, onAssociationsChanged, onStartDrawingAssociations, isInMtbMode, selectedFromMtbList, mtbTrailsList, currentMtbIndex, onNavigateMtbTrail, onBackToMtbList, showNpsMap, onToggleNpsMap, permalinkInfo, onSetPermalink, onClearPermalink, initialSidebarTab, onSidebarTabChange }) {
+function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, onClose, isAdmin, user, editMode, onDestinationUpdate, onDestinationDelete, onSaveNewPOI, onCancelNewPOI, onSaveNewOrganization, onCancelNewOrganization, previewCoords, onPreviewCoordsChange, linearFeature, onLinearFeatureUpdate, onLinearFeatureDelete, onNavigate, currentIndex, totalCount, poiNavigationList, associations, allDestinations, allLinearFeatures, allVirtualPois, onSelectDestination, onSelectLinearFeature, onAssociationsChanged, onStartDrawingAssociations, isInMtbMode, selectedFromMtbList, mtbTrailsList, currentMtbIndex, onNavigateMtbTrail, onBackToMtbList, permalinkInfo, onSetPermalink, onClearPermalink, initialSidebarTab, onSidebarTabChange }) {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
   const [editedData, setEditedData] = useState({});
@@ -3270,8 +3270,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
                 onShare={() => setShowShareModal(true)}
                 moreInfoLink={linearFeature.more_info_link}
                 trailStatus={trailStatus}
-                showNpsMap={showNpsMap}
-                onToggleNpsMap={onToggleNpsMap}
                 onCollectStatus={handleCollectStatusInline}
               />
             )
@@ -3580,8 +3578,6 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
               onShare={() => setShowShareModal(true)}
               moreInfoLink={destination.more_info_link}
               trailStatus={trailStatus}
-              showNpsMap={showNpsMap}
-              onToggleNpsMap={onToggleNpsMap}
               onCollectStatus={handleCollectStatusInline}
             />
           )


### PR DESCRIPTION
## Summary
- Filter boundaries panel to exclude county/state, use `poi_roles` array to catch dual-role POIs (City of Akron, City of Cleveland, etc.)
- Remove NPS map overlay entirely (image never existed in repo or production)
- Remove duplicate About link from login/user dropdowns
- Add About page to shared content panel CSS for consistent rounded-card styling

Closes #346

## Test plan
- [x] Boundaries panel shows cities + park only (13 boundaries, no counties/state)
- [x] No NPS Map chip in boundaries panel
- [x] No About link in login or user dropdown menus
- [x] About tab has white card with rounded corners matching News/Events
- [x] Build passes, test suite same as master (15 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)