### PR TITLE
fix: surface user-uploaded gallery photos as tooltip images

### DIFF
--- a/backend/migrations/051_backfill_has_primary_image_for_gallery.sql
+++ b/backend/migrations/051_backfill_has_primary_image_for_gallery.sql
@@ -1,0 +1,17 @@
+-- Backfill pois.has_primary_image for POIs whose only published media is gallery-role.
+-- The /api/pois/:id/thumbnail endpoint now falls back to oldest published gallery photo
+-- when no primary exists, so any POI with a published image/video should report
+-- has_primary_image=true to surface the tooltip.
+--
+-- Idempotent: only updates POIs currently flagged false.
+
+UPDATE pois
+SET has_primary_image = true,
+    updated_at = CURRENT_TIMESTAMP
+WHERE has_primary_image = false
+  AND id IN (
+    SELECT DISTINCT poi_id
+    FROM poi_media
+    WHERE media_type IN ('image', 'video')
+      AND moderation_status IN ('published', 'auto_approved')
+  );

--- a/backend/server.js
+++ b/backend/server.js
@@ -1019,33 +1019,32 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
     const { id } = req.params;
     const size = req.query.size; // small, medium, large — passed through to image server
 
-    // Fix: Query poi_media table for primary image (Gatehouse finding)
-    let result = await pool.query(`
-      SELECT image_server_asset_id
-      FROM poi_media
-      WHERE poi_id = $1
-        AND role = 'primary'
-        AND media_type IN ('image', 'video')
-        AND moderation_status IN ('published', 'auto_approved')
-      ORDER BY created_at DESC
+    // Fix: Query poi_media for primary image; fall back to oldest published gallery photo
+    // when no primary exists (so user-uploaded gallery photos surface as tooltip images).
+    // Single roundtrip via UNION ALL: priority=1 is primary (newest wins), priority=2 is
+    // gallery (oldest wins so the tooltip image doesn't churn on each new approval).
+    // (Gatehouse finding: collapsed prior two-query fallback into one. Performance Check.)
+    const result = await pool.query(`
+      (SELECT image_server_asset_id, 1 AS priority
+       FROM poi_media
+       WHERE poi_id = $1
+         AND role = 'primary'
+         AND media_type IN ('image', 'video')
+         AND moderation_status IN ('published', 'auto_approved')
+       ORDER BY created_at DESC
+       LIMIT 1)
+      UNION ALL
+      (SELECT image_server_asset_id, 2 AS priority
+       FROM poi_media
+       WHERE poi_id = $1
+         AND role = 'gallery'
+         AND media_type IN ('image', 'video')
+         AND moderation_status IN ('published', 'auto_approved')
+       ORDER BY created_at ASC
+       LIMIT 1)
+      ORDER BY priority
       LIMIT 1
     `, [id]);
-
-    // Fix: fall back to oldest published gallery photo when no primary exists.
-    // Without this, user-uploaded gallery photos can never become tooltip images
-    // even when the POI's has_primary_image flag is true.
-    if (result.rows.length === 0) {
-      result = await pool.query(`
-        SELECT image_server_asset_id
-        FROM poi_media
-        WHERE poi_id = $1
-          AND role = 'gallery'
-          AND media_type IN ('image', 'video')
-          AND moderation_status IN ('published', 'auto_approved')
-        ORDER BY created_at ASC
-        LIMIT 1
-      `, [id]);
-    }
 
     let assetId;
     if (result.rows.length > 0) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1020,7 +1020,7 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
     const size = req.query.size; // small, medium, large — passed through to image server
 
     // Fix: Query poi_media table for primary image (Gatehouse finding)
-    const result = await pool.query(`
+    let result = await pool.query(`
       SELECT image_server_asset_id
       FROM poi_media
       WHERE poi_id = $1
@@ -1030,6 +1030,22 @@ app.get('/api/pois/:id/thumbnail', async (req, res) => {
       ORDER BY created_at DESC
       LIMIT 1
     `, [id]);
+
+    // Fix: fall back to oldest published gallery photo when no primary exists.
+    // Without this, user-uploaded gallery photos can never become tooltip images
+    // even when the POI's has_primary_image flag is true.
+    if (result.rows.length === 0) {
+      result = await pool.query(`
+        SELECT image_server_asset_id
+        FROM poi_media
+        WHERE poi_id = $1
+          AND role = 'gallery'
+          AND media_type IN ('image', 'video')
+          AND moderation_status IN ('published', 'auto_approved')
+        ORDER BY created_at ASC
+        LIMIT 1
+      `, [id]);
+    }
 
     let assetId;
     if (result.rows.length > 0) {

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -592,6 +592,28 @@ export async function processPendingItems(pool) {
 }
 
 /**
+ * After publishing a photo row, ensure the POI's has_primary_image flag is true so
+ * the tooltip endpoint will be queried. The thumbnail endpoint falls back to gallery
+ * photos when no primary exists, so any published image/video makes the POI "have"
+ * a tooltip image. Idempotent: only writes when the flag is currently false.
+ */
+async function bumpHasPrimaryImageOnPhotoPublish(pool, contentType, contentId) {
+  if (contentType !== 'photo') return;
+  await pool.query(`
+    UPDATE pois
+    SET has_primary_image = true,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE id = (
+      SELECT poi_id FROM poi_media
+      WHERE id = $1
+        AND media_type IN ('image', 'video')
+        AND moderation_status IN ('published', 'auto_approved')
+    )
+      AND has_primary_image = false
+  `, [contentId]);
+}
+
+/**
  * Set moderation_status to 'published' for a content item
  */
 export async function approveItem(pool, contentType, contentId, adminUserId) {
@@ -600,6 +622,7 @@ export async function approveItem(pool, contentType, contentId, adminUserId) {
     `UPDATE ${table} SET moderation_status = 'published', moderated_by = $1, moderated_at = CURRENT_TIMESTAMP WHERE id = $2`,
     [adminUserId, contentId]
   );
+  await bumpHasPrimaryImageOnPhotoPublish(pool, contentType, contentId);
 }
 
 export async function rejectItem(pool, contentType, contentId, adminUserId, reason) {
@@ -621,6 +644,7 @@ export async function bulkApprove(pool, items, adminUserId) {
       `UPDATE ${table} SET moderation_status = 'published', moderated_by = $1, moderated_at = CURRENT_TIMESTAMP WHERE id = $2`,
       [adminUserId, id]
     );
+    await bumpHasPrimaryImageOnPhotoPublish(pool, type, id);
     approved++;
   }
   return { approved };
@@ -693,6 +717,9 @@ export async function editAndPublish(pool, contentType, contentId, edits, adminU
   if (setClauses.length === 0) return;
   console.log('[editAndPublish] SQL:', `UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $1`, values);
   await pool.query(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE id = $1`, values);
+  if (publish) {
+    await bumpHasPrimaryImageOnPhotoPublish(pool, contentType, contentId);
+  }
 }
 
 export async function createItem(pool, contentType, fields, adminUserId) {


### PR DESCRIPTION
## Summary

User-uploaded photos via `/api/pois/:id/media` are hardcoded to `role='gallery'`, but the tooltip endpoint `/api/pois/:id/thumbnail` only returned `role='primary'` photos. Result: a POI like Blue Hen Falls could have approved user uploads visible in the lightbox yet still show a **blank map tooltip** until an admin manually promoted one to primary.

This PR makes user uploads functionally useful for the tooltip without admin intervention.

## Changes

1. **`backend/server.js`** — thumbnail endpoint falls back to oldest published gallery photo when no primary exists. Implemented as a single `UNION ALL` query (priority=1 newest primary, priority=2 oldest gallery, outer `LIMIT 1`) so the cache-miss path is still one DB roundtrip. "Oldest gallery" so the tooltip image doesn't churn each time a new gallery photo is approved.
2. **`backend/services/moderationService.js`** — `approveItem`, `bulkApprove`, and `editAndPublish` now bump `pois.has_primary_image=true` after publishing a photo row. Without this the frontend gates the tooltip image request on the flag and never asks for the (now-available) gallery photo. Idempotent: only writes when the flag is currently false.
3. **`backend/migrations/051_backfill_has_primary_image_for_gallery.sql`** — idempotent backfill for existing POIs whose flag is false but have published media. Safe to re-run.

## Semantics preserved

- Primary still wins when present
- Among primaries, newest wins (existing behavior — DESC inside primary subquery)
- Among gallery photos, oldest wins (new — ASC inside gallery subquery)
- Admin "set primary" flow unchanged
- No new API surface

## Test plan

- [x] Local: backfill migration ran, 0 stale-false flags remain
- [x] Local: `GET /api/pois/5500/thumbnail` (gallery-only POI) returns 600x450 JPEG (was 404)
- [x] Local: `GET /api/pois/5660/thumbnail` (primary present) returns the primary (unchanged)
- [x] Browser: Bridal Veil Falls map marker hover shows tooltip image
- [x] Tests: 329 passed, 1 flake (Samsung S25 mobile nav — unrelated)
- [x] Gatehouse: Bug Hunter, Performance Check (1 HIGH addressed in c0d4358), Consistency Check, General Review all clean. Security Scan agent failed to fire across multiple retries (Gemini free-tier 429) — accepted given the diff is parameterized SQL queries + a backfill migration with no new auth surface
- [ ] Production: hover Blue Hen Falls (and other POIs with prior gallery-only uploads) → tooltip image displays

## Related

Fixes the scenario behind the Blue Hen Falls workaround Scott had to apply after merging #370 — user uploaded two photos, approved them both, tooltip stayed blank until he manually promoted one to primary.