### PR TITLE
feat: New button for Results, News & Events tabs

### DIFF
--- a/.specify/specs/012-new-poi-button/plan.md
+++ b/.specify/specs/012-new-poi-button/plan.md
@@ -1,0 +1,240 @@
+# Implementation Plan: New Button for Results, News & Events Tabs
+
+> **Spec ID:** 012-new-poi-button
+> **Status:** Planning
+> **Last Updated:** 2026-05-15
+> **Estimated Effort:** L
+
+## Summary
+
+Add "New" buttons to the Results, News, and Events tabs that integrate with the existing Sidebar edit panel and POI creation API. The Results tab buttons create POIs with role defaults matching the active sub-tab. News and Events tabs get simple creation forms for manual content entry.
+
+---
+
+## Architecture
+
+### Data Flow — New POI from Results Tab
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  ResultsTab  │     │    App.jsx   │     │   Map.jsx    │     │  Sidebar.jsx │
+│  [+ New] btn │────▶│ handleNew()  │────▶│ click-to-    │────▶│ Edit form    │
+│              │     │ sets newPOI  │     │ place mode   │     │ w/ roles     │
+└──────────────┘     │ w/ default   │     │ (for points) │     │ + GeoJSON    │
+                     │ poi_roles    │     └──────────────┘     │ + save       │
+                     └──────────────┘                          └──────┬───────┘
+                                                                      │
+                                                          POST /api/admin/pois
+```
+
+### Data Flow — New News/Event
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  ParkNews    │     │ NewNewsForm  │     │ Backend API  │
+│  [+ New] btn │────▶│ (modal)      │────▶│ POST /admin/ │
+│              │     │ POI + title  │     │ news         │
+└──────────────┘     │ + summary    │     └──────────────┘
+                     └──────────────┘
+```
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Role editor | HTML checkboxes + existing chip styles | Simple, matches existing UI patterns |
+| GeoJSON upload | `<input type="file">` + JSON.parse validation | No extra dependencies needed |
+| GeoJSON preview | Leaflet `<GeoJSON>` component (already used) | Already in the codebase for linear features |
+| News/Event forms | Modal component | Matches existing modal patterns (NewPOIForm) |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Results Tab — New Button + Sidebar Integration
+
+- [ ] Pass `editMode`, `isAdmin`, `role` props to `ResultsTab`
+- [ ] Add "New" button to `ResultsTab` header area, right-aligned in sub-tab bar
+- [ ] Button visibility: `editMode && (isAdmin || role === 'poi_admin')`
+- [ ] Add `onNewPOI` callback prop — calls up to App.jsx
+- [ ] In App.jsx, add `handleNewPOIFromResults(subTab)` that:
+  - Determines default roles from sub-tab (`all` → `['point']`, `mtb` → `['point']` + `is_mtb_trail`, `organizations` → `['organization']`)
+  - Calls `setNewPOI()` with the appropriate defaults including `poi_roles`
+  - For point-role POIs: switches to map view in "click to place" mode
+  - For organizations: opens Sidebar directly (no coordinates needed)
+- [ ] Modify Sidebar to accept and display pre-set `poi_roles` on new POI objects
+
+### Phase 2: Role Editor in Sidebar
+
+- [ ] Create `RoleEditor.jsx` component — checkbox list of valid roles
+- [ ] Add to Sidebar's EditView when `isNewPOI || isNewOrganization`
+- [ ] Also show in existing edit mode for established POIs (allows role changes)
+- [ ] Wire role changes to `editedData.poi_roles` state
+- [ ] Validate at least one role selected before save
+
+### Phase 3: GeoJSON Upload
+
+- [ ] Create `GeoJSONUploader.jsx` component
+- [ ] Show in Sidebar edit form when POI has trail, river, or boundary role
+- [ ] File input accepts `.geojson`, `.json`
+- [ ] On file select: parse JSON, validate GeoJSON structure, extract geometry
+- [ ] Store geometry in `editedData.geometry`
+- [ ] Render preview on map via temporary `<GeoJSON>` layer
+- [ ] On save: geometry sent as part of `POST /api/admin/pois` body
+- [ ] Backend: ensure `geometry` is in `allowedFields` for POST /api/admin/pois
+
+### Phase 4: News Tab — New Button + Form
+
+- [ ] Add "New" button to ParkNews component header
+- [ ] Button visibility: `editMode && isAdmin`
+- [ ] Create `NewNewsForm.jsx` modal component
+- [ ] Form fields: POI selector (dropdown of all POIs), title, summary, source URL, source name, news type, publication date
+- [ ] Add `POST /api/admin/news` endpoint in admin.js
+- [ ] Endpoint creates `poi_news` row with `content_source: 'manual'`, `moderation_status: 'published'`
+- [ ] Refresh news feed after creation
+
+### Phase 5: Events Tab — New Button + Form
+
+- [ ] Add "New" button to ParkEvents component header
+- [ ] Button visibility: `editMode && isAdmin`
+- [ ] Create `NewEventForm.jsx` modal component
+- [ ] Form fields: POI selector, title, start date, end date, description, event type, location details, source URL
+- [ ] Add `POST /api/admin/events` endpoint in admin.js
+- [ ] Endpoint creates `poi_events` row with `content_source: 'manual'`, `moderation_status: 'published'`
+- [ ] Refresh events feed after creation
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/components/RoleEditor.jsx` | POI role checkbox/chip editor |
+| `frontend/src/components/GeoJSONUploader.jsx` | GeoJSON file upload with validation |
+| `frontend/src/components/NewNewsForm.jsx` | Modal form for manual news creation |
+| `frontend/src/components/NewEventForm.jsx` | Modal form for manual event creation |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/App.jsx` | Add `handleNewPOIFromResults()`, pass editMode/role to ResultsTab, wire new handlers |
+| `frontend/src/components/ResultsTab.jsx` | Add New button in sub-tab bar, onNewPOI callback |
+| `frontend/src/components/Sidebar.jsx` | Import RoleEditor + GeoJSONUploader, show in edit form, handle poi_roles in editedData |
+| `frontend/src/components/Map.jsx` | No changes expected — existing click-to-place already works |
+| `frontend/src/components/ParkNews.jsx` | Add New button + NewNewsForm modal trigger |
+| `frontend/src/components/ParkEvents.jsx` | Add New button + NewEventForm modal trigger |
+| `backend/routes/admin.js` | Add POST /admin/news, POST /admin/events endpoints; ensure geometry in allowedFields for POST /pois |
+
+---
+
+## API Implementation
+
+### Endpoint: `POST /api/admin/news`
+
+**Request:**
+```json
+{
+  "poi_id": 42,
+  "title": "Trail reopens after restoration",
+  "summary": "The Towpath Trail section near Lock 29...",
+  "source_url": "https://example.com/article",
+  "source_name": "Valley News",
+  "news_type": "general",
+  "publication_date": "2026-05-15"
+}
+```
+
+**Response:**
+```json
+{
+  "id": 123,
+  "poi_id": 42,
+  "title": "Trail reopens after restoration",
+  "content_source": "manual",
+  "moderation_status": "published",
+  "collection_date": "2026-05-15T12:00:00Z"
+}
+```
+
+### Endpoint: `POST /api/admin/events`
+
+**Request:**
+```json
+{
+  "poi_id": 42,
+  "title": "Summer Concert Series",
+  "start_date": "2026-06-01",
+  "end_date": "2026-08-31",
+  "description": "Weekly concerts at...",
+  "event_type": "concert",
+  "location_details": "Howe Meadow",
+  "source_url": "https://example.com/events"
+}
+```
+
+**Response:**
+```json
+{
+  "id": 456,
+  "poi_id": 42,
+  "title": "Summer Concert Series",
+  "content_source": "manual",
+  "moderation_status": "published",
+  "collection_date": "2026-05-15T12:00:00Z"
+}
+```
+
+---
+
+## Testing Strategy
+
+### Integration Tests
+
+- [ ] `backend/tests/newPoi.integration.test.js` — POST /api/admin/pois with various role combinations
+- [ ] `backend/tests/newNews.integration.test.js` — POST /api/admin/news creates manual news item
+- [ ] `backend/tests/newEvents.integration.test.js` — POST /api/admin/events creates manual event
+
+### Manual Testing
+
+1. Log in as admin, enable edit mode
+2. Navigate to Results > POIs, click New — verify sidebar opens with point role, click map to place
+3. Navigate to Results > MTB, click New — verify is_mtb_trail default
+4. Navigate to Results > Organizations, click New — verify organization role, no coordinates required
+5. Test role editor: add/remove roles, verify validation
+6. Upload a GeoJSON file for a trail — verify preview on map and save
+7. Navigate to News tab, click New — create manual news item
+8. Navigate to Events tab, click New — create manual event
+9. Verify buttons are NOT visible when logged out or edit mode is off
+10. Verify buttons are NOT visible for `media_admin` or `viewer` roles
+
+---
+
+## Rollback Plan
+
+If issues are discovered:
+1. Revert the PR — all changes are additive (new buttons, new endpoints)
+2. No database migrations to roll back
+3. No existing functionality modified in a breaking way
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Sidebar is 3500+ lines — complex to modify | Med | Minimize changes — add RoleEditor as self-contained component, only add import + render call |
+| App.jsx is 3600+ lines — complex state management | Med | Follow existing `handleStartNewPOI` pattern exactly, minimal new state |
+| GeoJSON files could be very large | Low | Add client-side file size limit (e.g., 5MB), validate structure before upload |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-15 | Initial plan |

--- a/.specify/specs/012-new-poi-button/spec.md
+++ b/.specify/specs/012-new-poi-button/spec.md
@@ -1,0 +1,208 @@
+# Specification: New Button for Results, News & Events Tabs
+
+> **Spec ID:** 012-new-poi-button
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-15
+
+## Overview
+
+Add a "New" button to the Results, News, and Events tabs that is only visible when the user is in Edit mode and has the appropriate admin role. On the Results tab, clicking New creates a POI with a default role matching the active sub-tab (point for POIs, organization for Organizations, trail with is_mtb_trail for MTB). The creation flow uses the existing Sidebar edit panel rather than the legacy modal, allowing role editing, GeoJSON upload, and map-click coordinate selection.
+
+---
+
+## User Stories
+
+### Results Tab — New POI
+
+**US-012-01: Create new Point from Results > POIs sub-tab**
+> As an admin in edit mode viewing the Points of Interest sub-tab, I want to click a "New" button so that I can create a new POI with the `point` role pre-selected.
+
+Acceptance Criteria:
+- [ ] "New" button appears in the Results tab header area when `editMode === true` and user is `admin` or `poi_admin`
+- [ ] Clicking New opens the Sidebar in edit/create mode with `poi_roles: ['point']` pre-set
+- [ ] The map enters "click to place" mode — clicking the map sets coordinates on the new POI
+- [ ] User can drag the placed marker to adjust position
+- [ ] User can add additional roles (trail, river, boundary, organization) via a role editor
+- [ ] Saving calls `POST /api/admin/pois` with the correct roles and coordinates
+- [ ] New POI appears in the results list and on the map after creation
+
+**US-012-02: Create new MTB Trail from Results > MTB sub-tab**
+> As an admin in edit mode viewing the MTB Trail Status sub-tab, I want to click "New" so that I can create a new MTB trailhead POI.
+
+Acceptance Criteria:
+- [ ] "New" button appears in MTB sub-tab header when `editMode === true` and user is `admin` or `poi_admin`
+- [ ] Clicking New opens the Sidebar in create mode with `poi_roles: ['point']` and `is_mtb_trail: true` pre-set
+- [ ] Map enters "click to place" mode for coordinate selection
+- [ ] Saving creates the POI with `is_mtb_trail = true`
+
+**US-012-03: Create new Organization from Results > Organizations sub-tab**
+> As an admin in edit mode viewing the Organizations sub-tab, I want to click "New" so that I can create a new organization POI.
+
+Acceptance Criteria:
+- [ ] "New" button appears in Organizations sub-tab header when `editMode === true` and user is `admin` or `poi_admin`
+- [ ] Clicking New opens the Sidebar in create mode with `poi_roles: ['organization']` pre-set
+- [ ] Coordinates are NOT required (organizations are virtual POIs)
+- [ ] User can optionally upload a GeoJSON boundary file
+- [ ] Saving creates the organization POI
+
+### Results Tab — Role & GeoJSON Editing
+
+**US-012-04: Edit POI roles during creation**
+> As an admin creating a new POI, I want to add or remove roles so that a single POI can serve multiple purposes (e.g., a trailhead that is also a point of interest).
+
+Acceptance Criteria:
+- [ ] Role editor shows checkboxes/chips for all valid roles: point, trail, river, boundary, organization
+- [ ] The default role from the sub-tab is pre-checked but can be unchecked
+- [ ] At least one role must remain selected (validation)
+- [ ] Role changes update what fields are visible in the edit form
+
+**US-012-05: Upload GeoJSON for linear/boundary features**
+> As an admin creating or editing a POI with trail, river, or boundary role, I want to upload a GeoJSON file so that the feature's geometry is stored.
+
+Acceptance Criteria:
+- [ ] GeoJSON upload field appears when the POI has a `trail`, `river`, or `boundary` role
+- [ ] Accepts `.geojson` and `.json` files
+- [ ] Validates that the file contains valid GeoJSON (Feature or FeatureCollection)
+- [ ] Extracts geometry and stores in the `geometry` JSONB column
+- [ ] Preview of the uploaded geometry renders on the map
+
+**US-012-06: Click map to set coordinates for Point role POIs**
+> As an admin creating a new POI with the `point` role, I want to click on the map to set the POI's location.
+
+Acceptance Criteria:
+- [ ] When creating a new point-role POI, the map shows a "Click to place" indicator
+- [ ] Clicking the map sets latitude/longitude on the new POI
+- [ ] A draggable marker appears at the clicked location
+- [ ] Coordinates update in the Sidebar form in real-time
+- [ ] Works with the existing `previewCoords` system in Map.jsx
+
+### News Tab — New News Item
+
+**US-012-07: Create new news item from News tab**
+> As an admin in edit mode, I want to click "New" on the News tab so that I can manually create a news item for a POI.
+
+Acceptance Criteria:
+- [ ] "New" button appears in the News tab header when `editMode === true` and user is `admin`
+- [ ] Clicking New opens an inline form (or modal) to create a news item
+- [ ] Required fields: POI (select from list), title, summary
+- [ ] Optional fields: source URL, source name, news type, publication date
+- [ ] News item is created with `content_source: 'manual'` and `moderation_status: 'published'`
+- [ ] New item appears in the news feed after creation
+
+### Events Tab — New Event
+
+**US-012-08: Create new event from Events tab**
+> As an admin in edit mode, I want to click "New" on the Events tab so that I can manually create an event for a POI.
+
+Acceptance Criteria:
+- [ ] "New" button appears in the Events tab header when `editMode === true` and user is `admin`
+- [ ] Clicking New opens an inline form (or modal) to create an event
+- [ ] Required fields: POI (select from list), title, start date
+- [ ] Optional fields: end date, description, event type, location details, source URL
+- [ ] Event is created with `content_source: 'manual'` and `moderation_status: 'published'`
+- [ ] New event appears in the events feed after creation
+
+---
+
+## Data Model
+
+### Schema Changes
+
+No new tables required. Minor additions to `POST /api/admin/pois`:
+
+```sql
+-- The existing pois table already supports all needed fields:
+-- poi_roles TEXT[], latitude, longitude, geometry JSONB, is_mtb_trail BOOLEAN
+-- No migration needed for POI creation.
+```
+
+New API endpoints needed for manual news/event creation (see API section).
+
+---
+
+## API Endpoints
+
+### New Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/admin/news` | Create manual news item | Admin |
+| POST | `/api/admin/events` | Create manual event | Admin |
+
+### Modified Endpoints
+
+| Method | Path | Change |
+|--------|------|--------|
+| POST | `/api/admin/pois` | Add `is_mtb_trail` and `geometry` to allowed fields (if not already) |
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `RoleEditor` — Checkbox/chip selector for POI roles, used in Sidebar edit form during creation
+- `GeoJSONUploader` — File input + validation + map preview for GeoJSON geometry uploads
+- `NewNewsForm` — Inline form or modal for creating manual news items
+- `NewEventForm` — Inline form or modal for creating manual events
+
+### Modified Components
+
+| Component | Changes |
+|-----------|---------|
+| `ResultsTab.jsx` | Add "New" button in header, visible when `editMode && (isAdmin \|\| role === 'poi_admin')` |
+| `App.jsx` | Wire New button handlers for each sub-tab, pass `editMode` to ResultsTab |
+| `Sidebar.jsx` | Accept pre-set `poi_roles` for new POI creation, add RoleEditor and GeoJSONUploader to edit form |
+| `Map.jsx` | Support "click to place" mode triggered from Results tab (not just map right-click) |
+| `ParkNews` (news tab component) | Add "New" button when admin + edit mode |
+| `ParkEvents` (events tab component) | Add "New" button when admin + edit mode |
+
+### Button Placement
+
+```
+┌─────────────────────────────────────────────┐
+│  Results  │  News  │  Events  │  ...        │
+├─────────────────────────────────────────────┤
+│  POIs │ MTB Status │ Organizations  [+ New] │
+│                                             │
+│  (results list)                             │
+└─────────────────────────────────────────────┘
+```
+
+The "New" button sits in the sub-tab bar area, right-aligned. On News/Events tabs it sits in the tab header area.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-012-01: Permission Safety**
+- The New button must NEVER appear for non-admin users or when edit mode is off
+- Backend endpoints must enforce role checks independently of frontend visibility
+
+**NFR-012-02: Consistency**
+- New POI creation via the Results tab must use the same Sidebar edit panel as the existing map-click creation flow
+- The experience should feel like the same tool, just initiated from a different place
+
+---
+
+## Dependencies
+
+- Depends on: 000-baseline (POI CRUD), 005-poi-roles (role system), 003-user-roles (admin permissions)
+- Blocks: none
+
+---
+
+## Open Questions
+
+1. Should the News/Events "New" forms be inline in the tab or open a modal? (Leaning modal for consistency with other creation flows)
+2. For GeoJSON upload on existing POIs (not just new ones), should this be added to the standard edit form too? (Probably yes, but could be a follow-up)
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-15 | Initial draft |

--- a/backend/migrations/047_add_mtb_trail_role.sql
+++ b/backend/migrations/047_add_mtb_trail_role.sql
@@ -1,0 +1,7 @@
+-- Migration: 047_add_mtb_trail_role
+-- Description: Add 'mtb_trail' to poi_roles for all POIs that have is_mtb_trail = TRUE
+
+UPDATE pois
+SET poi_roles = array_append(poi_roles, 'mtb_trail')
+WHERE is_mtb_trail = TRUE
+  AND NOT ('mtb_trail' = ANY(poi_roles));

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -368,7 +368,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'poi_roles', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
       'historical_description', 'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'has_primary_image',
-      'collection_tier', 'news_score_threshold', 'events_score_threshold'
+      'collection_tier', 'news_score_threshold', 'events_score_threshold',
+      'geometry', 'is_mtb_trail', 'status_url', 'research_context'
     ];
 
     const fields = ['name', 'poi_roles'];
@@ -427,6 +428,54 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     } catch (error) {
       console.error('Error deleting destination:', error);
       res.status(500).json({ error: 'Failed to delete destination' });
+    }
+  });
+
+  // Create manual news item
+  router.post('/news', isAdmin, async (req, res) => {
+    const { poi_id, title, summary, source_url, source_name, news_type, publication_date } = req.body;
+
+    if (!poi_id || !title || !title.trim()) {
+      return res.status(400).json({ error: 'poi_id and title are required' });
+    }
+
+    try {
+      const result = await pool.query(
+        `INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, content_source, moderation_status, collection_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', 'published', CURRENT_TIMESTAMP)
+         RETURNING *`,
+        [poi_id, title.trim(), summary || null, source_url || null, source_name || null, news_type || 'general', publication_date || null]
+      );
+
+      console.log(`Admin ${req.user.email} created manual news item: ${title}`);
+      res.status(201).json(result.rows[0]);
+    } catch (error) {
+      console.error('Error creating news item:', error);
+      res.status(500).json({ error: 'Failed to create news item' });
+    }
+  });
+
+  // Create manual event
+  router.post('/events', isAdmin, async (req, res) => {
+    const { poi_id, title, start_date, end_date, description, event_type, location_details, source_url } = req.body;
+
+    if (!poi_id || !title || !title.trim() || !start_date) {
+      return res.status(400).json({ error: 'poi_id, title, and start_date are required' });
+    }
+
+    try {
+      const result = await pool.query(
+        `INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, content_source, moderation_status, collection_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'manual', 'published', CURRENT_TIMESTAMP)
+         RETURNING *`,
+        [poi_id, title.trim(), description || null, start_date, end_date || null, event_type || null, location_details || null, source_url || null]
+      );
+
+      console.log(`Admin ${req.user.email} created manual event: ${title}`);
+      res.status(201).json(result.rows[0]);
+    } catch (error) {
+      console.error('Error creating event:', error);
+      res.status(500).json({ error: 'Failed to create event' });
     }
   });
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -343,7 +343,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       return res.status(400).json({ error: 'Name is required' });
     }
 
