### PR TITLE
feat: add consistent 20-item pagination across all list views

### DIFF
--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -69,7 +69,8 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
   const [lightboxPoiId, setLightboxPoiId] = useState(null);
   const [user, setUser] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null); // "news:123" key
-  const LIMIT = 1000;
+  const [page, setPage] = useState(1);
+  const LIMIT = 20;
 
   // Handle focusItemId changes (e.g. user clicks Edit on a second article without
   // leaving the Moderation tab — the component stays mounted but props change).
@@ -82,6 +83,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     setSearchQuery('');
     setSearchInput(focusItemTitle || '');
     setIdFilter(focusItemId);
+    setPage(1);
   }, [focusItemId, focusItemTitle]);
 
   // After queue loads, auto-expand and open edit mode for the focused item
@@ -104,7 +106,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
   const fetchQueue = useCallback(async ({ silent = false } = {}) => {
     if (!silent) setLoading(true);
     try {
-      const params = new URLSearchParams({ page: 1, limit: LIMIT, status: statusFilter, sort: sortOrder });
+      const params = new URLSearchParams({ page, limit: LIMIT, status: statusFilter, sort: sortOrder });
       if (filter) params.set('type', filter);
       if (sourceFilter) params.set('source', sourceFilter);
       if (idFilter) {
@@ -125,9 +127,9 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     } finally {
       if (!silent) setLoading(false);
     }
-  }, [filter, statusFilter, sourceFilter, searchQuery, idFilter, sortOrder]);
+  }, [page, filter, statusFilter, sourceFilter, searchQuery, idFilter, sortOrder]);
 
-  useEffect(() => { fetchQueue(); }, [fetchQueue]);
+  useEffect(() => { fetchQueue(); setSelectedItems(new Set()); }, [fetchQueue]);
 
   // Auto-poll every 5 seconds to pick up background sweep changes
   useEffect(() => {
@@ -707,8 +709,8 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
         <input
           type="text"
           value={searchInput}
-          onChange={e => { setSearchInput(e.target.value); if (!e.target.value) { setIdFilter(null); setSearchQuery('');} }}
-          onKeyDown={e => { if (e.key === 'Enter') { setIdFilter(null); setSearchQuery(searchInput);} }}
+          onChange={e => { setSearchInput(e.target.value); if (!e.target.value) { setIdFilter(null); setSearchQuery(''); setPage(1);} }}
+          onKeyDown={e => { if (e.key === 'Enter') { setIdFilter(null); setSearchQuery(searchInput); setPage(1);} }}
           placeholder="Search by title or description..."
           style={{
             width: '100%', padding: '8px 12px', fontSize: '0.88rem',
@@ -731,6 +733,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
               setFilter(f.value);
               if (f.value === 'event') setSortOrder('date_asc');
               else if (f.value !== filter) setSortOrder('collected_desc');
+              setPage(1);
             }}
               style={filterBtn(filter === f.value)}>
               {f.label}
@@ -745,7 +748,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
             { label: 'Human', value: 'human' },
             { label: 'Newsletter', value: 'newsletter' },
           ].map(f => (
-            <button key={`src-${f.label}`} onClick={() => { setSourceFilter(f.value);}}
+            <button key={`src-${f.label}`} onClick={() => { setSourceFilter(f.value); setPage(1);}}
               style={filterBtn(sourceFilter === f.value)}>
               {f.label}
             </button>
@@ -759,7 +762,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
             { label: 'Approved', value: 'approved' },
             { label: 'Rejected', value: 'rejected' },
           ].map(f => (
-            <button key={f.value} onClick={() => { setStatusFilter(f.value);setSelectedItems(new Set()); }}
+            <button key={f.value} onClick={() => { setStatusFilter(f.value);setSelectedItems(new Set()); setPage(1);}}
               style={filterBtn(statusFilter === f.value)}>
               {f.label}
             </button>
@@ -775,7 +778,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
             { label: 'POI A\u2192Z', value: 'poi_asc' },
             { label: 'POI Z\u2192A', value: 'poi_desc' },
           ].map(f => (
-            <button key={f.value} onClick={() => setSortOrder(f.value)}
+            <button key={f.value} onClick={() => { setSortOrder(f.value); setPage(1);}}
               style={filterBtn(sortOrder === f.value)}>
               {f.label}
             </button>
@@ -1153,6 +1156,29 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
               );
             }
           })}
