### PR TITLE
feat: grouped legend sections + Astronomy activity (#6)

### DIFF
--- a/.specify/specs/015-grouped-legend-sections/plan.md
+++ b/.specify/specs/015-grouped-legend-sections/plan.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Grouped Legend Sections + Astronomy
+
+> **Spec ID:** 015-grouped-legend-sections
+> **Status:** Planning
+> **Last Updated:** 2026-05-18
+> **Estimated Effort:** S
+
+## Summary
+
+Refactor the `Legend` component in `frontend/src/components/Map.jsx` into three collapsible sections; partition the existing boundary list by `boundary_type`; add an Astronomy activity + icon + Fairlawn Rotary Observatory POI via a single idempotent SQL migration.
+
+---
+
+## Architecture
+
+### Component Layout
+
+```
+Legend (Map.jsx)
+├── search input
+├── LegendSection key="poi"  (open by default)
+│     ├── header: chevron + "Points of Interest" + (N) + All/None
+│     └── body: icon chips (existing .legend-icons grid)
+├── LegendSection key="parks"  (collapsed by default)
+│     ├── header: chevron + "Parks" + (N) + All/None
+│     └── body: park boundary chips (existing .boundary-chips grid)
+└── LegendSection key="municipal"  (collapsed by default)
+      ├── header: chevron + "Municipal" + (N) + All/None
+      └── body: municipal boundary chips (existing .boundary-chips grid)
+```
+
+### Data Flow
+
+1. `App.jsx` fetches `/api/linear-features` (existing) — response already includes `boundary_type`.
+2. `App.jsx` passes `linearFeatures` to `Map`.
+3. `Map` partitions boundaries into two new props:
+   - `parkBoundaries` = `boundary_type === 'park'`
+   - `municipalBoundaries` = `boundary_type IN ('municipal','city','township','village','county','state')`
+4. `Legend` renders three sections; local `useState` tracks open/closed.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Section toggle | React `useState` + native `hidden` attr | A11y-correct, no library needed |
+| Chevron | Inline SVG with CSS rotate transition | Matches existing inline-SVG icon style |
+| Section grouping | Client-side filter on existing `linearFeatures` payload | No API change, no new fetch |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Legend refactor (frontend)
+
+- [ ] In `Map.jsx`, replace the existing two-section JSX inside `Legend` (lines 95–183) with three `LegendSection` blocks.
+- [ ] Introduce `LegendSection` as a local component or render-helper inside `Map.jsx`.
+- [ ] Add `useState({ poi: true, parks: false, municipal: false })` for open/closed.
+- [ ] Replace the `boundaries` prop usage with `parkBoundaries` and `municipalBoundaries`.
+- [ ] In `Map` function (line ~1468) replace the single `boundaries={...}` line with the two filtered props.
+- [ ] In `App.jsx` (line ~2080) update `onShowAllBoundaries` to include all boundary types (`park`, `municipal`, `city`, `township`, `village`, `county`, `state`).
+- [ ] Add CSS rules in `frontend/src/App.css` for `.legend-section`, `.legend-section-header`, `.legend-section-chevron`, and count badge.
+
+### Phase 2: Astronomy data (backend migration)
+
+- [ ] Create `backend/migrations/051_add_astronomy.sql`.
+- [ ] Insert Astronomy activity (sort_order after current max).
+- [ ] Insert astronomy icon with inline telescope SVG (style follows lighthouses icon #47).
+- [ ] Insert Fairlawn Rotary Observatory POI.
+
+### Phase 3: Build, verify, review
+
+- [ ] `./run.sh build` (uses port 8081 from `.env`).
+- [ ] `./run.sh start` and Scott verifies in browser.
+- [ ] `./run.sh gatehouse` for review pass.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/051_add_astronomy.sql` | Seed Astronomy activity, icon, and Fairlawn Rotary POI |
+| `.specify/specs/015-grouped-legend-sections/spec.md` | This feature's specification |
+| `.specify/specs/015-grouped-legend-sections/plan.md` | This plan |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/components/Map.jsx` | Refactor `Legend` (lines 56–185); split `boundaries` prop at line 1468 into `parkBoundaries` + `municipalBoundaries` |
+| `frontend/src/App.jsx` | Update `onShowAllBoundaries` at line ~2080 to include all boundary types |
+| `frontend/src/App.css` | Add `.legend-section*` rules |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 051_add_astronomy
+-- Description: Seed Astronomy activity, icon, and Fairlawn Rotary Observatory POI (closes #6)
+
+DO $$
+DECLARE
+  next_sort INTEGER;
+BEGIN
+  -- Activity
+  SELECT COALESCE(MAX(sort_order), 0) + 1 INTO next_sort FROM activities;
+  INSERT INTO activities (name, sort_order)
+  VALUES ('Astronomy', next_sort)
+  ON CONFLICT (name) DO NOTHING;
+
+  -- Icon (with inline SVG)
+  SELECT COALESCE(MAX(sort_order), 0) + 1 INTO next_sort FROM icons;
+  INSERT INTO icons (name, label, svg_content, title_keywords, activity_fallbacks, sort_order, enabled)
+  VALUES (
+    'astronomy', 'Astronomy',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="15" fill="#3b1f5b" stroke="white" stroke-width="2"/><circle cx="22" cy="9" r="1.3" fill="white"/><circle cx="10" cy="8" r="0.9" fill="white"/><circle cx="8" cy="14" r="0.7" fill="white"/><circle cx="24" cy="16" r="0.8" fill="white"/><path d="M9 25 L15 14 M11 25 L17 14 M9 25 L11 25 M22 12 L17 14 M22 12 L24 11" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/></svg>',
+    'observatory,telescope,planetarium,astronomy,stargazing,star party', 'Astronomy',
+    next_sort, TRUE
+  )
+  ON CONFLICT (name) DO NOTHING;
+
+  -- POI: Fairlawn Rotary Observatory
+  IF NOT EXISTS (SELECT 1 FROM pois WHERE name = 'Fairlawn Rotary Observatory') THEN
+    INSERT INTO pois (
+      name, latitude, longitude, poi_roles, primary_activities,
+      property_owner, brief_description, more_info_link
+    )
+    VALUES (
+      'Fairlawn Rotary Observatory',
+      41.1693, -81.6308,
+      '{point}',
+      'Astronomy',
+      'Summit County Astronomy Club',
+      'Free public observatory operated by the Summit County Astronomy Club at 4160 Ira Road, Bath, OH. Programs are weather and volunteer dependent — check the meetup for open nights. Ages 7+. Official James Webb Space Telescope site. The grounds include a 1.3-mile Walk of Planets (Sun to Pluto) built with Bath Township. Equipment includes a Celestron EdgeHD 14" on an Astro-Physics 1200 mount plus multiple 11" pier-mounted telescopes across two roll-off-roof buildings.',
+      'https://www.meetup.com/summit-county-astronomy-meetup/'
+    );
+  END IF;
+END $$;
+```
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Load `http://localhost:8081` — POI expanded, Parks + Municipal collapsed.
+2. Click each section header — only that section toggles; chevron rotates.
+3. Use Parks All/None — toggles CVNP + Hampton Hills only.
+4. Use Municipal All/None — toggles Akron + Cuyahoga Falls + counties + Ohio only.
+5. POI section: confirm `Astronomy` chip with telescope icon appears.
+6. Toggle Astronomy: Fairlawn Rotary pin appears in Bath OH; click pin → info panel shows meetup link, SCAC ownership, description.
+7. Search box still narrows visible POIs.
+8. Mobile (≤768px): outer legend collapse still works.
+
+### Regression Checks
+
+- Trails/Rivers layer chips still functional (verify placement during implementation).
+- Existing visible boundaries (CVNP default-on) still render on map.
+- Icon admin UI (`/admin` → Icons) shows the new Astronomy row.
+
+---
+
+## Rollback Plan
+
+1. Revert PR via `gh pr revert`.
+2. Drop the Fairlawn Rotary POI row, Astronomy icon row, Astronomy activity row if needed:
+   ```sql
+   DELETE FROM pois WHERE name = 'Fairlawn Rotary Observatory';
+   DELETE FROM icons WHERE name = 'astronomy';
+   DELETE FROM activities WHERE name = 'Astronomy';
+   ```
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| County/state polygons large | Med | Sections default collapsed; render only on user toggle |
+| Sparse Parks section (2 entries) | Low | Accepted — structure for forthcoming parks |
+| Inline SVG icon may not read at chip scale | Low | Model after lighthouses #47; iterate via admin UI post-deploy |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-18 | Initial plan |

--- a/.specify/specs/015-grouped-legend-sections/spec.md
+++ b/.specify/specs/015-grouped-legend-sections/spec.md
@@ -1,0 +1,132 @@
+# Specification: Grouped Legend Sections + Astronomy
+
+> **Spec ID:** 015-grouped-legend-sections
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-18
+
+## Overview
+
+Reorganize the map legend panel into three collapsible sections — **Points of Interest** (expanded), **Parks** (collapsed), **Municipal** (collapsed) — so it stays scannable as the icon catalog and boundary list grow. Bundles issue #6: add Astronomy as a new activity, icon, and example POI for the Fairlawn Rotary Observatory in Bath, OH.
+
+---
+
+## User Stories
+
+### Legend Navigation
+
+**US-015-1: Quickly find a POI category**
+> As a map visitor, I want the legend grouped into clearly labeled sections so I can find what I'm looking for without scrolling past chips I don't care about.
+
+Acceptance Criteria:
+- [ ] Legend renders three sections in fixed order: Points of Interest, Parks, Municipal.
+- [ ] Each section has a header showing label + count badge (`Parks (2)`).
+- [ ] Points of Interest is expanded on first load; Parks and Municipal are collapsed.
+- [ ] Clicking a header toggles only that section. Chevron icon rotates to indicate state.
+- [ ] Section state is local UI only — does not persist across reloads.
+
+**US-015-2: Show/hide all within a boundary group**
+> As a map visitor, I want to toggle all park boundaries or all municipal boundaries independently so I'm not forced to enable cities just to see CVNP.
+
+Acceptance Criteria:
+- [ ] Parks and Municipal sections each have their own All/None controls inside the header.
+- [ ] All/None affects only the boundaries in that section.
+- [ ] The existing global "show all POIs" / "hide all POIs" controls stay in the POI header.
+
+**US-015-3: Municipal includes counties and state**
+> As a map visitor, I want to be able to toggle county and state boundaries from the legend.
+
+Acceptance Criteria:
+- [ ] County boundaries (Cuyahoga, Summit) appear as toggles in the Municipal section.
+- [ ] Ohio state boundary appears as a toggle in the Municipal section.
+- [ ] Existing municipal boundaries (Akron, Cuyahoga Falls) appear in the same section.
+
+### Astronomy (closes #6)
+
+**US-015-4: Browse astronomy sites on the map**
+> As a map visitor, I want an Astronomy filter chip so I can find observatories and stargazing spots.
+
+Acceptance Criteria:
+- [ ] An Astronomy chip with a telescope icon appears in the Points of Interest section.
+- [ ] Toggling it shows/hides POIs whose `primary_activities` includes "Astronomy".
+- [ ] The Fairlawn Rotary Observatory (4160 Ira Road, Bath OH) appears as an example POI with description, meetup link, and SCAC ownership.
+
+---
+
+## Data Model
+
+### Schema Changes
+
+None. `pois.boundary_type` already supports the values used (`park`, `municipal`, `city`, `township`, `village`, `county`, `state`). Astronomy reuses existing `activities`, `icons`, and `pois` tables.
+
+### Seed Inserts (migration 051)
+
+- `activities`: one row, `name='Astronomy'`.
+- `icons`: one row, `name='astronomy'`, inline SVG content, keyword/fallback set.
+- `pois`: one row for Fairlawn Rotary Observatory.
+
+---
+
+## API Endpoints
+
+No new endpoints. Existing `/api/linear-features` already returns `boundary_type`; existing `/api/admin/icons` already returns the icon catalog the frontend consumes.
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `LegendSection` (local helper inside `Map.jsx`) — renders header (button with chevron, label, count badge, optional All/None controls) and a `<div role="group">` body hidden via the native `hidden` attribute when collapsed.
+
+### Wireframes
+
+```
+┌────────────────────────────────────┐
+│  [search box]                      │
+│  ──────────────────────────────    │
+│  ▼ Points of Interest (15) [All|None]
+│    [Hiking] [Biking] [Camping] ... │
+│    [Astronomy] ...                 │
+│  ──────────────────────────────    │
+│  ▶ Parks (2)            [All|None] │
+│  ──────────────────────────────    │
+│  ▶ Municipal (5)        [All|None] │
+└────────────────────────────────────┘
+```
+
+---
+
+## Non-Functional Requirements
+
+**NFR-015-1: Accessibility**
+- Section headers are `<button>` elements with `aria-expanded` reflecting state.
+- Collapsed bodies use the `hidden` attribute so screen readers skip them.
+- Tab order: POI header → POI chips (when open) → Parks header → Municipal header.
+
+**NFR-015-2: No regression on existing legend behavior**
+- Search input still filters.
+- Trails/Rivers layer toggles still function (placed inside POI section).
+- Outer `isLegendExpanded` mobile collapse still works.
+
+---
+
+## Dependencies
+
+- Depends on: nothing (uses existing data + APIs).
+- Closes: issue #6 (Add Astronomy Activity).
+
+---
+
+## Open Questions
+
+None at draft time. Section default-state and grouping rules confirmed with Scott on 2026-05-18.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-18 | Initial draft |

--- a/backend/migrations/051_add_astronomy.sql
+++ b/backend/migrations/051_add_astronomy.sql
@@ -1,0 +1,50 @@
+-- Migration 051: Add Astronomy activity, icon, and Fairlawn Rotary Observatory POI
+-- Purpose: Closes issue #6 — adds the first astronomy site (Fairlawn Rotary in Bath, OH,
+-- operated by the Summit County Astronomy Club) as an example POI plus the supporting
+-- activity + icon catalog rows so the new chip surfaces in the legend automatically.
+
+DO $$
+DECLARE
+  next_activity_sort INTEGER;
+  next_icon_sort INTEGER;
+BEGIN
+  -- 1. Activity
+  SELECT COALESCE(MAX(sort_order), 0) + 1 INTO next_activity_sort FROM activities;
+  INSERT INTO activities (name, sort_order)
+  VALUES ('Astronomy', next_activity_sort)
+  ON CONFLICT (name) DO NOTHING;
+
+  -- 2. Icon (inline telescope SVG on a night-sky background)
+  SELECT COALESCE(MAX(sort_order), 0) + 1 INTO next_icon_sort FROM icons;
+  INSERT INTO icons (name, label, svg_content, title_keywords, activity_fallbacks, sort_order, enabled)
+  VALUES (
+    'astronomy',
+    'Astronomy',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="15" fill="#1a1a3e" stroke="white" stroke-width="2"/><circle cx="22" cy="9" r="1" fill="white"/><circle cx="9" cy="11" r="0.8" fill="white"/><circle cx="24" cy="20" r="0.6" fill="white"/><line x1="9" y1="22" x2="20" y2="11" stroke="white" stroke-width="2.5" stroke-linecap="round"/><line x1="12" y1="24" x2="9" y2="22" stroke="white" stroke-width="1.5" stroke-linecap="round"/><line x1="9" y1="22" x2="6" y2="24" stroke="white" stroke-width="1.5" stroke-linecap="round"/></svg>',
+    'observatory,telescope,planetarium,astronomy,stargazing,star party',
+    'Astronomy',
+    next_icon_sort,
+    TRUE
+  )
+  ON CONFLICT (name) DO NOTHING;
+
+  -- 3. POI: Fairlawn Rotary Observatory
+  IF NOT EXISTS (SELECT 1 FROM pois WHERE name = 'Fairlawn Rotary Observatory') THEN
+    INSERT INTO pois (
+      name, latitude, longitude, poi_roles, primary_activities,
+      property_owner, brief_description, more_info_link
+    )
+    VALUES (
+      'Fairlawn Rotary Observatory',
+      41.1693, -81.6308,
+      '{point}',
+      'Astronomy',
+      'Summit County Astronomy Club',
+      'Free public observatory operated by the Summit County Astronomy Club at 4160 Ira Road, Bath, OH. Programs are weather and volunteer dependent — check the meetup page for open nights. Ages 7 and up. Official James Webb Space Telescope site. The grounds include a 1.3-mile Walk of Planets (Sun to Pluto) built with Bath Township. Equipment includes a Celestron EdgeHD 14-inch on an Astro-Physics 1200 mount plus multiple 11-inch pier-mounted telescopes across two roll-off-roof buildings.',
+      'https://www.meetup.com/summit-county-astronomy-meetup/'
+    );
+    RAISE NOTICE 'Inserted Fairlawn Rotary Observatory POI';
+  ELSE
+    RAISE NOTICE 'Fairlawn Rotary Observatory POI already exists, skipping';
+  END IF;
+END $$;

--- a/backend/migrations/052_recategorize_cvnp_boundary_types.sql
+++ b/backend/migrations/052_recategorize_cvnp_boundary_types.sql
@@ -1,0 +1,17 @@
+-- Migration 052: Recategorize legacy boundary_type='cvnp' into park/municipal
+-- Purpose: Legacy bucket grouped the CVNP park polygon together with all
+-- the cities/townships that fall inside or border CVNP. The new grouped-legend
+-- feature (spec 015) needs accurate categorization so the Parks and Municipal
+-- sections populate from real data.
+--
+-- Reference: server.js:609 originally set boundary_type='cvnp' for every
+-- NULL boundary at startup. That bucket conflated parks with jurisdictions.
+
+UPDATE pois
+SET boundary_type = 'park'
+WHERE boundary_type = 'cvnp'
+  AND name = 'Cuyahoga Valley National Park';
+
+UPDATE pois
+SET boundary_type = 'municipal'
+WHERE boundary_type = 'cvnp';

--- a/backend/server.js
+++ b/backend/server.js
@@ -606,7 +606,7 @@ async function initDatabase() {
       ALTER TABLE pois ADD COLUMN IF NOT EXISTS boundary_color TEXT DEFAULT '#228B22'
     `);
     await client.query(`
-      UPDATE pois SET boundary_type = 'cvnp' WHERE 'boundary' = ANY(poi_roles) AND boundary_type IS NULL
+      UPDATE pois SET boundary_type = 'municipal' WHERE 'boundary' = ANY(poi_roles) AND boundary_type IS NULL
     `);
 
     await client.query(`

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2571,7 +2571,11 @@ body {
   border-radius: 6px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.15);
   z-index: 1000;
-  max-width: 320px;
+  width: 320px;
+  height: min(480px, 70vh);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Desktop popup mode when expanded */
@@ -2581,6 +2585,8 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
   bottom: auto;
+  width: auto;
+  height: auto;
   max-height: 80vh;
   overflow-y: auto;
   z-index: 2000;
@@ -2605,7 +2611,9 @@ body {
 
 /* Legend content wrapper - always visible on desktop */
 .legend-content {
-  display: block;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .legend h4 {
@@ -2641,6 +2649,86 @@ body {
   height: 1px;
   background: #e0e0e0;
   margin: 0.5rem 0;
+}
+
+/* Collapsible legend sections */
+.legend-section {
+  border-top: 1px solid #e0e0e0;
+  padding: 0.5rem 0;
+}
+
+.legend-section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.legend-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+}
+
+.legend-section-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  padding: 0.1rem 0;
+  cursor: pointer;
+  color: #333;
+  font: inherit;
+  flex: 1;
+  text-align: left;
+}
+
+.legend-section-toggle:hover .legend-section-title {
+  color: #000;
+}
+
+.legend-section-chevron {
+  display: inline-block;
+  font-size: 0.65rem;
+  color: #888;
+  transition: transform 0.15s ease;
+  width: 0.75rem;
+  text-align: center;
+}
+
+.legend-section-chevron.open {
+  transform: rotate(90deg);
+}
+
+.legend-section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.legend-section-count {
+  font-size: 0.75rem;
+  color: #888;
+  font-weight: 400;
+}
+
+.legend-section-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.legend-section-actions button {
+  padding: 0.15rem 0.4rem;
+  font-size: 0.7rem;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #525252;
+}
+
+.legend-section-actions button:hover {
+  background: #e8e8e8;
 }
 
 /* Boundary chips section */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2076,11 +2076,16 @@ function AppContent() {
             }
             return next;
           })}
-          onShowAllBoundaries={() => {
-            const boundaryIds = linearFeatures.filter(f => f.poi_roles?.includes('boundary') && !['county', 'state'].includes(f.boundary_type)).map(f => f.id);
-            setVisibleBoundaries(new Set(boundaryIds));
-          }}
-          onHideAllBoundaries={() => setVisibleBoundaries(new Set())}
+          onShowBoundaries={(ids) => setVisibleBoundaries(prev => {
+            const next = new Set(prev);
+            ids.forEach(id => next.add(id));
+            return next;
+          })}
+          onHideBoundaries={(ids) => setVisibleBoundaries(prev => {
+            const next = new Set(prev);
+            ids.forEach(id => next.delete(id));
+            return next;
+          })}
           searchQuery={activeFilters.search}
           onSearchChange={(value) => handleFilterChange('search', value)}
           onNewsRefresh={() => setNewsRefreshTrigger(prev => prev + 1)}

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -38,11 +38,42 @@ const DEFAULT_ZOOM = 11;
 
 const TOOLTIP_HOVER_DELAY = 250; // ms
 
+function LegendSection({ id, title, count, isOpen, onToggle, showActions, onShowAll, onHideAll, children }) {
+  const bodyId = `legend-section-${id}`;
+  return (
+    <div className="legend-section">
+      <div className="legend-section-header">
+        <button
+          type="button"
+          className="legend-section-toggle"
+          aria-expanded={isOpen}
+          aria-controls={bodyId}
+          onClick={onToggle}
+        >
+          <span className={`legend-section-chevron ${isOpen ? 'open' : ''}`} aria-hidden="true">&#9654;</span>
+          <span className="legend-section-title">{title}</span>
+          <span className="legend-section-count">({count})</span>
+        </button>
+        {showActions && isOpen && (
+          <div className="legend-section-actions">
+            <button type="button" onClick={onShowAll} title={`Show all ${title}`}>All</button>
+            <button type="button" onClick={onHideAll} title={`Hide all ${title}`}>None</button>
+          </div>
+        )}
+      </div>
+      <div id={bodyId} className="legend-section-body" hidden={!isOpen}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function Legend({
   showTrails, onToggleTrails,
   showRivers, onToggleRivers,
-  visibleBoundaries, onToggleBoundary, onShowAllBoundaries, onHideAllBoundaries,
-  boundaries, // Array of boundary objects with id, name, boundary_color
+  visibleBoundaries, onToggleBoundary,
+  onShowBoundaries, onHideBoundaries,
+  parkBoundaries = [], municipalBoundaries = [],
   visibleTypes, onToggleType, onShowAll, onHideAll,
   searchQuery, onSearchChange,
   isExpanded, _onClose,
@@ -92,6 +123,24 @@ function Legend({
     return [...poiTypes, ...layerIcons].sort((a, b) => a.label.localeCompare(b.label));
   }, [iconConfig, showTrails, showRivers, onToggleTrails, onToggleRivers]);
 
+  const [openSection, setOpenSection] = useState('poi');
+  const toggleSection = (key) => setOpenSection(prev => (prev === key ? null : key));
+
+  const renderBoundaryChip = (boundary) => (
+    <button
+      key={boundary.id}
+      className={`boundary-chip ${visibleBoundaries.has(boundary.id) ? 'active' : 'inactive'}`}
+      onClick={() => onToggleBoundary(boundary.id)}
+      title={boundary.name}
+    >
+      <span
+        className="boundary-chip-color"
+        style={{ backgroundColor: boundary.boundary_color || '#228B22' }}
+      />
+      <span className="boundary-chip-name">{boundary.name}</span>
+    </button>
+  );
+
   return (
     <div className={`legend ${isExpanded ? 'legend-expanded' : ''} ${editMode ? 'legend-edit-mode' : ''}`}>
       <div className="legend-content">
@@ -105,79 +154,83 @@ function Legend({
           />
         </div>
 
-        <div className="legend-divider"></div>
-
-        <div className="legend-header-row">
-          <h4>Points of Interest</h4>
-          <div className="legend-filter-btns">
-            <button onClick={onShowAll} title="Show All POIs">All</button>
-            <button onClick={onHideAll} title="Hide All POIs">None</button>
+        <LegendSection
+          id="poi"
+          title="Points of Interest"
+          count={iconTypes.length}
+          isOpen={openSection === 'poi'}
+          onToggle={() => toggleSection('poi')}
+          showActions
+          onShowAll={onShowAll}
+          onHideAll={onHideAll}
+        >
+          <div className="legend-icons" role="group" aria-label="Map layer filters">
+            {iconTypes.map(type => {
+              if (type.type === 'layer') {
+                return (
+                  <button
+                    key={type.id}
+                    className={`legend-icon-item ${type.isActive ? 'active' : 'inactive'}`}
+                    onClick={type.onToggle}
+                    aria-pressed={type.isActive}
+                    type="button"
+                  >
+                    <img src={`/icons/layers/${type.id}.svg`} alt="" aria-hidden="true" />
+                    <span>{type.label}</span>
+                  </button>
+                );
+              } else {
+                const isActive = visibleTypes.has(type.id);
+                return (
+                  <button
+                    key={type.id}
+                    className={`legend-icon-item ${isActive ? 'active' : 'inactive'}`}
+                    onClick={() => onToggleType(type.id)}
+                    aria-pressed={isActive}
+                    type="button"
+                  >
+                    {type.svg_content ? (
+                      <div className="legend-icon-svg" aria-hidden="true" dangerouslySetInnerHTML={{ __html: type.svg_content }} />
+                    ) : (
+                      <img src={type.iconUrl || `/icons/${type.svg_filename}`} alt="" aria-hidden="true" />
+                    )}
+                    <span>{type.label}</span>
+                  </button>
+                );
+              }
+            })}
           </div>
-        </div>
+        </LegendSection>
 
-        <div className="legend-icons" role="group" aria-label="Map layer filters">
-          {iconTypes.map(type => {
-            if (type.type === 'layer') {
-              return (
-                <button
-                  key={type.id}
-                  className={`legend-icon-item ${type.isActive ? 'active' : 'inactive'}`}
-                  onClick={type.onToggle}
-                  aria-pressed={type.isActive}
-                  type="button"
-                >
-                  <img src={`/icons/layers/${type.id}.svg`} alt="" aria-hidden="true" />
-                  <span>{type.label}</span>
-                </button>
-              );
-            } else {
-              const isActive = visibleTypes.has(type.id);
-              return (
-                <button
-                  key={type.id}
-                  className={`legend-icon-item ${isActive ? 'active' : 'inactive'}`}
-                  onClick={() => onToggleType(type.id)}
-                  aria-pressed={isActive}
-                  type="button"
-                >
-                  {type.svg_content ? (
-                    <div className="legend-icon-svg" aria-hidden="true" dangerouslySetInnerHTML={{ __html: type.svg_content }} />
-                  ) : (
-                    <img src={type.iconUrl || `/icons/${type.svg_filename}`} alt="" aria-hidden="true" />
-                  )}
-                  <span>{type.label}</span>
-                </button>
-              );
-            }
-          })}
-        </div>
+        <LegendSection
+          id="parks"
+          title="Parks"
+          count={parkBoundaries.length}
+          isOpen={openSection === 'parks'}
+          onToggle={() => toggleSection('parks')}
+          showActions={parkBoundaries.length > 0}
+          onShowAll={() => onShowBoundaries(parkBoundaries.map(b => b.id))}
+          onHideAll={() => onHideBoundaries(parkBoundaries.map(b => b.id))}
+        >
+          <div className="boundary-chips">
+            {parkBoundaries.map(renderBoundaryChip)}
+          </div>
+        </LegendSection>
 
-        <div className="legend-divider"></div>
-        <div className="boundary-chips-header">
-          <h4>Boundaries & Overlays</h4>
-          {boundaries && boundaries.length > 0 && (
-            <div className="boundary-chips-actions">
-              <button onClick={onShowAllBoundaries} title="Show All">All</button>
-              <button onClick={onHideAllBoundaries} title="Hide All">None</button>
-            </div>
-          )}
-        </div>
-        <div className="boundary-chips">
-          {boundaries && boundaries.map(boundary => (
-            <button
-              key={boundary.id}
-              className={`boundary-chip ${visibleBoundaries.has(boundary.id) ? 'active' : 'inactive'}`}
-              onClick={() => onToggleBoundary(boundary.id)}
-              title={boundary.name}
-            >
-              <span
-                className="boundary-chip-color"
-                style={{ backgroundColor: boundary.boundary_color || '#228B22' }}
-              />
-              <span className="boundary-chip-name">{boundary.name}</span>
-            </button>
-          ))}
-        </div>
+        <LegendSection
+          id="municipal"
+          title="Municipal"
+          count={municipalBoundaries.length}
+          isOpen={openSection === 'municipal'}
+          onToggle={() => toggleSection('municipal')}
+          showActions={municipalBoundaries.length > 0}
+          onShowAll={() => onShowBoundaries(municipalBoundaries.map(b => b.id))}
+          onHideAll={() => onHideBoundaries(municipalBoundaries.map(b => b.id))}
+        >
+          <div className="boundary-chips">
+            {municipalBoundaries.map(renderBoundaryChip)}
+          </div>
+        </LegendSection>
 
       </div>
     </div>
@@ -877,7 +930,7 @@ function CoordinateConfirmDialog({ destination, newLat, newLng, onConfirm, onCan
 
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default']);
 
-function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, selectedLinearFeature, onSelectLinearFeature, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowAllBoundaries, onHideAllBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, visiblePoiCount, iconConfig }) {
+function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, selectedLinearFeature, onSelectLinearFeature, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, visiblePoiCount, iconConfig }) {
   const [isLegendExpanded, setIsLegendExpanded] = useState(false);
   const [useSatellite, setUseSatellite] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState(null); // Just for UI display
@@ -1463,9 +1516,10 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
         onToggleRivers={onToggleRivers}
         visibleBoundaries={visibleBoundaries}
         onToggleBoundary={onToggleBoundary}
-        onShowAllBoundaries={onShowAllBoundaries}
-        onHideAllBoundaries={onHideAllBoundaries}
-        boundaries={linearFeatures.filter(f => f.poi_roles?.includes('boundary') && !['county', 'state'].includes(f.boundary_type))}
+        onShowBoundaries={onShowBoundaries}
+        onHideBoundaries={onHideBoundaries}
+        parkBoundaries={linearFeatures.filter(f => f.poi_roles?.includes('boundary') && f.boundary_type === 'park')}
+        municipalBoundaries={linearFeatures.filter(f => f.poi_roles?.includes('boundary') && ['municipal','city','township','village','county','state'].includes(f.boundary_type))}
         visibleTypes={visibleTypes}
         onToggleType={handleToggleType}
         onShowAll={handleShowAll}


### PR DESCRIPTION
## Summary

- Refactor the map legend into three accordion sections — **Points of Interest** (default open), **Parks**, **Municipal** — with a fixed 320×min(480px,70vh) panel. Only one section open at a time, no scrollbars, All/None controls render only on the open section.
- Bundles issue #6: adds Astronomy activity, inline-SVG telescope icon, and the Fairlawn Rotary Observatory POI in Bath, OH (Summit County Astronomy Club). Description includes meetup link, JWST site status, and the Celestron EdgeHD 14" / Astro-Physics 1200 setup.
- Migration `052` recategorizes legacy `boundary_type='cvnp'` rows into `park` (CVNP itself) vs. `municipal` (cities/townships) so the new sections populate correctly. `server.js` startup default for untyped boundaries flips from `cvnp` → `municipal`.

Spec: `.specify/specs/015-grouped-legend-sections/`

Closes #6

## Test plan
- [x] `./run.sh build` clean
- [x] Verified in browser at localhost:8084 — accordion behavior, fixed panel size, Parks (2) + Municipal (15) populated, Astronomy chip + Fairlawn Rotary pin appear
- [x] Gatehouse review (1 HIGH was false positive on `primary_activities` column type — confirmed `text` not `text[]`; 2 MEDIUMs are pre-existing repo state)
- [ ] Production smoke check post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)