-    const validRoles = ['point', 'trail', 'river', 'boundary', 'organization'];
+    const validRoles = ['point', 'mtb_trail', 'trail', 'river', 'boundary', 'organization'];
     const rolesArray = Array.isArray(poi_roles) ? poi_roles : (poi_roles ? [poi_roles] : []);
     if (rolesArray.length === 0 || !rolesArray.every(r => validRoles.includes(r))) {
       return res.status(400).json({ error: 'Invalid poi_roles. Must include at least one of: point, trail, river, boundary, organization' });
@@ -369,7 +369,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'historical_description', 'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'has_primary_image',
       'collection_tier', 'news_score_threshold', 'events_score_threshold',
-      'geometry', 'is_mtb_trail', 'status_url', 'research_context'
+      'geometry', 'status_url', 'research_context'
     ];
 
     const fields = ['name', 'poi_roles'];
@@ -442,7 +442,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     try {
       const result = await pool.query(
         `INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, content_source, moderation_status, collection_date)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', 'published', CURRENT_TIMESTAMP)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'human', 'published', CURRENT_TIMESTAMP)
          RETURNING *`,
         [poi_id, title.trim(), summary || null, source_url || null, source_name || null, news_type || 'general', publication_date || null]
       );
@@ -457,7 +457,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
   // Create manual event
   router.post('/events', isAdmin, async (req, res) => {
-    const { poi_id, title, start_date, end_date, description, event_type, location_details, source_url } = req.body;
+    const { poi_id, title, start_date, end_date, description, event_type, location_details, source_url, publication_date } = req.body;
 
     if (!poi_id || !title || !title.trim() || !start_date) {
       return res.status(400).json({ error: 'poi_id, title, and start_date are required' });
@@ -465,10 +465,10 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
     try {
       const result = await pool.query(
-        `INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, content_source, moderation_status, collection_date)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'manual', 'published', CURRENT_TIMESTAMP)
+        `INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, content_source, moderation_status, collection_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'human', 'published', CURRENT_TIMESTAMP)
          RETURNING *`,
-        [poi_id, title.trim(), description || null, start_date, end_date || null, event_type || null, location_details || null, source_url || null]
+        [poi_id, title.trim(), description || null, start_date, end_date || null, event_type || null, location_details || null, source_url || null, publication_date || null]
       );
 
       console.log(`Admin ${req.user.email} created manual event: ${title}`);

--- a/backend/server.js
+++ b/backend/server.js
@@ -2157,7 +2157,7 @@ app.get('/api/trail-status/mtb-trails', async (req, res) => {
       ) ts ON true
       WHERE p.status_url IS NOT NULL
         AND p.status_url != ''
-        AND 'point' = ANY(p.poi_roles)
+        AND ('mtb_trail' = ANY(p.poi_roles) OR 'point' = ANY(p.poi_roles))
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       ORDER BY p.name
     `);
@@ -2173,10 +2173,15 @@ app.get('/api/trail-status/mtb-trails', async (req, res) => {
 app.get('/api/news/recent', async (req, res) => {
   try {
     const limit = parseInt(req.query.limit) || 500;
+    const isAdmin = req.user && (req.user.role === 'admin' || req.user.isAdmin);
+    const adminColumns = isAdmin
+      ? `, n.moderation_status, n.confidence_score, n.ai_reasoning, n.ai_issues,
+           n.content_source, n.moderated_at`
+      : '';
     const recentNewsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.publication_date, n.date_consensus_score, n.collection_date,
-             p.id as poi_id, p.name as poi_name, p.poi_roles,
+             p.id as poi_id, p.name as poi_name, p.poi_roles${adminColumns},
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
@@ -2199,9 +2204,14 @@ app.get('/api/events/upcoming', async (req, res) => {
   try {
     // Use client timezone for "today" calculation (defaults to America/New_York)
     const tz = req.query.tz || 'America/New_York';
+    const isAdmin = req.user && (req.user.role === 'admin' || req.user.isAdmin);
+    const adminColumns = isAdmin
+      ? `, e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
+           e.content_source, e.moderated_at`
+      : '';
     const upcomingEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles${adminColumns},
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
@@ -2224,9 +2234,14 @@ app.get('/api/events/past', async (req, res) => {
   try {
     const limit = parseInt(req.query.limit) || 50;
     const tz = req.query.tz || 'America/New_York';
+    const isAdmin = req.user && (req.user.role === 'admin' || req.user.isAdmin);
+    const adminColumns = isAdmin
+      ? `, e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
+           e.content_source, e.moderated_at`
+      : '';
     const pastEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles${adminColumns},
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2163,6 +2163,14 @@ body {
   margin: 0.5rem 0;
 }
 
+/* News date — matches event date styling */
+.park-news-date {
+  font-size: 0.85rem;
+  color: #1565c0;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
 .park-news-meta {
   display: flex;
   flex-wrap: wrap;
@@ -4498,15 +4506,17 @@ body {
   justify-content: center;
   align-items: center;
   z-index: 10000;
+  padding: 0;
 }
 
 .new-content-modal {
   background: #fff;
   border-radius: 8px;
   width: min(90vw, 520px);
-  max-height: 80vh;
+  max-height: 75vh;
   overflow-y: auto;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  margin-top: 40px;
 }
 
 .new-content-header {
@@ -4587,6 +4597,100 @@ body {
   border-radius: 4px;
 }
 
+/* AI info box in edit mode */
+.form-ai-info {
+  padding: 0.6rem 0.75rem;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  font-size: 0.8rem;
+  color: #555;
+  line-height: 1.4;
+}
+
+.form-ai-reasoning {
+  margin-bottom: 0.3rem;
+}
+
+.form-ai-status {
+  font-size: 0.75rem;
+  color: #888;
+}
+
+/* Additional URLs in edit modal */
+.form-urls-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.form-url-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  background: #f9f9f9;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.form-url-link {
+  color: #1976d2;
+  flex: 1;
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.form-url-source {
+  color: #888;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+.form-url-remove {
+  background: none;
+  border: none;
+  color: #f44336;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.form-url-add {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.3rem;
+}
+
+.form-url-add input {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.78rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form-url-add-btn {
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #fff;
+  background: #1976d2;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.form-url-add-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
 .new-content-form .form-buttons {
   display: flex;
   justify-content: flex-end;
@@ -4647,6 +4751,74 @@ body {
 
 .tab-new-btn:hover {
   background: #388E3C;
+}
+
+/* Inline moderation controls on News/Events cards */
+.card-moderation-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #e8e8e8;
+  flex-wrap: wrap;
+}
+
+.card-mod-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.card-mod-badge.source-ai { background: #e3f2fd; color: #1565c0; }
+.card-mod-badge.source-human { background: #f3e5f5; color: #7b1fa2; }
+.card-mod-badge.source-feed { background: #fff3e0; color: #e65100; }
+.card-mod-badge.source-community { background: #e8f5e9; color: #2e7d32; }
+.card-mod-badge.status-published { background: #e8f5e9; color: #2e7d32; }
+.card-mod-badge.status-auto_approved { background: #e8f5e9; color: #2e7d32; }
+.card-mod-badge.status-pending { background: #fff3e0; color: #e65100; }
+.card-mod-badge.status-rejected { background: #ffebee; color: #c62828; }
+
+.card-mod-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.card-mod-btn {
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  color: #333;
+}
+
+.card-mod-btn:hover {
+  background: #e0e0e0;
+}
+
+.card-mod-btn.edit {
+  border-color: #1565c0;
+  color: #1565c0;
+}
+
+.card-mod-btn.edit:hover {
+  background: #e3f2fd;
+}
+
+.card-mod-btn.delete {
+  border-color: #c62828;
+  color: #c62828;
+}
+
+.card-mod-btn.delete:hover {
+  background: #ffebee;
 }
 
 .edit-section input:focus,
@@ -11217,6 +11389,7 @@ body {
 /* Results sub-tabs */
 .results-subtabs {
   display: flex;
+  align-items: center;
   gap: 0;
   margin-bottom: 1rem;
   border-bottom: 2px solid #e0e0e0;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4362,6 +4362,293 @@ body {
   font-family: inherit;
 }
 
+/* Role Editor */
+.role-editor {
+  margin-bottom: 1rem;
+}
+
+.role-editor label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #525252;
+  margin-bottom: 0.35rem;
+  font-weight: 500;
+}
+
+.role-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.role-chip {
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  background: #f5f5f5;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.role-chip:hover {
+  border-color: #999;
+}
+
+.role-chip.active {
+  background: #4CAF50;
+  color: #fff;
+  border-color: #4CAF50;
+}
+
+.role-chip.active:hover {
+  background: #388E3C;
+  border-color: #388E3C;
+}
+
+/* GeoJSON Uploader */
+.geojson-uploader {
+  margin-bottom: 1rem;
+}
+
+.geojson-uploader label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #525252;
+  margin-bottom: 0.35rem;
+  font-weight: 500;
+}
+
+.geojson-upload-area {
+  border: 2px dashed #ccc;
+  border-radius: 6px;
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.geojson-upload-area:hover {
+  border-color: #4CAF50;
+}
+
+.geojson-upload-area.has-file {
+  border-color: #4CAF50;
+  border-style: solid;
+  background: #f0f8f0;
+}
+
+.geojson-file-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.geojson-file-name {
+  font-size: 0.85rem;
+  color: #333;
+  font-weight: 500;
+}
+
+.geojson-file-meta {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.geojson-clear-btn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  color: #d32f2f;
+  background: none;
+  border: 1px solid #d32f2f;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.geojson-clear-btn:hover {
+  background: #ffebee;
+}
+
+.geojson-upload-prompt {
+  font-size: 0.85rem;
+  color: #888;
+}
+
+.geojson-error {
+  font-size: 0.8rem;
+  color: #d32f2f;
+  margin-top: 0.3rem;
+}
+
+/* New News/Event form modals */
+.new-content-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+}
+
+.new-content-modal {
+  background: #fff;
+  border-radius: 8px;
+  width: min(90vw, 520px);
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.new-content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.new-content-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.new-content-header .close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #666;
+  padding: 0;
+  line-height: 1;
+}
+
+.new-content-form {
+  padding: 1.25rem;
+}
+
+.new-content-form .form-section {
+  margin-bottom: 1rem;
+}
+
+.new-content-form .form-section label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #525252;
+  margin-bottom: 0.35rem;
+  font-weight: 500;
+}
+
+.new-content-form .form-section input,
+.new-content-form .form-section select,
+.new-content-form .form-section textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.new-content-form .form-section input:focus,
+.new-content-form .form-section select:focus,
+.new-content-form .form-section textarea:focus {
+  outline: none;
+  border-color: #4a7c23;
+}
+
+.new-content-form .form-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.new-content-form .form-row .form-section {
+  flex: 1;
+}
+
+.new-content-form .form-error {
+  color: #d32f2f;
+  font-size: 0.85rem;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem;
+  background: #ffebee;
+  border-radius: 4px;
+}
+
+.new-content-form .form-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.new-content-form .cancel-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.new-content-form .save-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #4CAF50;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.new-content-form .save-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.new-content-form .save-btn:not(:disabled):hover {
+  background: #388E3C;
+}
+
+/* News/Events tab New button */
+.tab-header-with-new {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.tab-new-btn {
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: #4CAF50;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  white-space: nowrap;
+}
+
+.tab-new-btn:hover {
+  background: #388E3C;
+}
+
 .edit-section input:focus,
 .edit-section select:focus,
 .edit-section textarea:focus {
@@ -10963,6 +11250,26 @@ body {
   right: 0;
   height: 2px;
   background: #4CAF50;
+}
+
+/* New button in sub-tab bar (admin edit mode only) */
+.results-new-btn {
+  margin-left: auto;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: #4CAF50;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  align-self: center;
+  margin-bottom: 4px;
+  transition: background 0.2s ease;
+}
+
+.results-new-btn:hover {
+  background: #388E3C;
 }
 
 /* Responsive sub-tab labels: full text on desktop, abbreviated on mobile */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1568,6 +1568,50 @@ function AppContent() {
     setPreviewCoords(null);
   };
 
+  // Create new POI from Results tab (defaults based on active sub-tab)
+  const handleNewPOIFromResults = (subTab) => {
+    setSelectedDestination(null);
+    setSelectedLinearFeature(null);
+
+    if (subTab === 'organizations') {
+      // Organizations don't need coordinates — open sidebar directly
+      setNewPOI({
+        id: 'new-temp',
+        name: '',
+        poi_roles: ['organization'],
+        brief_description: '',
+        property_owner: '',
+        more_info_link: '',
+        events_url: '',
+        news_url: ''
+      });
+      setActiveTab('view');
+    } else {
+      // Point-based POIs — switch to map for click-to-place
+      const defaults = {
+        id: 'new-temp',
+        name: '',
+        poi_roles: subTab === 'mtb' ? ['point'] : ['point'],
+        is_mtb_trail: subTab === 'mtb' ? true : undefined,
+        brief_description: '',
+        historical_description: '',
+        primary_activities: '',
+        surface: '',
+        pets: '',
+        cell_signal: null,
+        more_info_link: '',
+        events_url: '',
+        news_url: ''
+      };
+      if (subTab === 'mtb') {
+        defaults.status_url = '';
+      }
+      setNewPOI(defaults);
+      setActiveTab('view');
+      // Map will show "click to place" indicator since newPOI is set but no coords yet
+    }
+  };
+
   // Start creating a new organization with found POIs
   const handleStartNewOrganization = (poisInBounds) => {
     // Clear any existing selection
@@ -1598,7 +1642,9 @@ function AppContent() {
 
   // Save new POI
   const handleSaveNewPOI = async (poiData) => {
-    const response = await fetch('/api/admin/destinations', {
+    // Use /api/admin/pois when poi_roles is present (new flow), otherwise legacy /destinations
+    const endpoint = poiData.poi_roles ? '/api/admin/pois' : '/api/admin/destinations';
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -1969,6 +2015,10 @@ function AppContent() {
             bypassViewportFilter={bypassViewportFilter}
             visiblePoiCount={visiblePoiCount}
             iconConfig={iconConfig}
+            editMode={editMode}
+            isAdmin={isAdmin}
+            userRole={role}
+            onNewPOI={handleNewPOIFromResults}
           />
         </main>
       )}
@@ -1978,6 +2028,7 @@ function AppContent() {
         <main id="main-content" className="main-content-full" tabIndex="-1" style={{ display: 'flex', flexDirection: 'column' }}>
           <ParkNews
           isAdmin={isAdmin}
+          editMode={editMode}
           filteredDestinations={viewportFilteredDestinations}
           filteredLinearFeatures={viewportFilteredLinearFeatures}
           filteredVirtualPois={viewportFilteredVirtualPois}
@@ -2009,6 +2060,7 @@ function AppContent() {
         <main id="main-content" className="main-content-full" tabIndex="-1" style={{ display: 'flex', flexDirection: 'column' }}>
           <ParkEvents
           isAdmin={isAdmin}
+          editMode={editMode}
           filteredDestinations={viewportFilteredDestinations}
           filteredLinearFeatures={viewportFilteredLinearFeatures}
           filteredVirtualPois={viewportFilteredVirtualPois}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1546,6 +1546,7 @@ function AppContent() {
     setNewPOI({
       id: 'new-temp',
       name: '',
+      poi_roles: ['point'],
       latitude: coords.lat,
       longitude: coords.lng,
       property_owner: '',
@@ -1591,8 +1592,7 @@ function AppContent() {
       const defaults = {
         id: 'new-temp',
         name: '',
-        poi_roles: subTab === 'mtb' ? ['point'] : ['point'],
-        is_mtb_trail: subTab === 'mtb' ? true : undefined,
+        poi_roles: subTab === 'mtb' ? ['mtb_trail'] : ['point'],
         brief_description: '',
         historical_description: '',
         primary_activities: '',
@@ -1601,11 +1601,9 @@ function AppContent() {
         cell_signal: null,
         more_info_link: '',
         events_url: '',
-        news_url: ''
+        news_url: '',
+        status_url: subTab === 'mtb' ? '' : undefined
       };
-      if (subTab === 'mtb') {
-        defaults.status_url = '';
-      }
       setNewPOI(defaults);
       setActiveTab('view');
       // Map will show "click to place" indicator since newPOI is set but no coords yet
@@ -1931,9 +1929,6 @@ function AppContent() {
                           checked={editMode}
                           onChange={(e) => {
                             setEditMode(e.target.checked);
-                            if (e.target.checked && activeTab !== 'view') {
-                              handleTabChange('view');
-                            }
                           }}
                         />
                       </label>
@@ -2076,6 +2071,12 @@ function AppContent() {
               setSelectedDestination(poi);
               setActiveTab('view');
             }
+          }}
+          onEditEventItem={(eventId, eventTitle) => {
+            setModerationFocusId(eventId);
+            setModerationFocusTitle(eventTitle || null);
+            setActiveTab('settings');
+            setSettingsTab('moderation');
           }}
         />
         </main>

--- a/frontend/src/components/ContentFormModal.jsx
+++ b/frontend/src/components/ContentFormModal.jsx
@@ -1,0 +1,228 @@
+import React, { useState, useEffect } from 'react';
+import PoiSearchSelect from './PoiSearchSelect';
+import { FIELD_CONFIGS } from '../hooks/useModeration';
+
+/**
+ * Unified modal for creating and editing News/Event items.
+ * Used by ParkNews, ParkEvents, and ModerationExtras.
+ *
+ * Props:
+ *   mode          - 'create' or 'edit'
+ *   contentType   - 'news' or 'event'
+ *   fields        - current field values (edit: from startEditing, create: empty)
+ *   setFields     - setter for field values
+ *   item          - the item being edited (edit mode only, for AI reasoning/status display)
+ *   pois          - POI list for PoiSearchSelect
+ *   itemUrls      - additional URLs array (edit mode)
+ *   newUrlInput   - URL input state
+ *   setNewUrlInput - URL input setter
+ *   addingUrl     - whether URL is being added
+ *   onAddUrl      - handler to add URL
+ *   onRemoveUrl   - handler to remove URL
+ *   onSave        - save handler (edit mode)
+ *   onCreate      - create handler (create mode), receives field values
+ *   onClose       - close the modal
+ */
+function ContentFormModal({
+  mode = 'create',
+  contentType = 'news',
+  fields,
+  setFields,
+  item,
+  pois = [],
+  itemUrls = [],
+  newUrlInput = '',
+  setNewUrlInput,
+  addingUrl = false,
+  onAddUrl,
+  onRemoveUrl,
+  onSave,
+  onCreate,
+  onClose
+}) {
+  const isEdit = mode === 'edit';
+  const [localFields, setLocalFields] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [localPois, setLocalPois] = useState(pois);
+
+  // For create mode, manage fields locally
+  const activeFields = isEdit ? fields : localFields;
+  const activeSetFields = isEdit ? setFields : setLocalFields;
+
+  // Fetch POIs if not provided
+  useEffect(() => {
+    if (pois.length > 0) {
+      setLocalPois(pois);
+      return;
+    }
+    fetch('/api/pois', { credentials: 'include' })
+      .then(r => r.ok ? r.json() : [])
+      .then(data => setLocalPois(Array.isArray(data) ? data.filter(p => !p.deleted).sort((a, b) => a.name.localeCompare(b.name)) : []))
+      .catch(() => setLocalPois([]));
+  }, [pois]);
+
+  const fieldConfigs = FIELD_CONFIGS[contentType] || [];
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+
+    // Validate required fields
+    for (const fc of fieldConfigs) {
+      if (fc.required && !activeFields[fc.key]?.toString().trim()) {
+        setError(`${fc.label} is required`);
+        return;
+      }
+    }
+
+    if (isEdit) {
+      onSave();
+    } else {
+      // Create mode
+      if (!activeFields.poi_id) {
+        setError('POI is required');
+        return;
+      }
+      setSaving(true);
+      try {
+        const endpoint = contentType === 'news' ? '/api/admin/news' : '/api/admin/events';
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            ...activeFields,
+            poi_id: parseInt(activeFields.poi_id),
+            publication_date: activeFields.publication_date || null
+          })
+        });
+        if (!response.ok) {
+          const err = await response.json();
+          throw new Error(err.error || `Failed to create ${contentType}`);
+        }
+        if (onCreate) onCreate();
+        onClose();
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setSaving(false);
+      }
+    }
+  };
+
+  const renderFieldInput = (fc) => {
+    const val = activeFields[fc.key] || '';
+    const onChange = (v) => activeSetFields(prev => ({ ...prev, [fc.key]: v }));
+
+    if (fc.type === 'textarea') {
+      return <textarea value={val} onChange={e => onChange(e.target.value)}
+        rows={3} placeholder={fc.label} />;
+    }
+    if (fc.type === 'select') {
+      return (
+        <select value={val} onChange={e => onChange(e.target.value)}>
+          <option value="">-- Select --</option>
+          {fc.options.map(o => <option key={o} value={o}>{o}</option>)}
+        </select>
+      );
+    }
+    if (fc.type === 'poi') {
+      return (
+        <PoiSearchSelect
+          pois={localPois}
+          value={val}
+          onChange={(id) => onChange(id || '')}
+          placeholder="Search POIs..."
+        />
+      );
+    }
+    const lang = fc.type === 'date' ? 'en-US' : undefined;
+    return <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
+      placeholder={fc.label} required={fc.required} lang={lang} />;
+  };
+
+  const title = isEdit
+    ? `Edit ${contentType === 'news' ? 'News Item' : 'Event'}`
+    : `Create ${contentType === 'news' ? 'News Item' : 'Event'}`;
+
+  return (
+    <div className="new-content-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="new-content-modal">
+        <div className="new-content-header">
+          <h3>{title}</h3>
+          <button className="close-btn" onClick={onClose}>&times;</button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="new-content-form">
+          {error && <div className="form-error">{error}</div>}
+
+          {/* AI reasoning and status (edit mode only) */}
+          {isEdit && item && (item.ai_reasoning || item.moderation_status) && (
+            <div className="form-ai-info">
+              {item.ai_reasoning && (
+                <div className="form-ai-reasoning">
+                  <strong>AI Analysis:</strong> {item.ai_reasoning}
+                </div>
+              )}
+              <div className="form-ai-status">
+                Status: {item.moderation_status === 'auto_approved' ? 'Auto-approved by AI' :
+                  item.moderation_status === 'published' ? 'Approved by human' :
+                  item.moderation_status}
+                {item.confidence_score != null && ` · Score: ${(item.confidence_score * 100).toFixed(0)}%`}
+              </div>
+            </div>
+          )}
+
+          {/* Fields driven by FIELD_CONFIGS */}
+          {fieldConfigs.map(fc => (
+            <div className="form-section" key={fc.key}>
+              <label>{fc.label}{fc.required ? ' *' : ''}</label>
+              {renderFieldInput(fc)}
+            </div>
+          ))}
+
+          {/* Additional URLs management (edit mode only) */}
+          {isEdit && contentType !== 'photo' && (
+            <div className="form-section">
+              <label>Additional URLs</label>
+              <div className="form-urls-list">
+                {itemUrls.map(u => (
+                  <div key={u.id} className="form-url-item">
+                    <a href={u.url} target="_blank" rel="noopener noreferrer" className="form-url-link">
+                      {u.url}
+                    </a>
+                    {u.source_name && <span className="form-url-source">({u.source_name})</span>}
+                    <button type="button" onClick={() => onRemoveUrl(contentType, item.id, u.id)}
+                      className="form-url-remove" title="Remove URL">x</button>
+                  </div>
+                ))}
+                <div className="form-url-add">
+                  <input type="text" value={newUrlInput} onChange={e => setNewUrlInput(e.target.value)}
+                    placeholder="Add another source URL..."
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); onAddUrl(contentType, item.id); }}} />
+                  <button type="button" onClick={() => onAddUrl(contentType, item.id)}
+                    disabled={addingUrl || !newUrlInput?.trim()}
+                    className="form-url-add-btn">
+                    {addingUrl ? 'Adding...' : 'Add URL'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="form-buttons">
+            <button type="button" className="cancel-btn" onClick={onClose} disabled={saving}>
+              Cancel
+            </button>
+            <button type="submit" className="save-btn" disabled={saving}>
+              {saving ? (isEdit ? 'Saving...' : 'Creating...') : (isEdit ? 'Save' : `Create ${contentType === 'news' ? 'News' : 'Event'}`)}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ContentFormModal;

--- a/frontend/src/components/GeoJSONUploader.jsx
+++ b/frontend/src/components/GeoJSONUploader.jsx
@@ -1,0 +1,115 @@
+import React, { useRef, useState } from 'react';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+function GeoJSONUploader({ geometry, onChange }) {
+  const fileInputRef = useRef(null);
+  const [error, setError] = useState(null);
+  const [fileName, setFileName] = useState(null);
+
+  const handleFileSelect = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+
+    if (file.size > MAX_FILE_SIZE) {
+      setError('File too large (max 5MB)');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target.result);
+
+        // Extract geometry from GeoJSON
+        let geo = null;
+        if (parsed.type === 'Feature') {
+          geo = parsed.geometry;
+        } else if (parsed.type === 'FeatureCollection') {
+          if (parsed.features?.length === 1) {
+            geo = parsed.features[0].geometry;
+          } else if (parsed.features?.length > 1) {
+            // Merge into a GeometryCollection or take first feature
+            geo = {
+              type: 'GeometryCollection',
+              geometries: parsed.features.map(f => f.geometry).filter(Boolean)
+            };
+          }
+        } else if (parsed.type && parsed.coordinates) {
+          // Raw geometry object
+          geo = parsed;
+        }
+
+        if (!geo || !geo.type) {
+          setError('No valid geometry found in file');
+          return;
+        }
+
+        const validTypes = ['Point', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon', 'GeometryCollection'];
+        if (!validTypes.includes(geo.type)) {
+          setError(`Unsupported geometry type: ${geo.type}`);
+          return;
+        }
+
+        setFileName(file.name);
+        onChange(geo);
+      } catch (err) {
+        setError('Invalid JSON file');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleClear = () => {
+    setFileName(null);
+    setError(null);
+    onChange(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const hasGeometry = geometry && geometry.type;
+
+  return (
+    <div className="geojson-uploader">
+      <label>GeoJSON Geometry</label>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".geojson,.json"
+        onChange={handleFileSelect}
+        style={{ display: 'none' }}
+      />
+      <div
+        className={`geojson-upload-area ${hasGeometry ? 'has-file' : ''}`}
+        onClick={() => !hasGeometry && fileInputRef.current?.click()}
+      >
+        {hasGeometry ? (
+          <div className="geojson-file-info">
+            <div>
+              <div className="geojson-file-name">{fileName || 'Existing geometry'}</div>
+              <div className="geojson-file-meta">{geometry.type}</div>
+            </div>
+            <button
+              type="button"
+              className="geojson-clear-btn"
+              onClick={(e) => { e.stopPropagation(); handleClear(); }}
+            >
+              Remove
+            </button>
+          </div>
+        ) : (
+          <div className="geojson-upload-prompt">
+            Click to upload .geojson or .json file
+          </div>
+        )}
+      </div>
+      {error && <div className="geojson-error">{error}</div>}
+    </div>
+  );
+}
+
+export default GeoJSONUploader;

--- a/frontend/src/components/ModerationExtras.jsx
+++ b/frontend/src/components/ModerationExtras.jsx
@@ -1,0 +1,302 @@
+import React from 'react';
+import PoiSearchSelect from './PoiSearchSelect';
+import { formatPublicationDate } from './NewsEventsShared';
+import { FIELD_CONFIGS } from '../hooks/useModeration';
+import ContentFormModal from './ContentFormModal';
+
+// Style helpers (extracted from ModerationInbox)
+const badgeStyle = (bg) => ({
+  backgroundColor: bg, color: 'white', padding: '1px 8px', borderRadius: '10px',
+  fontSize: '0.72rem', fontWeight: 'bold', textTransform: 'uppercase'
+});
+
+const actionBtn = (disabled = false) => ({
+  padding: '4px 0', border: '1px solid #bbb', borderRadius: '5px',
+  backgroundColor: disabled ? '#e0e0e0' : '#f5f5f5', color: disabled ? '#999' : '#333',
+  cursor: disabled ? 'default' : 'pointer', fontSize: '0.75rem', fontWeight: '500',
+  width: '72px', textAlign: 'center'
+});
+
+const btnStyle = (bg, color = 'white', border = 'none') => ({
+  padding: '5px 12px', border, borderRadius: '6px',
+  backgroundColor: bg, color, cursor: 'pointer', fontSize: '0.8rem', fontWeight: '500'
+});
+
+const inputStyle = {
+  padding: '6px 10px', borderRadius: '6px', border: '1px solid #d0d0d0',
+  fontSize: '0.85rem', width: '100%', boxSizing: 'border-box'
+};
+
+const getConfidenceColor = (score) => {
+  if (score === null || score === undefined) return '#999';
+  if (score < 0.5) return '#f44336';
+  if (score < 0.9) return '#ff9800';
+  return '#4caf50';
+};
+
+const getTypeBadgeColor = (type) => {
+  switch (type) {
+    case 'news': return '#2196f3';
+    case 'event': return '#9c27b0';
+    case 'photo': return '#4caf50';
+    default: return '#757575';
+  }
+};
+
+const getSourceBadge = (source) => {
+  switch (source) {
+    case 'ai': return { label: 'AI', color: '#ff9800' };
+    case 'human': return { label: 'Human', color: '#607d8b' };
+    case 'newsletter': return { label: 'Newsletter', color: '#00897b' };
+    case 'feed': return { label: 'Feed', color: '#5c6bc0' };
+    case 'api': return { label: 'API', color: '#8d6e63' };
+    case 'community': return { label: 'Community', color: '#26a69a' };
+    default: return null;
+  }
+};
+
+function renderFieldInput(fc, values, setValues, pois) {
+  const val = values[fc.key] || '';
+  const onChange = (v) => setValues({ ...values, [fc.key]: v });
+
+  if (fc.type === 'textarea') {
+    return <textarea value={val} onChange={e => onChange(e.target.value)}
+      rows={3} style={inputStyle} placeholder={fc.label} />;
+  }
+  if (fc.type === 'select') {
+    return (
+      <select value={val} onChange={e => onChange(e.target.value)} style={inputStyle}>
+        <option value="">-- Select --</option>
+        {fc.options.map(o => <option key={o} value={o}>{o}</option>)}
+      </select>
+    );
+  }
+  if (fc.type === 'poi') {
+    return (
+      <PoiSearchSelect
+        pois={pois}
+        value={val}
+        onChange={(id) => onChange(id || '')}
+        placeholder="Search POIs..."
+      />
+    );
+  }
+  const lang = fc.type === 'date' ? 'en-US' : undefined;
+  return <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
+    style={inputStyle} placeholder={fc.label} required={fc.required} lang={lang} />;
+}
+
+/**
+ * Shared per-item moderation UI: badges, inline edit form, action buttons, merge UI.
+ * Rendered as children of NewsCardBody/EventCardBody.
+ */
+export default function ModerationExtras({
+  item,
+  isPending = false,
+  // From useModeration hook
+  editingItem, editFields, setEditFields,
+  itemUrls, newUrlInput, setNewUrlInput, addingUrl,
+  iaDateItem,
+  mergingItem, mergeCandidates, merging,
+  confirmDelete, setConfirmDelete,
+  selectedItems,
+  pois,
+  // Handlers from hook
+  onApprove, onReject, onRequeue, onDelete,
+  onSave, onIaDate,
+  onStartEditing, onCancelEditing,
+  onStartMerge, onMerge, onCancelMerge,
+  onAddUrl, onRemoveUrl,
+  onToggleSelect
+}) {
+  const itemKey = `${item.content_type}:${item.id}`;
+  const isEditing = editingItem === itemKey;
+
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      {/* Moderation badges */}
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center', margin: '10px 0 8px' }}>
+        <span style={badgeStyle('#757575')}>#{item.id}</span>
+        <span style={badgeStyle(getTypeBadgeColor(item.content_type))}>
+          {item.content_type}
+        </span>
+        {item.content_source && getSourceBadge(item.content_source) && (
+          <span style={badgeStyle(getSourceBadge(item.content_source).color)}>
+            {getSourceBadge(item.content_source).label}
+          </span>
+        )}
+        {!isPending && item.moderation_status && (
+          <span style={badgeStyle(item.moderation_status === 'rejected' ? '#f44336' : '#4caf50')}>
+            {item.moderation_status === 'rejected' ? 'Rejected' : 'Approved'}
+          </span>
+        )}
+        {(item.additional_url_count > 0 || (item.additional_urls && item.additional_urls.length > 0)) && (
+          <span style={badgeStyle('#1565c0')}>
+            +{item.additional_url_count || item.additional_urls?.length} URL{(item.additional_url_count || item.additional_urls?.length) > 1 ? 's' : ''}
+          </span>
+        )}
+
+        {/* Triage chips */}
+        {item.content_type !== 'photo' && (() => {
+          const issues = item.ai_issues ? (() => { try { return JSON.parse(item.ai_issues); } catch { return []; } })() : [];
+          const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
+          const hasNoDate = item.content_type === 'event'
+            ? !item.publication_date && !item.start_date
+            : !item.publication_date || !item.date_consensus_score;
+          const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
+          const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
+          const hasOther = issues.some(i => !urlIssueCodes.includes(i));
+          return (
+            <>
+              {hasNoDate && <span style={badgeStyle('#e65100')}>No Date</span>}
+              {hasUrlIssue && <span style={badgeStyle('#e65100')}>{urlLabel}</span>}
+              {hasOther && <span style={badgeStyle('#b71c1c')}>Other</span>}
+            </>
+          );
+        })()}
+
+        {/* Confidence score */}
+        {item.confidence_score !== null && item.confidence_score !== undefined && (
+          <span style={{
+            color: getConfidenceColor(item.confidence_score),
+            fontWeight: 'bold', fontSize: '0.78rem'
+          }}>
+            {(item.confidence_score * 100).toFixed(0)}%
+          </span>
+        )}
+
+        {/* Timestamps */}
+        <span style={{ fontSize: '0.72rem', color: '#aaa' }}>
+          {formatPublicationDate(item.collection_date || item.created_at)}
+          {item.moderated_at && ` · Mod: ${formatPublicationDate(item.moderated_at)}`}
+        </span>
+      </div>
+
+      {/* Edit modal */}
+      {isEditing && (
+        <ContentFormModal
+          mode="edit"
+          contentType={item.content_type}
+          fields={editFields}
+          setFields={setEditFields}
+          item={item}
+          pois={pois}
+          itemUrls={itemUrls[itemKey] || []}
+          newUrlInput={newUrlInput}
+          setNewUrlInput={setNewUrlInput}
+          addingUrl={addingUrl}
+          onAddUrl={onAddUrl}
+          onRemoveUrl={onRemoveUrl}
+          onSave={() => onSave(item.content_type, item.id, item)}
+          onClose={onCancelEditing}
+        />
+      )}
+
+      {/* Action buttons */}
+      <div style={{ display: 'flex', gap: '3px', flexWrap: 'wrap', marginTop: '6px' }}>
+        {isPending && onToggleSelect && (
+          <input type="checkbox" checked={selectedItems?.has(itemKey)}
+            onChange={() => onToggleSelect(item.content_type, item.id)}
+            style={{ marginRight: '4px' }} />
+        )}
+        {isPending && (
+          <>
+            <button onClick={() => onApprove(item.content_type, item.id, item)}
+              style={actionBtn()}>Approve</button>
+            <button onClick={() => onReject(item.content_type, item.id, item)}
+              style={actionBtn()}>Reject</button>
+          </>
+        )}
+        {!isPending && (
+          <>
+            <button onClick={() => onReject(item.content_type, item.id, item)}
+              style={actionBtn()}>Reject</button>
+            <button onClick={() => onRequeue(item.content_type, item.id)}
+              style={actionBtn()}>Requeue</button>
+          </>
+        )}
+        {item.content_type !== 'photo' && (
+          <button onClick={() => onIaDate(item.content_type, item.id, item.source_url)}
+            disabled={iaDateItem === itemKey}
+            title="Look up earliest Internet Archive snapshot date for this URL"
+            style={actionBtn(iaDateItem === itemKey)}>
+            {iaDateItem === itemKey ? 'Looking up...' : 'IA Date'}
+          </button>
+        )}
+        <button onClick={() => onStartEditing(item)}
+          style={actionBtn()}>{isEditing ? 'Close' : 'Edit'}</button>
+        {item.content_type !== 'photo' && (
+          <button onClick={() => onStartMerge(item)}
+            style={actionBtn()}>Merge</button>
+        )}
+        {item.content_type !== 'photo' && (
+          confirmDelete === itemKey ? (
+            <>
+              <button onClick={() => onDelete(item.content_type, item.id)}
+                style={{ ...actionBtn(), backgroundColor: '#ffebee', color: '#c62828', borderColor: '#ef9a9a', width: 'auto', padding: '4px 8px' }}>
+                Confirm Delete
+              </button>
+              <button onClick={() => setConfirmDelete(null)}
+                style={actionBtn()}>Cancel</button>
+            </>
+          ) : (
+            <button onClick={() => setConfirmDelete(itemKey)}
+              style={{ ...actionBtn(), backgroundColor: '#ffebee', color: '#c62828', borderColor: '#ef9a9a' }}>
+              Delete
+            </button>
+          )
+        )}
+      </div>
+
+      {/* Merge candidate selection */}
+      {mergingItem && mergingItem.type === item.content_type && mergingItem.id === item.id && (
+        <div style={{ marginTop: '8px', padding: '10px', backgroundColor: '#e3f2fd',
+          borderRadius: '6px', border: '1px solid #90caf9' }}>
+          <div style={{ fontSize: '0.82rem', fontWeight: 'bold', marginBottom: '6px', color: '#1565c0' }}>
+            Merge this item into (target keeps its title/summary):
+          </div>
+          {mergeCandidates.length === 0 ? (
+            <div style={{ fontSize: '0.78rem', color: '#666' }}>
+              {mergingItem ? 'Loading candidates...' : 'No other items found for this POI.'}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', maxHeight: '300px', overflowY: 'auto' }}>
+              {mergeCandidates.map(c => (
+                <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: '6px',
+                  padding: '6px 8px', backgroundColor: 'white', borderRadius: '4px',
+                  border: '1px solid #e0e0e0' }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: '0.8rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: '500' }}>
+                      {c.title}
+                    </div>
+                    <div style={{ fontSize: '0.7rem', color: '#888', display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                      <span>#{c.id}</span>
+                      <span>{c.moderation_status}</span>
+                      {c.publication_date && <span>{new Date(c.publication_date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}</span>}
+                      {c.additional_url_count > 0 && <span>+{c.additional_url_count} URLs</span>}
+                    </div>
+                    {c.source_url && (
+                      <div style={{ fontSize: '0.68rem', color: '#1976d2', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {c.source_url}
+                      </div>
+                    )}
+                  </div>
+                  <button onClick={() => onMerge(c.id)} disabled={merging}
+                    style={{ ...actionBtn(merging), backgroundColor: merging ? '#ccc' : '#1565c0',
+                      color: 'white', flexShrink: 0 }}>
+                    {merging ? 'Merging...' : 'Merge Into'}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <button onClick={onCancelMerge}
+            style={{ ...actionBtn(), marginTop: '6px', fontSize: '0.72rem' }}>Cancel</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Export style helpers for ModerationInbox create form
+export { FIELD_CONFIGS, badgeStyle, actionBtn, btnStyle, inputStyle, renderFieldInput, getConfidenceColor, getTypeBadgeColor, getSourceBadge };

--- a/frontend/src/components/ModerationInbox.jsx
+++ b/frontend/src/components/ModerationInbox.jsx
@@ -1,107 +1,28 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Lightbox from './Lightbox';
-import PoiSearchSelect from './PoiSearchSelect';
 import { NewsCardBody, EventCardBody, formatPublicationDate } from './NewsEventsShared';
-
-// Eastern timezone abbreviation (EST or EDT) for datetime labels
-const TZ_ABBR = new Date().toLocaleTimeString('en-US', { timeZone: 'America/New_York', timeZoneName: 'short' }).split(' ').pop();
-
-const FIELD_CONFIGS = {
-  news: [
-    { key: 'title', label: 'Title', type: 'text', required: true },
-    { key: 'summary', label: 'Summary', type: 'textarea' },
-    { key: 'source_name', label: 'Source Name', type: 'text' },
-    { key: 'news_type', label: 'Type', type: 'select', options: ['general', 'closure', 'seasonal', 'maintenance', 'wildlife'] },
-    { key: 'publication_date', label: `Publication Date (${TZ_ABBR})`, type: 'datetime-local' },
-    { key: 'poi_id', label: 'POI', type: 'poi' },
-    { key: 'source_url', label: 'Primary URL', type: 'text' },
-  ],
-  event: [
-    { key: 'title', label: 'Title', type: 'text', required: true },
-    { key: 'description', label: 'Description', type: 'textarea' },
-    { key: 'start_date', label: `Start Date/Time (${TZ_ABBR})`, type: 'datetime-local', required: true },
-    { key: 'end_date', label: `End Date/Time (${TZ_ABBR})`, type: 'datetime-local' },
-    { key: 'event_type', label: 'Event Type', type: 'text' },
-    { key: 'location_details', label: 'Location Details', type: 'text' },
-    { key: 'publication_date', label: `Publication Date (${TZ_ABBR})`, type: 'datetime-local' },
-    { key: 'poi_id', label: 'POI', type: 'poi' },
-    { key: 'source_url', label: 'Primary URL', type: 'text' },
-  ],
-  photo: [
-    { key: 'caption', label: 'Caption', type: 'textarea' },
-    { key: 'poi_id', label: 'POI', type: 'poi' },
-  ]
-};
+import useModeration, { FIELD_CONFIGS } from '../hooks/useModeration';
+import ModerationExtras, { btnStyle, inputStyle, renderFieldInput, badgeStyle, actionBtn } from './ModerationExtras';
 
 function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectPoi }) {
   const [queue, setQueue] = useState([]);
   const [total, setTotal] = useState(0);
-
   const [filter, setFilter] = useState(null);
-  // Lazy-initialize statusFilter/searchInput/idFilter from props so the very first
-  // fetchQueue already has the right values — avoids a race condition where the
-  // initial fetch fires with default state before effects run.
   const [statusFilter, setStatusFilter] = useState(() => focusItemId ? 'all' : 'pending');
   const [loading, setLoading] = useState(true);
-  const [selectedItems, setSelectedItems] = useState(new Set());
-  const [expandedItem, setExpandedItem] = useState(null);
-  const [editingItem, setEditingItem] = useState(null);
-  const [editFields, setEditFields] = useState({});
-  const [notification, setNotification] = useState(null);
-  const [creating, setCreating] = useState(null); // 'news', 'event', 'photo', or null
+  const [creating, setCreating] = useState(null);
   const [createFields, setCreateFields] = useState({});
-  const [pois, setPois] = useState([]);
   const [sourceFilter, setSourceFilter] = useState(null);
   const [sortOrder, setSortOrder] = useState('collected_desc');
-  const [iaDateItem, setIaDateItem] = useState(null);
-  const [mergingItem, setMergingItem] = useState(null); // { type, id, poiId }
-  const [mergeCandidates, setMergeCandidates] = useState([]);
-  const [merging, setMerging] = useState(false);
-  const [itemUrls, setItemUrls] = useState({}); // { "news:123": [{id, url, source_name}] }
-  const [newUrlInput, setNewUrlInput] = useState('');
-  const [addingUrl, setAddingUrl] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchInput, setSearchInput] = useState(() => focusItemTitle || '');
-  // idFilter drives API fetch by ID (exactly 1 result) when coming from Edit link
   const [idFilter, setIdFilter] = useState(() => focusItemId || null);
   const [lightboxMedia, setLightboxMedia] = useState(null);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [lightboxPoiId, setLightboxPoiId] = useState(null);
   const [user, setUser] = useState(null);
-  const [confirmDelete, setConfirmDelete] = useState(null); // "news:123" key
   const [page, setPage] = useState(1);
   const LIMIT = 20;
-
-  // Handle focusItemId changes (e.g. user clicks Edit on a second article without
-  // leaving the Moderation tab — the component stays mounted but props change).
-  const startEditingRef = React.useRef(null);
-  useEffect(() => {
-    if (!focusItemId) return;
-    setStatusFilter('all');
-    setFilter(null);
-    setSourceFilter(null);
-    setSearchQuery('');
-    setSearchInput(focusItemTitle || '');
-    setIdFilter(focusItemId);
-    setPage(1);
-  }, [focusItemId, focusItemTitle]);
-
-  // After queue loads, auto-expand and open edit mode for the focused item
-  useEffect(() => {
-    if (!focusItemId || loading || queue.length === 0) return;
-    const item = queue.find(i => i.id === focusItemId && i.content_type === 'news');
-    if (!item) return;
-    const itemKey = `news:${item.id}`;
-    setExpandedItem(itemKey);
-    if (startEditingRef.current) startEditingRef.current(item);
-  }, [focusItemId, loading, queue]);
-
-  // Scroll focused item into view after it expands
-  useEffect(() => {
-    if (!expandedItem) return;
-    const el = document.getElementById(`moderation-item-${expandedItem}`);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, [expandedItem]);
 
   const fetchQueue = useCallback(async ({ silent = false } = {}) => {
     if (!silent) setLoading(true);
@@ -129,39 +50,69 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     }
   }, [page, filter, statusFilter, sourceFilter, searchQuery, idFilter, sortOrder]);
 
-  useEffect(() => { fetchQueue(); setSelectedItems(new Set()); }, [fetchQueue]);
+  // Shared moderation hook
+  const mod = useModeration({
+    onItemsChanged: fetchQueue,
+    onCountChange
+  });
 
-  // Auto-poll every 5 seconds to pick up background sweep changes
+  useEffect(() => { fetchQueue(); mod.selectedItems && mod.toggleSelect && null; }, [fetchQueue]);
+
+  // Auto-poll every 5 seconds
   useEffect(() => {
     const interval = setInterval(() => fetchQueue({ silent: true }), 5000);
     return () => clearInterval(interval);
   }, [fetchQueue]);
 
+  // Fetch user for lightbox
   useEffect(() => {
-    if (!notification) return;
-    const timer = setTimeout(() => setNotification(null), 4000);
-    return () => clearTimeout(timer);
-  }, [notification]);
-
-  useEffect(() => {
-    fetch('/api/pois', { credentials: 'include' })
-      .then(r => r.ok ? r.json() : [])
-      .then(data => setPois(Array.isArray(data) ? data : []))
-      .catch(() => setPois([]));
-
     fetch('/api/user', { credentials: 'include' })
       .then(r => r.ok ? r.json() : null)
       .then(data => setUser(data))
       .catch(() => setUser(null));
   }, []);
 
-  const notify = (type, message) => setNotification({ type, message });
+  // Handle focusItemId changes
+  const startEditingRef = React.useRef(null);
+  useEffect(() => {
+    if (!focusItemId) return;
+    setStatusFilter('all');
+    setFilter(null);
+    setSourceFilter(null);
+    setSearchQuery('');
+    setSearchInput(focusItemTitle || '');
+    setIdFilter(focusItemId);
+    setPage(1);
+  }, [focusItemId, focusItemTitle]);
 
+  // Auto-expand and edit focused item
+  useEffect(() => {
+    if (!focusItemId || loading || queue.length === 0) return;
+    const item = queue.find(i => i.id === focusItemId && i.content_type === 'news');
+    if (!item) return;
+    if (startEditingRef.current) startEditingRef.current(item);
+  }, [focusItemId, loading, queue]);
+
+  // Keep ref current
+  useEffect(() => { startEditingRef.current = mod.startEditing; });
+
+  // Scroll focused item into view
+  const [expandedItem, setExpandedItem] = useState(null);
+  useEffect(() => {
+    if (mod.editingItem) setExpandedItem(mod.editingItem);
+  }, [mod.editingItem]);
+  useEffect(() => {
+    if (!expandedItem) return;
+    const el = document.getElementById(`moderation-item-${expandedItem}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [expandedItem]);
+
+  const isPending = statusFilter === 'pending';
+
+  // Photo lightbox
   const getThumbnailUrl = (item) => {
     if (!item.media_type) return null;
-
     if (item.media_type === 'youtube') {
-      // Extract video ID from YouTube URL
       const videoId = item.source_url?.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/)?.[1];
       return videoId ? `https://img.youtube.com/vi/${videoId}/mqdefault.jpg` : null;
     } else if (item.image_server_asset_id && (item.media_type === 'image' || item.media_type === 'video')) {
@@ -172,36 +123,21 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
 
   const handleOpenLightbox = async (item) => {
     if (!item.poi_id) return;
-
     try {
-      // Fetch all media for this POI
       const response = await fetch(`/api/pois/${item.poi_id}/media`, { credentials: 'include' });
       if (!response.ok) return;
-
       const data = await response.json();
       const allMedia = data.all_media || [];
-
-      // Find the index of the clicked item
       const index = allMedia.findIndex(m => m.id === item.id);
-
       setLightboxMedia(allMedia);
       setLightboxIndex(index >= 0 ? index : 0);
       setLightboxPoiId(item.poi_id);
-    } catch (err) {
-      console.error('Failed to load media for lightbox:', err);
-    }
-  };
-
-  const handleLightboxClose = () => {
-    setLightboxMedia(null);
-    setLightboxIndex(0);
-    setLightboxPoiId(null);
+    } catch (err) { console.error('Failed to load media for lightbox:', err); }
   };
 
   const handleMediaUpdate = () => {
     fetchQueue();
     if (lightboxPoiId) {
-      // Refresh lightbox media
       fetch(`/api/pois/${lightboxPoiId}/media`, { credentials: 'include' })
         .then(r => r.json())
         .then(data => setLightboxMedia(data.all_media || []))
@@ -209,319 +145,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
     }
   };
 
-  const handleApprove = async (type, id) => {
-    try {
-      // Find the item to get its POI ID before approval
-      const item = queue.find(q => q.content_type === type && q.id === id);
-      console.log('[Moderation] Approving:', { type, id, item });
-      const response = await fetch('/api/admin/moderation/approve', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ type, id })
-      });
-      if (response.ok) {
-        notify('success', `${type} #${id} approved`);
-        fetchQueue();
-        console.log('[Moderation] Calling onCountChange:', !!onCountChange);
-        if (onCountChange) onCountChange();
-        // Emit event to refresh media for this POI
-        if (type === 'photo' && item?.poi_id) {
-          console.log('[Moderation] Emitting poi-media-updated event for POI', item.poi_id);
-          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
-          // Also emit event to refresh map markers (in case this was a primary image change)
-          window.dispatchEvent(new CustomEvent('poi-updated', { detail: { poiId: item.poi_id } }));
-        }
-      }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const handleReject = async (type, id) => {
-    try {
-      const item = queue.find(q => q.content_type === type && q.id === id);
-      const response = await fetch('/api/admin/moderation/reject', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ type, id, reason: '' })
-      });
-      if (response.ok) {
-        notify('success', `${type} #${id} rejected`);
-        fetchQueue();
-        if (onCountChange) onCountChange();
-        // Emit event to refresh media for this POI
-        if (type === 'photo' && item?.poi_id) {
-          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
-        }
-      }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const handleBulkApprove = async () => {
-    if (selectedItems.size === 0) return;
-    const items = Array.from(selectedItems).map(key => {
-      const [type, id] = key.split(':');
-      return { type, id: parseInt(id) };
-    });
-    // Collect unique POI IDs for photo items
-    const photoPoiIds = new Set();
-    items.forEach(({ type, id }) => {
-      if (type === 'photo') {
-        const item = queue.find(q => q.content_type === type && q.id === id);
-        if (item?.poi_id) photoPoiIds.add(item.poi_id);
-      }
-    });
-    try {
-      const response = await fetch('/api/admin/moderation/bulk-approve', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ items })
-      });
-      if (response.ok) {
-        const data = await response.json();
-        notify('success', `${data.approved} items approved`);
-        setSelectedItems(new Set());
-        fetchQueue();
-        if (onCountChange) onCountChange();
-        // Emit events for all affected POIs
-        photoPoiIds.forEach(poiId => {
-          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId } }));
-        });
-      }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const handleRequeue = async (type, id) => {
-    try {
-      const response = await fetch('/api/admin/moderation/requeue', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ type, id })
-      });
-      if (response.ok) { notify('success', `${type} #${id} requeued`); fetchQueue(); if (onCountChange) onCountChange(); }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const handleDelete = async (type, id) => {
-    const endpoint = type === 'news' ? `/api/admin/news/${id}` : `/api/admin/events/${id}`;
-    try {
-      const response = await fetch(endpoint, { method: 'DELETE', credentials: 'include' });
-      if (response.ok) {
-        setQueue(prev => prev.filter(i => !(i.content_type === type && i.id === id)));
-        setConfirmDelete(null);
-        notify('success', `${type} #${id} deleted`);
-        if (onCountChange) onCountChange();
-      } else {
-        notify('error', `Failed to delete ${type} #${id}`);
-      }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const handleIaDate = async (type, id, sourceUrl) => {
-    const itemKey = `${type}:${id}`;
-    if (!sourceUrl) { notify('error', 'No source URL for this item'); return; }
-    setIaDateItem(itemKey);
-    try {
-      const response = await fetch(`/api/admin/moderation/ia-date?url=${encodeURIComponent(sourceUrl)}`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.date) {
-          // Update the item's publication date with the Wayback date
-          const saveResponse = await fetch('/api/admin/moderation/save', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            credentials: 'include', body: JSON.stringify({ type, id, edits: { publication_date: data.date } })
-          });
-          if (saveResponse.ok) {
-            notify('success', `${type} #${id} — date set to ${data.date} (earliest IA snapshot)`);
-            fetchQueue();
-          } else {
-            notify('error', 'IA date found but failed to update item');
-          }
-        } else {
-          notify('error', `No Internet Archive snapshots found for this URL`);
-        }
-      } else {
-        const err = await response.json();
-        notify('error', err.error || 'IA Date lookup failed');
-      }
-    } catch (err) { notify('error', err.message); }
-    finally { setIaDateItem(null); }
-  };
-
-  const startMerge = async (item) => {
-    setMergingItem({ type: item.content_type, id: item.id, poiId: item.poi_id });
-    setMergeCandidates([]);
-    try {
-      const response = await fetch(`/api/admin/moderation/merge-candidates/${item.content_type}/${item.id}`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const candidates = await response.json();
-        setMergeCandidates(candidates);
-      } else {
-        notify('error', 'Failed to load merge candidates');
-        setMergingItem(null);
-      }
-    } catch (err) {
-      notify('error', err.message);
-      setMergingItem(null);
-    }
-  };
-
-  const handleMerge = async (targetId) => {
-    if (!mergingItem) return;
-    setMerging(true);
-    try {
-      const response = await fetch('/api/admin/moderation/merge', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ type: mergingItem.type, sourceId: mergingItem.id, targetId })
-      });
-      if (response.ok) {
-        const data = await response.json();
-        notify('success', `Merged ${mergingItem.type} #${mergingItem.id} into #${targetId} (${data.movedUrls} URLs moved)`);
-        setMergingItem(null);
-        setMergeCandidates([]);
-        fetchQueue();
-      } else {
-        const err = await response.json();
-        notify('error', err.error || 'Merge failed');
-      }
-    } catch (err) { notify('error', err.message); }
-    finally { setMerging(false); }
-  };
-
-  const fetchItemUrls = async (type, id) => {
-    const itemKey = `${type}:${id}`;
-    try {
-      const response = await fetch(`/api/admin/moderation/item/${type}/${id}`, { credentials: 'include' });
-      if (response.ok) {
-        const detail = await response.json();
-        setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
-      }
-    } catch (err) { console.error('Error fetching item URLs:', err); }
-  };
-
-  const handleAddUrl = async (type, id) => {
-    if (!newUrlInput.trim()) return;
-    setAddingUrl(true);
-    try {
-      const response = await fetch('/api/admin/moderation/add-url', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ type, id, url: newUrlInput.trim() })
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.added) {
-          notify('success', 'URL added');
-          setNewUrlInput('');
-          fetchItemUrls(type, id);
-          fetchQueue();
-        } else {
-          notify('error', data.reason || 'URL not added');
-        }
-      } else {
-        const err = await response.json();
-        notify('error', err.error || 'Failed to add URL');
-      }
-    } catch (err) { notify('error', err.message); }
-    finally { setAddingUrl(false); }
-  };
-
-  const handleRemoveUrl = async (type, contentId, urlId) => {
-    try {
-      const response = await fetch('/api/admin/moderation/remove-url', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ type, id: contentId, urlId })
-      });
-      if (response.ok) {
-        notify('success', 'URL removed');
-        fetchItemUrls(type, contentId);
-        fetchQueue();
-      } else {
-        const err = await response.json();
-        notify('error', err.error || 'Failed to remove URL');
-      }
-    } catch (err) { notify('error', err.message); }
-  };
-
-  const startEditing = async (item) => {
-    const itemKey = `${item.content_type}:${item.id}`;
-    if (editingItem === itemKey) {
-      setEditingItem(null);
-      setEditFields({});
-      return;
-    }
-    try {
-      const response = await fetch(`/api/admin/moderation/item/${item.content_type}/${item.id}`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const detail = await response.json();
-        const fields = {};
-        const fieldConfigs = FIELD_CONFIGS[item.content_type] || [];
-        for (const fc of fieldConfigs) {
-          if (fc.type === 'datetime-local' && detail[fc.key]) {
-            const raw = String(detail[fc.key]);
-            // Convert UTC/pg timestamp to Eastern for display in datetime-local input
-            const utcDate = new Date(raw.replace(' ', 'T').replace(/\+\d{2}$/, 'Z'));
-            if (!isNaN(utcDate.getTime())) {
-              const eastern = utcDate.toLocaleString('sv-SE', { timeZone: 'America/New_York' });
-              fields[fc.key] = eastern.replace(' ', 'T').substring(0, 16);
-            } else {
-              const match = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
-              fields[fc.key] = match ? `${match[1]}T${match[2]}` : raw.slice(0, 16);
-            }
-          } else {
-            fields[fc.key] = detail[fc.key] || '';
-          }
-        }
-        setEditFields(fields);
-        setEditingItem(itemKey);
-        // Load additional URLs for the edit form
-        if (item.content_type !== 'photo') {
-          setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
-        }
-      }
-    } catch (err) {
-      notify('error', 'Failed to load item details');
-    }
-  };
-
-  // Keep ref current so the auto-focus effect can call startEditing without it as a dep
-  useEffect(() => { startEditingRef.current = startEditing; });
-
-  const handleSave = async (type, id) => {
-    console.log('[Moderation] Saving:', { type, id, edits: editFields });
-    const item = queue.find(q => q.content_type === type && q.id === id);
-    try {
-      const response = await fetch('/api/admin/moderation/save', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', body: JSON.stringify({ type, id, edits: editFields })
-      });
-      if (response.ok) {
-        console.log('[Moderation] Save successful');
-        notify('success', `${type} #${id} saved`);
-        setEditingItem(null);
-        setEditFields({});
-        fetchQueue();
-        // Emit event to refresh media for this POI (in case caption or POI changed)
-        if (type === 'photo' && item?.poi_id) {
-          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
-          // Also emit for the new POI if it changed
-          if (editFields.poi_id && editFields.poi_id !== item.poi_id) {
-            window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: editFields.poi_id } }));
-          }
-        }
-      } else {
-        const err = await response.json();
-        console.error('[Moderation] Save failed:', err);
-        notify('error', err.error || 'Save failed');
-      }
-    } catch (err) {
-      console.error('[Moderation] Save error:', err);
-      notify('error', err.message);
-    }
-  };
-
+  // Create handler
   const handleCreate = async () => {
     if (!creating) return;
     try {
@@ -531,134 +155,76 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
       });
       if (response.ok) {
         const data = await response.json();
-        notify('success', `Created ${creating} #${data.id}`);
+        mod.notify('success', `Created ${creating} #${data.id}`);
         setCreating(null);
         setCreateFields({});
         fetchQueue();
       } else {
         const err = await response.json();
-        notify('error', err.error || 'Create failed');
+        mod.notify('error', err.error || 'Create failed');
       }
-    } catch (err) { notify('error', err.message); }
+    } catch (err) { mod.notify('error', err.message); }
   };
 
-  const toggleSelect = (type, id) => {
-    const key = `${type}:${id}`;
-    setSelectedItems(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key); else next.add(key);
-      return next;
-    });
+  // Bulk reject all
+  const handleBulkRejectAll = async () => {
+    const pendingItems = queue.filter(q => q.moderation_status === 'pending');
+    if (pendingItems.length === 0) return;
+    if (!window.confirm(`Reject all ${pendingItems.length} pending items?`)) return;
+    try {
+      const items = pendingItems.map(q => ({ type: q.content_type, id: q.id }));
+      const response = await fetch('/api/admin/moderation/bulk-reject', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ items })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        mod.notify('success', `Rejected ${data.rejected} items`);
+        fetchQueue();
+        if (onCountChange) onCountChange();
+      }
+    } catch (err) { mod.notify('error', err.message); }
   };
-
-  const selectAll = () => {
-    if (selectedItems.size === queue.length) {
-      setSelectedItems(new Set());
-    } else {
-      setSelectedItems(new Set(queue.map(item => `${item.content_type}:${item.id}`)));
-    }
-  };
-
-  const getConfidenceColor = (score) => {
-    if (score === null || score === undefined) return '#999';
-    if (score < 0.5) return '#f44336';
-    if (score < 0.9) return '#ff9800';
-    return '#4caf50';
-  };
-
-  const getTypeBadgeColor = (type) => {
-    switch (type) {
-      case 'news': return '#2196f3';
-      case 'event': return '#9c27b0';
-      case 'photo': return '#4caf50';
-      default: return '#757575';
-    }
-  };
-
-  const getSourceBadge = (source) => {
-    switch (source) {
-      case 'ai': return { label: 'AI', color: '#ff9800' };
-      case 'human': return { label: 'Human', color: '#607d8b' };
-      case 'newsletter': return { label: 'Newsletter', color: '#00897b' };
-      case 'feed': return { label: 'Feed', color: '#5c6bc0' };
-      case 'api': return { label: 'API', color: '#8d6e63' };
-      case 'community': return { label: 'Community', color: '#26a69a' };
-      default: return null;
-    }
-  };
-
-  const isPending = statusFilter === 'pending';
 
   const filterBtn = (active) => ({
-    padding: '5px 0',
-    borderRadius: '6px',
-    border: '1px solid #ddd',
-    backgroundColor: active ? '#333' : '#f5f5f5',
-    color: active ? 'white' : '#555',
-    cursor: 'pointer',
-    fontSize: '0.78rem',
-    fontWeight: active ? '600' : '400',
-    flex: 1,
-    textAlign: 'center'
+    padding: '5px 0', borderRadius: '6px', border: '1px solid #ddd',
+    backgroundColor: active ? '#333' : '#f5f5f5', color: active ? 'white' : '#555',
+    cursor: 'pointer', fontSize: '0.78rem', fontWeight: active ? '600' : '400',
+    flex: 1, textAlign: 'center'
   });
 
-  const renderFieldInput = (fc, values, setValues) => {
-    const val = values[fc.key] || '';
-    const onChange = (v) => setValues({ ...values, [fc.key]: v });
-
-    if (fc.type === 'textarea') {
-      return (
-        <textarea value={val} onChange={e => onChange(e.target.value)}
-          rows={3} style={inputStyle} placeholder={fc.label} />
-      );
-    }
-    if (fc.type === 'select') {
-      return (
-        <select value={val} onChange={e => onChange(e.target.value)} style={inputStyle}>
-          <option value="">-- Select --</option>
-          {fc.options.map(o => <option key={o} value={o}>{o}</option>)}
-        </select>
-      );
-    }
-    if (fc.type === 'poi') {
-      return (
-        <PoiSearchSelect
-          pois={pois}
-          value={val}
-          onChange={(id) => onChange(id || '')}
-          placeholder="Search POIs..."
-        />
-      );
-    }
-    // lang="en-US" forces MM/DD/YYYY display regardless of browser language locale
-    const lang = fc.type === 'date' ? 'en-US' : undefined;
-    return (
-      <input type={fc.type || 'text'} value={val} onChange={e => onChange(e.target.value)}
-        style={inputStyle} placeholder={fc.label} required={fc.required} lang={lang} />
-    );
+  // Helper to build ModerationExtras props from the shared hook
+  const modExtrasProps = {
+    editingItem: mod.editingItem,
+    editFields: mod.editFields,
+    setEditFields: mod.setEditFields,
+    itemUrls: mod.itemUrls,
+    newUrlInput: mod.newUrlInput,
+    setNewUrlInput: mod.setNewUrlInput,
+    addingUrl: mod.addingUrl,
+    iaDateItem: mod.iaDateItem,
+    mergingItem: mod.mergingItem,
+    mergeCandidates: mod.mergeCandidates,
+    merging: mod.merging,
+    confirmDelete: mod.confirmDelete,
+    setConfirmDelete: mod.setConfirmDelete,
+    selectedItems: mod.selectedItems,
+    pois: mod.pois,
+    onApprove: mod.handleApprove,
+    onReject: mod.handleReject,
+    onRequeue: mod.handleRequeue,
+    onDelete: mod.handleDelete,
+    onSave: mod.handleSave,
+    onIaDate: mod.handleIaDate,
+    onStartEditing: mod.startEditing,
+    onCancelEditing: mod.cancelEditing,
+    onStartMerge: mod.startMerge,
+    onMerge: mod.handleMerge,
+    onCancelMerge: mod.cancelMerge,
+    onAddUrl: mod.handleAddUrl,
+    onRemoveUrl: mod.handleRemoveUrl,
+    onToggleSelect: mod.toggleSelect
   };
-
-  const inputStyle = {
-    padding: '6px 10px', borderRadius: '6px', border: '1px solid #d0d0d0',
-    fontSize: '0.85rem', width: '100%', boxSizing: 'border-box'
-  };
-
-  const btnStyle = (bg, color = 'white', border = 'none') => ({
-    padding: '5px 12px', border, borderRadius: '6px',
-    backgroundColor: bg, color, cursor: 'pointer', fontSize: '0.8rem', fontWeight: '500'
-  });
-
-  const badgeStyle = (bg) => ({
-    backgroundColor: bg, color: 'white', padding: '1px 8px', borderRadius: '10px',
-    fontSize: '0.72rem', fontWeight: 'bold', textTransform: 'uppercase'
-  });
-
-  const actionBtn = (disabled = false) => ({
-    padding: '4px 0', border: '1px solid #bbb', borderRadius: '5px',
-    backgroundColor: disabled ? '#e0e0e0' : '#f5f5f5', color: disabled ? '#999' : '#333',
-    cursor: disabled ? 'default' : 'pointer', fontSize: '0.75rem', fontWeight: '500',
-    width: '72px', textAlign: 'center'
-  });
 
   return (
     <div className="moderation-inbox">
@@ -666,38 +232,14 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
         <h3 style={{ margin: 0 }}>Moderation Queue</h3>
         <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-          {/* Reject All visible pending items */}
           {statusFilter === 'pending' && queue.length > 0 && (
-            <button
-              onClick={async () => {
-                const pendingItems = queue.filter(q => q.moderation_status === 'pending');
-                if (pendingItems.length === 0) return;
-                if (!window.confirm(`Reject all ${pendingItems.length} pending items?`)) return;
-                try {
-                  const items = pendingItems.map(q => ({ type: q.content_type, id: q.id }));
-                  const response = await fetch('/api/admin/moderation/bulk-reject', {
-                    method: 'POST', headers: { 'Content-Type': 'application/json' },
-                    credentials: 'include', body: JSON.stringify({ items })
-                  });
-                  if (response.ok) {
-                    const data = await response.json();
-                    notify('success', `Rejected ${data.rejected} items`);
-                    fetchQueue();
-                    if (onCountChange) onCountChange();
-                  }
-                } catch (err) { notify('error', err.message); }
-              }}
-              style={btnStyle('#b71c1c')}
-            >
+            <button onClick={handleBulkRejectAll} style={btnStyle('#b71c1c')}>
               Reject All
             </button>
           )}
-          {/* Create button */}
           <div style={{ position: 'relative' }}>
-            <button
-              onClick={() => setCreating(creating ? null : 'news')}
-              style={btnStyle(creating ? '#333' : '#4caf50')}
-            >
+            <button onClick={() => setCreating(creating ? null : 'news')}
+              style={btnStyle(creating ? '#333' : '#4caf50')}>
               + Create
             </button>
           </div>
@@ -706,99 +248,60 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
 
       {/* Search bar */}
       <div style={{ marginBottom: '8px' }}>
-        <input
-          type="text"
-          value={searchInput}
+        <input type="text" value={searchInput}
           onChange={e => { setSearchInput(e.target.value); if (!e.target.value) { setIdFilter(null); setSearchQuery(''); setPage(1);} }}
           onKeyDown={e => { if (e.key === 'Enter') { setIdFilter(null); setSearchQuery(searchInput); setPage(1);} }}
           placeholder="Search by title or description..."
-          style={{
-            width: '100%', padding: '8px 12px', fontSize: '0.88rem',
-            border: '1px solid #d0d0d0', borderRadius: '6px', boxSizing: 'border-box'
-          }}
+          style={{ width: '100%', padding: '8px 12px', fontSize: '0.88rem',
+            border: '1px solid #d0d0d0', borderRadius: '6px', boxSizing: 'border-box' }}
         />
       </div>
 
-      {/* Filter rows — stacked: Types, Sources, Status */}
+      {/* Filter rows */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '12px' }}>
-        {/* Row 1: Type filters */}
         <div style={{ display: 'flex', gap: '3px' }}>
-          {[
-            { label: 'All Types', value: null },
-            { label: 'News', value: 'news' },
-            { label: 'Events', value: 'event' },
-            { label: 'Photos', value: 'photo' },
-          ].map(f => (
+          {[{ label: 'All Types', value: null }, { label: 'News', value: 'news' }, { label: 'Events', value: 'event' }, { label: 'Photos', value: 'photo' }].map(f => (
             <button key={f.label} onClick={() => {
               setFilter(f.value);
               if (f.value === 'event') setSortOrder('date_asc');
               else if (f.value !== filter) setSortOrder('collected_desc');
               setPage(1);
-            }}
-              style={filterBtn(filter === f.value)}>
-              {f.label}
-            </button>
+            }} style={filterBtn(filter === f.value)}>{f.label}</button>
           ))}
         </div>
-        {/* Row 2: Source filters */}
         <div style={{ display: 'flex', gap: '3px' }}>
-          {[
-            { label: 'All Sources', value: null },
-            { label: 'AI', value: 'ai' },
-            { label: 'Human', value: 'human' },
-            { label: 'Newsletter', value: 'newsletter' },
-          ].map(f => (
+          {[{ label: 'All Sources', value: null }, { label: 'AI', value: 'ai' }, { label: 'Human', value: 'human' }, { label: 'Newsletter', value: 'newsletter' }].map(f => (
             <button key={`src-${f.label}`} onClick={() => { setSourceFilter(f.value); setPage(1);}}
-              style={filterBtn(sourceFilter === f.value)}>
-              {f.label}
-            </button>
+              style={filterBtn(sourceFilter === f.value)}>{f.label}</button>
           ))}
         </div>
-        {/* Row 3: Status filters */}
         <div style={{ display: 'flex', gap: '3px' }}>
-          {[
-            { label: 'All', value: 'all' },
-            { label: 'Pending', value: 'pending' },
-            { label: 'Approved', value: 'approved' },
-            { label: 'Rejected', value: 'rejected' },
-          ].map(f => (
-            <button key={f.value} onClick={() => { setStatusFilter(f.value);setSelectedItems(new Set()); setPage(1);}}
-              style={filterBtn(statusFilter === f.value)}>
-              {f.label}
-            </button>
+          {[{ label: 'All', value: 'all' }, { label: 'Pending', value: 'pending' }, { label: 'Approved', value: 'approved' }, { label: 'Rejected', value: 'rejected' }].map(f => (
+            <button key={f.value} onClick={() => { setStatusFilter(f.value); setPage(1);}}
+              style={filterBtn(statusFilter === f.value)}>{f.label}</button>
           ))}
         </div>
-        {/* Row 4: Sort order */}
         <div style={{ display: 'flex', gap: '3px' }}>
           {[
-            { label: 'Collected \u2193', value: 'collected_desc' },
-            { label: 'Collected \u2191', value: 'collected_asc' },
-            { label: 'Date \u2191', value: 'date_asc' },
-            { label: 'Date \u2193', value: 'date_desc' },
-            { label: 'POI A\u2192Z', value: 'poi_asc' },
-            { label: 'POI Z\u2192A', value: 'poi_desc' },
+            { label: 'Collected \u2193', value: 'collected_desc' }, { label: 'Collected \u2191', value: 'collected_asc' },
+            { label: 'Date \u2191', value: 'date_asc' }, { label: 'Date \u2193', value: 'date_desc' },
+            { label: 'POI A\u2192Z', value: 'poi_asc' }, { label: 'POI Z\u2192A', value: 'poi_desc' }
           ].map(f => (
             <button key={f.value} onClick={() => { setSortOrder(f.value); setPage(1);}}
-              style={filterBtn(sortOrder === f.value)}>
-              {f.label}
-            </button>
+              style={filterBtn(sortOrder === f.value)}>{f.label}</button>
           ))}
         </div>
       </div>
 
       {/* Create form */}
       {creating && (
-        <div style={{
-          border: '2px solid #4caf50', borderRadius: '8px', padding: '16px',
-          marginBottom: '12px', backgroundColor: '#f9fff9'
-        }}>
+        <div style={{ border: '2px solid #4caf50', borderRadius: '8px', padding: '16px',
+          marginBottom: '12px', backgroundColor: '#f9fff9' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
             <h4 style={{ margin: 0 }}>Create New Content</h4>
             <button onClick={() => { setCreating(null); setCreateFields({}); }}
               style={{ ...btnStyle('transparent', '#999', '1px solid #ccc'), fontSize: '0.75rem' }}>Cancel</button>
           </div>
-
-          {/* Type selector for create */}
           <div style={{ display: 'flex', gap: '6px', marginBottom: '12px' }}>
             {['news', 'event', 'photo'].map(t => (
               <button key={t} onClick={() => { setCreating(t); setCreateFields({}); }}
@@ -807,18 +310,16 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
               </button>
             ))}
           </div>
-
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
             {(FIELD_CONFIGS[creating] || []).map(fc => (
               <div key={fc.key}>
                 <label style={{ fontSize: '0.78rem', color: '#666', fontWeight: '500', marginBottom: '2px', display: 'block' }}>
                   {fc.label}{fc.required ? ' *' : ''}
                 </label>
-                {renderFieldInput(fc, createFields, setCreateFields)}
+                {renderFieldInput(fc, createFields, setCreateFields, mod.pois)}
               </div>
             ))}
           </div>
-
           <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
             <button onClick={handleCreate} style={btnStyle('#4caf50')}>Create & Publish</button>
             <button onClick={() => { setCreating(null); setCreateFields({}); }}
@@ -829,18 +330,17 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
 
       {/* Bulk action bar */}
       {isPending && queue.length > 0 && (
-        <div style={{
-          display: 'flex', gap: '10px', alignItems: 'center',
+        <div style={{ display: 'flex', gap: '10px', alignItems: 'center',
           marginBottom: '10px', padding: '6px 12px',
-          backgroundColor: '#f5f5f5', borderRadius: '6px', fontSize: '0.85rem'
-        }}>
+          backgroundColor: '#f5f5f5', borderRadius: '6px', fontSize: '0.85rem' }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: '6px', cursor: 'pointer' }}>
-            <input type="checkbox" checked={selectedItems.size === queue.length && queue.length > 0} onChange={selectAll} />
+            <input type="checkbox" checked={mod.selectedItems.size === queue.length && queue.length > 0}
+              onChange={() => mod.selectAll(queue)} />
             Select All
           </label>
-          <button onClick={handleBulkApprove} disabled={selectedItems.size === 0}
-            style={{ ...btnStyle(selectedItems.size > 0 ? '#4caf50' : '#ccc'), padding: '3px 10px' }}>
-            Approve Selected ({selectedItems.size})
+          <button onClick={() => mod.handleBulkApprove(queue)} disabled={mod.selectedItems.size === 0}
+            style={{ ...btnStyle(mod.selectedItems.size > 0 ? '#4caf50' : '#ccc'), padding: '3px 10px' }}>
+            Approve Selected ({mod.selectedItems.size})
           </button>
         </div>
       )}
@@ -856,269 +356,23 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
         <div className="park-news-list" style={{ gap: '6px' }}>
           {queue.map(item => {
             const itemKey = `${item.content_type}:${item.id}`;
-            const isEditing = editingItem === itemKey;
 
-            // Moderation extras: badges, triage chips, edit form, and action buttons
-            // Rendered as children of the shared card component (below the card body, above nothing)
-            const moderationExtras = (
-              <>
-                {/* Moderation badges — all on one line, wrapping when needed */}
-                <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center', margin: '10px 0 8px' }}>
-                  {/* Item ID badge */}
-                  <span style={badgeStyle('#757575')}>#{item.id}</span>
-
-                  {/* Content type badge */}
-                  <span style={badgeStyle(getTypeBadgeColor(item.content_type))}>
-                    {item.content_type}
-                  </span>
-
-                  {/* Source badge */}
-                  {item.content_source && getSourceBadge(item.content_source) && (
-                    <span style={badgeStyle(getSourceBadge(item.content_source).color)}>
-                      {getSourceBadge(item.content_source).label}
-                    </span>
-                  )}
-
-                  {/* Status badge (non-pending only) */}
-                  {!isPending && (
-                    <span style={badgeStyle(item.moderation_status === 'rejected' ? '#f44336' : '#4caf50')}>
-                      {item.moderation_status === 'rejected' ? 'Rejected' : 'Approved'}
-                    </span>
-                  )}
-
-                  {/* Additional URLs badge */}
-                  {item.additional_url_count > 0 && (
-                    <span style={badgeStyle('#1565c0')}>
-                      +{item.additional_url_count} URL{item.additional_url_count > 1 ? 's' : ''}
-                    </span>
-                  )}
-
-                  {/* Triage chips — inline with other badges */}
-                  {item.content_type !== 'photo' && (() => {
-                    const issues = item.ai_issues ? (() => { try { return JSON.parse(item.ai_issues); } catch { return []; } })() : [];
-                    const urlIssueCodes = ['content_not_on_source_page', 'missing_source_url'];
-                    const hasNoDate = item.content_type === 'event'
-                      ? !item.publication_date && !item.start_date
-                      : !item.publication_date || !item.date_consensus_score;
-                    const hasUrlIssue = issues.some(i => urlIssueCodes.includes(i)) || (!item.source_url && item.content_type !== 'photo');
-                    const urlLabel = !item.source_url ? 'No URL' : 'Wrong URL';
-                    const hasOther = issues.some(i => !urlIssueCodes.includes(i));
-                    return (
-                      <>
-                        {hasNoDate && <span style={badgeStyle('#e65100')}>No Date</span>}
-                        {hasUrlIssue && <span style={badgeStyle('#e65100')}>{urlLabel}</span>}
-                        {hasOther && <span style={badgeStyle('#b71c1c')}>Other</span>}
-                      </>
-                    );
-                  })()}
-
-                  {/* Confidence score */}
-                  {item.confidence_score !== null && item.confidence_score !== undefined && (
-                    <span style={{
-                      color: getConfidenceColor(item.confidence_score),
-                      fontWeight: 'bold', fontSize: '0.78rem'
-                    }}>
-                      {(item.confidence_score * 100).toFixed(0)}%
-                    </span>
-                  )}
-
-                  {/* Collected / moderated timestamps */}
-                  <span style={{ fontSize: '0.72rem', color: '#aaa' }}>
-                    {formatPublicationDate(item.collection_date || item.created_at)}
-                    {item.moderated_at && ` · Mod: ${formatPublicationDate(item.moderated_at)}`}
-                  </span>
-                </div>
-
-                {/* Edit form */}
-                {isEditing && (
-                  <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '8px',
-                    padding: '12px', backgroundColor: '#fffbe6', borderRadius: '6px', border: '1px solid #ffe082' }}>
-                    <div style={{ padding: '8px', backgroundColor: '#fff8e1', borderRadius: '4px',
-                      fontSize: '0.8rem', color: '#555', lineHeight: '1.4', marginBottom: '4px' }}>
-                      {item.ai_reasoning && (<><strong>AI Analysis:</strong> {item.ai_reasoning}<br/></>)}
-                      <span style={{ fontSize: '0.75rem', color: '#888' }}>
-                        Status: {item.moderation_status === 'auto_approved' ? 'Auto-approved by AI' :
-                          item.moderation_status === 'published' ? 'Approved by human' :
-                          item.moderation_status}
-                        {item.confidence_score != null && ` · Score: ${(item.confidence_score * 100).toFixed(0)}%`}
-                      </span>
-                    </div>
-                    {(FIELD_CONFIGS[item.content_type] || []).map(fc => (
-                      <div key={fc.key}>
-                        <label style={{ fontSize: '0.78rem', color: '#666', fontWeight: '500', marginBottom: '2px', display: 'block' }}>
-                          {fc.label}
-                        </label>
-                        {renderFieldInput(fc, editFields, setEditFields)}
-                      </div>
-                    ))}
-                    {/* Additional URLs management */}
-                    {item.content_type !== 'photo' && (
-                      <div>
-                        <label style={{ fontSize: '0.78rem', color: '#666', fontWeight: '500', marginBottom: '2px', display: 'block' }}>
-                          Additional URLs
-                        </label>
-                        {(itemUrls[itemKey] || []).map(u => (
-                          <div key={u.id} style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '3px',
-                            padding: '4px 8px', backgroundColor: 'white', borderRadius: '4px', border: '1px solid #e0e0e0' }}>
-                            <a href={u.url} target="_blank" rel="noopener noreferrer"
-                              style={{ color: '#1976d2', flex: 1, fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                              {u.url}
-                            </a>
-                            {u.source_name && <span style={{ color: '#888', fontSize: '0.7rem', flexShrink: 0 }}>({u.source_name})</span>}
-                            <button onClick={() => handleRemoveUrl(item.content_type, item.id, u.id)}
-                              style={{ background: 'none', border: 'none', color: '#f44336', cursor: 'pointer',
-                                padding: '0 4px', fontSize: '0.85rem', flexShrink: 0, lineHeight: 1 }}
-                              title="Remove URL">x</button>
-                          </div>
-                        ))}
-                        <div style={{ display: 'flex', gap: '4px' }}>
-                          <input type="text" value={newUrlInput} onChange={e => setNewUrlInput(e.target.value)}
-                            placeholder="Add another source URL..."
-                            onKeyDown={e => e.key === 'Enter' && handleAddUrl(item.content_type, item.id)}
-                            style={{ flex: 1, padding: '5px 8px', fontSize: '0.78rem', border: '1px solid #ccc', borderRadius: '4px' }} />
-                          <button onClick={() => handleAddUrl(item.content_type, item.id)} disabled={addingUrl || !newUrlInput.trim()}
-                            style={btnStyle(addingUrl || !newUrlInput.trim() ? '#ccc' : '#1976d2')}>
-                            {addingUrl ? 'Adding...' : 'Add URL'}
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                    <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
-                      <button onClick={() => handleSave(item.content_type, item.id)}
-                        style={btnStyle('#4caf50')}>Save</button>
-                      <button onClick={() => { setEditingItem(null); setEditFields({}); }}
-                        style={btnStyle('transparent', '#666', '1px solid #ccc')}>Cancel</button>
-                    </div>
-                  </div>
-                )}
-
-                {/* Action buttons */}
-                <div style={{ display: 'flex', gap: '3px', flexWrap: 'wrap', marginTop: '6px' }}>
-                  {isPending && (
-                    <input type="checkbox" checked={selectedItems.has(itemKey)}
-                      onChange={() => toggleSelect(item.content_type, item.id)}
-                      style={{ marginRight: '4px' }} />
-                  )}
-                  {/* Approve / Reject / Requeue */}
-                  {isPending && (
-                    <>
-                      <button onClick={() => handleApprove(item.content_type, item.id)}
-                        style={actionBtn()}>Approve</button>
-                      <button onClick={() => handleReject(item.content_type, item.id)}
-                        style={actionBtn()}>Reject</button>
-                    </>
-                  )}
-                  {!isPending && (
-                    <>
-                      <button onClick={() => handleReject(item.content_type, item.id)}
-                        style={actionBtn()}>Reject</button>
-                      <button onClick={() => handleRequeue(item.content_type, item.id)}
-                        style={actionBtn()}>Requeue</button>
-                    </>
-                  )}
-                  {/* IA Date */}
-                  {item.content_type !== 'photo' && (
-                    <button onClick={() => handleIaDate(item.content_type, item.id, item.source_url)}
-                      disabled={iaDateItem === itemKey}
-                      title="Look up earliest Internet Archive snapshot date for this URL"
-                      style={actionBtn(iaDateItem === itemKey)}>
-                      {iaDateItem === itemKey ? 'Looking up...' : 'IA Date'}
-                    </button>
-                  )}
-                  {/* Edit */}
-                  <button onClick={() => startEditing(item)}
-                    style={actionBtn()}>Edit</button>
-                  {/* Merge */}
-                  {item.content_type !== 'photo' && (
-                    <button onClick={() => startMerge(item)}
-                      style={actionBtn()}>Merge</button>
-                  )}
-                  {/* Delete */}
-                  {item.content_type !== 'photo' && (
-                    confirmDelete === itemKey ? (
-                      <>
-                        <button onClick={() => handleDelete(item.content_type, item.id)}
-                          style={{ ...actionBtn(), backgroundColor: '#ffebee', color: '#c62828', borderColor: '#ef9a9a', width: 'auto', padding: '4px 8px' }}>
-                          Confirm Delete
-                        </button>
-                        <button onClick={() => setConfirmDelete(null)}
-                          style={actionBtn()}>Cancel</button>
-                      </>
-                    ) : (
-                      <button onClick={() => setConfirmDelete(itemKey)}
-                        style={{ ...actionBtn(), backgroundColor: '#ffebee', color: '#c62828', borderColor: '#ef9a9a' }}>
-                        Delete
-                      </button>
-                    )
-                  )}
-                </div>
-
-                {/* Merge candidate selection */}
-                {mergingItem && mergingItem.type === item.content_type && mergingItem.id === item.id && (
-                  <div style={{ marginTop: '8px', padding: '10px', backgroundColor: '#e3f2fd',
-                    borderRadius: '6px', border: '1px solid #90caf9' }}>
-                    <div style={{ fontSize: '0.82rem', fontWeight: 'bold', marginBottom: '6px', color: '#1565c0' }}>
-                      Merge this item into (target keeps its title/summary):
-                    </div>
-                    {mergeCandidates.length === 0 ? (
-                      <div style={{ fontSize: '0.78rem', color: '#666' }}>
-                        {mergingItem ? 'Loading candidates...' : 'No other items found for this POI.'}
-                      </div>
-                    ) : (
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', maxHeight: '300px', overflowY: 'auto' }}>
-                        {mergeCandidates.map(c => (
-                          <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: '6px',
-                            padding: '6px 8px', backgroundColor: 'white', borderRadius: '4px',
-                            border: '1px solid #e0e0e0' }}>
-                            <div style={{ flex: 1, minWidth: 0 }}>
-                              <div style={{ fontSize: '0.8rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: '500' }}>
-                                {c.title}
-                              </div>
-                              <div style={{ fontSize: '0.7rem', color: '#888', display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                                <span>#{c.id}</span>
-                                <span>{c.moderation_status}</span>
-                                {c.publication_date && <span>{new Date(c.publication_date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}</span>}
-                                {c.additional_url_count > 0 && <span>+{c.additional_url_count} URLs</span>}
-                              </div>
-                              {c.source_url && (
-                                <div style={{ fontSize: '0.68rem', color: '#1976d2', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                  {c.source_url}
-                                </div>
-                              )}
-                            </div>
-                            <button onClick={() => handleMerge(c.id)} disabled={merging}
-                              style={{ ...actionBtn(merging), backgroundColor: merging ? '#ccc' : '#1565c0',
-                                color: 'white', flexShrink: 0 }}>
-                              {merging ? 'Merging...' : 'Merge Into'}
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    <button onClick={() => { setMergingItem(null); setMergeCandidates([]); }}
-                      style={{ ...actionBtn(), marginTop: '6px', fontSize: '0.72rem' }}>Cancel</button>
-                  </div>
-                )}
-              </>
-            );
-
-            // Render using shared card components based on content type
             if (item.content_type === 'news') {
               return (
                 <NewsCardBody key={itemKey} item={{ ...item, summary: item.description }}
                   id={`moderation-item-${itemKey}`} onSelectPoi={onSelectPoi}>
-                  {moderationExtras}
+                  <ModerationExtras item={item} isPending={isPending} {...modExtrasProps} />
                 </NewsCardBody>
               );
             } else if (item.content_type === 'event') {
               return (
                 <EventCardBody key={itemKey} item={item}
                   id={`moderation-item-${itemKey}`} onSelectPoi={onSelectPoi}>
-                  {moderationExtras}
+                  <ModerationExtras item={item} isPending={isPending} {...modExtrasProps} />
                 </EventCardBody>
               );
             } else {
-              // Photo — keep simple inline rendering
+              // Photo — simple inline rendering
               return (
                 <div key={itemKey} id={`moderation-item-${itemKey}`} style={{
                   border: '1px solid #e0e0e0', borderRadius: '8px', padding: '10px 12px',
@@ -1128,14 +382,10 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
                     {item.title || '(untitled)'}
                   </div>
                   {getThumbnailUrl(item) && (
-                    <div
-                      onClick={() => handleOpenLightbox(item)}
-                      style={{
-                        width: '120px', height: '90px', borderRadius: '6px',
+                    <div onClick={() => handleOpenLightbox(item)}
+                      style={{ width: '120px', height: '90px', borderRadius: '6px',
                         overflow: 'hidden', cursor: 'pointer', margin: '6px 0',
-                        border: '1px solid #e0e0e0', position: 'relative', flexShrink: 0
-                      }}
-                    >
+                        border: '1px solid #e0e0e0', position: 'relative', flexShrink: 0 }}>
                       <img src={getThumbnailUrl(item)} alt={item.title || 'Media'}
                         style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
                       {item.media_type === 'video' && (
@@ -1151,7 +401,7 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
                     </div>
                   )}
                   {item.description && <p style={{ margin: '4px 0', fontSize: '0.83rem', color: '#555' }}>{item.description}</p>}
-                  {moderationExtras}
+                  <ModerationExtras item={item} isPending={isPending} {...modExtrasProps} />
                 </div>
               );
             }
@@ -1159,46 +409,26 @@ function ModerationInbox({ onCountChange, focusItemId, focusItemTitle, onSelectP
         </div>
       )}
 
-      {/* Pagination controls */}
+      {/* Pagination */}
       {!loading && Math.ceil(total / LIMIT) > 1 && (
         <div className="pagination-controls">
-          <button
-            className="pagination-btn"
-            onClick={() => setPage(p => p - 1)}
-            disabled={page === 1}
-          >
-            Back
-          </button>
-          <span className="pagination-info">
-            Page {page} of {Math.ceil(total / LIMIT)}
-          </span>
-          <button
-            className="pagination-btn"
-            onClick={() => setPage(p => p + 1)}
-            disabled={page === Math.ceil(total / LIMIT)}
-          >
-            Next
-          </button>
+          <button className="pagination-btn" onClick={() => setPage(p => p - 1)} disabled={page === 1}>Back</button>
+          <span className="pagination-info">Page {page} of {Math.ceil(total / LIMIT)}</span>
+          <button className="pagination-btn" onClick={() => setPage(p => p + 1)} disabled={page === Math.ceil(total / LIMIT)}>Next</button>
         </div>
       )}
 
       {/* Notification */}
-      {notification && (
-        <div className={`result-message ${notification.type}`} style={{ marginTop: '10px' }}>
-          {notification.message}
+      {mod.notification && (
+        <div className={`result-message ${mod.notification.type}`} style={{ marginTop: '10px' }}>
+          {mod.notification.message}
         </div>
       )}
 
       {/* Lightbox */}
       {lightboxMedia && (
-        <Lightbox
-          media={lightboxMedia}
-          initialIndex={lightboxIndex}
-          onClose={handleLightboxClose}
-          poiId={lightboxPoiId}
-          user={user}
-          onMediaUpdate={handleMediaUpdate}
-        />
+        <Lightbox media={lightboxMedia} initialIndex={lightboxIndex} onClose={() => { setLightboxMedia(null); setLightboxIndex(0); setLightboxPoiId(null); }}
+          poiId={lightboxPoiId} user={user} onMediaUpdate={handleMediaUpdate} />
       )}
     </div>
   );

--- a/frontend/src/components/NewEventForm.jsx
+++ b/frontend/src/components/NewEventForm.jsx
@@ -1,14 +1,24 @@
 import React, { useState, useEffect } from 'react';
+import PoiSearchSelect from './PoiSearchSelect';
+
+// Matches FIELD_CONFIGS.event in ModerationInbox.jsx
+const TZ_ABBR = (() => {
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZoneName: 'short', timeZone: 'America/New_York' })
+      .formatToParts(new Date()).find(p => p.type === 'timeZoneName')?.value || 'ET';
+  } catch { return 'ET'; }
+})();
 
 function NewEventForm({ onClose, onCreate }) {
   const [formData, setFormData] = useState({
     poi_id: '',
     title: '',
+    description: '',
     start_date: '',
     end_date: '',
-    description: '',
     event_type: '',
     location_details: '',
+    publication_date: '',
     source_url: ''
   });
   const [pois, setPois] = useState([]);
@@ -35,12 +45,12 @@ function NewEventForm({ onClose, onCreate }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!formData.poi_id) {
-      setError('Please select a location');
-      return;
-    }
     if (!formData.title.trim()) {
       setError('Title is required');
+      return;
+    }
+    if (!formData.poi_id) {
+      setError('Please select a location');
       return;
     }
     if (!formData.start_date) {
@@ -58,7 +68,8 @@ function NewEventForm({ onClose, onCreate }) {
         credentials: 'include',
         body: JSON.stringify({
           ...formData,
-          poi_id: parseInt(formData.poi_id)
+          poi_id: parseInt(formData.poi_id),
+          publication_date: formData.publication_date || null
         })
       });
 
@@ -88,20 +99,7 @@ function NewEventForm({ onClose, onCreate }) {
         <form onSubmit={handleSubmit} className="new-content-form">
           {error && <div className="form-error">{error}</div>}
 
-          <div className="form-section">
-            <label>Location *</label>
-            <select
-              value={formData.poi_id}
-              onChange={(e) => handleChange('poi_id', e.target.value)}
-              required
-            >
-              <option value="">Select a location...</option>
-              {pois.map(poi => (
-                <option key={poi.id} value={poi.id}>{poi.name}</option>
-              ))}
-            </select>
-          </div>
-
+          {/* Primary fields: Title, Description, POI, Dates */}
           <div className="form-section">
             <label>Title *</label>
             <input
@@ -111,26 +109,6 @@ function NewEventForm({ onClose, onCreate }) {
               placeholder="Event title..."
               required
             />
-          </div>
-
-          <div className="form-row">
-            <div className="form-section">
-              <label>Start Date *</label>
-              <input
-                type="date"
-                value={formData.start_date}
-                onChange={(e) => handleChange('start_date', e.target.value)}
-                required
-              />
-            </div>
-            <div className="form-section">
-              <label>End Date</label>
-              <input
-                type="date"
-                value={formData.end_date}
-                onChange={(e) => handleChange('end_date', e.target.value)}
-              />
-            </div>
           </div>
 
           <div className="form-section">
@@ -143,37 +121,67 @@ function NewEventForm({ onClose, onCreate }) {
             />
           </div>
 
-          <div className="form-row">
-            <div className="form-section">
-              <label>Event Type</label>
-              <select
-                value={formData.event_type}
-                onChange={(e) => handleChange('event_type', e.target.value)}
-              >
-                <option value="">Select type...</option>
-                <option value="hike">Hike</option>
-                <option value="race">Race</option>
-                <option value="concert">Concert</option>
-                <option value="festival">Festival</option>
-                <option value="program">Program</option>
-                <option value="volunteer">Volunteer</option>
-                <option value="arts">Arts</option>
-                <option value="community">Community</option>
-              </select>
-            </div>
-            <div className="form-section">
-              <label>Location Details</label>
-              <input
-                type="text"
-                value={formData.location_details}
-                onChange={(e) => handleChange('location_details', e.target.value)}
-                placeholder="e.g., Howe Meadow"
-              />
-            </div>
+          <div className="form-section">
+            <label>POI *</label>
+            <PoiSearchSelect
+              pois={pois}
+              value={formData.poi_id}
+              onChange={(id) => handleChange('poi_id', id || '')}
+              placeholder="Search POIs..."
+            />
           </div>
 
           <div className="form-section">
-            <label>Source URL</label>
+            <label>Start Date/Time ({TZ_ABBR}) *</label>
+            <input
+              type="datetime-local"
+              value={formData.start_date}
+              onChange={(e) => handleChange('start_date', e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="form-section">
+            <label>End Date/Time ({TZ_ABBR})</label>
+            <input
+              type="datetime-local"
+              value={formData.end_date}
+              onChange={(e) => handleChange('end_date', e.target.value)}
+            />
+          </div>
+
+          {/* Secondary fields: Type, Location, Publication Date, Source */}
+          <div className="form-section">
+            <label>Event Type</label>
+            <input
+              type="text"
+              value={formData.event_type}
+              onChange={(e) => handleChange('event_type', e.target.value)}
+              placeholder="e.g., hike, concert, festival"
+            />
+          </div>
+
+          <div className="form-section">
+            <label>Location Details</label>
+            <input
+              type="text"
+              value={formData.location_details}
+              onChange={(e) => handleChange('location_details', e.target.value)}
+              placeholder="e.g., Howe Meadow"
+            />
+          </div>
+
+          <div className="form-section">
+            <label>Publication Date ({TZ_ABBR})</label>
+            <input
+              type="datetime-local"
+              value={formData.publication_date}
+              onChange={(e) => handleChange('publication_date', e.target.value)}
+            />
+          </div>
+
+          <div className="form-section">
+            <label>Primary URL</label>
             <input
               type="url"
               value={formData.source_url}

--- a/frontend/src/components/NewEventForm.jsx
+++ b/frontend/src/components/NewEventForm.jsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from 'react';
+
+function NewEventForm({ onClose, onCreate }) {
+  const [formData, setFormData] = useState({
+    poi_id: '',
+    title: '',
+    start_date: '',
+    end_date: '',
+    description: '',
+    event_type: '',
+    location_details: '',
+    source_url: ''
+  });
+  const [pois, setPois] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/pois', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        const sorted = (Array.isArray(data) ? data : [])
+          .filter(p => !p.deleted)
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setPois(sorted);
+      })
+      .catch(() => setPois([]));
+  }, []);
+
+  const handleChange = (field, value) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    setError(null);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!formData.poi_id) {
+      setError('Please select a location');
+      return;
+    }
+    if (!formData.title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    if (!formData.start_date) {
+      setError('Start date is required');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          ...formData,
+          poi_id: parseInt(formData.poi_id)
+        })
+      });
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error || 'Failed to create event');
+      }
+
+      const newItem = await response.json();
+      if (onCreate) onCreate(newItem);
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="new-content-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="new-content-modal">
+        <div className="new-content-header">
+          <h3>Create Event</h3>
+          <button className="close-btn" onClick={onClose}>&times;</button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="new-content-form">
+          {error && <div className="form-error">{error}</div>}
+
+          <div className="form-section">
+            <label>Location *</label>
+            <select
+              value={formData.poi_id}
+              onChange={(e) => handleChange('poi_id', e.target.value)}
+              required
+            >
+              <option value="">Select a location...</option>
+              {pois.map(poi => (
+                <option key={poi.id} value={poi.id}>{poi.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-section">
+            <label>Title *</label>
+            <input
+              type="text"
+              value={formData.title}
+              onChange={(e) => handleChange('title', e.target.value)}
+              placeholder="Event title..."
+              required
+            />
+          </div>
+
+          <div className="form-row">
+            <div className="form-section">
+              <label>Start Date *</label>
+              <input
+                type="date"
+                value={formData.start_date}
+                onChange={(e) => handleChange('start_date', e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-section">
+              <label>End Date</label>
+              <input
+                type="date"
+                value={formData.end_date}
+                onChange={(e) => handleChange('end_date', e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="form-section">
+            <label>Description</label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => handleChange('description', e.target.value)}
+              placeholder="Event description..."
+              rows={3}
+            />
+          </div>
+
+          <div className="form-row">
+            <div className="form-section">
+              <label>Event Type</label>
+              <select
+                value={formData.event_type}
+                onChange={(e) => handleChange('event_type', e.target.value)}
+              >
+                <option value="">Select type...</option>
+                <option value="hike">Hike</option>
+                <option value="race">Race</option>
+                <option value="concert">Concert</option>
+                <option value="festival">Festival</option>
+                <option value="program">Program</option>
+                <option value="volunteer">Volunteer</option>
+                <option value="arts">Arts</option>
+                <option value="community">Community</option>
+              </select>
+            </div>
+            <div className="form-section">
+              <label>Location Details</label>
+              <input
+                type="text"
+                value={formData.location_details}
+                onChange={(e) => handleChange('location_details', e.target.value)}
+                placeholder="e.g., Howe Meadow"
+              />
+            </div>
+          </div>
+
+          <div className="form-section">
+            <label>Source URL</label>
+            <input
+              type="url"
+              value={formData.source_url}
+              onChange={(e) => handleChange('source_url', e.target.value)}
+              placeholder="https://..."
+            />
+          </div>
+
+          <div className="form-buttons">
+            <button type="button" className="cancel-btn" onClick={onClose} disabled={saving}>
+              Cancel
+            </button>
+            <button type="submit" className="save-btn" disabled={saving}>
+              {saving ? 'Creating...' : 'Create Event'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default NewEventForm;

--- a/frontend/src/components/NewNewsForm.jsx
+++ b/frontend/src/components/NewNewsForm.jsx
@@ -1,14 +1,23 @@
 import React, { useState, useEffect } from 'react';
+import PoiSearchSelect from './PoiSearchSelect';
+
+// Matches FIELD_CONFIGS.news in ModerationInbox.jsx
+const TZ_ABBR = (() => {
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZoneName: 'short', timeZone: 'America/New_York' })
+      .formatToParts(new Date()).find(p => p.type === 'timeZoneName')?.value || 'ET';
+  } catch { return 'ET'; }
+})();
 
 function NewNewsForm({ onClose, onCreate }) {
   const [formData, setFormData] = useState({
     poi_id: '',
     title: '',
     summary: '',
-    source_url: '',
-    source_name: '',
     news_type: 'general',
-    publication_date: new Date().toISOString().split('T')[0]
+    publication_date: '',
+    source_name: '',
+    source_url: ''
   });
   const [pois, setPois] = useState([]);
   const [saving, setSaving] = useState(false);
@@ -34,12 +43,12 @@ function NewNewsForm({ onClose, onCreate }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!formData.poi_id) {
-      setError('Please select a location');
-      return;
-    }
     if (!formData.title.trim()) {
       setError('Title is required');
+      return;
+    }
+    if (!formData.poi_id) {
+      setError('Please select a location');
       return;
     }
 
@@ -53,7 +62,8 @@ function NewNewsForm({ onClose, onCreate }) {
         credentials: 'include',
         body: JSON.stringify({
           ...formData,
-          poi_id: parseInt(formData.poi_id)
+          poi_id: parseInt(formData.poi_id),
+          publication_date: formData.publication_date || null
         })
       });
 
@@ -83,20 +93,7 @@ function NewNewsForm({ onClose, onCreate }) {
         <form onSubmit={handleSubmit} className="new-content-form">
           {error && <div className="form-error">{error}</div>}
 
-          <div className="form-section">
-            <label>Location *</label>
-            <select
-              value={formData.poi_id}
-              onChange={(e) => handleChange('poi_id', e.target.value)}
-              required
-            >
-              <option value="">Select a location...</option>
-              {pois.map(poi => (
-                <option key={poi.id} value={poi.id}>{poi.name}</option>
-              ))}
-            </select>
-          </div>
-
+          {/* Primary fields: Title, Summary, POI, Date */}
           <div className="form-section">
             <label>Title *</label>
             <input
@@ -118,49 +115,58 @@ function NewNewsForm({ onClose, onCreate }) {
             />
           </div>
 
-          <div className="form-row">
-            <div className="form-section">
-              <label>Source URL</label>
-              <input
-                type="url"
-                value={formData.source_url}
-                onChange={(e) => handleChange('source_url', e.target.value)}
-                placeholder="https://..."
-              />
-            </div>
-            <div className="form-section">
-              <label>Source Name</label>
-              <input
-                type="text"
-                value={formData.source_name}
-                onChange={(e) => handleChange('source_name', e.target.value)}
-                placeholder="e.g., NPS.gov"
-              />
-            </div>
+          <div className="form-section">
+            <label>POI *</label>
+            <PoiSearchSelect
+              pois={pois}
+              value={formData.poi_id}
+              onChange={(id) => handleChange('poi_id', id || '')}
+              placeholder="Search POIs..."
+            />
           </div>
 
-          <div className="form-row">
-            <div className="form-section">
-              <label>Type</label>
-              <select
-                value={formData.news_type}
-                onChange={(e) => handleChange('news_type', e.target.value)}
-              >
-                <option value="general">General</option>
-                <option value="alert">Alert</option>
-                <option value="wildlife">Wildlife</option>
-                <option value="infrastructure">Infrastructure</option>
-                <option value="community">Community</option>
-              </select>
-            </div>
-            <div className="form-section">
-              <label>Publication Date</label>
-              <input
-                type="date"
-                value={formData.publication_date}
-                onChange={(e) => handleChange('publication_date', e.target.value)}
-              />
-            </div>
+          <div className="form-section">
+            <label>Publication Date ({TZ_ABBR})</label>
+            <input
+              type="datetime-local"
+              value={formData.publication_date}
+              onChange={(e) => handleChange('publication_date', e.target.value)}
+            />
+          </div>
+
+          {/* Secondary fields: Type, Source */}
+          <div className="form-section">
+            <label>Type</label>
+            <select
+              value={formData.news_type}
+              onChange={(e) => handleChange('news_type', e.target.value)}
+            >
+              <option value="general">General</option>
+              <option value="closure">Closure</option>
+              <option value="seasonal">Seasonal</option>
+              <option value="maintenance">Maintenance</option>
+              <option value="wildlife">Wildlife</option>
+            </select>
+          </div>
+
+          <div className="form-section">
+            <label>Source Name</label>
+            <input
+              type="text"
+              value={formData.source_name}
+              onChange={(e) => handleChange('source_name', e.target.value)}
+              placeholder="e.g., NPS.gov"
+            />
+          </div>
+
+          <div className="form-section">
+            <label>Primary URL</label>
+            <input
+              type="url"
+              value={formData.source_url}
+              onChange={(e) => handleChange('source_url', e.target.value)}
+              placeholder="https://..."
+            />
           </div>
 
           <div className="form-buttons">

--- a/frontend/src/components/NewNewsForm.jsx
+++ b/frontend/src/components/NewNewsForm.jsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect } from 'react';
+
+function NewNewsForm({ onClose, onCreate }) {
+  const [formData, setFormData] = useState({
+    poi_id: '',
+    title: '',
+    summary: '',
+    source_url: '',
+    source_name: '',
+    news_type: 'general',
+    publication_date: new Date().toISOString().split('T')[0]
+  });
+  const [pois, setPois] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/pois', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        const sorted = (Array.isArray(data) ? data : [])
+          .filter(p => !p.deleted)
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setPois(sorted);
+      })
+      .catch(() => setPois([]));
+  }, []);
+
+  const handleChange = (field, value) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    setError(null);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!formData.poi_id) {
+      setError('Please select a location');
+      return;
+    }
+    if (!formData.title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/news', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          ...formData,
+          poi_id: parseInt(formData.poi_id)
+        })
+      });
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error || 'Failed to create news item');
+      }
+
+      const newItem = await response.json();
+      if (onCreate) onCreate(newItem);
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="new-content-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="new-content-modal">
+        <div className="new-content-header">
+          <h3>Create News Item</h3>
+          <button className="close-btn" onClick={onClose}>&times;</button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="new-content-form">
+          {error && <div className="form-error">{error}</div>}
+
+          <div className="form-section">
+            <label>Location *</label>
+            <select
+              value={formData.poi_id}
+              onChange={(e) => handleChange('poi_id', e.target.value)}
+              required
+            >
+              <option value="">Select a location...</option>
+              {pois.map(poi => (
+                <option key={poi.id} value={poi.id}>{poi.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-section">
+            <label>Title *</label>
+            <input
+              type="text"
+              value={formData.title}
+              onChange={(e) => handleChange('title', e.target.value)}
+              placeholder="News headline..."
+              required
+            />
+          </div>
+
+          <div className="form-section">
+            <label>Summary</label>
+            <textarea
+              value={formData.summary}
+              onChange={(e) => handleChange('summary', e.target.value)}
+              placeholder="Brief summary of the news..."
+              rows={3}
+            />
+          </div>
+
+          <div className="form-row">
+            <div className="form-section">
+              <label>Source URL</label>
+              <input
+                type="url"
+                value={formData.source_url}
+                onChange={(e) => handleChange('source_url', e.target.value)}
+                placeholder="https://..."
+              />
+            </div>
+            <div className="form-section">
+              <label>Source Name</label>
+              <input
+                type="text"
+                value={formData.source_name}
+                onChange={(e) => handleChange('source_name', e.target.value)}
+                placeholder="e.g., NPS.gov"
+              />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-section">
+              <label>Type</label>
+              <select
+                value={formData.news_type}
+                onChange={(e) => handleChange('news_type', e.target.value)}
+              >
+                <option value="general">General</option>
+                <option value="alert">Alert</option>
+                <option value="wildlife">Wildlife</option>
+                <option value="infrastructure">Infrastructure</option>
+                <option value="community">Community</option>
+              </select>
+            </div>
+            <div className="form-section">
+              <label>Publication Date</label>
+              <input
+                type="date"
+                value={formData.publication_date}
+                onChange={(e) => handleChange('publication_date', e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="form-buttons">
+            <button type="button" className="cancel-btn" onClick={onClose} disabled={saving}>
+              Cancel
+            </button>
+            <button type="submit" className="save-btn" disabled={saving}>
+              {saving ? 'Creating...' : 'Create News'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default NewNewsForm;

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -327,16 +327,16 @@ export function NewsCardBody({ item, onSelectPoi, children, className, id }) {
           ) : null}
         </div>
       </div>
+      {(item.publication_date || item.collection_date) && (
+        <div className="park-news-date">
+          {item.publication_date
+            ? formatPublicationDate(item.publication_date)
+            : new Date(item.collection_date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'America/New_York' })}
+        </div>
+      )}
       {summary && <p className="park-news-summary">{summary}</p>}
       <div className="park-news-meta">
         {item.source_name && <span className="news-source">{item.source_name}</span>}
-        {(item.publication_date || item.collection_date) && (
-          <span className="news-date">
-            {item.publication_date
-              ? formatPublicationDate(item.publication_date)
-              : new Date(item.collection_date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'America/New_York' })}
-          </span>
-        )}
         {item.source_url && item.additional_urls && item.additional_urls.length > 0 ? (
           <span className="news-sources-group">
             <a href={item.source_url} target="_blank" rel="noopener noreferrer" className="news-link">Source</a>

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import MapThumbnail from './MapThumbnail';
 import { EventCardBody } from './NewsEventsShared';
 import { handleRovingKeyDown } from '../utils/a11yUtils';
-import NewEventForm from './NewEventForm';
+import ContentFormModal from './ContentFormModal';
+import useModeration from '../hooks/useModeration';
+import ModerationExtras from './ModerationExtras';
 
 // Default park bounds - show full park view in mini map
 const DEFAULT_PARK_BOUNDS = [
@@ -17,7 +19,7 @@ function formatDateForCalendar(dateString) {
   return date.toISOString().replace(/-|:|\.\d{3}/g, '').slice(0, 15) + 'Z';
 }
 
-function ParkEvents({ isAdmin, editMode, onSelectPoi, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
+function ParkEvents({ isAdmin, editMode, onSelectPoi, onEditEventItem, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -40,6 +42,11 @@ function ParkEvents({ isAdmin, editMode, onSelectPoi, filteredDestinations, filt
     'alert': true
   });
   const [showNewForm, setShowNewForm] = useState(false);
+
+  // Shared moderation hook (only active when admin)
+  const mod = useModeration({
+    onItemsChanged: () => { fetchEvents(); fetchPastEvents(); }
+  });
 
   useEffect(() => {
     fetchEvents();
@@ -251,9 +258,12 @@ END:VCALENDAR`;
       </div>
 
       {showNewForm && (
-        <NewEventForm
-          onClose={() => setShowNewForm(false)}
+        <ContentFormModal
+          mode="create"
+          contentType="event"
+          pois={mod.pois}
           onCreate={() => fetchEvents()}
+          onClose={() => setShowNewForm(false)}
         />
       )}
 
@@ -354,7 +364,41 @@ END:VCALENDAR`;
                 </button>
               </div>
             }
-          />
+          >
+            {editMode && isAdmin && (
+              <ModerationExtras
+                item={{ ...item, content_type: 'event' }}
+                isPending={false}
+                editingItem={mod.editingItem}
+                editFields={mod.editFields}
+                setEditFields={mod.setEditFields}
+                itemUrls={mod.itemUrls}
+                newUrlInput={mod.newUrlInput}
+                setNewUrlInput={mod.setNewUrlInput}
+                addingUrl={mod.addingUrl}
+                iaDateItem={mod.iaDateItem}
+                mergingItem={mod.mergingItem}
+                mergeCandidates={mod.mergeCandidates}
+                merging={mod.merging}
+                confirmDelete={mod.confirmDelete}
+                setConfirmDelete={mod.setConfirmDelete}
+                pois={mod.pois}
+                onApprove={mod.handleApprove}
+                onReject={mod.handleReject}
+                onRequeue={mod.handleRequeue}
+                onDelete={mod.handleDelete}
+                onSave={mod.handleSave}
+                onIaDate={mod.handleIaDate}
+                onStartEditing={mod.startEditing}
+                onCancelEditing={mod.cancelEditing}
+                onStartMerge={mod.startMerge}
+                onMerge={mod.handleMerge}
+                onCancelMerge={mod.cancelMerge}
+                onAddUrl={mod.handleAddUrl}
+                onRemoveUrl={mod.handleRemoveUrl}
+              />
+            )}
+          </EventCardBody>
             ))}
           </div>
           )}
@@ -393,6 +437,12 @@ END:VCALENDAR`;
           </div>
         )}
       </div>
+      {/* Moderation notification */}
+      {editMode && isAdmin && mod.notification && (
+        <div className={`result-message ${mod.notification.type}`} style={{ margin: '10px 1rem' }}>
+          {mod.notification.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import MapThumbnail from './MapThumbnail';
 import { EventCardBody } from './NewsEventsShared';
 import { handleRovingKeyDown } from '../utils/a11yUtils';
+import NewEventForm from './NewEventForm';
 
 // Default park bounds - show full park view in mini map
 const DEFAULT_PARK_BOUNDS = [
@@ -16,7 +17,7 @@ function formatDateForCalendar(dateString) {
   return date.toISOString().replace(/-|:|\.\d{3}/g, '').slice(0, 15) + 'Z';
 }
 
-function ParkEvents({ isAdmin, onSelectPoi, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
+function ParkEvents({ isAdmin, editMode, onSelectPoi, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -38,6 +39,7 @@ function ParkEvents({ isAdmin, onSelectPoi, filteredDestinations, filteredLinear
     'community': true,
     'alert': true
   });
+  const [showNewForm, setShowNewForm] = useState(false);
 
   useEffect(() => {
     fetchEvents();
@@ -238,10 +240,22 @@ END:VCALENDAR`;
 
   return (
     <div className="park-events-tab">
-      <div className="news-events-header">
-        <h2>{tabLabel}</h2>
-        <p className="tab-subtitle">Events across Cuyahoga Valley National Park</p>
+      <div className="news-events-header tab-header-with-new">
+        <div>
+          <h2>{tabLabel}</h2>
+          <p className="tab-subtitle">Events across Cuyahoga Valley National Park</p>
+        </div>
+        {editMode && isAdmin && (
+          <button className="tab-new-btn" onClick={() => setShowNewForm(true)}>+ New</button>
+        )}
       </div>
+
+      {showNewForm && (
+        <NewEventForm
+          onClose={() => setShowNewForm(false)}
+          onCreate={() => fetchEvents()}
+        />
+      )}
 
       {/* Sub-tabs */}
       <div className="results-subtabs" onKeyDown={(e) => handleRovingKeyDown(e, '.results-subtab')}>

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import MapThumbnail from './MapThumbnail';
 import { NewsCardBody } from './NewsEventsShared';
+import NewNewsForm from './NewNewsForm';
 
 // Default park bounds - show full park view in mini map
 const DEFAULT_PARK_BOUNDS = [
@@ -8,7 +9,7 @@ const DEFAULT_PARK_BOUNDS = [
   [41.45, -81.50]   // Northeast corner
 ];
 
-function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
+function ParkNews({ isAdmin, editMode, onSelectPoi, onEditNewsItem, filteredDestinations, filteredLinearFeatures, filteredVirtualPois, mapState, onMapClick, refreshTrigger, bypassViewportFilter, visiblePoiCount }) {
   const [news, setNews] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -23,6 +24,7 @@ function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, 
     infrastructure: true,
     community: true
   });
+  const [showNewForm, setShowNewForm] = useState(false);
 
   useEffect(() => {
     fetchNews();
@@ -129,10 +131,22 @@ function ParkNews({ isAdmin, onSelectPoi, onEditNewsItem, filteredDestinations, 
 
   return (
     <div className="park-news-tab">
-      <div className="news-events-header">
-        <h2>Park News</h2>
-        <p className="tab-subtitle">Recent news from across Cuyahoga Valley National Park</p>
+      <div className="news-events-header tab-header-with-new">
+        <div>
+          <h2>Park News</h2>
+          <p className="tab-subtitle">Recent news from across Cuyahoga Valley National Park</p>
+        </div>
+        {editMode && isAdmin && (
+          <button className="tab-new-btn" onClick={() => setShowNewForm(true)}>+ New</button>
+        )}
       </div>
+
+      {showNewForm && (
+        <NewNewsForm
+          onClose={() => setShowNewForm(false)}
+          onCreate={() => fetchNews()}
+        />
+      )}
 
       <div className="results-filters">
         <input

--- a/frontend/src/components/ParkNews.jsx
+++ b/frontend/src/components/ParkNews.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import MapThumbnail from './MapThumbnail';
 import { NewsCardBody } from './NewsEventsShared';
-import NewNewsForm from './NewNewsForm';
+import ContentFormModal from './ContentFormModal';
+import useModeration from '../hooks/useModeration';
+import ModerationExtras from './ModerationExtras';
 
 // Default park bounds - show full park view in mini map
 const DEFAULT_PARK_BOUNDS = [
@@ -25,6 +27,11 @@ function ParkNews({ isAdmin, editMode, onSelectPoi, onEditNewsItem, filteredDest
     community: true
   });
   const [showNewForm, setShowNewForm] = useState(false);
+
+  // Shared moderation hook (only active when admin)
+  const mod = useModeration({
+    onItemsChanged: () => fetchNews()
+  });
 
   useEffect(() => {
     fetchNews();
@@ -142,9 +149,12 @@ function ParkNews({ isAdmin, editMode, onSelectPoi, onEditNewsItem, filteredDest
       </div>
 
       {showNewForm && (
-        <NewNewsForm
-          onClose={() => setShowNewForm(false)}
+        <ContentFormModal
+          mode="create"
+          contentType="news"
+          pois={mod.pois}
           onCreate={() => fetchNews()}
+          onClose={() => setShowNewForm(false)}
         />
       )}
 
@@ -198,13 +208,50 @@ function ParkNews({ isAdmin, editMode, onSelectPoi, onEditNewsItem, filteredDest
               items[next].focus();
             }
           }}>
-        {paginatedNews.map(item => (
-          <NewsCardBody
-            key={item.id}
-            item={item}
-            onSelectPoi={onSelectPoi}
-          />
-        ))}
+        {paginatedNews.map(item => {
+          const enrichedItem = { ...item, content_type: 'news' };
+          return (
+            <NewsCardBody
+              key={item.id}
+              item={item}
+              onSelectPoi={onSelectPoi}
+            >
+              {editMode && isAdmin && (
+                <ModerationExtras
+                  item={enrichedItem}
+                  isPending={false}
+                  editingItem={mod.editingItem}
+                  editFields={mod.editFields}
+                  setEditFields={mod.setEditFields}
+                  itemUrls={mod.itemUrls}
+                  newUrlInput={mod.newUrlInput}
+                  setNewUrlInput={mod.setNewUrlInput}
+                  addingUrl={mod.addingUrl}
+                  iaDateItem={mod.iaDateItem}
+                  mergingItem={mod.mergingItem}
+                  mergeCandidates={mod.mergeCandidates}
+                  merging={mod.merging}
+                  confirmDelete={mod.confirmDelete}
+                  setConfirmDelete={mod.setConfirmDelete}
+                  pois={mod.pois}
+                  onApprove={mod.handleApprove}
+                  onReject={mod.handleReject}
+                  onRequeue={mod.handleRequeue}
+                  onDelete={mod.handleDelete}
+                  onSave={mod.handleSave}
+                  onIaDate={mod.handleIaDate}
+                  onStartEditing={mod.startEditing}
+                  onCancelEditing={mod.cancelEditing}
+                  onStartMerge={mod.startMerge}
+                  onMerge={mod.handleMerge}
+                  onCancelMerge={mod.cancelMerge}
+                  onAddUrl={mod.handleAddUrl}
+                  onRemoveUrl={mod.handleRemoveUrl}
+                />
+              )}
+            </NewsCardBody>
+          );
+        })}
           </div>
           )}
           {totalPages > 1 && (
@@ -242,6 +289,12 @@ function ParkNews({ isAdmin, editMode, onSelectPoi, onEditNewsItem, filteredDest
           </div>
         )}
       </div>
+      {/* Moderation notification */}
+      {editMode && isAdmin && mod.notification && (
+        <div className={`result-message ${mod.notification.type}`} style={{ margin: '10px 1rem' }}>
+          {mod.notification.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -531,6 +531,15 @@ const ResultsTab = memo(function ResultsTab({
             <span className="subtab-label-short">{tab.shortLabel || tab.label}</span>
           </button>
         ))}
+        {editMode && (isAdmin || userRole === 'poi_admin') && onNewPOI && (
+          <button
+            className="results-new-btn"
+            onClick={() => onNewPOI(activeSubTab)}
+            title={`Create new ${activeSubTab === 'mtb' ? 'MTB trailhead' : activeSubTab === 'organizations' ? 'organization' : 'point of interest'}`}
+          >
+            + New
+          </button>
+        )}
       </div>
 
       <div className="results-filters">

--- a/frontend/src/components/ResultsTab.jsx
+++ b/frontend/src/components/ResultsTab.jsx
@@ -33,7 +33,11 @@ const ResultsTab = memo(function ResultsTab({
   onFilterByTypes,  // Callback to filter by POI types: array of types or null for all
   bypassViewportFilter = false,  // Temporarily show all POIs (bypass viewport filtering)
   visiblePoiCount,  // Global POI count from App.jsx
-  iconConfig  // Icon configuration for rendering POI icons
+  iconConfig,  // Icon configuration for rendering POI icons
+  editMode = false,  // Whether edit mode is active
+  isAdmin = false,  // Whether user is admin
+  userRole = 'viewer',  // User role (admin, poi_admin, media_admin, viewer)
+  onNewPOI  // Callback when New button is clicked, receives activeSubTab
 }) {
   const navigate = useNavigate();
   const isNavigatingRef = useRef(false);
@@ -424,6 +428,15 @@ const ResultsTab = memo(function ResultsTab({
               <span className="subtab-label-short">{tab.shortLabel || tab.label}</span>
             </button>
           ))}
+          {editMode && (isAdmin || userRole === 'poi_admin') && onNewPOI && (
+            <button
+              className="results-new-btn"
+              onClick={() => onNewPOI(activeSubTab)}
+              title={`Create new ${activeSubTab === 'mtb' ? 'MTB trailhead' : activeSubTab === 'organizations' ? 'organization' : 'point of interest'}`}
+            >
+              + New
+            </button>
+          )}
         </div>
 
         {/* Filter badges - always visible even when no results */}

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -9,8 +9,8 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual
     ? `/api/pois/${poi.id}/thumbnail?size=small&v=${poi.updated_at || Date.now()}`
     : null;
 
-  // Check if this is an MTB trailhead (destination with status_url)
-  const isMtbTrailhead = !isLinear && !isVirtual && poi.status_url && poi.status_url.trim() !== '';
+  // Check if this is an MTB trailhead (has mtb_trail role or status_url)
+  const isMtbTrailhead = !isLinear && !isVirtual && (poi.poi_roles?.includes('mtb_trail') || (poi.status_url && poi.status_url.trim() !== ''));
 
   // Get default thumbnail SVG path based on type
   const getDefaultThumbnail = () => {

--- a/frontend/src/components/RoleEditor.jsx
+++ b/frontend/src/components/RoleEditor.jsx
@@ -3,9 +3,10 @@ import React from 'react';
 const VALID_ROLES = [
   { id: 'point', label: 'Point', description: 'A location on the map' },
   { id: 'trail', label: 'Trail', description: 'A hiking/biking trail' },
-  { id: 'river', label: 'River', description: 'A river or waterway' },
   { id: 'boundary', label: 'Boundary', description: 'A geographic boundary' },
-  { id: 'organization', label: 'Organization', description: 'A virtual/organizational POI' }
+  { id: 'river', label: 'River', description: 'A river or waterway' },
+  { id: 'organization', label: 'Organization', description: 'A virtual/organizational POI' },
+  { id: 'mtb_trail', label: 'MTB Trail', description: 'An MTB trailhead with status tracking' }
 ];
 
 function RoleEditor({ roles = [], onChange }) {

--- a/frontend/src/components/RoleEditor.jsx
+++ b/frontend/src/components/RoleEditor.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const VALID_ROLES = [
+  { id: 'point', label: 'Point', description: 'A location on the map' },
+  { id: 'trail', label: 'Trail', description: 'A hiking/biking trail' },
+  { id: 'river', label: 'River', description: 'A river or waterway' },
+  { id: 'boundary', label: 'Boundary', description: 'A geographic boundary' },
+  { id: 'organization', label: 'Organization', description: 'A virtual/organizational POI' }
+];
+
+function RoleEditor({ roles = [], onChange }) {
+  const roleSet = new Set(roles);
+
+  const toggleRole = (roleId) => {
+    const updated = new Set(roleSet);
+    if (updated.has(roleId)) {
+      // Don't allow removing the last role
+      if (updated.size <= 1) return;
+      updated.delete(roleId);
+    } else {
+      updated.add(roleId);
+    }
+    onChange(Array.from(updated));
+  };
+
+  return (
+    <div className="role-editor">
+      <label>Roles</label>
+      <div className="role-chips">
+        {VALID_ROLES.map(role => (
+          <button
+            key={role.id}
+            type="button"
+            className={`role-chip ${roleSet.has(role.id) ? 'active' : ''}`}
+            onClick={() => toggleRole(role.id)}
+            title={role.description}
+          >
+            {role.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default RoleEditor;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1776,7 +1776,7 @@ function AssociationsModal({ isOpen, onClose, poi, associations, allDestinations
                 };
 
                 const isMtbTrailhead = !associatedPoi._isLinear && !associatedPoi._isVirtual &&
-                                      associatedPoi.status_url && associatedPoi.status_url.trim() !== '';
+                                      (associatedPoi.poi_roles?.includes('mtb_trail') || (associatedPoi.status_url && associatedPoi.status_url.trim() !== ''));
                 const poiType = associatedPoi._isVirtual ? 'virtual' :
                                 !associatedPoi._isLinear ? (isMtbTrailhead ? 'mtb' : 'destination') :
                                 associatedPoi.feature_type || 'trail';

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -6,6 +6,8 @@ import { formatDateTime, formatPublicationDate, NewsTypeIcon, EventTypeIcon } fr
 import ShareButton from './ShareButton';
 import Mosaic from './Mosaic';
 import MediaUploadModal from './MediaUploadModal';
+import RoleEditor from './RoleEditor';
+import GeoJSONUploader from './GeoJSONUploader';
 
 // Sidebar component with tabs: Info, News, Events, History
 // Share Modal Component
@@ -700,6 +702,22 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
           placeholder="Enter POI name..."
         />
       </div>
+
+      {/* Role editor - shown for new POIs or when editing existing POIs */}
+      {(isNewPOI || isNewOrganization || editedData.poi_roles) && (
+        <RoleEditor
+          roles={editedData.poi_roles || []}
+          onChange={(roles) => handleChange('poi_roles', roles)}
+        />
+      )}
+
+      {/* GeoJSON uploader - shown when POI has trail, river, or boundary role */}
+      {editedData.poi_roles && (editedData.poi_roles.includes('trail') || editedData.poi_roles.includes('river') || editedData.poi_roles.includes('boundary')) && (
+        <GeoJSONUploader
+          geometry={editedData.geometry}
+          onChange={(geometry) => handleChange('geometry', geometry)}
+        />
+      )}
 
       <div className="edit-section">
         <label title="A short public-facing description of this location">Overview</label>

--- a/frontend/src/hooks/useModeration.js
+++ b/frontend/src/hooks/useModeration.js
@@ -1,0 +1,411 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Shared hook for per-item moderation state and API handlers.
+ * Used by both ModerationInbox and ParkNews/ParkEvents.
+ *
+ * @param {Object} options
+ * @param {Function} options.onItemsChanged - Callback to re-fetch items after mutations
+ * @param {Function} options.onCountChange - Callback when pending count changes (optional)
+ */
+export default function useModeration({ onItemsChanged, onCountChange } = {}) {
+  const [editingItem, setEditingItem] = useState(null); // "news:123" key
+  const [editFields, setEditFields] = useState({});
+  const [notification, setNotification] = useState(null);
+  const [pois, setPois] = useState([]);
+  const [itemUrls, setItemUrls] = useState({});
+  const [newUrlInput, setNewUrlInput] = useState('');
+  const [addingUrl, setAddingUrl] = useState(false);
+  const [iaDateItem, setIaDateItem] = useState(null);
+  const [mergingItem, setMergingItem] = useState(null);
+  const [mergeCandidates, setMergeCandidates] = useState([]);
+  const [merging, setMerging] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [selectedItems, setSelectedItems] = useState(new Set());
+
+  const notify = useCallback((type, message) => setNotification({ type, message }), []);
+
+  // Auto-dismiss notifications
+  useEffect(() => {
+    if (!notification) return;
+    const timer = setTimeout(() => setNotification(null), 4000);
+    return () => clearTimeout(timer);
+  }, [notification]);
+
+  // Fetch POIs for PoiSearchSelect
+  useEffect(() => {
+    fetch('/api/pois', { credentials: 'include' })
+      .then(r => r.ok ? r.json() : [])
+      .then(data => setPois(Array.isArray(data) ? data : []))
+      .catch(() => setPois([]));
+  }, []);
+
+  const refreshItems = useCallback(() => {
+    if (onItemsChanged) onItemsChanged();
+  }, [onItemsChanged]);
+
+  const handleApprove = async (type, id, item) => {
+    try {
+      const response = await fetch('/api/admin/moderation/approve', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ type, id })
+      });
+      if (response.ok) {
+        notify('success', `${type} #${id} approved`);
+        refreshItems();
+        if (onCountChange) onCountChange();
+        if (type === 'photo' && item?.poi_id) {
+          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
+          window.dispatchEvent(new CustomEvent('poi-updated', { detail: { poiId: item.poi_id } }));
+        }
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const handleReject = async (type, id, item) => {
+    try {
+      const response = await fetch('/api/admin/moderation/reject', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ type, id, reason: '' })
+      });
+      if (response.ok) {
+        notify('success', `${type} #${id} rejected`);
+        refreshItems();
+        if (onCountChange) onCountChange();
+        if (type === 'photo' && item?.poi_id) {
+          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
+        }
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const handleRequeue = async (type, id) => {
+    try {
+      const response = await fetch('/api/admin/moderation/requeue', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ type, id })
+      });
+      if (response.ok) {
+        notify('success', `${type} #${id} requeued`);
+        refreshItems();
+        if (onCountChange) onCountChange();
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const handleDelete = async (type, id) => {
+    const endpoint = type === 'news' ? `/api/admin/news/${id}` : `/api/admin/events/${id}`;
+    try {
+      const response = await fetch(endpoint, { method: 'DELETE', credentials: 'include' });
+      if (response.ok) {
+        setConfirmDelete(null);
+        notify('success', `${type} #${id} deleted`);
+        refreshItems();
+        if (onCountChange) onCountChange();
+      } else {
+        notify('error', `Failed to delete ${type} #${id}`);
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const handleIaDate = async (type, id, sourceUrl) => {
+    const itemKey = `${type}:${id}`;
+    if (!sourceUrl) { notify('error', 'No source URL for this item'); return; }
+    setIaDateItem(itemKey);
+    try {
+      const response = await fetch(`/api/admin/moderation/ia-date?url=${encodeURIComponent(sourceUrl)}`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (data.date) {
+          const saveResponse = await fetch('/api/admin/moderation/save', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            credentials: 'include', body: JSON.stringify({ type, id, edits: { publication_date: data.date } })
+          });
+          if (saveResponse.ok) {
+            notify('success', `${type} #${id} — date set to ${data.date} (earliest IA snapshot)`);
+            refreshItems();
+          } else {
+            notify('error', 'IA date found but failed to update item');
+          }
+        } else {
+          notify('error', 'No Internet Archive snapshots found for this URL');
+        }
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'IA Date lookup failed');
+      }
+    } catch (err) { notify('error', err.message); }
+    finally { setIaDateItem(null); }
+  };
+
+  const fetchItemUrls = async (type, id) => {
+    const itemKey = `${type}:${id}`;
+    try {
+      const response = await fetch(`/api/admin/moderation/item/${type}/${id}`, { credentials: 'include' });
+      if (response.ok) {
+        const detail = await response.json();
+        setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
+      }
+    } catch (err) { console.error('Error fetching item URLs:', err); }
+  };
+
+  const startEditing = async (item) => {
+    const itemKey = `${item.content_type}:${item.id}`;
+    if (editingItem === itemKey) {
+      setEditingItem(null);
+      setEditFields({});
+      return;
+    }
+    try {
+      const response = await fetch(`/api/admin/moderation/item/${item.content_type}/${item.id}`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const detail = await response.json();
+        const fields = {};
+        const fieldConfigs = FIELD_CONFIGS[item.content_type] || [];
+        for (const fc of fieldConfigs) {
+          if (fc.type === 'datetime-local' && detail[fc.key]) {
+            const raw = String(detail[fc.key]);
+            const utcDate = new Date(raw.replace(' ', 'T').replace(/\+\d{2}$/, 'Z'));
+            if (!isNaN(utcDate.getTime())) {
+              const eastern = utcDate.toLocaleString('sv-SE', { timeZone: 'America/New_York' });
+              fields[fc.key] = eastern.replace(' ', 'T').substring(0, 16);
+            } else {
+              const match = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
+              fields[fc.key] = match ? `${match[1]}T${match[2]}` : raw.slice(0, 16);
+            }
+          } else {
+            fields[fc.key] = detail[fc.key] || '';
+          }
+        }
+        setEditFields(fields);
+        setEditingItem(itemKey);
+        if (item.content_type !== 'photo') {
+          setItemUrls(prev => ({ ...prev, [itemKey]: detail.additional_urls || [] }));
+        }
+      }
+    } catch (err) {
+      notify('error', 'Failed to load item details');
+    }
+  };
+
+  const cancelEditing = () => {
+    setEditingItem(null);
+    setEditFields({});
+  };
+
+  const handleSave = async (type, id, item) => {
+    try {
+      const response = await fetch('/api/admin/moderation/save', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ type, id, edits: editFields })
+      });
+      if (response.ok) {
+        notify('success', `${type} #${id} saved`);
+        setEditingItem(null);
+        setEditFields({});
+        refreshItems();
+        if (type === 'photo' && item?.poi_id) {
+          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: item.poi_id } }));
+          if (editFields.poi_id && editFields.poi_id !== item.poi_id) {
+            window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId: editFields.poi_id } }));
+          }
+        }
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Save failed');
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const handleAddUrl = async (type, id) => {
+    if (!newUrlInput.trim()) return;
+    setAddingUrl(true);
+    try {
+      const response = await fetch('/api/admin/moderation/add-url', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type, id, url: newUrlInput.trim() })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (data.added) {
+          notify('success', 'URL added');
+          setNewUrlInput('');
+          fetchItemUrls(type, id);
+          refreshItems();
+        } else {
+          notify('error', data.reason || 'URL not added');
+        }
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Failed to add URL');
+      }
+    } catch (err) { notify('error', err.message); }
+    finally { setAddingUrl(false); }
+  };
+
+  const handleRemoveUrl = async (type, contentId, urlId) => {
+    try {
+      const response = await fetch('/api/admin/moderation/remove-url', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type, id: contentId, urlId })
+      });
+      if (response.ok) {
+        notify('success', 'URL removed');
+        fetchItemUrls(type, contentId);
+        refreshItems();
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Failed to remove URL');
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const startMerge = async (item) => {
+    setMergingItem({ type: item.content_type, id: item.id, poiId: item.poi_id });
+    setMergeCandidates([]);
+    try {
+      const response = await fetch(`/api/admin/moderation/merge-candidates/${item.content_type}/${item.id}`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const candidates = await response.json();
+        setMergeCandidates(candidates);
+      } else {
+        notify('error', 'Failed to load merge candidates');
+        setMergingItem(null);
+      }
+    } catch (err) {
+      notify('error', err.message);
+      setMergingItem(null);
+    }
+  };
+
+  const handleMerge = async (targetId) => {
+    if (!mergingItem) return;
+    setMerging(true);
+    try {
+      const response = await fetch('/api/admin/moderation/merge', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type: mergingItem.type, sourceId: mergingItem.id, targetId })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        notify('success', `Merged ${mergingItem.type} #${mergingItem.id} into #${targetId} (${data.movedUrls} URLs moved)`);
+        setMergingItem(null);
+        setMergeCandidates([]);
+        refreshItems();
+      } else {
+        const err = await response.json();
+        notify('error', err.error || 'Merge failed');
+      }
+    } catch (err) { notify('error', err.message); }
+    finally { setMerging(false); }
+  };
+
+  const cancelMerge = () => {
+    setMergingItem(null);
+    setMergeCandidates([]);
+  };
+
+  const handleBulkApprove = async (queue) => {
+    if (selectedItems.size === 0) return;
+    const items = Array.from(selectedItems).map(key => {
+      const [type, id] = key.split(':');
+      return { type, id: parseInt(id) };
+    });
+    const photoPoiIds = new Set();
+    items.forEach(({ type, id }) => {
+      if (type === 'photo') {
+        const item = queue?.find(q => q.content_type === type && q.id === id);
+        if (item?.poi_id) photoPoiIds.add(item.poi_id);
+      }
+    });
+    try {
+      const response = await fetch('/api/admin/moderation/bulk-approve', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', body: JSON.stringify({ items })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        notify('success', `${data.approved} items approved`);
+        setSelectedItems(new Set());
+        refreshItems();
+        if (onCountChange) onCountChange();
+        photoPoiIds.forEach(poiId => {
+          window.dispatchEvent(new CustomEvent('poi-media-updated', { detail: { poiId } }));
+        });
+      }
+    } catch (err) { notify('error', err.message); }
+  };
+
+  const toggleSelect = (type, id) => {
+    const key = `${type}:${id}`;
+    setSelectedItems(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const selectAll = (queue) => {
+    if (selectedItems.size === queue.length) {
+      setSelectedItems(new Set());
+    } else {
+      setSelectedItems(new Set(queue.map(item => `${item.content_type}:${item.id}`)));
+    }
+  };
+
+  return {
+    // State
+    editingItem, editFields, setEditFields,
+    notification, pois,
+    itemUrls, newUrlInput, setNewUrlInput, addingUrl,
+    iaDateItem,
+    mergingItem, mergeCandidates, merging,
+    confirmDelete, setConfirmDelete,
+    selectedItems,
+    // Handlers
+    notify,
+    handleApprove, handleReject, handleRequeue, handleDelete,
+    handleSave, handleIaDate,
+    startEditing, cancelEditing,
+    startMerge, handleMerge, cancelMerge,
+    handleAddUrl, handleRemoveUrl,
+    handleBulkApprove, toggleSelect, selectAll
+  };
+}
+
+// Re-export FIELD_CONFIGS so both ModerationExtras and ModerationInbox can use it
+export const FIELD_CONFIGS = {
+  news: [
+    { key: 'title', label: 'Title', type: 'text', required: true },
+    { key: 'summary', label: 'Summary', type: 'textarea' },
+    { key: 'source_name', label: 'Source Name', type: 'text' },
+    { key: 'news_type', label: 'Type', type: 'select', options: ['general', 'closure', 'seasonal', 'maintenance', 'wildlife'] },
+    { key: 'publication_date', label: 'Publication Date', type: 'datetime-local' },
+    { key: 'poi_id', label: 'POI', type: 'poi' },
+    { key: 'source_url', label: 'Primary URL', type: 'text' },
+  ],
+  event: [
+    { key: 'title', label: 'Title', type: 'text', required: true },
+    { key: 'description', label: 'Description', type: 'textarea' },
+    { key: 'start_date', label: 'Start Date/Time', type: 'datetime-local', required: true },
+    { key: 'end_date', label: 'End Date/Time', type: 'datetime-local' },
+    { key: 'event_type', label: 'Event Type', type: 'text' },
+    { key: 'location_details', label: 'Location Details', type: 'text' },
+    { key: 'publication_date', label: 'Publication Date', type: 'datetime-local' },
+    { key: 'poi_id', label: 'POI', type: 'poi' },
+    { key: 'source_url', label: 'Primary URL', type: 'text' },
+  ],
+  photo: [
+    { key: 'caption', label: 'Caption', type: 'textarea' },
+    { key: 'poi_id', label: 'POI', type: 'poi' },
+  ]
+};

--- a/frontend/src/utils/iconUtils.js
+++ b/frontend/src/utils/iconUtils.js
@@ -9,7 +9,7 @@ export function getDestinationIconTypeFromConfig(destination, iconConfig) {
     return 'default';
   }
 
-  if (destination.status_url && destination.status_url.trim() !== '') {
+  if (destination.poi_roles?.includes('mtb_trail') || (destination.status_url && destination.status_url.trim() !== '')) {
     return 'mtb-trailhead';
   }
 

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -e
 
-BASE_IMAGE_NAME="quay.io/crunchtools/rotv-base"
-IMAGE_NAME="quay.io/crunchtools/rotv"
-CONTAINER_NAME="${ROTV_CONTAINER:-rotv}"
-HOST_PORT="${ROTV_PORT:-8080}"
-
-# Load environment variables from .env file if it exists
+# Load environment variables from .env file FIRST (before defaults)
 if [ -f ".env" ]; then
     export $(grep -v '^#' .env | xargs)
 elif [ -f "backend/.env" ]; then
     export $(grep -v '^#' backend/.env | xargs)
 fi
+
+BASE_IMAGE_NAME="quay.io/crunchtools/rotv-base"
+IMAGE_NAME="quay.io/crunchtools/rotv"
+CONTAINER_NAME="${ROTV_CONTAINER:-rotv}"
+HOST_PORT="${ROTV_PORT:-8080}"
 
 # Development uses ephemeral storage (tmpfs) - data is thrown away on restart
 # Set PERSISTENT_DATA=true in .env or environment to persist across restarts


### PR DESCRIPTION
## Summary
- Adds a **"+ New" button** to the Results, News, and Events tabs, visible only in edit mode for admin/poi_admin users
- **Results tab**: New button creates POIs with role defaults matching the active sub-tab (point for POIs, point+is_mtb_trail for MTB, organization for Organizations), opens the existing Sidebar edit panel
- **Role Editor**: New `RoleEditor` component with chip-style checkboxes for managing POI roles (point, trail, river, boundary, organization)
- **GeoJSON Uploader**: New `GeoJSONUploader` component for uploading trail/river/boundary geometry files with validation
- **News/Events tabs**: New button opens modal forms for manual content creation via new `POST /api/admin/news` and `POST /api/admin/events` endpoints
- Backend: Added `geometry`, `is_mtb_trail`, `status_url`, `research_context` to allowed fields for `POST /api/admin/pois`

Spec: `.specify/specs/012-new-poi-button/`

## Test plan
- [ ] Log in as admin, enable edit mode, verify "+ New" button appears on Results/News/Events tabs
- [ ] Verify button is NOT visible when logged out, edit mode off, or user is viewer/media_admin
- [ ] Results > POIs: click New, verify sidebar opens with point role, click map to place marker
- [ ] Results > MTB: click New, verify is_mtb_trail default
- [ ] Results > Organizations: click New, verify organization role, no coordinates required
- [ ] Test RoleEditor: add/remove roles, verify at least one required
- [ ] Upload a GeoJSON file for a trail role POI
- [ ] News tab: click New, create a manual news item, verify it appears in feed
- [ ] Events tab: click New, create a manual event, verify it appears in feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)