+        </div>
+      )}
+
+      {/* Pagination controls */}
+      {!loading && Math.ceil(total / LIMIT) > 1 && (
+        <div className="pagination-controls">
+          <button
+            className="pagination-btn"
+            onClick={() => setPage(p => p - 1)}
+            disabled={page === 1}
+          >
+            Back
+          </button>
+          <span className="pagination-info">
+            Page {page} of {Math.ceil(total / LIMIT)}
+          </span>
+          <button
+            className="pagination-btn"
+            onClick={() => setPage(p => p + 1)}
+            disabled={page === Math.ceil(total / LIMIT)}
+          >
+            Next
+          </button>
         </div>
       )}
 

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -22,6 +22,8 @@ function ParkEvents({ isAdmin, onSelectPoi, filteredDestinations, filteredLinear
   const [error, setError] = useState(null);
   const stableBoundsRef = useRef(DEFAULT_PARK_BOUNDS);
   const [searchText, setSearchText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 20;
   const [activeSubTab, setActiveSubTab] = useState('future');
   const [pastEvents, setPastEvents] = useState([]);
   const [pastLoading, setPastLoading] = useState(false);
@@ -142,6 +144,12 @@ function ParkEvents({ isAdmin, onSelectPoi, filteredDestinations, filteredLinear
     return filtered;
   }, [sourceEvents, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, searchText, typeFilters]);
 
+  const totalPages = Math.ceil(filteredEvents.length / PAGE_SIZE);
+  const paginatedEvents = filteredEvents.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
   const generateCalendarUrl = (event) => {
     const title = encodeURIComponent(event.title);
     const startDate = formatDateForCalendar(event.start_date);
@@ -239,14 +247,14 @@ END:VCALENDAR`;
       <div className="results-subtabs" onKeyDown={(e) => handleRovingKeyDown(e, '.results-subtab')}>
         <button
           className={`results-subtab ${activeSubTab === 'future' ? 'active' : ''}`}
-          onClick={() => setActiveSubTab('future')}
+          onClick={() => { setActiveSubTab('future'); setCurrentPage(1); }}
           tabIndex={activeSubTab === 'future' ? 0 : -1}
         >
           Future
         </button>
         <button
           className={`results-subtab ${activeSubTab === 'past' ? 'active' : ''}`}
-          onClick={() => setActiveSubTab('past')}
+          onClick={() => { setActiveSubTab('past'); setCurrentPage(1); }}
           tabIndex={activeSubTab === 'past' ? 0 : -1}
         >
           Past
@@ -259,7 +267,7 @@ END:VCALENDAR`;
           className="results-search-input"
           placeholder="Search events by title, description, or location..."
           value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
+          onChange={(e) => { setSearchText(e.target.value); setCurrentPage(1); }}
         />
         <div className="results-type-filters">
           {[
@@ -276,7 +284,7 @@ END:VCALENDAR`;
             <div
               key={f.key}
               className={`type-filter-chip ${f.key} ${typeFilters[f.key] ? 'active' : 'inactive'}`}
-              onClick={() => setTypeFilters(prev => ({ ...prev, [f.key]: !prev[f.key] }))}
+              onClick={() => { setTypeFilters(prev => ({ ...prev, [f.key]: !prev[f.key] })); setCurrentPage(1); }}
             >
               <span className="type-filter-icon">{f.icon}</span>
               {f.label}
@@ -284,7 +292,7 @@ END:VCALENDAR`;
           ))}
         </div>
         <div className="results-count">
-          Showing {filteredEvents.length} of {sourceEvents.length} events
+          Showing {filteredEvents.length === 0 ? '0' : `${((currentPage - 1) * PAGE_SIZE) + 1}-${Math.min(currentPage * PAGE_SIZE, filteredEvents.length)}`} of {filteredEvents.length} events
         </div>
       </div>
 
@@ -307,7 +315,7 @@ END:VCALENDAR`;
               items[next].focus();
             }
           }}>
-            {filteredEvents.map(item => (
+            {paginatedEvents.map(item => (
           <EventCardBody
             key={item.id}
             item={item}
@@ -335,6 +343,27 @@ END:VCALENDAR`;
           />
             ))}
           </div>
+          )}
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p - 1)}
+                disabled={currentPage === 1}
+              >
+                Back
+              </button>
+              <span className="pagination-info">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p + 1)}
+                disabled={currentPage === totalPages}
+              >
+                Next
+              </button>
+            </div>
           )}
         </div>
         {/* Map thumbnail sidebar */}

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -15,7 +15,7 @@ function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, 
   const stableBoundsRef = useRef(DEFAULT_PARK_BOUNDS);
   const [searchText, setSearchText] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
