### PR TITLE
feat: domain-based URL ownership for news/events collection

### DIFF
--- a/.specify/specs/012-news-url-ownership/plan.md
+++ b/.specify/specs/012-news-url-ownership/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: News/Events URL Ownership
+
+> **Spec ID:** 012-news-url-ownership
+> **Status:** Planning
+> **Last Updated:** 2026-05-14
+> **Estimated Effort:** S
+
+## Summary
+
+Add a domain-ownership lookup to the news/events save functions. Before inserting, check if the source_url domain matches another POI's news_url or events_url — if so, reassign to that POI. Include a one-time migration to fix existing misattributed records.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. At collection start, build a domain→POI map from all POIs with news_url or events_url
+2. In `saveNewsItems()` and `saveEventItems()`, extract domain from each item's source_url
+3. Look up domain in the map — if it matches a different POI, swap poi_id before insert
+4. Log the reassignment
+
+---
+
+## Implementation Steps
+
+### Phase 1: Domain Ownership Lookup
+
+- [ ] Add `buildDomainOwnershipMap(pool)` helper in `newsService.js` that queries all POIs with news_url/events_url and returns a `Map<domain, poiId>`
+- [ ] Call it once at the start of `collectNewsForPoi()` (or pass it through from the job runner to avoid repeated queries)
+
+### Phase 2: Reassignment in Save Functions
+
+- [ ] In `saveNewsItems()`, before insert, check source_url domain against the map. If domain owner differs from target poiId, use the domain owner's poiId instead. Log the swap.
+- [ ] In `saveEventItems()`, same logic.
+
+### Phase 3: Data Migration
+
+- [ ] Write migration `backend/migrations/XXX_fix_news_url_ownership.sql` that reassigns existing misattributed records
+- [ ] Alternatively, run the fix as a Node script that uses the same domain map logic
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/services/newsService.js` | Add `buildDomainOwnershipMap()`, modify `saveNewsItems()` and `saveEventItems()` to check domain ownership before insert |
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/XXX_fix_news_url_ownership.sql` | One-time fix for existing misattributed records |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: fix_news_url_ownership
+-- Reassign news/events whose source_url domain matches a different POI's news_url or events_url
+
+-- (Domain extraction + UPDATE joins against pois table)
+```
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Run collection for a physical POI that has content from an org domain
+2. Verify collected items are assigned to the org POI, not the physical POI
+3. Verify migration corrects existing misattributed records
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Domain map becomes stale during long collection runs | Low | Rebuild map at job start; runs are <30min |
+| False positive: generic domains (e.g., nps.gov) matching wrong POI | Med | Only match against POIs that have explicit news_url/events_url set |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-14 | Initial plan |

--- a/.specify/specs/012-news-url-ownership/spec.md
+++ b/.specify/specs/012-news-url-ownership/spec.md
@@ -1,0 +1,75 @@
+# Specification: News/Events URL Ownership
+
+> **Spec ID:** 012-news-url-ownership
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-14
+
+## Overview
+
+When collecting news and events for a POI, the AI sometimes finds content hosted on a domain that belongs to a different organization POI (e.g., a news article about Botzum Station sourced from cvsr.org, which is CVSR's domain). Currently these items get assigned to the POI being collected, not to the organization that owns the URL. This feature adds domain-based ownership detection to the collection pipeline so that items are automatically reassigned to the correct organization POI.
+
+---
+
+## User Stories
+
+### Data Integrity
+
+**US-012-1: Automatic URL Ownership Reassignment**
+> As a site administrator, I want news and events collected from an organization's domain to be attributed to that organization so that content is correctly categorized without manual intervention.
+
+Acceptance Criteria:
+- [ ] During save, if a news/event source_url domain matches another POI's news_url or events_url domain, the item is saved under the domain-owning POI instead
+- [ ] The reassignment is logged so administrators can see what happened
+- [ ] Existing misattributed items are corrected via a one-time data migration
+
+**US-012-2: Data Cleanup**
+> As a site administrator, I want existing misattributed news and events corrected so that the database is accurate going forward.
+
+Acceptance Criteria:
+- [ ] A migration script identifies and reassigns all news/events whose source_url domain matches a different POI's news_url or events_url
+- [ ] The migration logs each reassignment for audit purposes
+
+---
+
+## Data Model
+
+### Schema Changes
+
+No schema changes required. The fix operates on existing `poi_id` foreign keys in `poi_news` and `poi_events`.
+
+---
+
+## API Endpoints
+
+No new endpoints required. The change is internal to the collection pipeline.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-012-1: Performance**
+- Domain lookup query must be cached per collection run, not executed per-item
+- No measurable impact on collection throughput
+
+---
+
+## Dependencies
+
+- Depends on: Existing news/events collection pipeline in `newsService.js`
+- Depends on: POIs having `news_url` and `events_url` fields populated
+
+---
+
+## Open Questions
+
+None — behavior confirmed: reassign to the domain-owning POI.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-14 | Initial draft |

--- a/backend/migrations/047_fix_news_url_ownership.sql
+++ b/backend/migrations/047_fix_news_url_ownership.sql
@@ -1,0 +1,44 @@
+-- Migration: 047_fix_news_url_ownership
+-- Description: Reassign news/events whose source_url domain matches a different
+-- POI's news_url or events_url to the domain-owning POI.
+
+-- Build a temporary domain→POI mapping from news_url and events_url
+CREATE TEMPORARY TABLE poi_domain_map AS
+SELECT DISTINCT ON (domain)
+  domain,
+  poi_id
+FROM (
+  SELECT
+    id AS poi_id,
+    LOWER(REGEXP_REPLACE(REGEXP_REPLACE(news_url, '^https?://(www\.)?', ''), '/.*$', '')) AS domain
+  FROM pois
+  WHERE news_url IS NOT NULL AND deleted = false
+
+  UNION ALL
+
+  SELECT
+    id AS poi_id,
+    LOWER(REGEXP_REPLACE(REGEXP_REPLACE(events_url, '^https?://(www\.)?', ''), '/.*$', '')) AS domain
+  FROM pois
+  WHERE events_url IS NOT NULL AND deleted = false
+) sub
+WHERE domain IS NOT NULL AND domain != ''
+ORDER BY domain, poi_id;
+
+-- Fix news items
+UPDATE poi_news n
+SET poi_id = dm.poi_id
+FROM poi_domain_map dm
+WHERE LOWER(REGEXP_REPLACE(REGEXP_REPLACE(n.source_url, '^https?://(www\.)?', ''), '/.*$', '')) = dm.domain
+  AND n.poi_id != dm.poi_id
+  AND n.source_url IS NOT NULL;
+
+-- Fix events
+UPDATE poi_events e
+SET poi_id = dm.poi_id
+FROM poi_domain_map dm
+WHERE LOWER(REGEXP_REPLACE(REGEXP_REPLACE(e.source_url, '^https?://(www\.)?', ''), '/.*$', '')) = dm.domain
+  AND e.poi_id != dm.poi_id
+  AND e.source_url IS NOT NULL;
+
+DROP TABLE poi_domain_map;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -36,6 +36,7 @@ import {
   collectPoi,
   saveNewsItems,
   saveEventItems,
+  buildDomainOwnershipMap,
   getCollectionProgress,
   clearProgress,
   updateProgress,
@@ -2810,8 +2811,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         logInfo(runId, 'news_single', poi.id, poi.name, `Saving ${news.length} news items to database...`);
         await flushJobLogs();
 
+        const domainOwnershipMap = await buildDomainOwnershipMap(pool);
         const saveLog = (msg) => { logInfo(runId, 'news_single', poi.id, poi.name, msg); };
-        const savedNews = await saveNewsItems(pool, poi.id, news, { log: saveLog });
+        const savedNews = await saveNewsItems(pool, poi.id, news, { log: saveLog, domainOwnershipMap });
         await flushJobLogs();
 
         updateProgress(poi.id, {
@@ -2916,8 +2918,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         logInfo(runId, 'events_single', poi.id, poi.name, `Saving ${events.length} event items to database...`);
         await flushJobLogs();
 
+        const domainOwnershipMap = await buildDomainOwnershipMap(pool);
         const saveLog = (msg) => { logInfo(runId, 'events_single', poi.id, poi.name, msg); };
-        const savedEvents = await saveEventItems(pool, poi.id, events, { log: saveLog });
+        const savedEvents = await saveEventItems(pool, poi.id, events, { log: saveLog, domainOwnershipMap });
         await flushJobLogs();
 
         updateProgress(poi.id, {

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1537,7 +1537,7 @@ function normalizeUrl(url) {
 export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
-  const { log = null } = options;
+  const { log = null, domainOwnershipMap = null } = options;
 
   for (const item of newsItems) {
     try {
@@ -1566,6 +1566,14 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         continue;
       }
 
+      // Domain ownership check: if source URL belongs to another POI's domain, reassign
+      let effectivePoiId = poiId;
+      const domainOwner = checkDomainOwnership(resolvedUrl || item.source_url, poiId, domainOwnershipMap);
+      if (domainOwner) {
+        effectivePoiId = domainOwner.poiId;
+        if (log) log(`[Save] Reassigning "${item.title}" → ${domainOwner.poiName} (domain ownership)`);
+      }
+
       // Normalize the title for duplicate checking
       const normalizedTitle = normalizeNewsTitle(item.title);
 
@@ -1578,7 +1586,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
            OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3)
            OR (poi_id = $2 AND TRIM(LOWER(REGEXP_REPLACE(REGEXP_REPLACE(title, '\\s*\\|\\s*(\\d{4}-\\d{2}-\\d{2}|[A-Z][a-z]+\\s+\\d{1,2}(,\\s*\\d{4})?)\\s*$', '', 'i'), '^[Tt]he\\s+', ''))) = $4)
          )`,
