### PR TITLE
fix: return JSON (not HTML) for media upload and unmatched API routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1332,9 +1332,14 @@ app.post('/api/pois/:id/media', isAuthenticated, upload.single('file'), async (r
       ]);
     } catch (insertErr) {
       if (assetId) {
+        // Fix: deleteAsset returns {success, error} and does not throw — check both paths (Gemini review)
         try {
-          await imageServerClient.deleteAsset(assetId);
-          console.warn(`[upload] Rolled back orphan asset ${assetId} after DB insert failure`);
+          const rollback = await imageServerClient.deleteAsset(assetId);
+          if (rollback && rollback.success) {
+            console.warn(`[upload] Rolled back orphan asset ${assetId} after DB insert failure`);
+          } else {
+            console.error(`[upload] Orphan asset ${assetId} — manual cleanup required:`, rollback && rollback.error);
+          }
         } catch (rollbackErr) {
           console.error(`[upload] Orphan asset ${assetId} — manual cleanup required:`, rollbackErr);
         }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1301,33 +1301,46 @@ app.post('/api/pois/:id/media', isAuthenticated, upload.single('file'), async (r
     const moderatedAt = null;
     const moderatedBy = null; // Set during approval, not upload
 
-    // Create poi_media record
-    const insertResult = await pool.query(`
-      INSERT INTO poi_media (
-        poi_id,
+    // Create poi_media record — roll back image-server asset on failure to prevent orphans
+    let insertResult;
+    try {
+      insertResult = await pool.query(`
+        INSERT INTO poi_media (
+          poi_id,
+          media_type,
+          image_server_asset_id,
+          youtube_url,
+          caption,
+          role,
+          moderation_status,
+          submitted_by,
+          moderated_at,
+          moderated_by
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING id
+      `, [
+        parseInt(id),
         media_type,
-        image_server_asset_id,
-        youtube_url,
-        caption,
-        role,
-        moderation_status,
-        submitted_by,
-        moderated_at,
-        moderated_by
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-      RETURNING id
-    `, [
-      parseInt(id),
-      media_type,
-      assetId,
-      youtubeUrlValue,
-      caption || null,
-      'gallery',
-      moderationStatus,
-      user.id,
-      moderatedAt,
-      moderatedBy
-    ]);
+        assetId,
+        youtubeUrlValue,
+        caption || null,
+        'gallery',
+        moderationStatus,
+        user.id,
+        moderatedAt,
+        moderatedBy
+      ]);
+    } catch (insertErr) {
+      if (assetId) {
+        try {
+          await imageServerClient.deleteAsset(assetId);
+          console.warn(`[upload] Rolled back orphan asset ${assetId} after DB insert failure`);
+        } catch (rollbackErr) {
+          console.error(`[upload] Orphan asset ${assetId} — manual cleanup required:`, rollbackErr);
+        }
+      }
+      throw insertErr;
+    }
 
     const mediaId = insertResult.rows[0].id;
 
@@ -2668,11 +2681,24 @@ app.use(async (req, res, next) => {
 // Serve static files (after OG middlewares)
 app.use(express.static(staticPath));
 
-// SPA fallback - serve index.html for non-API routes
-app.get('*', (req, res) => {
-  if (!req.path.startsWith('/api') && !req.path.startsWith('/auth') && !req.path.startsWith('/share')) {
-    res.sendFile(path.join(staticPath, 'index.html'));
+// SPA fallback - serve index.html for non-API routes; surface JSON 404 for unmatched API/auth/share
+app.get('*', (req, res, next) => {
+  if (req.path.startsWith('/api') || req.path.startsWith('/auth') || req.path.startsWith('/share')) {
+    return res.status(404).json({ error: 'Not found', path: req.path });
   }
+  res.sendFile(path.join(staticPath, 'index.html'));
+});
+
+// Global JSON error handler — never let Express's HTML finalhandler surface to clients
+// Fix: prevent "<!DOCTYPE" parse errors in browser fetch() callers (PR for fix/media-upload-html-errors)
+app.use((err, req, res, next) => {
+  if (res.headersSent) return next(err);
+  const status = err.status || err.statusCode || (err.code === 'LIMIT_FILE_SIZE' ? 413 : 500);
+  const message = err.code === 'LIMIT_FILE_SIZE'
+    ? 'File too large (max 10MB)'
+    : (err.expose ? err.message : (status >= 500 ? 'Internal server error' : err.message || 'Request failed'));
+  console.error(`[error] ${req.method} ${req.path} -> ${status}:`, err.message);
+  res.status(status).json({ error: message, code: err.code });
 });
 
 // Start server

--- a/frontend/src/components/Lightbox.jsx
+++ b/frontend/src/components/Lightbox.jsx
@@ -314,7 +314,7 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
       </div>
 
       {/* Upload Modal */}
-      {uploadModalOpen && (
+      {uploadModalOpen && poiId && (
         <MediaUploadModal
           poiId={poiId}
           onClose={() => setUploadModalOpen(false)}

--- a/frontend/src/components/MediaUploadModal.jsx
+++ b/frontend/src/components/MediaUploadModal.jsx
@@ -115,9 +115,15 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
           })
         });
 
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          const text = await response.text();
+          throw new Error(`Request failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
+        }
+
         if (!response.ok) {
           const errorData = await response.json();
-          throw new Error(errorData.error || 'Failed to add YouTube video');
+          throw new Error(errorData.error || `Failed to add YouTube video (HTTP ${response.status})`);
         }
 
         const result = await response.json();
@@ -146,9 +152,15 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
           body: formData
         });
 
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          const text = await response.text();
+          throw new Error(`Upload failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
+        }
+
         if (!response.ok) {
           const errorData = await response.json();
-          throw new Error(errorData.error || 'Failed to upload');
+          throw new Error(errorData.error || `Upload failed (HTTP ${response.status})`);
         }
 
         const result = await response.json();


### PR DESCRIPTION
## Summary

User-facing media uploads at `POST /api/pois/:id/media` were surfacing as `Unexpected token '<', "<!DOCTYPE "... is not valid JSON` in the browser. Three root causes, all fixed in this PR:

- **No Express JSON error middleware** — uncaught route errors and multer `LIMIT_FILE_SIZE` fell through to Express's default HTML finalhandler. Added a global handler at end of `server.js` that returns `{error, code}` JSON with proper status (413 for oversize uploads).
- **SPA fallback hung on `/api`, `/auth`, `/share`** — the old handler had no `res.*` or `next()` for excluded prefixes, so requests hung until CloudFlare 524'd. Now returns JSON 404 immediately.
- **No atomic rollback** — if the `poi_media` INSERT failed after the image-server upload succeeded, the asset was orphaned. Wrapped INSERT in try/catch that calls `imageServerClient.deleteAsset(assetId)` on failure and detects non-throwing rollback failures (per Gemini review).

Plus two frontend defenses:

- `Lightbox.jsx`: guard `MediaUploadModal` with `&& poiId`, matching existing pattern in `Sidebar.jsx:3773` / `ImageUploader.jsx:244`. Empty `poiId` was producing `/api/pois//media`, which Express collapsed to `/api/pois/media` (HTML 404).
- `MediaUploadModal.jsx`: check `Content-Type` before `response.json()` in both upload and YouTube branches; surface HTTP status + body excerpt when non-JSON, so future regressions are diagnosable from the browser.

## Bug evidence

- Image server had orphan asset 418 (POI 5482, 1.3MB) with **zero** matching rows in `poi_media`
- Production moderation queue showed **no** successful user-submitted `role=gallery` uploads ever — all admin path

## Test plan

- [x] Local probes: unmatched `/api/foo` returns JSON 404 (was hang), unmatched `/auth/foo` returns JSON 404 (was hang), SPA fallback intact for app routes
- [x] End-to-end browser upload on local container: `poi_media` row created, asset uploaded, no `<!DOCTYPE` error
- [x] Vitest/Playwright integration suite: 327 passed / 3 flaky-test failures (map satellite toggle, header tab nav) unrelated to this PR's surface area
- [x] Gemini Pro code review: one IMPORTANT issue found (silent rollback failure) — fixed in follow-up commit
- [ ] Verify in production after merge: trigger an upload from prod UI, confirm row in moderation queue

## Cleanup needed post-merge

Two orphan assets on prod image server need manual deletion:
- Asset **418** (pre-existing, from the original bug)
- Asset **419** (created by local verification during this PR — local container uploads to prod image server)