### PR TITLE
feat: admin-editable About page with markdown

### DIFF
--- a/.specify/specs/013-editable-about/plan.md
+++ b/.specify/specs/013-editable-about/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Editable About Page
+
+> **Spec ID:** 013-editable-about
+> **Status:** Planning
+> **Last Updated:** 2026-05-15
+> **Estimated Effort:** M
+
+## Summary
+
+Store About page text content (Story, Tutorial intro, Privacy Policy) as markdown in the `admin_settings` table. Add a public GET endpoint and an admin PUT endpoint. On the frontend, add `marked` + `DOMPurify` for rendering and a simple textarea editor triggered by an Edit button when in admin edit mode.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. Migration seeds current hardcoded content as markdown into `admin_settings`
+2. `GET /api/about-content` reads all three keys in one query
+3. Frontend fetches on About page mount, caches in state
+4. `marked` renders markdown to HTML, `DOMPurify` sanitizes it
+5. Admin clicks Edit -> textarea with raw markdown -> Save -> `PUT /api/admin/about-content/:key` -> re-fetch
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Markdown parser | `marked` | Lightweight (~40KB), zero deps, widely used, already proven pattern |
+| HTML sanitizer | `DOMPurify` | Industry standard XSS prevention for user-authored HTML |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Database Migration
+
+- [ ] Create `backend/migrations/018_about_content.sql`
+- [ ] INSERT default markdown for `about_story_md`, `about_tutorial_md`, `about_privacy_md` using `ON CONFLICT DO NOTHING`
+- [ ] Convert current JSX content to equivalent markdown for seeding
+
+### Phase 2: Backend API
+
+- [ ] Add `GET /api/about-content` route (public, no auth)
+- [ ] Add `PUT /api/admin/about-content/:key` route (admin only)
+- [ ] Validate `:key` against allowlist of three keys
+- [ ] Wire routes into Express app
+
+### Phase 3: Frontend Dependencies
+
+- [ ] `npm install marked dompurify` in frontend
+- [ ] Create a small `MarkdownRenderer` component that wraps marked + DOMPurify
+
+### Phase 4: AboutPage Refactor
+
+- [ ] Fetch `/api/about-content` on mount
+- [ ] Replace `AboutStory` hardcoded JSX with MarkdownRenderer
+- [ ] Replace `AboutTutorial` intro text with MarkdownRenderer (keep Tour button)
+- [ ] Replace `PrivacyPolicy` hardcoded JSX with MarkdownRenderer
+- [ ] Add Edit button + textarea editor for each tab (visible when admin + editMode)
+- [ ] Save handler calls PUT endpoint, updates local state
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/018_about_content.sql` | Seed default markdown content |
+| `frontend/src/components/MarkdownRenderer.jsx` | Shared marked + DOMPurify wrapper |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/routes/admin.js` | Add PUT `/admin/about-content/:key` |
+| `backend/server.js` or routes index | Add GET `/api/about-content` |
+| `frontend/src/components/AboutPage.jsx` | Fetch content, render markdown, add edit UI |
+| `frontend/src/components/PrivacyPolicy.jsx` | Accept markdown content as prop, use MarkdownRenderer |
+| `frontend/package.json` | Add `marked`, `dompurify` |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 018_about_content
+-- Seed About page content into admin_settings
+
+INSERT INTO admin_settings (key, value) VALUES
+('about_story_md', '...markdown...'),
+('about_tutorial_md', '...markdown...'),
+('about_privacy_md', '...markdown...')
+ON CONFLICT (key) DO NOTHING;
+```
+
+---
+
+## API Implementation
+
+### GET /api/about-content
+
+```sql
+SELECT key, value FROM admin_settings WHERE key IN ('about_story_md', 'about_tutorial_md', 'about_privacy_md');
+```
+
+Returns JSON object with all three keys.
+
+### PUT /api/admin/about-content/:key
+
+```sql
+INSERT INTO admin_settings (key, value) VALUES ($1, $2)
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+```
+
+---
+
+## Testing Strategy
+
+### Integration Tests
+
+- [ ] GET `/api/about-content` returns all three keys after migration
+- [ ] PUT `/api/admin/about-content/about_story_md` updates content (admin auth)
+- [ ] PUT `/api/admin/about-content/bad_key` returns 400
+- [ ] PUT without admin auth returns 401/403
+
+### Manual Testing
+
+1. Open About page as visitor - see rendered Story, Tutorial, Privacy
+2. Log in as admin, enable edit mode - see Edit buttons on all three tabs
+3. Click Edit on Story tab - see markdown textarea
+4. Modify, save - see updated rendered content
+5. Refresh page - content persists
+6. Check `/privacy` standalone route still works
+
+---
+
+## Rollback Plan
+
+1. Revert the frontend changes (About page renders hardcoded content again)
+2. Migration is additive only (INSERT ON CONFLICT DO NOTHING) - safe to leave in place
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| XSS from admin-authored markdown | Med | DOMPurify sanitization on render |
+| Large markdown content in admin_settings | Low | Text column has no practical limit; about page content is small |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-15 | Initial plan |

--- a/.specify/specs/013-editable-about/spec.md
+++ b/.specify/specs/013-editable-about/spec.md
@@ -1,0 +1,158 @@
+# Specification: Editable About Page
+
+> **Spec ID:** 013-editable-about
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-15
+
+## Overview
+
+Make the About page's text tabs (Story, Tutorial, Privacy Policy) admin-editable using markdown stored in the database. Admins see an "Edit" button that opens a markdown editor; changes render as HTML for all visitors. This follows the same pattern as inline POI field editing in the Sidebar.
+
+---
+
+## User Stories
+
+### Admin Content Management
+
+**US-013-1: Edit Story Content**
+> As an admin, I want to edit the Story tab content in markdown so that I can update the ROTV narrative without code changes.
+
+Acceptance Criteria:
+- [ ] Admin sees an "Edit" button on the Story tab
+- [ ] Clicking Edit reveals a markdown textarea with the current content
+- [ ] Saving persists the markdown to the database
+- [ ] Non-admin visitors see the rendered HTML (no edit button)
+
+**US-013-2: Edit Tutorial Content**
+> As an admin, I want to edit the Tutorial tab intro text so that I can update onboarding copy without a deploy.
+
+Acceptance Criteria:
+- [ ] Admin sees an "Edit" button on the Tutorial tab
+- [ ] The "Take a Tour" button remains functional and is not part of the editable content
+- [ ] Markdown is saved and rendered the same way as Story
+
+**US-013-3: Edit Privacy Policy**
+> As an admin, I want to edit the Privacy Policy in markdown so that I can keep it current as the project evolves.
+
+Acceptance Criteria:
+- [ ] Admin sees an "Edit" button on the Privacy Policy tab
+- [ ] The standalone `/privacy` route also renders the database-backed content
+- [ ] Markdown is saved and rendered the same way as Story
+
+**US-013-4: Seed Default Content**
+> As a developer, I want the current hardcoded content to be the default seed so that the migration is seamless.
+
+Acceptance Criteria:
+- [ ] Migration inserts current Story, Tutorial, and Privacy text as markdown
+- [ ] If admin_settings rows already exist for these keys, they are not overwritten
+- [ ] App renders identically before and after the migration (no visual regression)
+
+---
+
+## Data Model
+
+### Schema Changes
+
+Uses the existing `admin_settings` table (key/value pattern already in use for GitHub tokens, feature flags, etc.).
+
+New keys:
+
+| Key | Value |
+|-----|-------|
+| `about_story_md` | Markdown content for the Story tab |
+| `about_tutorial_md` | Markdown content for the Tutorial tab intro |
+| `about_privacy_md` | Markdown content for the Privacy Policy tab |
+
+No new tables required.
+
+---
+
+## API Endpoints
+
+### New Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/about-content` | Returns all three markdown blobs as JSON | No |
+| PUT | `/api/admin/about-content/:key` | Updates a single about content key | Admin |
+
+### GET /api/about-content
+
+Response:
+```json
+{
+  "about_story_md": "## One Map for Everything...",
+  "about_tutorial_md": "## Learn How ROTV Works...",
+  "about_privacy_md": "# Privacy Policy..."
+}
+```
+
+### PUT /api/admin/about-content/:key
+
+Request:
+```json
+{
+  "content": "## Updated markdown content..."
+}
+```
+
+`:key` must be one of: `about_story_md`, `about_tutorial_md`, `about_privacy_md`.
+
+---
+
+## UI/UX Requirements
+
+### Markdown Library
+
+Add `marked` (lightweight, zero-dependency markdown parser) to the frontend. Uses **GitHub Flavored Markdown (GFM)** — the same syntax as GitHub READMEs, issues, and comments.
+
+### Editing Pattern
+
+- When `isAdmin && editMode`, show an "Edit" button in the top-right of each tab's content area
+- Clicking Edit replaces the rendered HTML with a `<textarea>` containing raw markdown
+- Save/Cancel buttons appear below the textarea
+- A "Markdown Guide" link below the textarea opens GitHub's markdown reference in a new tab
+- Save calls `PUT /api/admin/about-content/:key` and re-renders
+- Textarea auto-resizes to fit content (same pattern as Sidebar POI editing)
+
+### Rendering
+
+- All visitors see markdown rendered as HTML via `marked`
+- Sanitize output with `DOMPurify` to prevent XSS from admin-authored markdown
+- Links open in new tab (`target="_blank"`)
+
+---
+
+## Non-Functional Requirements
+
+**NFR-013-1: Security**
+- Markdown output must be sanitized before rendering (DOMPurify)
+- Only admin role can write; the PUT endpoint uses `isAdmin` middleware
+- GET endpoint is public (content is public information)
+
+**NFR-013-2: Performance**
+- About content is fetched once when the About page opens, not on every tab switch
+- No loading spinners needed for sub-100ms queries
+
+---
+
+## Dependencies
+
+- Depends on: existing `admin_settings` table, existing `AuthContext` and `isAdmin` middleware
+- Blocks: nothing
+
+---
+
+## Open Questions
+
+None — the pattern is well-established in this codebase.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-15 | Initial draft |

