### PR TITLE
feat: improved About page with sub-tabs (#347)

### DIFF
--- a/.specify/specs/011-improved-about-page/spec.md
+++ b/.specify/specs/011-improved-about-page/spec.md
@@ -1,0 +1,146 @@
+# Specification: Improved About Page
+
+> **Spec ID:** 011-improved-about-page
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-11
+
+## Overview
+
+Transform the About tab from a single static page into a sub-tabbed experience matching the pattern used by Results/Events/Settings. Consolidates Story, Tutorial, Feedback, and Privacy into one place, removes Settings from the main tab bar, and moves it under the Login button.
+
+---
+
+## User Stories
+
+### Navigation
+
+**US-001: Sub-tab Navigation**
+> As a user, I want the About page to have sub-tabs so that I can find Story, Tutorial, Feedback, and Privacy content without hunting through menus.
+
+Acceptance Criteria:
+- [ ] About tab renders sub-tabs: Story | Tutorial | Send Feedback | Privacy Policy
+- [ ] Sub-tabs use roving tabindex for keyboard navigation (Tab moves focus to active sub-tab, arrow keys move between sub-tabs)
+- [ ] Active sub-tab is visually indicated and persists during the session
+- [ ] Default sub-tab on first visit is Story
+
+**US-002: Settings Relocation**
+> As a user, I want Settings accessible from the Login/Account menu so that the main tab bar stays focused on content discovery.
+
+Acceptance Criteria:
+- [ ] Settings is removed from the main tab row
+- [ ] Settings link appears in the Login/Account dropdown (for authenticated users)
+- [ ] Settings page still functions identically (General, Newsletter, Admin sub-tabs)
+
+**US-003: RSS Feed in Settings**
+> As a user, I want to find the RSS feed link in Settings alongside Newsletter so that subscription options are grouped together.
+
+Acceptance Criteria:
+- [ ] New "RSS Feed" sub-tab appears to the right of Newsletter in Settings
+- [ ] RSS sub-tab shows the Buttondown RSS link with a brief description
+- [ ] RSS link removed from Login/Account dropdown
+
+### Content
+
+**US-004: Story Sub-tab**
+> As a visitor, I want to read about what ROTV is and why it exists so that I understand the project's purpose and community roots.
+
+Acceptance Criteria:
+- [ ] Story content focuses on: the problem (fragmented info), the solution (living map), and the open source community ethos
+- [ ] Content is concise (fits in one scroll on desktop)
+- [ ] No FAQ — just the narrative
+
+**US-005: Tutorial Sub-tab**
+> As a new user, I want to launch the guided tour from the About page so that I can learn how to use the map.
+
+Acceptance Criteria:
+- [ ] Tutorial sub-tab shows brief intro text and a "Take a Tour" button
+- [ ] Clicking the button starts the existing GuidedTour
+
+**US-006: Send Feedback Sub-tab**
+> As a user, I want to send feedback directly from the About page so that I don't need to find it in a dropdown menu.
+
+Acceptance Criteria:
+- [ ] Renders the existing FeedbackForm component inline
+- [ ] Feedback link removed from Login/Account dropdown (About tab is the canonical location)
+
+**US-007: Privacy Policy Sub-tab**
+> As a user, I want to read the privacy policy within the About page so that legal information is easy to find.
+
+Acceptance Criteria:
+- [ ] Renders the existing PrivacyPolicy component inline
+- [ ] Privacy Policy link removed from Login/Account dropdown
+
+---
+
+## UI/UX Requirements
+
+### Sub-tab Layout
+
+```
+[Story] [Tutorial] [Send Feedback] [Privacy Policy]
+─────────────────────────────────────────────────────
+| Content area (scrollable)                          |
+|                                                    |
+└────────────────────────────────────────────────────┘
+```
+
+- Sub-tabs should match the visual pattern of Settings sub-tabs (horizontal row, active underline, same font/spacing)
+- Content area scrolls independently within the card
+- On mobile, sub-tab labels can abbreviate if needed (e.g., "Story", "Tour", "Feedback", "Privacy")
+
+### Main Tab Bar Change
+
+Before: `Results | News | Events | About | Settings`
+After: `Results | News | Events | About`
+
+### Login/Account Dropdown Change
+
+Before: `RSS Feed | Privacy Policy | Send Feedback`
+After: `Settings | Send Feedback` (Send Feedback stays as a quick shortcut)
+
+Wait — per the issue, Send Feedback moves INTO About. Let me revise:
+
+After (logged in): `Settings`
+After (not logged in): _(just login buttons)_
+
+Actually, re-reading the issue: "Move Settings tab to an entry under the Login button." So:
+
+After (logged in dropdown): `[user info] | Settings | Logout`
+After (login dropdown): `[Google] [Facebook]`
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Accessibility**
+- Roving tabindex on About sub-tabs (matches existing implementation in Settings)
+- All sub-tab panels are `role="tabpanel"` with proper `aria-labelledby`
+
+**NFR-002: URL Routing**
+- `/about` defaults to Story sub-tab
+- `/about/story`, `/about/tutorial`, `/about/feedback`, `/about/privacy` are deep-linkable
+
+---
+
+## Dependencies
+
+- Depends on: #215 (roving tabindex implementation — already merged)
+- Depends on: #212 (guided tour — already merged)
+- Depends on: #217 (feedback form — already merged)
+
+---
+
+## Resolved Questions
+
+1. **Send Feedback** — fully moves into About page. No shortcut in dropdown.
+2. **Story content** — approved. See `story-draft.md` in this spec directory.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-11 | Initial draft |

--- a/.specify/specs/011-improved-about-page/story-draft.md
+++ b/.specify/specs/011-improved-about-page/story-draft.md
@@ -1,0 +1,25 @@
+# Story Content (Approved)
+
+## One Map for Everything Happening in the Cuyahoga Valley
+
+The Cuyahoga Valley has over 300 parks, trailheads, preserves, and landmarks, but the information about them is scattered across dozens of websites run by the National Park Service, Cleveland Metroparks, Summit Metro Parks, and countless other organizations. A mountain biker checking whether trails are rideable might need to check TrailForks, Twitter, and two different park district websites. A family looking for weekend activities doesn't have time to visit dozens of event calendars.
+
+The result: people stick to what they already know and miss 95% of what the valley offers.
+
+**Roots of the Valley fixes that.** We traverse the deepest corners of the web to aggregate news, events, and social signals that traditional search engines miss, distilling them into one seamless, interactive map. Every point of interest shows its latest news, upcoming events, and current trail status. Open one page and immediately see what's open, what's happening this weekend, and what's worth discovering for the first time.
+
+---
+
+## Built in the Open
+
+The Cuyahoga Valley is public land, maintained through shared stewardship by rangers, volunteers, trail crews, and the people who use it every day. Roots of the Valley works the same way.
+
+The entire project, code, data, and infrastructure, is open source. Anyone can see how it works, suggest improvements, or adapt it for their own region.
+
+**Transparency.** When ROTV says a trail is closed, you can trace exactly where that information came from. There's no opaque algorithm deciding what you see. The collection sources are public, the moderation queue is human-reviewed, and the codebase is on GitHub.
+
+**Durability.** Free services disappear all the time, the company pivots, the funding dries up, or the product gets buried under ads and paywalls. ROTV can't be acquired, shut down, or locked behind a subscription. The community owns it.
+
+**Participation.** The same people who maintain trails, lead hikes, and organize cleanups can contribute to ROTV. Park districts can submit event feeds. Developers can contribute features. The goal is to build the same volunteer stewardship network online that already exists on the trails.
+
+The valley belongs to everyone. The map should too.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13744,59 +13744,68 @@ button.feedback-link-inline {
 }
 
 /* ===========================================
-   About Page
+   About Page (Sub-tabbed)
    =========================================== */
 
 .about-page {
   overflow-y: auto;
 }
 
-.about-content h2 {
+.about-tab-content {
+  margin-top: 1rem;
+}
+
+/* Story sub-tab */
+.about-story h2 {
   color: #2d6a4f;
-  font-size: 1.6rem;
-  margin-bottom: 0.5rem;
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+  margin-top: 1.5rem;
 }
 
-.about-tagline {
-  font-size: 1.1rem;
-  color: #555;
-  margin-bottom: 2rem;
+.about-story h2:first-child {
+  margin-top: 0;
+}
+
+.about-story p {
+  color: #444;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.about-story a {
+  color: #2d6a4f;
+  text-decoration: none;
+}
+
+.about-story a:hover {
+  text-decoration: underline;
+}
+
+.about-divider {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 2rem 0;
+}
+
+.about-closing {
   font-style: italic;
+  color: #2d6a4f;
+  font-weight: 500;
+  margin-top: 1.5rem;
 }
 
-.about-section {
-  margin-bottom: 2rem;
-}
-
-.about-section h3 {
-  color: #333;
-  font-size: 1.2rem;
+/* Tutorial sub-tab */
+.about-tutorial h2 {
+  color: #2d6a4f;
+  font-size: 1.4rem;
   margin-bottom: 0.75rem;
 }
 
-.about-section p {
+.about-tutorial p {
   color: #444;
   line-height: 1.6;
-}
-
-.about-features-list {
-  list-style: none;
-  padding: 0;
-}
-
-.about-features-list li {
-  padding: 0.5rem 0;
-  color: #444;
-  line-height: 1.5;
-  border-bottom: 1px solid #eee;
-}
-
-.about-features-list li:last-child {
-  border-bottom: none;
-}
-
-.about-features-list li strong {
-  color: #2d6a4f;
+  margin-bottom: 1rem;
 }
 
 .about-tour-btn {
@@ -13814,23 +13823,75 @@ button.feedback-link-inline {
   background: #1b4332;
 }
 
-.about-credits {
-  border-top: 1px solid #ddd;
-  padding-top: 1.5rem;
+/* Inline feedback form */
+.feedback-inline {
+  max-width: 600px;
 }
 
-.about-credits a {
+.feedback-inline h2 {
   color: #2d6a4f;
-  text-decoration: none;
+  font-size: 1.4rem;
+  margin-bottom: 0.25rem;
 }
 
-.about-credits a:hover {
+.feedback-inline .feedback-subtitle {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+/* Privacy Policy inline mode — strip container styling to match other About sub-tabs */
+.privacy-inline {
+  min-height: unset;
+  background: none;
+  padding: 0;
+  display: block;
+}
+
+.privacy-inline .privacy-policy-content {
+  max-width: none;
+  background: none;
+  border-radius: 0;
+  padding: 0;
+  box-shadow: none;
+}
+
+.privacy-inline .privacy-policy-content h1 {
+  color: #2d6a4f;
+  font-size: 1.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.privacy-inline .privacy-policy-content h2 {
+  color: #2d6a4f;
+  font-size: 1.1rem;
+}
+
+.privacy-inline .privacy-policy-content p,
+.privacy-inline .privacy-policy-content li {
+  color: #444;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* RSS Feed link in Settings */
+.rss-feed-link {
+  display: inline-block;
+  color: #2d6a4f;
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
+.rss-feed-link:hover {
   text-decoration: underline;
 }
 
 @media (max-width: 768px) {
-  .about-content h2 {
-    font-size: 1.3rem;
+  .about-story h2 {
+    font-size: 1.2rem;
+  }
+
+  .about-tab-btn {
+    font-size: 0.8rem;
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -118,6 +118,8 @@ function AppContent() {
 
   // Settings sub-tab state: 'general', 'activities', 'news', 'google'
   const [settingsTab, setSettingsTab] = useState('general');
+  // About sub-tab state: 'story', 'tutorial', 'feedback', 'privacy'
+  const [aboutTab, setAboutTab] = useState('story');
   const [jobsExpandTarget, setJobsExpandTarget] = useState(null);
 
   // Moderation queue pending count for badge
@@ -551,6 +553,10 @@ function AppContent() {
       // POI sub-tab path: /:poiSlug/:subTab (e.g., /the-rabbit-hole-akron/news)
       poiSlug = pathParts[0];
       setInitialSidebarTab(pathParts[1] === 'info' ? 'view' : pathParts[1]);
+    } else if (pathParts.length === 2 && pathParts[0] === 'about' && ['story', 'tutorial', 'feedback', 'privacy'].includes(pathParts[1])) {
+      // About sub-tab path: /about/story, /about/tutorial, etc.
+      setActiveTab('about');
+      setAboutTab(pathParts[1]);
     } else if (pathParts.length === 1 && mainTabPaths.includes(pathParts[0])) {
       // Main tab path: /news, /events, /results, /edit, /settings
       setActiveTab(pathParts[0]);
@@ -677,6 +683,19 @@ function AppContent() {
     const mainTabPaths = ['results', 'news', 'events', 'settings', 'about'];
     if (pathParts.length === 1 && mainTabPaths.includes(pathParts[0])) {
       setActiveTab(pathParts[0]);
+      if (selectedDestination || selectedLinearFeature) {
+        setSelectedDestination(null);
+        setSelectedLinearFeature(null);
+        document.title = 'Roots of The Valley';
+      }
+      return;
+    }
+
+    // Handle About sub-tab paths: /about/story, /about/tutorial, /about/feedback, /about/privacy
+    const aboutSubTabs = ['story', 'tutorial', 'feedback', 'privacy'];
+    if (pathParts.length === 2 && pathParts[0] === 'about' && aboutSubTabs.includes(pathParts[1])) {
+      setActiveTab('about');
+      setAboutTab(pathParts[1]);
       if (selectedDestination || selectedLinearFeature) {
         setSelectedDestination(null);
         setSelectedLinearFeature(null);
@@ -1782,7 +1801,6 @@ function AppContent() {
               { id: 'news', label: 'News', show: true },
               { id: 'events', label: 'Events', show: true },
               { id: 'about', label: 'About', show: true },
-              { id: 'settings', label: 'Settings', show: isAuthenticated },
             ];
             return navTabs.filter(t => t.show).map(tab => {
               const i = idx++;
@@ -1844,26 +1862,11 @@ function AppContent() {
                       <span className="user-email-inline">{user?.email}</span>
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
-                    <a
-                      className="dropdown-item-inline privacy-link-inline"
-                      href="https://buttondown.com/rotv/rss"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      RSS Feed
-                    </a>
-                    <a
-                      className="dropdown-item-inline privacy-link-inline"
-                      href="/privacy"
-                      onClick={(e) => { e.preventDefault(); setShowUserDropdown(false); navigate('/privacy'); }}
-                    >
-                      Privacy Policy
-                    </a>
                     <button
-                      className="dropdown-item-inline privacy-link-inline feedback-link-inline"
-                      onClick={() => { setShowUserDropdown(false); setShowFeedbackForm(true); }}
+                      className="dropdown-item-inline privacy-link-inline"
+                      onClick={() => { setShowUserDropdown(false); handleTabChange('settings'); }}
                     >
-                      Send Feedback
+                      Settings
                     </button>
                     <button
                       className="dropdown-item-inline"
@@ -1931,27 +1934,6 @@ function AppContent() {
                         <path fill="#1877F2" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
                       </svg>
                       Continue with Facebook
-                    </button>
-                    <a
-                      className="privacy-link-inline"
-                      href="https://buttondown.com/rotv/rss"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      RSS Feed
-                    </a>
-                    <a
-                      className="privacy-link-inline"
-                      href="/privacy"
-                      onClick={(e) => { e.preventDefault(); setShowLoginDropdown(false); navigate('/privacy'); }}
-                    >
-                      Privacy Policy
-                    </a>
-                    <button
-                      className="privacy-link-inline feedback-link-inline"
-                      onClick={() => { setShowLoginDropdown(false); setShowFeedbackForm(true); }}
-                    >
-                      Send Feedback
                     </button>
                   </div>
                 </>
@@ -2050,7 +2032,7 @@ function AppContent() {
       {/* About tab content */}
       {activeTab === 'about' && (
         <main id="main-content" className="main-content-full" tabIndex="-1">
-          <AboutPage onStartTour={startTour} />
+          <AboutPage onStartTour={startTour} aboutTab={aboutTab} onTabChange={setAboutTab} />
         </main>
       )}
 
@@ -2074,6 +2056,13 @@ function AppContent() {
                 tabIndex={settingsTab === 'newsletter' ? 0 : -1}
               >
                 Newsletter
+              </button>
+              <button
+                className={`settings-tab-btn ${settingsTab === 'rss' ? 'active' : ''}`}
+                onClick={() => setSettingsTab('rss')}
+                tabIndex={settingsTab === 'rss' ? 0 : -1}
+              >
+                RSS Feed
               </button>
             </nav>
             <nav className="settings-tabs settings-tabs-row2">
@@ -2189,6 +2178,20 @@ function AppContent() {
               )}
               {settingsTab === 'users' && <UsersSettings />}
               {settingsTab === 'newsletter' && <NewsletterSettings user={user} />}
+              {settingsTab === 'rss' && (
+                <div className="settings-section">
+                  <h3>RSS Feed</h3>
+                  <p>Subscribe to the Roots of the Valley RSS feed to get news and events delivered to your favorite feed reader.</p>
+                  <a
+                    href="https://buttondown.com/rotv/rss"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rss-feed-link"
+                  >
+                    https://buttondown.com/rotv/rss
+                  </a>
+                </div>
+              )}
             </div>
             </>
             ) : (

--- a/frontend/src/components/AboutPage.jsx
+++ b/frontend/src/components/AboutPage.jsx
@@ -1,69 +1,140 @@
 import React from 'react';
+import { handleRovingKeyDown } from '../utils/a11yUtils';
+import FeedbackForm from './FeedbackForm';
+import PrivacyPolicy from './PrivacyPolicy';
 
-function AboutPage({ onStartTour }) {
+function AboutStory() {
   return (
-    <main className="about-page">
-      <div className="about-content">
-        <h2>About Roots of The Valley</h2>
-        <p className="about-tagline">
-          An interactive map exploring the history, nature, and community of Cuyahoga Valley National Park.
-        </p>
+    <div className="about-story">
+      <h2>One Map for Everything Happening in the Cuyahoga Valley</h2>
 
-        <section className="about-section">
-          <h3>What is ROTV?</h3>
-          <p>
-            Roots of The Valley is a discovery engine for Cuyahoga Valley National Park and the surrounding area.
-            We aggregate news, events, trail conditions, and historical information from dozens of local sources
-            so you can find what&apos;s happening without searching everywhere yourself.
-          </p>
-        </section>
+      <p>
+        The Cuyahoga Valley has over 300 parks, trailheads, preserves, and landmarks, but the
+        information about them is scattered across dozens of websites run by the National Park
+        Service, Cleveland Metroparks, Summit Metro Parks, and countless other organizations.
+        A mountain biker checking whether trails are rideable might need to check TrailForks,
+        Twitter, and two different park district websites. A family looking for weekend activities
+        doesn't have time to visit dozens of event calendars.
+      </p>
 
-        <section className="about-section">
-          <h3>Features</h3>
-          <ul className="about-features-list">
-            <li>
-              <strong>Interactive Map</strong> &mdash; Browse 200+ points of interest including trails, historic sites, waterfalls, and more
-            </li>
-            <li>
-              <strong>Dynamic Results</strong> &mdash; The results list updates as you zoom and pan the map
-            </li>
-            <li>
-              <strong>Park News</strong> &mdash; AI-curated news from local sources, filtered to your map view
-            </li>
-            <li>
-              <strong>Events</strong> &mdash; Concerts, hikes, programs, and community events happening near you
-            </li>
-            <li>
-              <strong>POI & Boundary Overlays</strong> &mdash; Toggle point of interest types and park boundaries
-            </li>
-            <li>
-              <strong>Place Details</strong> &mdash; Click any POI for Info, News, Events, History, and Associations
-            </li>
-            <li>
-              <strong>Newsletter</strong> &mdash; Sign up for a weekly digest of news and events (requires login)
-            </li>
-          </ul>
-        </section>
+      <p>
+        The result: people stick to what they already know and miss 95% of what the valley offers.
+      </p>
 
-        <section className="about-section">
-          <h3>Get Started</h3>
-          <p>
-            New here? Take a quick guided tour to learn how ROTV works.
-          </p>
-          <button className="about-tour-btn" onClick={onStartTour}>
-            Take a Tour
+      <p>
+        <strong>Roots of the Valley fixes that.</strong> We traverse the deepest corners of the web
+        to aggregate news, events, and social signals that traditional search engines miss, distilling
+        them into one seamless, interactive map. Every point of interest shows its latest news,
+        upcoming events, and current trail status. Open one page and immediately see what's open,
+        what's happening this weekend, and what's worth discovering for the first time.
+      </p>
+
+      <hr className="about-divider" />
+
+      <h2>Built in the Open</h2>
+
+      <p>
+        The Cuyahoga Valley is public land, maintained through shared stewardship by rangers,
+        volunteers, trail crews, and the people who use it every day. Roots of the Valley works
+        the same way.
+      </p>
+
+      <p>
+        The entire project, code, data, and infrastructure, is open source. Anyone can see how it
+        works, suggest improvements, or adapt it for their own region.
+      </p>
+
+      <p>
+        <strong>Transparency.</strong> When ROTV says a trail is closed, you can trace exactly where
+        that information came from. There's no opaque algorithm deciding what you see. The collection
+        sources are public, the moderation queue is human-reviewed, and the codebase is
+        on <a href="https://github.com/crunchtools/rotv" target="_blank" rel="noopener noreferrer">GitHub</a>.
+      </p>
+
+      <p>
+        <strong>Durability.</strong> Free services disappear all the time, the company pivots, the
+        funding dries up, or the product gets buried under ads and paywalls. ROTV can't be acquired,
+        shut down, or locked behind a subscription. The community owns it.
+      </p>
+
+      <p>
+        <strong>Participation.</strong> The same people who maintain trails, lead hikes, and organize
+        cleanups can contribute to ROTV. Park districts can submit event feeds. Developers can
+        contribute features. The goal is to build the same volunteer stewardship network online that
+        already exists on the trails.
+      </p>
+
+      <p className="about-closing">The valley belongs to everyone. The map should too.</p>
+    </div>
+  );
+}
+
+function AboutTutorial({ onStartTour }) {
+  return (
+    <div className="about-tutorial">
+      <h2>Learn How ROTV Works</h2>
+      <p>
+        New here? Take a quick guided tour to learn how to use the interactive map,
+        find events, check trail conditions, and discover new places in the valley.
+      </p>
+      <button className="about-tour-btn" onClick={onStartTour}>
+        Take a Tour
+      </button>
+    </div>
+  );
+}
+
+function AboutPage({ onStartTour, aboutTab, onTabChange }) {
+  return (
+    <div className="about-page">
+      <div className="settings-tabs-wrapper" onKeyDown={(e) => handleRovingKeyDown(e, '.about-tab-btn')}>
+        <nav className="settings-tabs" role="tablist" aria-label="About sections">
+          <button
+            className={`settings-tab-btn about-tab-btn ${aboutTab === 'story' ? 'active' : ''}`}
+            onClick={() => onTabChange('story')}
+            tabIndex={aboutTab === 'story' ? 0 : -1}
+            role="tab"
+            aria-selected={aboutTab === 'story'}
+          >
+            Story
           </button>
-        </section>
-
-        <section className="about-section about-credits">
-          <h3>Credits</h3>
-          <p>
-            Built by <a href="https://crunchtools.com" target="_blank" rel="noopener noreferrer">Crunchtools</a>.
-            Feedback welcome &mdash; use the Send Feedback option in the menu.
-          </p>
-        </section>
+          <button
+            className={`settings-tab-btn about-tab-btn ${aboutTab === 'tutorial' ? 'active' : ''}`}
+            onClick={() => onTabChange('tutorial')}
+            tabIndex={aboutTab === 'tutorial' ? 0 : -1}
+            role="tab"
+            aria-selected={aboutTab === 'tutorial'}
+          >
+            Tutorial
+          </button>
+          <button
+            className={`settings-tab-btn about-tab-btn ${aboutTab === 'feedback' ? 'active' : ''}`}
+            onClick={() => onTabChange('feedback')}
+            tabIndex={aboutTab === 'feedback' ? 0 : -1}
+            role="tab"
+            aria-selected={aboutTab === 'feedback'}
+          >
+            Send Feedback
+          </button>
+          <button
+            className={`settings-tab-btn about-tab-btn ${aboutTab === 'privacy' ? 'active' : ''}`}
+            onClick={() => onTabChange('privacy')}
+            tabIndex={aboutTab === 'privacy' ? 0 : -1}
+            role="tab"
+            aria-selected={aboutTab === 'privacy'}
+          >
+            Privacy Policy
+          </button>
+        </nav>
       </div>
-    </main>
+
+      <div className="about-tab-content" role="tabpanel">
+        {aboutTab === 'story' && <AboutStory />}
+        {aboutTab === 'tutorial' && <AboutTutorial onStartTour={onStartTour} />}
+        {aboutTab === 'feedback' && <FeedbackForm inline />}
+        {aboutTab === 'privacy' && <PrivacyPolicy inline />}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/FeedbackForm.jsx
+++ b/frontend/src/components/FeedbackForm.jsx
@@ -8,7 +8,7 @@ const TYPES = [
   { value: 'general', label: 'General Feedback' }
 ];
 
-function FeedbackForm({ onClose }) {
+function FeedbackForm({ onClose, inline = false }) {
   const [type, setType] = useState('general');
   const [message, setMessage] = useState('');
   const [name, setName] = useState('');
@@ -19,6 +19,7 @@ function FeedbackForm({ onClose }) {
   const [success, setSuccess] = useState(null);
 
   useEffect(() => {
+    if (inline) return;
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') onClose();
     };
@@ -28,7 +29,7 @@ function FeedbackForm({ onClose }) {
       window.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = 'auto';
     };
-  }, [onClose]);
+  }, [onClose, inline]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -68,99 +69,104 @@ function FeedbackForm({ onClose }) {
     }
   };
 
+  const formContent = success ? (
+    <div className="feedback-success">
+      <div className="success-icon">&#10003;</div>
+      <h3>Thank you for your feedback!</h3>
+      <p>Your submission has been recorded as issue #{success}.</p>
+      {!inline && <button className="feedback-done-btn" onClick={onClose}>Close</button>}
+    </div>
+  ) : (
+    <>
+      <h2>Send Feedback</h2>
+      <p className="feedback-subtitle">Help us improve Roots of the Valley</p>
+
+      <form className="feedback-form" onSubmit={handleSubmit}>
+        <div className="feedback-field">
+          <label>What kind of feedback?</label>
+          <div className="feedback-radio-group">
+            {TYPES.map((t) => (
+              <label key={t.value} className={`feedback-radio-label ${type === t.value ? 'selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="feedback-type"
+                  value={t.value}
+                  checked={type === t.value}
+                  onChange={() => setType(t.value)}
+                />
+                {t.label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="feedback-field">
+          <label htmlFor="feedback-message">Message</label>
+          <textarea
+            id="feedback-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Tell us what's on your mind..."
+            maxLength={1000}
+            required
+          />
+          <span className={`feedback-char-count ${message.length > 900 ? 'near-limit' : ''}`}>
+            {message.length}/1000
+          </span>
+        </div>
+
+        <div className="feedback-field">
+          <label htmlFor="feedback-name">Name <span className="field-optional">(optional)</span></label>
+          <input
+            type="text"
+            id="feedback-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name"
+            maxLength={100}
+          />
+        </div>
+
+        <div className="feedback-field">
+          <label htmlFor="feedback-email">Email <span className="field-optional">(optional, if you'd like a response)</span></label>
+          <input
+            type="email"
+            id="feedback-email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+          />
+        </div>
+
+        {/* Honeypot */}
+        <div className="feedback-hp" aria-hidden="true">
+          <input
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            value={hp}
+            onChange={(e) => setHp(e.target.value)}
+          />
+        </div>
+
+        {error && <div className="feedback-error">{error}</div>}
+
+        <button type="submit" className="feedback-submit" disabled={submitting}>
+          {submitting ? 'Submitting...' : 'Send Feedback'}
+        </button>
+      </form>
+    </>
+  );
+
+  if (inline) {
+    return <div className="feedback-inline">{formContent}</div>;
+  }
+
   return createPortal(
     <div className="feedback-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="feedback-modal">
         <button className="feedback-close" onClick={onClose}>&times;</button>
-
-        {success ? (
-          <div className="feedback-success">
-            <div className="success-icon">&#10003;</div>
-            <h3>Thank you for your feedback!</h3>
-            <p>Your submission has been recorded as issue #{success}.</p>
-            <button className="feedback-done-btn" onClick={onClose}>Close</button>
-          </div>
-        ) : (
-          <>
-            <h2>Send Feedback</h2>
-            <p className="feedback-subtitle">Help us improve Roots of the Valley</p>
-
-            <form className="feedback-form" onSubmit={handleSubmit}>
-              <div className="feedback-field">
-                <label>What kind of feedback?</label>
-                <div className="feedback-radio-group">
-                  {TYPES.map((t) => (
-                    <label key={t.value} className={`feedback-radio-label ${type === t.value ? 'selected' : ''}`}>
-                      <input
-                        type="radio"
-                        name="feedback-type"
-                        value={t.value}
-                        checked={type === t.value}
-                        onChange={() => setType(t.value)}
-                      />
-                      {t.label}
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              <div className="feedback-field">
-                <label htmlFor="feedback-message">Message</label>
-                <textarea
-                  id="feedback-message"
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  placeholder="Tell us what's on your mind..."
-                  maxLength={1000}
-                  required
-                />
-                <span className={`feedback-char-count ${message.length > 900 ? 'near-limit' : ''}`}>
-                  {message.length}/1000
-                </span>
-              </div>
-
-              <div className="feedback-field">
-                <label htmlFor="feedback-name">Name <span className="field-optional">(optional)</span></label>
-                <input
-                  type="text"
-                  id="feedback-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="Your name"
-                  maxLength={100}
-                />
-              </div>
-
-              <div className="feedback-field">
-                <label htmlFor="feedback-email">Email <span className="field-optional">(optional, if you'd like a response)</span></label>
-                <input
-                  type="email"
-                  id="feedback-email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                />
-              </div>
-
-              {/* Honeypot */}
-              <div className="feedback-hp" aria-hidden="true">
-                <input
-                  type="text"
-                  tabIndex={-1}
-                  autoComplete="off"
-                  value={hp}
-                  onChange={(e) => setHp(e.target.value)}
-                />
-              </div>
-
-              {error && <div className="feedback-error">{error}</div>}
-
-              <button type="submit" className="feedback-submit" disabled={submitting}>
-                {submitting ? 'Submitting...' : 'Send Feedback'}
-              </button>
-            </form>
-          </>
-        )}
+        {formContent}
       </div>
     </div>,
     document.body

--- a/frontend/src/components/PrivacyPolicy.jsx
+++ b/frontend/src/components/PrivacyPolicy.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-function PrivacyPolicy() {
+function PrivacyPolicy({ inline = false }) {
   const navigate = useNavigate();
 
   return (
-    <div className="privacy-policy-page">
+    <div className={`privacy-policy-page ${inline ? 'privacy-inline' : ''}`}>
       <div className="privacy-policy-content">
-        <button className="privacy-back-btn" onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}>
-          &larr; Back
-        </button>
+        {!inline && (
+          <button className="privacy-back-btn" onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}>
+            &larr; Back
+          </button>
+        )}
 
         <h1>Privacy Policy</h1>
         <p className="privacy-updated">Last updated: May 2026</p>


### PR DESCRIPTION
## Summary
- About tab restructured with sub-tabs: Story | Tutorial | Send Feedback | Privacy Policy
- Story content: problem/solution narrative focused on user value + open source community
- Settings moved from main tab bar into Login/Account dropdown
- RSS Feed added as Settings sub-tab alongside Newsletter
- FeedbackForm and PrivacyPolicy refactored for inline rendering
- Roving tabindex keyboard navigation on About sub-tabs
- Deep-linkable URLs: /about/story, /about/tutorial, /about/feedback, /about/privacy

Closes #347

## Test plan
- [x] About tab shows 4 sub-tabs with correct content
- [x] Arrow keys navigate between sub-tabs
- [x] Settings gone from main tab bar, accessible from user dropdown
- [x] RSS Feed sub-tab in Settings with Buttondown link
- [x] Privacy Policy renders inline without nested container
- [x] Send Feedback renders inline without modal
- [x] Login dropdown is just login buttons
- [x] Deep links work (/about/privacy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)