-        [normalizedUrl, poiId, normalizedTitleNoArticle, normalizeTitle(normalizedTitle)]
+        [normalizedUrl, effectivePoiId, normalizedTitleNoArticle, normalizeTitle(normalizedTitle)]
       );
 
       if (existing.rows.length > 0) {
@@ -1609,7 +1617,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       `, [
-        poiId,
+        effectivePoiId,
         item.title,
         item.summary,
         resolvedUrl,
@@ -1641,7 +1649,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 export async function saveEventItems(pool, poiId, eventItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
-  const { log = null } = options;
+  const { log = null, domainOwnershipMap = null } = options;
 
   for (const item of eventItems) {
     try {
@@ -1687,6 +1695,14 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         continue;
       }
 
+      // Domain ownership check: if source URL belongs to another POI's domain, reassign
+      let effectivePoiId = poiId;
+      const domainOwner = checkDomainOwnership(resolvedUrl || item.source_url, poiId, domainOwnershipMap);
+      if (domainOwner) {
+        effectivePoiId = domainOwner.poiId;
+        if (log) log(`[Save] Reassigning event "${item.title}" → ${domainOwner.poiName} (domain ownership)`);
+      }
+
       const normalizedEventUrl = normalizeUrl(resolvedUrl);
       const normalizedEventTitle = normalizeTitle(item.title);
       const existing = await pool.query(
@@ -1695,7 +1711,7 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
            ($1::text IS NOT NULL AND LOWER(REGEXP_REPLACE(source_url, '/+$', '')) = $1::text)
            OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3 AND start_date = $4)
          )`,
-        [normalizedEventUrl, poiId, normalizedEventTitle, item.start_date]
+        [normalizedEventUrl, effectivePoiId, normalizedEventTitle, item.start_date]
       );
 
       if (existing.rows.length > 0) {
@@ -1732,7 +1748,7 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       `, [
-        poiId,
+        effectivePoiId,
         item.title,
         item.description,
         item.start_date,
@@ -1772,6 +1788,9 @@ async function processPoiBatch(pool, pois, sheets, dispatchInterval = DISPATCH_I
   let processed = 0;
   const results = [];
 
+  // Build domain ownership map once for the entire batch
+  const domainOwnershipMap = await buildDomainOwnershipMap(pool);
+
   // Semaphore for limiting concurrency
   let inFlight = 0;
   let nextIndex = 0;
@@ -1791,8 +1810,8 @@ async function processPoiBatch(pool, pois, sheets, dispatchInterval = DISPATCH_I
     try {
       console.log(`[${index + 1}/${pois.length}] Starting: ${poi.name} (${inFlight} in flight)`);
       const { news, events, metadata } = await collectPoi(pool, poi, sheets, timezone);
-      const savedNews = await saveNewsItems(pool, poi.id, news);
-      const savedEvents = await saveEventItems(pool, poi.id, events);
+      const savedNews = await saveNewsItems(pool, poi.id, news, { domainOwnershipMap });
+      const savedEvents = await saveEventItems(pool, poi.id, events, { domainOwnershipMap });
       console.log(`[${index + 1}/${pois.length}] ✓ ${poi.name}: ${savedNews} news, ${savedEvents} events`);
       results.push({ newsFound: savedNews, eventsFound: savedEvents, success: true, poiName: poi.name });
     } catch (error) {
@@ -1941,6 +1960,9 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
   );
   const pois = poisResult.rows;
 
+  // Build domain ownership map once for the entire job
+  const domainOwnershipMap = await buildDomainOwnershipMap(pool);
+
   // Initialize counters from existing progress
   let newsFound = job.news_found || 0;
   let eventsFound = job.events_found || 0;
@@ -1996,8 +2018,8 @@ export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobDat
         const { news, events, metadata } = await collectPoi(pool, poi, sheets, 'America/New_York');
         tracker.updateProgress(poi.id, { phase: 'save', message: `${news.length} news, ${events.length} events` });
         const saveLog = (msg) => { logInfo(jobId, 'news', poi.id, poi.name, msg); };
-        const savedNews = await saveNewsItems(pool, poi.id, news, { log: saveLog });
-        const savedEvents = await saveEventItems(pool, poi.id, events, { log: saveLog });
+        const savedNews = await saveNewsItems(pool, poi.id, news, { log: saveLog, domainOwnershipMap });
+        const savedEvents = await saveEventItems(pool, poi.id, events, { log: saveLog, domainOwnershipMap });
         logInfo(jobId, 'news', poi.id, poi.name, `[${index + 1}/${total}] ${savedNews} news, ${savedEvents} events saved`, { news_found: news.length, events_found: events.length, news_saved: savedNews, events_saved: savedEvents });
 
         // Update last_news_collection timestamp
@@ -2119,6 +2141,60 @@ export async function runBatchNewsCollection(pool, poiIds, sheets = null, source
   });
 
   return { jobId, totalPois };
+}
+
+/**
+ * Extract domain from a URL, stripping www. prefix.
+ * @param {string} url - URL to extract domain from
+ * @returns {string|null} - Lowercase domain or null
+ */
+function extractDomain(url) {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a map of domain → POI ID from all POIs that have news_url or events_url.
+ * Used to detect when collected content belongs to a different organization.
+ * @param {Pool} pool - Database connection pool
+ * @returns {Map<string, {poiId: number, poiName: string}>} - domain → POI info
+ */
+export async function buildDomainOwnershipMap(pool) {
+  const result = await pool.query(
+    `SELECT id, name, news_url, events_url FROM pois
+     WHERE (news_url IS NOT NULL OR events_url IS NOT NULL) AND deleted = false`
+  );
+  const map = new Map();
+  for (const row of result.rows) {
+    for (const url of [row.news_url, row.events_url]) {
+      const domain = extractDomain(url);
+      if (domain) {
+        map.set(domain, { poiId: row.id, poiName: row.name });
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Check if a source URL's domain belongs to a different POI.
+ * @param {string} sourceUrl - The source URL to check
+ * @param {number} currentPoiId - The POI this item is currently assigned to
+ * @param {Map} domainMap - Domain ownership map from buildDomainOwnershipMap()
+ * @returns {{poiId: number, poiName: string}|null} - The owning POI if different, or null
+ */
+function checkDomainOwnership(sourceUrl, currentPoiId, domainMap) {
+  if (!sourceUrl || !domainMap) return null;
+  const domain = extractDomain(sourceUrl);
+  if (!domain) return null;
+  const owner = domainMap.get(domain);
+  if (owner && owner.poiId !== currentPoiId) return owner;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds domain-based URL ownership detection to the news/events collection pipeline
- When a collected item's source URL domain matches another POI's `news_url` or `events_url`, the item is automatically reassigned to the domain-owning POI
- Fixes 47 existing misattributed records (19 news + 28 events) via migration 047
- Affects all 4 collection paths: batch jobs, pg-boss jobs, single-POI news, and single-POI events

Closes #354

## Test plan
- [x] Container builds successfully
- [x] 315/315 relevant tests pass (15 pre-existing UI tour overlay failures unrelated)
- [x] Migration verified: all 47 misattributed records corrected on container restart
- [ ] User verification: trigger single-POI collection for a physical POI and verify items from org domains get reassigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)