### PR TITLE
fix: newsletter digest TZ + start times + brand polish

### DIFF
--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -70,13 +70,13 @@ export async function generateDigest(pool, tz = 'America/New_York') {
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
     h1 {
-      color: #2c5f2d;
-      border-bottom: 3px solid #2c5f2d;
+      color: #2d5016;
+      border-bottom: 3px solid #2d5016;
       padding-bottom: 10px;
       margin-top: 0;
     }
     h2 {
-      color: #2c5f2d;
+      color: #2d5016;
       margin-top: 30px;
       font-size: 1.3em;
     }
@@ -100,7 +100,7 @@ export async function generateDigest(pool, tz = 'America/New_York') {
       margin-bottom: 5px;
     }
     .poi-name {
-      color: #2c5f2d;
+      color: #2d5016;
       font-weight: 500;
       font-size: 0.9em;
     }
@@ -109,7 +109,7 @@ export async function generateDigest(pool, tz = 'America/New_York') {
       color: #555;
     }
     .read-more {
-      color: #2c5f2d;
+      color: #2d5016;
       text-decoration: none;
       font-weight: 500;
     }
@@ -125,19 +125,30 @@ export async function generateDigest(pool, tz = 'America/New_York') {
       text-align: center;
     }
     .footer a {
-      color: #2c5f2d;
+      color: #2d5016;
       text-decoration: none;
     }
     .no-content {
       color: #666;
       font-style: italic;
     }
+    .brand-banner {
+      display: block;
+      width: 100%;
+      max-width: 540px;
+      height: auto;
+      margin: 0 auto 20px;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body>
   <div class="container">
+    <a href="https://rootsofthevalley.org">
+      <img src="https://rootsofthevalley.org/brand/rotv-header-1200x490.png" alt="Roots of The Valley" class="brand-banner" />
+    </a>
     <h1>What's Happening in the Valley This Weekend</h1>
-    <p>Your weekly digest from <a href="https://rootsofthevalley.org" style="color: #2c5f2d;">Roots of The Valley</a></p>
+    <p>Your weekly digest from <a href="https://rootsofthevalley.org" style="color: #2d5016;">Roots of The Valley</a></p>
 `;
 
   // Events section
@@ -147,10 +158,13 @@ export async function generateDigest(pool, tz = 'America/New_York') {
 `;
     events.forEach(event => {
       const startDate = new Date(event.start_date);
-      const dateStr = startDate.toLocaleDateString('en-US', {
+      const dateStr = startDate.toLocaleString('en-US', {
         weekday: 'long',
         month: 'long',
-        day: 'numeric'
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: tz
       });
 
       html += `


### PR DESCRIPTION
## Summary

- **Latent TZ bug fix**: digest formatter now passes `timeZone: tz` to `toLocaleString`, so events render in `America/New_York` instead of the Node process's local TZ. Without this, an event at `2026-05-23 00:00:00+00` (= Fri 5/22 8 PM EDT) gets mis-labeled as "Saturday, May 23" if the container runs in UTC.
- **Start times in event rows**: switched `toLocaleDateString` → `toLocaleString` with `hour/minute`, so same-day events (e.g. two Cleveland Metroparks archery sessions back-to-back) no longer read as visual duplicates.
- **Brand alignment**: replaced the slightly-off newsletter green (`#2c5f2d`) with the site primary (`#2d5016`) — 6 occurrences.
- **Header banner**: added a linked `<img>` of `/brand/rotv-header-1200x490.png` at the top of the email so subscribers recognize the source at a glance.

Single file: `backend/services/newsletterDigestService.js`, +23/-9.

## Test plan

- [ ] After merge + deploy, trigger digest manually from admin Jobs panel
- [ ] Send test send to scott.mccarty@gmail.com
- [ ] Verify event rows show weekday + date + start time
- [ ] Verify the Fri 5/22 8 PM Kristine Jackson concert reads "Friday, May 22" (not "Saturday")
- [ ] Verify banner image loads and links to rootsofthevalley.org
- [ ] Verify green matches the site header

🤖 Generated with [Claude Code](https://claude.com/claude-code)