-  const PAGE_SIZE = 50;
+  const PAGE_SIZE = 20;
   const [typeFilters, setTypeFilters] = useState({
     general: true,
     alert: true,

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -43,6 +43,8 @@ const ResultsTab = memo(function ResultsTab({
     initialShowMtbOnly ? 'mtb' : initialShowOrganizationsOnly ? 'organizations' : 'all'
   );
   const [searchText, setSearchText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 20;
 
   // Sub-tab configuration (fetched from server, with hardcoded fallback)
   const DEFAULT_SUBTABS = [
@@ -234,6 +236,14 @@ const ResultsTab = memo(function ResultsTab({
     };
   }, [activeSubTab, viewportFilteredDestinations, viewportFilteredLinearFeatures, viewportFilteredVirtualPois, allDestinations, allLinearFeatures, allVirtualPois, searchText, enabledFilters, bypassViewportFilter, isInTransition, iconConfig]);
 
+  const totalPages = Math.ceil(sortedPois.length / PAGE_SIZE) || 1;
+  const clampedPage = Math.min(currentPage, totalPages);
+  if (clampedPage !== currentPage) setCurrentPage(clampedPage);
+  const paginatedPois = sortedPois.slice(
+    (clampedPage - 1) * PAGE_SIZE,
+    clampedPage * PAGE_SIZE
+  );
+
   // Event delegation handler - single handler for all tiles
   const handleListClick = useCallback((e) => {
     const tile = e.target.closest('.results-tile');
@@ -315,14 +325,17 @@ const ResultsTab = memo(function ResultsTab({
       }
       return newSet;
     });
+    setCurrentPage(1);
   }, []);
 
   const showAllFilters = useCallback(() => {
     setEnabledFilters(new Set(allFilterTypes));
+    setCurrentPage(1);
   }, [allFilterTypes]);
 
   const hideAllFilters = useCallback(() => {
     setEnabledFilters(new Set());
+    setCurrentPage(1);
   }, []);
 
   // Clear transition state when App.jsx bypassViewportFilter catches up
@@ -375,6 +388,7 @@ const ResultsTab = memo(function ResultsTab({
     }
 
     setActiveSubTab(tab);
+    setCurrentPage(1);
 
     // Don't clear bypass filter here - let App.jsx MTB Route Effect handle it
     // This prevents flickering when switching from MTB to All Results
@@ -419,7 +433,7 @@ const ResultsTab = memo(function ResultsTab({
             className="results-search-input"
             placeholder="Search by name or description..."
             value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
+            onChange={(e) => { setSearchText(e.target.value); setCurrentPage(1); }}
           />
           {activeSubTab === 'all' && (
             <>
@@ -442,7 +456,7 @@ const ResultsTab = memo(function ResultsTab({
             </>
           )}
           <div className="results-count">
-            Showing {poiCount} of {totalCount} POIs
+            Showing {sortedPois.length === 0 ? '0' : `${((currentPage - 1) * PAGE_SIZE) + 1}-${Math.min(currentPage * PAGE_SIZE, sortedPois.length)}`} of {sortedPois.length} POIs
           </div>
         </div>
 
@@ -535,7 +549,7 @@ const ResultsTab = memo(function ResultsTab({
           </>
         )}
         <div className="results-count">
-          Showing {poiCount} of {totalCount} POIs
+          Showing {sortedPois.length === 0 ? '0' : `${((currentPage - 1) * PAGE_SIZE) + 1}-${Math.min(currentPage * PAGE_SIZE, sortedPois.length)}`} of {sortedPois.length} POIs
         </div>
       </div>
 
@@ -552,7 +566,7 @@ const ResultsTab = memo(function ResultsTab({
               tiles[next].focus();
             }
           }}>
-            {sortedPois.map(poi => {
+            {paginatedPois.map(poi => {
               const type = poi._isVirtual ? 'virtual' : (poi._isLinear ? 'linear' : 'point');
               const poiKey = `${type}-${poi.id}`;
               const isSelected = poi._isLinear
@@ -573,6 +587,27 @@ const ResultsTab = memo(function ResultsTab({
               );
             })}
           </div>
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p - 1)}
+                disabled={currentPage === 1}
+              >
+                Back
+              </button>
+              <span className="pagination-info">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                className="pagination-btn"
+                onClick={() => setCurrentPage(p => p + 1)}
+                disabled={currentPage === totalPages}
+              >
+                Next
+              </button>
+            </div>
+          )}
         </div>
         {mapState && (
           <div className="map-thumbnail-sidebar">


### PR DESCRIPTION
## Summary
- Adds 20-item-per-page pagination with Back/Next controls to **Results**, **Events**, and **Moderation** views
- Changes **News** from 50 to 20 items per page to match
- All views use the same `pagination-controls` CSS classes for consistent styling
- Page resets to 1 on filter, search, sort, or subtab changes
- Moderation uses server-side pagination (backend already supported it); Results, News, and Events use client-side slicing
- Results tab clamps page when viewport changes reduce the POI count

## Test plan
- [x] Build passes
- [x] 315/331 tests pass (15 pre-existing failures, identical to master)
- [ ] Verify pagination controls appear on Results, News, Events, and Moderation tabs
- [ ] Verify page resets when changing filters, search, or sort
- [ ] Verify Results tab handles map pan/zoom without breaking pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)