--- a/backend/migrations/049_about_content.sql
+++ b/backend/migrations/049_about_content.sql
@@ -1,0 +1,103 @@
+-- Seed About page content into admin_settings as markdown.
+-- Converts the hardcoded JSX content from AboutPage.jsx and PrivacyPolicy.jsx
+-- so admins can edit it without code changes.
+
+INSERT INTO admin_settings (key, value) VALUES
+('about_story_md', '## One Map for Everything Happening in the Cuyahoga Valley
+
+The Cuyahoga Valley has over 300 parks, trailheads, preserves, and landmarks, but the information about them is scattered across dozens of websites run by the National Park Service, Cleveland Metroparks, Summit Metro Parks, and countless other organizations. A mountain biker checking whether trails are rideable might need to check TrailForks, Twitter, and two different park district websites. A family looking for weekend activities doesn''t have time to visit dozens of event calendars.
+
+The result: people stick to what they already know and miss 95% of what the valley offers.
+
+**Roots of the Valley fixes that.** We traverse the deepest corners of the web to aggregate news, events, and social signals that traditional search engines miss, distilling them into one seamless, interactive map. Every point of interest shows its latest news, upcoming events, and current trail status. Open one page and immediately see what''s open, what''s happening this weekend, and what''s worth discovering for the first time.
+
+---
+
+## Built in the Open
+
+The Cuyahoga Valley is public land, maintained through shared stewardship by rangers, volunteers, trail crews, and the people who use it every day. Roots of the Valley works the same way.
+
+The entire project, code, data, and infrastructure, is open source. Anyone can see how it works, suggest improvements, or adapt it for their own region.
+
+**Transparency.** When ROTV says a trail is closed, you can trace exactly where that information came from. There''s no opaque algorithm deciding what you see. The collection sources are public, the moderation queue is human-reviewed, and the codebase is on [GitHub](https://github.com/crunchtools/rotv).
+
+**Durability.** Free services disappear all the time, the company pivots, the funding dries up, or the product gets buried under ads and paywalls. ROTV can''t be acquired, shut down, or locked behind a subscription. The community owns it.
+
+**Participation.** The same people who maintain trails, lead hikes, and organize cleanups can contribute to ROTV. Park districts can submit event feeds. Developers can contribute features. The goal is to build the same volunteer stewardship network online that already exists on the trails.
+
+*The valley belongs to everyone. The map should too.*')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO admin_settings (key, value) VALUES
+('about_tutorial_md', '## Learn How ROTV Works
+
+New here? Take a quick guided tour to learn how to use the interactive map, find events, check trail conditions, and discover new places in the valley.')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO admin_settings (key, value) VALUES
+('about_privacy_md', '# Privacy Policy
+
+*Last updated: May 2026*
+
+## The Short Version
+
+Roots of the Valley is a free, open source community project. We don''t run ads. We don''t sell data. We don''t track you. We collect the minimum information needed to let you sign in, and that''s it.
+
+## What We Collect
+
+When you sign in with Google or Facebook, we receive:
+
+- Your name
+- Your email address
+- Your profile photo
+
+That''s the full list. We don''t request access to your contacts, calendar, files, or anything else.
+
+## How We Use It
+
+Your account information is used for one purpose: identifying you when you sign in. We use your name and photo to show who''s logged in. We use your email to associate your session with your account. We don''t send marketing emails, newsletters (unless you explicitly subscribe), or third-party communications.
+
+## What We Don''t Do
+
+- We don''t sell your data. Ever. To anyone.
+- We don''t run advertisements.
+- We don''t use third-party analytics or tracking scripts.
+- We don''t share your information with other organizations.
+- We don''t build advertising profiles or behavioral models.
+
+ROTV is a community project, not a business. There is no revenue model that depends on your data. The plan is to create a non-profit to govern this project permanently.
+
+## Cookies
+
+We use a single session cookie to keep you logged in. That''s it. No tracking cookies, no third-party cookies, no cookie consent banners because there''s nothing to consent to beyond basic session management.
+
+## Where Your Data Lives
+
+Your account data is stored in a PostgreSQL database on infrastructure we control. We don''t use third-party data processors, cloud analytics platforms, or customer data platforms. The data sits on our server and nowhere else.
+
+## Your Rights
+
+- **Delete your account:** Contact us and we''ll remove all your data.
+- **Export your data:** Contact us and we''ll provide everything we have on you (it''s not much).
+- **Know what we have:** This page is the complete picture. There are no hidden data stores.
+
+## Photos You Upload
+
+When you submit a photo or video to a point of interest, you retain full ownership and all rights to that content. By uploading, you grant ROTV a non-exclusive license to display it on the site, in the weekly newsletter, and on ROTV social media accounts — nothing more. We won''t sell your photos or videos, use them in unrelated advertising, or sub-license them to third parties.
+
+All uploads go through moderation before they appear on the site. If you want something removed, contact us and we''ll take it down.
+
+## Open Source Transparency
+
+Don''t take our word for it. The entire ROTV codebase is open source under the AGPL-3.0 license. You can read exactly how authentication works, what we store in the database, and how data flows through the system.
+
+[View the source code on GitHub](https://github.com/crunchtools/rotv)
+
+## Changes to This Policy
+
+If we ever change this policy, we''ll update the date at the top of this page. Given that our entire model is "collect nothing, sell nothing," we don''t anticipate meaningful changes.
+
+## Contact
+
+Questions? Open an issue on [GitHub](https://github.com/crunchtools/rotv/issues) or email admin@rootsofthevalley.org.')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -540,7 +540,10 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'blocklist_urls',
       'moderation_trusted_domains',
       'trusted_event_paths',
-      'github_api_token'
+      'github_api_token',
+      'about_story_md',
+      'about_tutorial_md',
+      'about_privacy_md'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });

--- a/backend/server.js
+++ b/backend/server.js
@@ -895,6 +895,23 @@ async function initDatabase() {
   }
 }
 
+// API Routes - About page content (public, markdown stored in admin_settings)
+app.get('/api/about-content', async (req, res) => {
+  try {
+    const result = await pool.query(
+      `SELECT key, value FROM admin_settings WHERE key IN ('about_story_md', 'about_tutorial_md', 'about_privacy_md')`
+    );
+    const content = {};
+    for (const row of result.rows) {
+      content[row.key] = row.value;
+    }
+    res.json(content);
+  } catch (error) {
+    console.error('Error fetching about content:', error);
+    res.status(500).json({ error: 'Failed to fetch about content' });
+  }
+});
+
 // API Routes - Unified POIs
 app.get('/api/pois', async (req, res) => {
   try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "rotv-frontend",
-  "version": "1.14.2",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotv-frontend",
-      "version": "1.14.2",
+      "version": "0.0.0",
       "dependencies": {
+        "dompurify": "^3.4.3",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
+        "marked": "^18.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
@@ -1164,6 +1166,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1287,6 +1296,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1435,6 +1453,18 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "dompurify": "^3.4.3",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
+    "marked": "^18.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14318,6 +14318,164 @@ button.feedback-link-inline {
   background: #1b4332;
 }
 
+/* Markdown-rendered content inherits about-story styles */
+.about-story .markdown-content h2 {
+  color: #2d6a4f;
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.about-story .markdown-content h2:first-child {
+  margin-top: 0;
+}
+
+.about-story .markdown-content p {
+  color: #444;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.about-story .markdown-content a {
+  color: #2d6a4f;
+  text-decoration: none;
+}
+
+.about-story .markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.about-story .markdown-content hr {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 2rem 0;
+}
+
+.about-story .markdown-content em:last-child {
+  display: block;
+  color: #2d6a4f;
+  font-weight: 500;
+  margin-top: 1.5rem;
+}
+
+/* Tutorial markdown content */
+.about-tutorial .markdown-content h2 {
+  color: #2d6a4f;
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.about-tutorial .markdown-content p {
+  color: #444;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+/* Privacy markdown content */
+.privacy-markdown-content h1 {
+  color: #333;
+  font-size: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.privacy-markdown-content h2 {
+  color: #2d6a4f;
+  font-size: 1.25rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.privacy-markdown-content p {
+  color: #444;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.privacy-markdown-content ul {
+  padding-left: 1.5rem;
+}
+
+.privacy-markdown-content li {
+  color: #444;
+  line-height: 1.7;
+  margin-bottom: 0.25rem;
+}
+
+.privacy-markdown-content a {
+  color: #2d6a4f;
+  text-decoration: none;
+}
+
+.privacy-markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.privacy-markdown-content em:first-child {
+  display: block;
+  color: #888;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+/* About page edit button */
+.about-edit-btn {
+  float: right;
+  background: #2d6a4f;
+  color: white;
+  border: none;
+  padding: 0.4rem 1rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.about-edit-btn:hover {
+  background: #1b4332;
+}
+
+/* About page markdown editor */
+.about-editor {
+  margin-top: 0.5rem;
+}
+
+.about-editor-textarea {
+  width: 100%;
+  min-height: 200px;
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.about-editor-textarea:focus {
+  outline: none;
+  border-color: #2d6a4f;
+  box-shadow: 0 0 0 2px rgba(45, 106, 79, 0.2);
+}
+
+.about-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.about-editor-help {
+  margin-left: auto;
+  color: #888;
+  font-size: 0.8rem;
+  text-decoration: none;
+}
+
+.about-editor-help:hover {
+  color: #2d6a4f;
+  text-decoration: underline;
+}
+
 /* Inline feedback form */
 .feedback-inline {
   max-width: 600px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2085,7 +2085,7 @@ function AppContent() {
       {/* About tab content */}
       {activeTab === 'about' && (
         <main id="main-content" className="main-content-full" tabIndex="-1">
-          <AboutPage onStartTour={startTour} aboutTab={aboutTab} onTabChange={setAboutTab} />
+          <AboutPage onStartTour={startTour} aboutTab={aboutTab} onTabChange={setAboutTab} isAdmin={isAdmin} editMode={editMode} />
         </main>
       )}
 

--- a/frontend/src/components/AboutPage.jsx
+++ b/frontend/src/components/AboutPage.jsx
@@ -1,82 +1,129 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { handleRovingKeyDown } from '../utils/a11yUtils';
 import FeedbackForm from './FeedbackForm';
 import PrivacyPolicy from './PrivacyPolicy';
+import MarkdownRenderer from './MarkdownRenderer';
 
-function AboutStory() {
+function AboutEditor({ contentKey, content, onSave }) {
+  const [draft, setDraft] = useState(content || '');
+  const [saving, setSaving] = useState(false);
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    setDraft(content || '');
+  }, [content]);
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (ta) {
+      ta.style.height = 'auto';
+      ta.style.height = ta.scrollHeight + 'px';
+    }
+  }, [draft]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/settings/${contentKey}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ value: draft })
+      });
+      if (!res.ok) throw new Error('Save failed');
+      onSave(contentKey, draft);
+    } catch (err) {
+      console.error('Error saving about content:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setDraft(content || '');
+    onSave(null);
+  };
+
   return (
-    <div className="about-story">
-      <h2>One Map for Everything Happening in the Cuyahoga Valley</h2>
-
-      <p>
-        The Cuyahoga Valley has over 300 parks, trailheads, preserves, and landmarks, but the
-        information about them is scattered across dozens of websites run by the National Park
-        Service, Cleveland Metroparks, Summit Metro Parks, and countless other organizations.
-        A mountain biker checking whether trails are rideable might need to check TrailForks,
-        Twitter, and two different park district websites. A family looking for weekend activities
-        doesn't have time to visit dozens of event calendars.
-      </p>
-
-      <p>
-        The result: people stick to what they already know and miss 95% of what the valley offers.
-      </p>
-
-      <p>
-        <strong>Roots of the Valley fixes that.</strong> We traverse the deepest corners of the web
-        to aggregate news, events, and social signals that traditional search engines miss, distilling
-        them into one seamless, interactive map. Every point of interest shows its latest news,
-        upcoming events, and current trail status. Open one page and immediately see what's open,
-        what's happening this weekend, and what's worth discovering for the first time.
-      </p>
-
-      <hr className="about-divider" />
-
-      <h2>Built in the Open</h2>
-
-      <p>
-        The Cuyahoga Valley is public land, maintained through shared stewardship by rangers,
-        volunteers, trail crews, and the people who use it every day. Roots of the Valley works
-        the same way.
-      </p>
-
-      <p>
-        The entire project, code, data, and infrastructure, is open source. Anyone can see how it
-        works, suggest improvements, or adapt it for their own region.
-      </p>
-
-      <p>
-        <strong>Transparency.</strong> When ROTV says a trail is closed, you can trace exactly where
-        that information came from. There's no opaque algorithm deciding what you see. The collection
-        sources are public, the moderation queue is human-reviewed, and the codebase is
-        on <a href="https://github.com/crunchtools/rotv" target="_blank" rel="noopener noreferrer">GitHub</a>.
-      </p>
-
-      <p>
-        <strong>Durability.</strong> Free services disappear all the time, the company pivots, the
-        funding dries up, or the product gets buried under ads and paywalls. ROTV can't be acquired,
-        shut down, or locked behind a subscription. The community owns it.
-      </p>
-
-      <p>
-        <strong>Participation.</strong> The same people who maintain trails, lead hikes, and organize
-        cleanups can contribute to ROTV. Park districts can submit event feeds. Developers can
-        contribute features. The goal is to build the same volunteer stewardship network online that
-        already exists on the trails.
-      </p>
-
-      <p className="about-closing">The valley belongs to everyone. The map should too.</p>
+    <div className="about-editor">
+      <textarea
+        ref={textareaRef}
+        className="about-editor-textarea"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={saving}
+      />
+      <div className="about-editor-actions">
+        <button className="save-btn" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button className="cancel-btn" onClick={handleCancel} disabled={saving}>
+          Cancel
+        </button>
+        <a
+          href="https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="about-editor-help"
+        >
+          Markdown Guide
+        </a>
+      </div>
     </div>
   );
 }
 
-function AboutTutorial({ onStartTour }) {
+function AboutStory({ content, isAdmin, editMode }) {
+  const [editing, setEditing] = useState(false);
+  const [localContent, setLocalContent] = useState(content);
+
+  useEffect(() => {
+    setLocalContent(content);
+  }, [content]);
+
+  const handleSave = (key, newContent) => {
+    if (key) setLocalContent(newContent);
+    setEditing(false);
+  };
+
+  return (
+    <div className="about-story">
+      {isAdmin && editMode && !editing && (
+        <button className="about-edit-btn" onClick={() => setEditing(true)}>Edit</button>
+      )}
+      {editing ? (
+        <AboutEditor contentKey="about_story_md" content={localContent} onSave={handleSave} />
+      ) : (
+        <MarkdownRenderer content={localContent} className="about-story-content" />
+      )}
+    </div>
+  );
+}
+
+function AboutTutorial({ onStartTour, content, isAdmin, editMode }) {
+  const [editing, setEditing] = useState(false);
+  const [localContent, setLocalContent] = useState(content);
+
+  useEffect(() => {
+    setLocalContent(content);
+  }, [content]);
+
+  const handleSave = (key, newContent) => {
+    if (key) setLocalContent(newContent);
+    setEditing(false);
+  };
+
   return (
     <div className="about-tutorial">
-      <h2>Learn How ROTV Works</h2>
-      <p>
-        New here? Take a quick guided tour to learn how to use the interactive map,
-        find events, check trail conditions, and discover new places in the valley.
-      </p>
+      {isAdmin && editMode && !editing && (
+        <button className="about-edit-btn" onClick={() => setEditing(true)}>Edit</button>
+      )}
+      {editing ? (
+        <AboutEditor contentKey="about_tutorial_md" content={localContent} onSave={handleSave} />
+      ) : (
+        <MarkdownRenderer content={localContent} className="about-tutorial-content" />
+      )}
       <button className="about-tour-btn" onClick={onStartTour}>
         Take a Tour
       </button>
@@ -84,7 +131,16 @@ function AboutTutorial({ onStartTour }) {
   );
 }
 
-function AboutPage({ onStartTour, aboutTab, onTabChange }) {
+function AboutPage({ onStartTour, aboutTab, onTabChange, isAdmin, editMode }) {
+  const [aboutContent, setAboutContent] = useState({});
+
+  useEffect(() => {
+    fetch('/api/about-content')
+      .then(res => res.ok ? res.json() : {})
+      .then(data => setAboutContent(data))
+      .catch(() => {});
+  }, []);
+
   return (
     <div className="about-page">
       <div className="settings-tabs-wrapper" onKeyDown={(e) => handleRovingKeyDown(e, '.about-tab-btn')}>
@@ -129,10 +185,16 @@ function AboutPage({ onStartTour, aboutTab, onTabChange }) {
       </div>
 
       <div className="about-tab-content" role="tabpanel">
-        {aboutTab === 'story' && <AboutStory />}
-        {aboutTab === 'tutorial' && <AboutTutorial onStartTour={onStartTour} />}
+        {aboutTab === 'story' && (
+          <AboutStory content={aboutContent.about_story_md} isAdmin={isAdmin} editMode={editMode} />
+        )}
+        {aboutTab === 'tutorial' && (
+          <AboutTutorial onStartTour={onStartTour} content={aboutContent.about_tutorial_md} isAdmin={isAdmin} editMode={editMode} />
+        )}
         {aboutTab === 'feedback' && <FeedbackForm inline />}
-        {aboutTab === 'privacy' && <PrivacyPolicy inline />}
+        {aboutTab === 'privacy' && (
+          <PrivacyPolicy inline content={aboutContent.about_privacy_md} isAdmin={isAdmin} editMode={editMode} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/MarkdownRenderer.jsx
+++ b/frontend/src/components/MarkdownRenderer.jsx
@@ -1,0 +1,32 @@
+import React, { useMemo } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+// Configure marked for GFM with links opening in new tabs
+marked.use({
+  gfm: true,
+  breaks: false,
+  renderer: {
+    link({ href, title, text }) {
+      const titleAttr = title ? ` title="${title}"` : '';
+      return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+    }
+  }
+});
+
+function MarkdownRenderer({ content, className }) {
+  const html = useMemo(() => {
+    if (!content) return '';
+    const raw = marked.parse(content);
+    return DOMPurify.sanitize(raw, { ADD_ATTR: ['target'] });
+  }, [content]);
+
+  return (
+    <div
+      className={`markdown-content ${className || ''}`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export default MarkdownRenderer;

--- a/frontend/src/components/PrivacyPolicy.jsx
+++ b/frontend/src/components/PrivacyPolicy.jsx
@@ -1,8 +1,106 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import MarkdownRenderer from './MarkdownRenderer';
 
-function PrivacyPolicy({ inline = false }) {
+function PrivacyEditor({ content, onSave }) {
+  const [draft, setDraft] = useState(content || '');
+  const [saving, setSaving] = useState(false);
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    setDraft(content || '');
+  }, [content]);
+
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (ta) {
+      ta.style.height = 'auto';
+      ta.style.height = ta.scrollHeight + 'px';
+    }
+  }, [draft]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/admin/settings/about_privacy_md', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ value: draft })
+      });
+      if (!res.ok) throw new Error('Save failed');
+      onSave(draft);
+    } catch (err) {
+      console.error('Error saving privacy content:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setDraft(content || '');
+    onSave(null);
+  };
+
+  return (
+    <div className="about-editor">
+      <textarea
+        ref={textareaRef}
+        className="about-editor-textarea"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={saving}
+      />
+      <div className="about-editor-actions">
+        <button className="save-btn" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button className="cancel-btn" onClick={handleCancel} disabled={saving}>
+          Cancel
+        </button>
+        <a
+          href="https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="about-editor-help"
+        >
+          Markdown Guide
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function PrivacyPolicy({ inline = false, content, isAdmin, editMode }) {
   const navigate = useNavigate();
+  const [editing, setEditing] = useState(false);
+  const [localContent, setLocalContent] = useState(content);
+  const [standaloneContent, setStandaloneContent] = useState(null);
+
+  useEffect(() => {
+    setLocalContent(content);
+  }, [content]);
+
+  // Standalone route: fetch content directly if not provided as prop
+  useEffect(() => {
+    if (!inline && !content) {
+      fetch('/api/about-content')
+        .then(res => res.ok ? res.json() : {})
+        .then(data => {
+          if (data.about_privacy_md) {
+            setStandaloneContent(data.about_privacy_md);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [inline, content]);
+
+  const displayContent = localContent || standaloneContent;
+
+  const handleSave = (newContent) => {
+    if (newContent) setLocalContent(newContent);
+    setEditing(false);
+  };
 
   return (
     <div className={`privacy-policy-page ${inline ? 'privacy-inline' : ''}`}>
@@ -13,133 +111,15 @@ function PrivacyPolicy({ inline = false }) {
           </button>
         )}
 
-        <h1>Privacy Policy</h1>
-        <p className="privacy-updated">Last updated: May 2026</p>
+        {isAdmin && editMode && !editing && (
+          <button className="about-edit-btn" onClick={() => setEditing(true)}>Edit</button>
+        )}
 
-        <section>
-          <h2>The Short Version</h2>
-          <p>
-            Roots of the Valley is a free, open source community project. We don't run ads.
-            We don't sell data. We don't track you. We collect the minimum information needed
-            to let you sign in, and that's it.
-          </p>
-        </section>
-
-        <section>
-          <h2>What We Collect</h2>
-          <p>When you sign in with Google or Facebook, we receive:</p>
-          <ul>
-            <li>Your name</li>
-            <li>Your email address</li>
-            <li>Your profile photo</li>
-          </ul>
-          <p>
-            That's the full list. We don't request access to your contacts, calendar,
-            files, or anything else.
-          </p>
-        </section>
-
-        <section>
-          <h2>How We Use It</h2>
-          <p>Your account information is used for one purpose: identifying you when you sign in.
-            We use your name and photo to show who's logged in. We use your email to
-            associate your session with your account. We don't send marketing emails,
-            newsletters (unless you explicitly subscribe), or third-party communications.
-          </p>
-        </section>
-
-        <section>
-          <h2>What We Don't Do</h2>
-          <ul>
-            <li>We don't sell your data. Ever. To anyone.</li>
-            <li>We don't run advertisements.</li>
-            <li>We don't use third-party analytics or tracking scripts.</li>
-            <li>We don't share your information with other organizations.</li>
-            <li>We don't build advertising profiles or behavioral models.</li>
-          </ul>
-          <p>
-            ROTV is a community project, not a business. There is no revenue model that
-            depends on your data. The plan is to create a non-profit to govern this project
-            permanently.
-          </p>
-        </section>
-
-        <section>
-          <h2>Cookies</h2>
-          <p>
-            We use a single session cookie to keep you logged in. That's it. No tracking
-            cookies, no third-party cookies, no cookie consent banners because there's
-            nothing to consent to beyond basic session management.
-          </p>
-        </section>
-
-        <section>
-          <h2>Where Your Data Lives</h2>
-          <p>
-            Your account data is stored in a PostgreSQL database on infrastructure we
-            control. We don't use third-party data processors, cloud analytics platforms,
-            or customer data platforms. The data sits on our server and nowhere else.
-          </p>
-        </section>
-
-        <section>
-          <h2>Your Rights</h2>
-          <ul>
-            <li><strong>Delete your account:</strong> Contact us and we'll remove all your data.</li>
-            <li><strong>Export your data:</strong> Contact us and we'll provide everything we have on you (it's not much).</li>
-            <li><strong>Know what we have:</strong> This page is the complete picture. There are no hidden data stores.</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2>Photos You Upload</h2>
-          <p>
-            When you submit a photo or video to a point of interest, you retain full
-            ownership and all rights to that content. By uploading, you grant ROTV a
-            non-exclusive license to display it on the site, in the weekly newsletter,
-            and on ROTV social media accounts — nothing more. We won't sell your photos
-            or videos, use them in unrelated advertising, or sub-license them to third
-            parties.
-          </p>
-          <p>
-            All uploads go through moderation before they appear on the site. If you
-            want something removed, contact us and we'll take it down.
-          </p>
-        </section>
-
-        <section>
-          <h2>Open Source Transparency</h2>
-          <p>
-            Don't take our word for it. The entire ROTV codebase is open source under
-            the AGPL-3.0 license. You can read exactly how authentication works, what
-            we store in the database, and how data flows through the system.
-          </p>
-          <p>
-            <a href="https://github.com/crunchtools/rotv" target="_blank" rel="noopener noreferrer">
-              View the source code on GitHub
-            </a>
-          </p>
-        </section>
-
-        <section>
-          <h2>Changes to This Policy</h2>
-          <p>
-            If we ever change this policy, we'll update the date at the top of this page.
-            Given that our entire model is "collect nothing, sell nothing," we don't
-            anticipate meaningful changes.
-          </p>
-        </section>
-
-        <section>
-          <h2>Contact</h2>
-          <p>
-            Questions? Open an issue on{' '}
-            <a href="https://github.com/crunchtools/rotv/issues" target="_blank" rel="noopener noreferrer">
-              GitHub
-            </a>{' '}
-            or email admin@rootsofthevalley.org.
-          </p>
-        </section>
+        {editing ? (
+          <PrivacyEditor content={displayContent} onSave={handleSave} />
+        ) : (
+          <MarkdownRenderer content={displayContent} className="privacy-markdown-content" />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Store Story, Tutorial, and Privacy Policy content as GitHub Flavored Markdown in `admin_settings` table
- Admins toggle edit mode to see Edit buttons on each tab — opens textarea with raw markdown and a Markdown Guide link
- Content renders via `marked` + `DOMPurify` for all visitors (XSS-safe)
- New `GET /api/about-content` public endpoint, reuses existing `PUT /api/admin/settings/:key` with 3 new allowed keys
- Migration 049 seeds current hardcoded content as markdown (`ON CONFLICT DO NOTHING`)
- Standalone `/privacy` route fetches from API with same renderer
- Spec and plan in `.specify/specs/013-editable-about/`

## Test plan
- [ ] About > Story tab renders markdown identically to old hardcoded content
- [ ] About > Tutorial tab renders markdown, Tour button still works
- [ ] About > Privacy tab renders markdown, standalone `/privacy` route works
- [ ] Admin edit mode shows Edit button on all three text tabs
- [ ] Editing + saving persists content through page refresh
- [ ] Cancel discards changes without saving
- [ ] Non-admin visitors never see Edit buttons
- [ ] Markdown Guide link opens GitHub docs in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)