### PR TITLE
feat: hide empty tabs in POI sidebar (#211)

### DIFF
--- a/.specify/specs/014-hide-empty-tabs/plan.md
+++ b/.specify/specs/014-hide-empty-tabs/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Hide Empty Tabs in POI Sidebar
+
+> **Spec ID:** 014-hide-empty-tabs
+> **Status:** Planning
+> **Last Updated:** 2026-05-16
+> **Estimated Effort:** S
+
+## Summary
+
+Backend adds `news_count`, `events_count`, `associations_count` to POI detail responses via subqueries. Frontend computes a `visibleTabs` set from those counts plus `historical_description` and renders tab buttons conditionally. Admins in edit mode bypass the filter.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. User clicks a POI on the map.
+2. Sidebar fetches `/api/pois/:id` (or `/api/destinations/:id` / `/api/linear-features/:id`).
+3. Response now includes `news_count`, `events_count`, `associations_count`.
+4. Sidebar computes `visibleTabs` array. `view` always present. `news`, `events`, `history`, `associations` included iff their count/field is non-empty (or user is admin in edit mode).
+5. Tab buttons render via `visibleTabs.map(...)`.
+6. If `sidebarTab` ∉ `visibleTabs`, reset to `view`.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Counts | SQL subqueries in existing POI queries | Single round trip, no client-side count fetches |
+| Tab gating | Array filter + map in JSX | Replaces hardcoded button list with data-driven render |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend Counts
+
+- [ ] Augment `/api/pois/:id` query in `backend/server.js` to compute three counts via correlated subqueries
+- [ ] Augment `/api/destinations/:id` and `/api/linear-features/:id` likewise (verify which endpoints the sidebar uses for each POI type)
+- [ ] Test query plans manually with a representative POI to confirm low cost
+
+### Phase 2: Frontend Tab Gating
+
+- [ ] In `Sidebar.jsx`, derive `visibleTabs` based on POI data + admin/edit state
+- [ ] Replace hardcoded tab button JSX with a render driven by `visibleTabs` (apply at both occurrences — destinations and linear features)
+- [ ] Add a `useEffect` that resets `sidebarTab` to `'view'` when current tab is filtered out
+- [ ] Verify deep-link routing still works (URL → sidebarTab synchronization)
+
+### Phase 3: Verification
+
+- [ ] Manual: open a POI with all 5 tabs populated → all visible
+- [ ] Manual: open a POI with only Info → only Info visible
+- [ ] Manual: open a POI with News + Events, no History/Associations → 3 tabs
+- [ ] Manual: admin in edit mode → all 5 visible regardless
+- [ ] Manual: deep-link to `/some-poi/associations` where empty → falls back to Info
+- [ ] Manual: linear feature (trail) → same logic applies
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/server.js` | Add count subqueries to `/api/pois/:id`, `/api/destinations/:id`, `/api/linear-features/:id` |
+| `frontend/src/components/Sidebar.jsx` | Derive `visibleTabs`, render tabs from array, reset active tab if filtered |
+
+No new files. No migrations.
+
+---
+
+## API Implementation
+
+### Endpoint: `GET /api/pois/:id` (modified)
+
+**Response (new fields):**
+```json
+{
+  "id": 123,
+  "name": "Example POI",
+  "historical_description": null,
+  "news_count": 4,
+  "events_count": 0,
+  "associations_count": 2
+}
+```
+
+Counts are integers. Visibility threshold is `> 0`.
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Open POI with no News/Events/History/Associations → only Info tab visible
+2. Open POI with News only → Info + News tabs visible
+3. Open POI with all categories → all 5 tabs visible
+4. Sign in as admin, enable edit mode, open empty POI → all 5 tabs visible
+5. Deep-link to `/poi-slug/associations` on POI with no associations → URL resolves to Info tab
+6. Add a news item via admin, refresh page as public viewer → News tab now appears
+7. Open a linear feature (trail) with empty Associations → Associations tab hidden
+
+### Automated
+
+Existing Playwright smoke tests should still pass (they test core map functionality, not tab visibility). No new tests required for this PATCH-scope behavioral tweak; if Gemini review flags coverage, add one Playwright test.
+
+---
+
+## Rollback Plan
+
+Revert the PR. The migration is purely additive (response fields + frontend filter), so revert is safe.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Count subqueries slow down POI detail fetch | Low | Subqueries hit `poi_id` indexed columns; verify with EXPLAIN |
+| Deep-link routing breaks when target tab is hidden | Med | Add useEffect to fall back to Info + update URL |
+| Admin loses access to empty tabs | High | Bypass filter when `isAdmin && editMode` |
+| Tab strip layout shifts when tabs disappear | Low | Existing CSS handles variable child count |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-16 | Initial plan |

--- a/.specify/specs/014-hide-empty-tabs/spec.md
+++ b/.specify/specs/014-hide-empty-tabs/spec.md
@@ -1,0 +1,123 @@
+# Specification: Hide Empty Tabs in POI Sidebar
+
+> **Spec ID:** 014-hide-empty-tabs
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-16
+
+## Overview
+
+The POI sidebar currently renders every tab (Info, News, Events, History, Associations) regardless of whether the tab has content. Users click empty tabs expecting information and get an "empty" message. This spec hides tabs that have no content for public viewers while preserving full tab visibility for admin users in edit mode (who need the empty tabs to add content).
+
+Source: GitHub issue #211, feedback from Robbie Schneider (April 11, 2026).
+
+---
+
+## User Stories
+
+### Public Viewer
+
+**US-001: Hide empty tabs**
+> As a public viewer, I want to see only tabs that have content so that I don't waste clicks discovering empty sections.
+
+Acceptance Criteria:
+- [ ] Sidebar tabs with zero content items are not rendered for non-admin users
+- [ ] The Info tab is always shown (it always has at least a name)
+- [ ] Tab visibility is recalculated when the POI changes
+- [ ] Works for both regular POIs (destinations) and linear features (trails, rivers, boundaries)
+
+**US-002: Default to a visible tab**
+> As a public viewer arriving via a deep link to a tab that is no longer visible, I want to land on the Info tab instead of a blank panel.
+
+Acceptance Criteria:
+- [ ] If the active tab becomes hidden (e.g., URL deep-link to `/poi/news` but POI has no news), the sidebar falls back to Info
+- [ ] The URL is updated to reflect the fallback so the back button behaves predictably
+
+### Admin / Content Curator
+
+**US-003: Admin always sees all tabs**
+> As an admin in edit mode, I want to see all tabs even when empty so I can add content (news, events, history, associations).
+
+Acceptance Criteria:
+- [ ] When `isAdmin && editMode`, all five tabs render regardless of content
+- [ ] Behavior matches existing admin workflow — no regression for content curation
+
+### Automatic Recovery
+
+**US-004: Tabs reappear when content is added**
+> As a public viewer revisiting a POI after content was added, I want the relevant tab to reappear automatically.
+
+Acceptance Criteria:
+- [ ] Tab visibility is driven by the POI detail response on each fetch — no client-side caching of "this tab is hidden"
+- [ ] When a new event, news item, or association is added, the next page load shows the tab
+
+---
+
+## Data Model
+
+No schema changes. Visibility is derived from existing tables (`poi_news`, `poi_events`, `poi_associations`, `pois.historical_description`).
+
+---
+
+## API Endpoints
+
+### Modified Endpoints
+
+| Method | Path | Change |
+|--------|------|--------|
+| GET | `/api/pois/:id` | Add `news_count`, `events_count`, `associations_count` to response |
+| GET | `/api/destinations/:id` | Same additions (if used by sidebar) |
+| GET | `/api/linear-features/:id` | Same additions |
+
+Counts respect existing visibility rules:
+- `news_count`: `poi_news` rows with `moderation_status IN ('published', 'auto_approved')`
+- `events_count`: `poi_events` rows with `moderation_status IN ('published', 'auto_approved')` AND upcoming (matches default Events tab view)
+- `associations_count`: rows in `poi_associations` where this POI is either side
+
+`has_history` is derivable client-side from existing `historical_description` field.
+
+---
+
+## UI/UX Requirements
+
+### Behavior
+
+- **Public viewer:** tabs render iff they have content
+- **Admin in edit mode:** all tabs render
+- **Deep link to hidden tab:** fallback to Info
+
+### Visual
+
+No new visual treatment. Tabs that disappear simply aren't in the tab strip. Existing tab strip layout works unchanged with fewer buttons.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: No additional round trips**
+- Counts must come from the existing POI detail fetch — do not introduce N additional API calls per POI open.
+
+**NFR-002: Query cost**
+- Count additions to the POI detail query must use indexed columns or subqueries that complete in well under 50ms.
+
+---
+
+## Dependencies
+
+None.
+
+---
+
+## Open Questions
+
+1. Should "past events" make the Events tab visible, or only upcoming? **Resolved: upcoming only** (matches current default Events tab behavior).
+2. Linear features — do they have Associations? **Yes**, same logic applies.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-16 | Initial draft |

--- a/backend/server.js
+++ b/backend/server.js
@@ -1980,8 +1980,16 @@ app.get('/api/theme-video/:theme', async (req, res) => {
 // Public news and events endpoints
 app.get('/api/pois/:id/tab-counts', async (req, res) => {
   try {
-    const { id } = req.params;
-    const tz = req.query.tz || 'America/New_York';
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'Invalid POI id' });
+    }
+    // Whitelist tz to IANA-style identifiers (Region/City, optionally Region/City/Subcity)
+    // to avoid feeding arbitrary strings to Postgres AT TIME ZONE (PR #368 review).
+    const rawTz = req.query.tz;
+    const tz = (typeof rawTz === 'string' && /^[A-Za-z_]+\/[A-Za-z_]+(?:\/[A-Za-z_]+)?$/.test(rawTz))
+      ? rawTz
+      : 'America/New_York';
     const result = await pool.query(`
       SELECT
         (SELECT COUNT(*) FROM poi_news n
@@ -1992,7 +2000,9 @@ app.get('/api/pois/:id/tab-counts', async (req, res) => {
            AND e.moderation_status IN ('published', 'auto_approved')
            AND (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date) AS events_count
     `, [id, tz]);
-    const row = result.rows[0];
+    // The subquery-only SELECT always returns exactly one row, but guard anyway
+    // so a future refactor with a FROM clause doesn't silently break (PR #368 review).
+    const row = result.rows[0] || { news_count: 0, events_count: 0 };
     res.json({
       news_count: parseInt(row.news_count, 10),
       events_count: parseInt(row.events_count, 10)

--- a/backend/server.js
+++ b/backend/server.js
@@ -1978,6 +1978,31 @@ app.get('/api/theme-video/:theme', async (req, res) => {
 });
 
 // Public news and events endpoints
+app.get('/api/pois/:id/tab-counts', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const tz = req.query.tz || 'America/New_York';
+    const result = await pool.query(`
+      SELECT
+        (SELECT COUNT(*) FROM poi_news n
+         WHERE n.poi_id = $1
+           AND n.moderation_status IN ('published', 'auto_approved')) AS news_count,
+        (SELECT COUNT(*) FROM poi_events e
+         WHERE e.poi_id = $1
+           AND e.moderation_status IN ('published', 'auto_approved')
+           AND (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date) AS events_count
+    `, [id, tz]);
+    const row = result.rows[0];
+    res.json({
+      news_count: parseInt(row.news_count, 10),
+      events_count: parseInt(row.events_count, 10)
+    });
+  } catch (error) {
+    console.error('Error fetching POI tab counts:', error);
+    res.status(500).json({ error: 'Failed to fetch tab counts' });
+  }
+});
+
 app.get('/api/pois/:id/news', async (req, res) => {
   try {
     const { id } = req.params;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2703,20 +2703,18 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       setTabCounts({ news_count: null, events_count: null });
       return;
     }
+    // Reset to "loading" so we don't briefly show the prior POI's tabs (#211).
     setTabCounts({ news_count: null, events_count: null });
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let cancelled = false;
-    fetch(`/api/pois/${poiId}/tab-counts?tz=${encodeURIComponent(tz)}`)
+    const controller = new AbortController();
+    fetch(`/api/pois/${poiId}/tab-counts?tz=${encodeURIComponent(tz)}`, { signal: controller.signal })
       .then(res => (res.ok ? res.json() : { news_count: 0, events_count: 0 }))
-      .then(data => {
-        if (!cancelled) setTabCounts(data);
-      })
-      .catch(() => {
-        if (!cancelled) setTabCounts({ news_count: 0, events_count: 0 });
+      .then(data => setTabCounts(data))
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setTabCounts({ news_count: 0, events_count: 0 });
       });
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [displayItem?.id]);
 
   // Compute how many associations this POI has (associations is preloaded globally)

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2423,6 +2423,14 @@ function TrailStatus({ poiId, _poiName, isAdmin, editMode, _selectedFromMtbList,
   );
 }
 
+const SIDEBAR_TAB_LABELS = {
+  view: 'Info',
+  news: 'News',
+  events: 'Events',
+  history: 'History',
+  associations: 'Associations',
+};
+
 function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, onClose, isAdmin, user, editMode, onDestinationUpdate, onDestinationDelete, onSaveNewPOI, onCancelNewPOI, onSaveNewOrganization, onCancelNewOrganization, previewCoords, onPreviewCoordsChange, linearFeature, onLinearFeatureUpdate, onLinearFeatureDelete, onNavigate, currentIndex, totalCount, poiNavigationList, associations, allDestinations, allLinearFeatures, allVirtualPois, onSelectDestination, onSelectLinearFeature, onAssociationsChanged, onStartDrawingAssociations, isInMtbMode, selectedFromMtbList, mtbTrailsList, currentMtbIndex, onNavigateMtbTrail, onBackToMtbList, permalinkInfo, onSetPermalink, onClearPermalink, initialSidebarTab, onSidebarTabChange }) {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
@@ -2455,6 +2463,9 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
   const [, setEventsCount] = useState(0);
   const [, setCollectResult] = useState(null);
   const [trailStatus, setTrailStatus] = useState(null);
+  // Tab-count state for hiding empty sidebar tabs (issue #211).
+  // null = not yet loaded; numbers = confirmed counts.
+  const [tabCounts, setTabCounts] = useState({ news_count: null, events_count: null });
 
   /* const [organizationData, setOrganizationData] = useState({
     name: '',
@@ -2684,6 +2695,60 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
   const displayItem = linearFeature || destination;
   const isLinearFeature = !!linearFeature;
 
+  // Fetch news/events counts when the selected POI changes, so we can hide
+  // empty tabs for public viewers (#211).
+  useEffect(() => {
+    const poiId = displayItem?.id;
+    if (!poiId) {
+      setTabCounts({ news_count: null, events_count: null });
+      return;
+    }
+    setTabCounts({ news_count: null, events_count: null });
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let cancelled = false;
+    fetch(`/api/pois/${poiId}/tab-counts?tz=${encodeURIComponent(tz)}`)
+      .then(res => (res.ok ? res.json() : { news_count: 0, events_count: 0 }))
+      .then(data => {
+        if (!cancelled) setTabCounts(data);
+      })
+      .catch(() => {
+        if (!cancelled) setTabCounts({ news_count: 0, events_count: 0 });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [displayItem?.id]);
+
+  // Compute how many associations this POI has (associations is preloaded globally)
+  const poiAssociationsCount = useMemo(() => {
+    if (!displayItem?.id) return 0;
+    return (associations || []).filter(a =>
+      a.virtual_poi_id === displayItem.id || a.physical_poi_id === displayItem.id
+    ).length;
+  }, [associations, displayItem?.id]);
+
+  // Decide which sidebar tabs to render. Info ('view') is always shown.
+  // Admin users in edit mode see every tab so they can add missing content.
+  // While counts are loading (null), be conservative and hide news/events;
+  // they'll pop in once the counts arrive.
+  const visibleTabs = useMemo(() => {
+    const tabs = ['view'];
+    const adminOverride = isAdmin && editMode;
+    if (adminOverride || (tabCounts.news_count !== null && tabCounts.news_count > 0)) {
+      tabs.push('news');
+    }
+    if (adminOverride || (tabCounts.events_count !== null && tabCounts.events_count > 0)) {
+      tabs.push('events');
+    }
+    if (adminOverride || (displayItem?.historical_description && displayItem.historical_description.trim())) {
+      tabs.push('history');
+    }
+    if (adminOverride || poiAssociationsCount > 0) {
+      tabs.push('associations');
+    }
+    return tabs;
+  }, [isAdmin, editMode, tabCounts.news_count, tabCounts.events_count, displayItem?.historical_description, poiAssociationsCount]);
+
   // Helper to change sidebar tab and update URL
   const handleSidebarTabChange = useCallback((tab) => {
     setSidebarTab(tab);
@@ -2710,6 +2775,16 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       setIsEditing(false);
     }
   }, [displayItem, isAdmin, editMode, isNewPOI, selectedFromMtbList]);
+
+  // If the active tab has been filtered out of visibleTabs (e.g. deep-link to
+  // /poi/associations when the POI has no associations), fall back to Info.
+  // Skip while a permalink is active — permalinks force news/events deliberately.
+  useEffect(() => {
+    if (permalinkInfo) return;
+    if (sidebarTab !== 'view' && !visibleTabs.includes(sidebarTab)) {
+      setSidebarTab('view');
+    }
+  }, [visibleTabs, sidebarTab, permalinkInfo]);
 
   // Sync editedData coords when previewCoords changes (from map drag) - only for destinations
   useEffect(() => {
@@ -3222,36 +3297,15 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
 
         {/* Sidebar Tabs - same as destinations */}
         <div className="sidebar-tabs">
-          <button
-            className={`sidebar-tab ${sidebarTab === 'view' ? 'active' : ''}`}
-            onClick={() => handleSidebarTabChange('view')}
-          >
-            Info
-          </button>
-          <button
-            className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
-            onClick={() => handleSidebarTabChange('news')}
-          >
-            News
-          </button>
-          <button
-            className={`sidebar-tab ${sidebarTab === 'events' ? 'active' : ''}`}
-            onClick={() => handleSidebarTabChange('events')}
-          >
-            Events
-          </button>
-          <button
-            className={`sidebar-tab ${sidebarTab === 'history' ? 'active' : ''}`}
-            onClick={() => handleSidebarTabChange('history')}
-          >
-            History
-          </button>
-          <button
-            className={`sidebar-tab ${sidebarTab === 'associations' ? 'active' : ''}`}
-            onClick={() => handleSidebarTabChange('associations')}
-          >
-            Associations
-          </button>
+          {visibleTabs.map(tab => (
+            <button
+              key={tab}
+              className={`sidebar-tab ${sidebarTab === tab ? 'active' : ''}`}
+              onClick={() => handleSidebarTabChange(tab)}
+            >
+              {SIDEBAR_TAB_LABELS[tab]}
+            </button>
+          ))}
         </div>
 
         {/* Tab Content */}
@@ -3527,38 +3581,17 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         )}
       </div>
 
-      {/* Sidebar Tabs - always shown */}
+      {/* Sidebar Tabs - filtered to non-empty (#211); admins in edit mode see all */}
       <div className="sidebar-tabs">
-        <button
-          className={`sidebar-tab ${sidebarTab === 'view' ? 'active' : ''}`}
-          onClick={() => handleSidebarTabChange('view')}
-        >
-          Info
-        </button>
-        <button
-          className={`sidebar-tab ${sidebarTab === 'news' ? 'active' : ''}`}
-          onClick={() => handleSidebarTabChange('news')}
-        >
-          News
-        </button>
-        <button
-          className={`sidebar-tab ${sidebarTab === 'events' ? 'active' : ''}`}
-          onClick={() => handleSidebarTabChange('events')}
-        >
-          Events
-        </button>
-        <button
-          className={`sidebar-tab ${sidebarTab === 'history' ? 'active' : ''}`}
-          onClick={() => handleSidebarTabChange('history')}
-        >
-          History
-        </button>
-        <button
-          className={`sidebar-tab ${sidebarTab === 'associations' ? 'active' : ''}`}
-          onClick={() => handleSidebarTabChange('associations')}
-        >
-          Associations
-        </button>
+        {visibleTabs.map(tab => (
+          <button
+            key={tab}
+            className={`sidebar-tab ${sidebarTab === tab ? 'active' : ''}`}
+            onClick={() => handleSidebarTabChange(tab)}
+          >
+            {SIDEBAR_TAB_LABELS[tab]}
+          </button>
+        ))}
       </div>
 
       {/* Tab Content */}


### PR DESCRIPTION
## Summary
- Public viewers no longer see sidebar tabs (News, Events, History, Associations) when those tabs are empty. Info is always shown.
- Admins in edit mode still see every tab so they can add content.
- New backend endpoint `/api/pois/:id/tab-counts` returns `news_count` and `events_count` (events filtered to upcoming-only). Associations and history are derived client-side from already-loaded data.
- If a deep-link targets a now-hidden tab, the sidebar falls back to Info.

Spec: `.specify/specs/014-hide-empty-tabs/`.

Closes #211. Source: Robbie Schneider's April 11, 2026 feedback.

## Test plan
- [x] POI with news + upcoming events shows News + Events tabs
- [x] POI with only news shows News tab, hides Events
- [x] POI with no content shows only Info tab
- [x] Admin in edit mode sees all 5 tabs regardless of content
- [x] Deep-link to `/poi/associations` for empty POI falls back to Info
- [ ] Linear feature (trail) with empty Associations hides the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)