### PR TITLE
fix: Settings dropdown styling matches Sign Out

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -344,6 +344,10 @@ body {
   background: #f5f5f5;
 }
 
+.settings-item-inline {
+  color: #333;
+}
+
 /* Filter Bar */
 .filter-bar {
   background: white;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1863,7 +1863,7 @@ function AppContent() {
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
                     <button
-                      className="dropdown-item-inline privacy-link-inline"
+                      className="dropdown-item-inline settings-item-inline"
                       onClick={() => { setShowUserDropdown(false); handleTabChange('settings'); }}
                     >
                       Settings


### PR DESCRIPTION
## Summary
- Removed `privacy-link-inline` class from Settings button in user dropdown so it matches Sign Out's font size (0.9rem), left alignment, padding, and hover background
- Added `settings-item-inline` class with neutral dark color (#333) instead of inheriting the red (#c62828) used for destructive actions like Sign Out

## Test plan
- [x] Verified on localhost — Settings now has same look/feel as Sign Out
- [ ] No underline on hover
- [ ] Left-aligned with Sign Out and Edit Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)