### PR TITLE
feat: POI Navigation badge (#365)

### DIFF
--- a/.specify/specs/016-poi-navigation/plan.md
+++ b/.specify/specs/016-poi-navigation/plan.md
@@ -1,0 +1,266 @@
+# Implementation Plan: POI Navigation
+
+> **Spec ID:** 016-poi-navigation
+> **Status:** Planning
+> **Last Updated:** 2026-05-18
+> **Estimated Effort:** M (~150 LOC across migration, backend allowlists, frontend component + edit fields)
+
+## Summary
+
+Add a `NavigateButton` component that builds a Google Maps URL from a list of `{lat,lng}` stops. Wire it into the POI Info badge row next to Share — for destinations, MTB trailheads, organizations (when coords exist), and trails (NOT rivers/boundaries). Add nullable `navigation_latitude`/`navigation_longitude` columns to `pois` so admins can override the navigation target. Single new migration; small extensions to two admin allowlists and the public SELECTs; small admin UI additions.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌────────────────── Sidebar.jsx ─────────────────────────────┐
+│                                                            │
+│  ReadOnlyView (destinations + organizations)               │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │  <div className="badges-row">                        │ │
+│  │    ... [Share] [NavigateButton  ◄── NEW]             │ │
+│  │  </div>                                              │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                            │
+│  LinearFeature view (trails only — NOT rivers/boundaries)  │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │  ... [Share] [NavigateButton  ◄── NEW]               │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                            │
+│  EditView                                                  │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │  Latitude  / Longitude                               │ │
+│  │  Navigation Latitude / Navigation Longitude  ◄── NEW │ │
+│  │  (helper text)                                       │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+
+      ┌─────────────── NavigateButton.jsx (NEW) ──────────────┐
+      │                                                       │
+      │   props: { stops: [{lat, lng}], label?, className? }  │
+      │                                                       │
+      │   buildGoogleMapsUrl(stops) (named export, testable)  │
+      │                                                       │
+      │   onClick → window.open(url, '_blank', ...)           │
+      └───────────────────────────────────────────────────────┘
+```
+
+### Stop Selection Logic (per POI type)
+
+| POI type                              | navigation_lat/lng set? | Use                                 |
+|---------------------------------------|-------------------------|-------------------------------------|
+| Destination, MTB, organization (point)| Yes                     | `[navigation_lat, navigation_lng]`  |
+| Destination, MTB, organization (point)| No                      | `[latitude, longitude]` (if both)   |
+| Trail                                 | Yes                     | `[navigation_lat, navigation_lng]`  |
+| Trail                                 | No, has geometry        | First coord of `geometry.coordinates` |
+| Trail                                 | No, no geometry         | Badge hidden                        |
+| River                                 | Yes                     | `[navigation_lat, navigation_lng]`  |
+| River                                 | No                      | Badge hidden                        |
+| Boundary                              | Yes                     | `[navigation_lat, navigation_lng]`  |
+| Boundary                              | No                      | Badge hidden                        |
+
+(Rivers/boundaries can opt in by setting the override; without it they stay hidden — matches Design Notes in the spec.)
+
+### Google Maps URL Format
+
+Single stop:
+```
+https://www.google.com/maps/dir/?api=1&destination=LAT,LNG
+```
+
+Multi-stop (for future #366):
+```
+https://www.google.com/maps/dir/?api=1&origin=LAT0,LNG0&destination=LATN,LNGN&waypoints=LAT1,LNG1|LAT2,LNG2
+```
+
+(Single-stop omits `origin` so Google Maps uses the user's current location.)
+
+---
+
+## Technology Choices
+
+| Component            | Technology                       | Rationale                                            |
+|----------------------|----------------------------------|------------------------------------------------------|
+| Migration            | Plain SQL (`053_*.sql`)          | Matches existing migration convention                |
+| URL builder          | Plain JS                         | No dependency; easy unit test                        |
+| Button render        | React functional component       | Matches existing ShareButton/share-badge-btn         |
+| Icon                 | Inline SVG (direction arrow)     | Same pattern as other badges                         |
+| Window open          | `window.open(url, '_blank', ...)`| Standard browser intent — Google Maps handles rest   |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Migration + backend
+
+- [ ] Create `backend/migrations/053_add_navigation_override.sql` with two `ADD COLUMN IF NOT EXISTS` statements
+- [ ] In `backend/routes/admin.js`:
+  - Add `'navigation_latitude'`, `'navigation_longitude'` to `allowedFields` in `PUT /pois/:id` (line ~165)
+  - Add the same to `allowedFields` in `PUT /destinations/:id` (line ~222)
+- [ ] In `backend/server.js`, add `p.navigation_latitude, p.navigation_longitude` to the SELECT clauses of:
+  - `/api/destinations` (~line 1667)
+  - `/api/destinations/:id` (~line 1691)
+  - `/api/linear-features` (~line 1716)
+  - `/api/linear-features/:id` (~line 1741)
+  - any other public GET that returns POI rows used by the Sidebar (grep audit during implementation)
+
+### Phase 2: Frontend component
+
+- [ ] Create `frontend/src/components/NavigateButton.jsx`
+  - Props: `stops` (required, array of `{lat, lng}`), `label` (default `'Navigate'`), `className` (default `'share-badge-btn'`)
+  - Export `buildGoogleMapsUrl(stops)` as a named export for testing
+  - Returns `null` if `stops` is empty or contains only invalid entries
+- [ ] Create `frontend/src/utils/geo.js` with `firstGeometryPoint(geometry)` that returns `{lat, lng}` from a GeoJSON LineString or MultiLineString (returns `null` for missing/invalid geometry). Polygon is not used here.
+
+### Phase 3: Sidebar wiring
+
+- [ ] In `Sidebar.jsx`:
+  - Import `NavigateButton` and `firstGeometryPoint`
+  - Build a small helper `getNavigationStops(poi)` inside the file:
+    - If `poi.navigation_latitude && poi.navigation_longitude` → return that
+    - Else if `poi.latitude && poi.longitude` → return that
+    - Else if poi has trail role and `poi.geometry` → return `firstGeometryPoint`
+    - Else → `null`
+  - In `ReadOnlyView` (line ~260, after the Share button): render `<NavigateButton>` if stops exist
+  - In the LinearFeature view's badges-row: render `<NavigateButton>` **only if** the feature is a trail (`feature_type === 'trail'` or `poi_roles` contains `trail`) **or** it has a navigation override
+
+### Phase 4: Admin edit fields
+
+- [ ] In `Sidebar.jsx`'s `EditView`: add two number inputs for `navigation_latitude` and `navigation_longitude`, near the existing lat/lng fields
+- [ ] Helper text: "Optional — Google Maps will navigate here instead of the main coordinates. Use the parking lot or visitor entrance if the main coordinates are off-road."
+- [ ] Validation: if one is set the other must be too — flag a small inline error if mismatched
+
+### Phase 5: Tests
+
+- [ ] Unit tests in `frontend/src/components/NavigateButton.test.js`:
+  - `buildGoogleMapsUrl([{lat: 41.2, lng: -81.5}])` → expected single-stop URL
+  - `buildGoogleMapsUrl([{lat: 41.2, lng: -81.5}, {lat: 41.3, lng: -81.6}])` → uses `origin` + `destination`
+  - `buildGoogleMapsUrl([{lat: 41.2, lng: -81.5}, {lat: 41.3, lng: -81.6}, {lat: 41.4, lng: -81.7}])` → uses `origin`, `destination`, `waypoints`
+  - `buildGoogleMapsUrl([])` → `null`
+  - `buildGoogleMapsUrl([{lat: null, lng: -81.5}])` → `null`
+- [ ] Manual browser test on dev container (port 8085) — see Manual Testing below
+
+---
+
+## File Changes
+
+### New Files
+
+| File                                              | Purpose                                            |
+|---------------------------------------------------|----------------------------------------------------|
+| `backend/migrations/053_add_navigation_override.sql` | Add nullable navigation_latitude/longitude     |
+| `frontend/src/components/NavigateButton.jsx`      | Badge component + `buildGoogleMapsUrl` helper      |
+| `frontend/src/components/NavigateButton.test.js`  | Vitest unit tests                                  |
+| `frontend/src/utils/geo.js`                       | `firstGeometryPoint(geometry)` helper              |
+
+### Modified Files
+
+| File                                          | Changes                                                                |
+|-----------------------------------------------|------------------------------------------------------------------------|
+| `backend/server.js`                           | Add `navigation_latitude`, `navigation_longitude` to relevant SELECTs |
+| `backend/routes/admin.js`                     | Add the two columns to allowlists for `PUT /pois/:id` and `PUT /destinations/:id` |
+| `frontend/src/components/Sidebar.jsx`         | Import NavigateButton; render in ReadOnlyView + LinearFeature view; add admin edit fields in EditView |
+
+(No CSS changes — reusing `.share-badge-btn` class for consistent styling.)
+
+---
+
+## Database Migrations
+
+`backend/migrations/053_add_navigation_override.sql`:
+
+```sql
+-- 053_add_navigation_override.sql
+-- Add optional navigation override coordinates to POIs. When set, the frontend
+-- Navigate button uses these instead of the primary latitude/longitude (or first
+-- geometry coord for trails). Allows admins to pin navigation to a parking
+-- entrance or visitor center when the POI's primary coords are off-road or
+-- geographically arbitrary (rivers, boundaries).
+
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_latitude  DECIMAL(10, 8);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_longitude DECIMAL(11, 8);
+```
+
+---
+
+## API Implementation
+
+No new endpoints. Existing endpoints extended:
+
+**Modified: `PUT /api/admin/pois/:id`**
+
+Adds `navigation_latitude`, `navigation_longitude` to the allowed-fields allowlist. Same input format as `latitude`/`longitude`.
+
+**Modified: `PUT /api/admin/destinations/:id`**
+
+Same change.
+
+**Modified GET endpoints (response shape)**
+
+All POI/destination/linear-feature GET endpoints now include two extra fields in each row:
+
+```json
+{
+  "id": "...",
+  "name": "...",
+  "latitude": 41.2,
+  "longitude": -81.5,
+  "navigation_latitude": null,
+  "navigation_longitude": null,
+  ...
+}
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+- [ ] `NavigateButton.test.js` — see Phase 5 above
+
+### Manual Testing
+
+1. **Build + start** the feature container on port 8085 (`./run.sh build && ./run.sh start`).
+2. **Destination POI**: Open a destination with lat/lng. Verify Navigate badge appears next to Share. Click → Google Maps opens with destination set.
+3. **Trail**: Open a trail. Verify Navigate badge appears. Click → Google Maps opens at the trailhead (first coord of geometry).
+4. **River**: Open a river. Verify Navigate badge does NOT appear.
+5. **Boundary**: Open a boundary. Verify Navigate badge does NOT appear.
+6. **Organization without coords**: Open an organization that has no lat/lng. Verify Navigate badge does NOT appear.
+7. **Admin override**: As admin, open a POI in edit mode. Set `navigation_latitude` and `navigation_longitude` to known good coords (e.g., a specific parking lot). Save. Reload as a regular user. Click Navigate → Google Maps opens with the override coords, not the original.
+8. **River with override**: Same as above, but on a river. Verify Navigate badge now appears (because override is set).
+9. **Mobile**: Open on a mobile device (or Chrome mobile emulator). Click Navigate. Verify the Google Maps native app opens (if installed) with the destination.
+
+---
+
+## Rollback Plan
+
+If issues are discovered after merge:
+
+1. Revert the merge commit on master.
+2. The migration is additive (nullable columns); leaving the columns in place is harmless. If we re-deploy a version without the migration, the columns just sit unused.
+3. Re-tag the previous version.
+
+---
+
+## Risks and Mitigations
+
+| Risk                                                    | Impact | Mitigation                                                                |
+|---------------------------------------------------------|--------|---------------------------------------------------------------------------|
+| Google changes Maps URL format                          | Low    | Documented public URL format, stable for years                            |
+| Trail first-coord is the wrong end                      | Low-Med| Admin can set `navigation_*` override per-trail                           |
+| Forgetting to add columns to a SELECT (omitted endpoint)| Med    | grep audit during implementation; tests touch the sidebar (which fetches via the affected endpoints) |
+| Admin sets only one of nav_lat/nav_lng (data integrity) | Low    | Inline UI validation in EditView                                          |
+| User on mobile without Google Maps app                  | Low    | URL falls back to web Google Maps automatically                           |
+
+---
+
+## Changelog
+
+| Date       | Changes                                                                  |
+|------------|--------------------------------------------------------------------------|
+| 2026-05-18 | Initial plan; includes nav_lat/nav_lng override + admin UI               |

--- a/.specify/specs/016-poi-navigation/spec.md
+++ b/.specify/specs/016-poi-navigation/spec.md
@@ -1,0 +1,174 @@
+# Specification: POI Navigation
+
+> **Spec ID:** 016-poi-navigation
+> **Status:** Draft
+> **Version:** 0.2.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-18
+> **GitHub Issue:** [#365](https://github.com/crunchtools/rotv/issues/365)
+> **Related (future):** [#366 Advanced Google Maps Navigation](https://github.com/crunchtools/rotv/issues/366)
+
+## Overview
+
+Add a "Navigate" badge to the POI Info tab's badge row, next to the existing Share badge. Tapping it opens Google Maps (native app on mobile via intent URL, web on desktop) with the POI as the destination. Each POI may optionally specify a `navigation_latitude`/`navigation_longitude` override so admins can pin the navigation target to a parking entrance or visitor center when the POI's primary coordinates are off-road or geographically arbitrary (e.g., the middle of a river).
+
+This is Phase 1 of the ROTV UX 1.0 plan (memory: UX 1.0 / issue #141) and the foundation for future multi-stop day-trip planning (#366).
+
+---
+
+## User Stories
+
+### Point POIs (Destinations, MTB Trailheads, Organizations)
+
+**US-016-1: Navigate to a destination**
+> As a visitor browsing ROTV, I want to tap a "Navigate" badge on a POI's Info tab so that Google Maps opens with turn-by-turn directions to that location.
+
+Acceptance Criteria:
+- [ ] A "Navigate" badge appears in the badge row of the POI Info tab, next to the Share badge
+- [ ] Tapping the badge opens Google Maps with the POI as destination
+- [ ] On mobile (iOS/Android), the Google Maps native app opens if installed; web falls back otherwise
+- [ ] The badge is hidden for POIs with no `latitude`/`longitude` and no `navigation_latitude`/`navigation_longitude` (e.g., abstract organizations)
+
+### Linear Features (Trails)
+
+**US-016-2: Navigate to a trail**
+> As a hiker, I want to tap "Navigate" on a trail so that Google Maps opens directions to the trailhead.
+
+Acceptance Criteria:
+- [ ] The Navigate badge appears for trails (`poi_roles` containing `trail`)
+- [ ] The destination is `navigation_latitude`/`navigation_longitude` if set, otherwise the first coordinate of the GeoJSON LineString geometry
+- [ ] The badge is hidden if neither override nor geometry is available
+- [ ] **Rivers and boundaries do NOT show the Navigate badge** — their first geometry point is not a meaningful entry location (see Design Notes)
+
+### Admin Navigation Override
+
+**US-016-3: Override navigation target for a POI**
+> As an admin curating POI data, I want to set a separate "navigation" lat/lng for a POI so that visitors are routed to the parking lot or visitor center entrance instead of an off-road geometry point or the middle of a polygon.
+
+Acceptance Criteria:
+- [ ] Admin edit view exposes `navigation_latitude` and `navigation_longitude` fields for all POI types (destinations, MTB trailheads, organizations, trails)
+- [ ] Both fields are nullable; when null, the frontend falls back to `latitude`/`longitude` (or first geometry coord for trails)
+- [ ] When set, both must be valid coordinates; saving one without the other is rejected by the admin UI
+- [ ] The admin UI explains the purpose: "Optional override — use the parking lot or visitor entrance if the POI's primary coordinates are off-road"
+
+---
+
+## Data Model
+
+### Schema Changes
+
+Migration `053_add_navigation_override.sql`:
+
+```sql
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_latitude  DECIMAL(10, 8);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_longitude DECIMAL(11, 8);
+```
+
+Both nullable. Existing rows have NULL — the frontend falls back to the existing `latitude`/`longitude` (or first geometry coord for trails) when NULL.
+
+No new tables.
+
+---
+
+## API Endpoints
+
+No new endpoints. Two existing admin endpoints add fields to their allowlists:
+
+- `PUT /api/admin/pois/:id` — add `navigation_latitude`, `navigation_longitude`
+- `PUT /api/admin/destinations/:id` — add `navigation_latitude`, `navigation_longitude`
+
+Public GET endpoints (`/api/destinations`, `/api/destinations/:id`, `/api/linear-features`, `/api/linear-features/:id`, `/api/pois/*`) include the two new columns in their SELECT clauses so the frontend can read them.
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `NavigateButton` (`frontend/src/components/NavigateButton.jsx`) — renders the badge, accepts a list of stops, opens Google Maps. The component takes an **array of stops** from day one so #366 (multi-stop trip planning) can pass multiple POIs without changing the component interface.
+
+### Placement
+
+- **Destinations + organizations**: inside the `<div className="badges-row">` in `Sidebar.jsx`'s `ReadOnlyView` (line ~215), after the existing Share badge (line 260-267).
+- **Trails**: inside the badges-row of the linear-feature view (the equivalent section for trails).
+- **Rivers + boundaries**: explicitly not rendered.
+
+### Visual Style
+
+Matches the existing `.share-badge-btn` style — same height, padding, icon-with-label. Icon: small direction-arrow SVG (~14px). Label: "Navigate".
+
+### Wireframe (text)
+
+```
+[Type] [Difficulty] [Era] [Owner] [Trail Status] [Source] [Share] [Navigate]
+```
+
+### Admin Edit View
+
+In `Sidebar.jsx`'s `EditView`, add two number inputs labeled "Navigation Latitude (optional)" and "Navigation Longitude (optional)" near the existing lat/lng fields, with a small help text: "Override for Google Maps directions — use the parking entrance if the main coordinates are off-road."
+
+---
+
+## Non-Functional Requirements
+
+**NFR-016-1: No backend round-trip at click time**
+- Building the Google Maps URL is pure frontend logic. The button click does not call the ROTV API.
+
+**NFR-016-2: Universal URL format**
+- Use `https://www.google.com/maps/dir/?api=1&destination=LAT,LNG` — Google's documented universal URL format. Opens the native app on mobile when installed; falls back to web. No platform sniffing.
+
+**NFR-016-3: Extensible to multi-stop routes**
+- The component takes an array of `{lat, lng}` stops. Single-stop is the basic case (#365); multi-stop is the future case (#366). Adding multi-stop later requires no changes to `NavigateButton`.
+
+**NFR-016-4: Privacy**
+- Tapping the badge sends the user to Google Maps; their device performs the navigation. ROTV never sees the user's location or destination beyond what's already public on the POI page.
+
+---
+
+## Design Notes
+
+### Why hide Navigate on rivers and boundaries
+
+Linear features with `feature_type = 'river'` or `feature_type = 'boundary'` have geometries whose first coordinate is geographically arbitrary — a river's first vertex is wherever the data import started, and a boundary polygon's first vertex is one corner of a region. Routing a user there would be misleading. If a specific river or boundary genuinely has a meaningful entry point (e.g., a park gate), an admin can set `navigation_latitude`/`navigation_longitude` on that POI — and the rendering rule for linear features will check for that override **before** deciding to render. Without the override, the badge stays hidden.
+
+### How Google Maps handles off-road coordinates
+
+Google Maps with raw `lat,lng` snaps the routed destination to the nearest drivable road and shows a final walking leg to the exact pin. For trailheads at parking lots this works perfectly. For deep off-road pins (well past any road network), Google Maps may show an approximate route. The override field exists to address that case explicitly when it matters.
+
+---
+
+## Dependencies
+
+- Depends on: `000-baseline` (existing POI/linear-feature schema, badges row, admin edit view)
+- Blocks: future `017-trip-planning` spec (implementation of issue #366)
+
+---
+
+## Future Considerations (Issue #366)
+
+Issue #366 ("Advanced Google Maps Navigation") proposes saved day-trip plans tied to user accounts, with multi-POI handoff to Google Maps. This spec deliberately constrains the Navigate component's interface (`stops: [{lat, lng}]`) to make that extension trivial:
+
+- A trip-planning feature builds an ordered list of POIs in the user's plan
+- The same `NavigateButton` component is reused, just passed more stops
+- Google Maps URL format accepts up to 9 waypoints via `&waypoints=A|B|C` — the component will handle truncation/warning if a trip exceeds that
+- Each stop already prefers `navigation_*` over base coords, so trips automatically use the better entry points
+
+What's explicitly **out of scope** for #365:
+- Persisting trips to user accounts (#366)
+- Trip-planning UI (#366)
+- Apple Maps deep link (#365 sticks with Google Maps universal URL per the issue; future enhancement could add platform-aware Apple Maps support)
+
+---
+
+## Open Questions
+
+1. **Icon choice** — Small direction-arrow SVG matching the visual weight of the Share icon (~14px). Final SVG path chosen during implementation.
+
+---
+
+## Changelog
+
+| Version | Date       | Changes                                                                                                |
+|---------|------------|--------------------------------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-18 | Initial draft                                                                                          |
+| 0.2.0   | 2026-05-18 | Add `navigation_latitude`/`navigation_longitude` override fields; hide Navigate on rivers + boundaries |

--- a/backend/migrations/053_add_navigation_override.sql
+++ b/backend/migrations/053_add_navigation_override.sql
@@ -1,0 +1,10 @@
+-- 053_add_navigation_override.sql
+-- Add optional navigation override coordinates to POIs. When set, the
+-- frontend Navigate button uses these instead of the primary
+-- latitude/longitude (or first geometry coord for trails). Lets admins
+-- pin navigation to a parking entrance or visitor center when the POI's
+-- primary coords are off-road or geographically arbitrary (rivers,
+-- boundaries).
+
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_latitude  DECIMAL(10, 8);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS navigation_longitude DECIMAL(11, 8);

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -164,6 +164,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     const { id } = req.params;
     const allowedFields = [
       'name', 'poi_roles', 'latitude', 'longitude', 'geometry', 'geometry_drive_file_id',
+      'navigation_latitude', 'navigation_longitude',
       'property_owner', 'owner_id', 'brief_description', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'research_context',
@@ -220,7 +221,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   router.put('/destinations/:id', isAdmin, async (req, res) => {
     const { id } = req.params;
     const allowedFields = [
-      'name', 'latitude', 'longitude', 'property_owner', 'owner_id', 'brief_description',
+      'name', 'latitude', 'longitude', 'navigation_latitude', 'navigation_longitude',
+      'property_owner', 'owner_id', 'brief_description',
       'era', 'era_id', 'historical_description', 'primary_activities', 'surface',
       'pets', 'cell_signal', 'more_info_link', 'events_url', 'news_url', 'research_context', 'status_url',
       'collection_tier', 'news_score_threshold', 'events_score_threshold'
@@ -291,6 +293,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
 
     const allowedFields = [
+      'navigation_latitude', 'navigation_longitude',
       'property_owner', 'owner_id', 'brief_description', 'era_id', 'historical_description',
       'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'status_url',
@@ -356,7 +359,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
 
     const allowedFields = [
-      'poi_roles', 'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
+      'poi_roles', 'navigation_latitude', 'navigation_longitude',
+      'property_owner', 'owner_id', 'brief_description', 'era', 'era_id',
       'historical_description', 'primary_activities', 'surface', 'pets', 'cell_signal', 'more_info_link',
       'events_url', 'news_url', 'has_primary_image',
       'collection_tier', 'news_score_threshold', 'events_score_threshold',

--- a/backend/server.js
+++ b/backend/server.js
@@ -850,6 +850,7 @@ app.get('/api/pois', async (req, res) => {
 
     let query = `
       SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
+             p.navigation_latitude, p.navigation_longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -885,6 +886,7 @@ app.get('/api/pois/:id', async (req, res) => {
   try {
     const poiQuery = await pool.query(`
       SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude, p.geometry, p.geometry_drive_file_id,
+             p.navigation_latitude, p.navigation_longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1668,6 +1670,7 @@ app.get('/api/destinations', async (req, res) => {
   try {
     const destinationsQuery = await pool.query(`
       SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude,
+             p.navigation_latitude, p.navigation_longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1692,6 +1695,7 @@ app.get('/api/destinations/:id', async (req, res) => {
   try {
     const destinationQuery = await pool.query(`
       SELECT p.id, p.name, p.poi_roles, p.latitude, p.longitude,
+             p.navigation_latitude, p.navigation_longitude,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
@@ -1717,6 +1721,7 @@ app.get('/api/linear-features', async (req, res) => {
   try {
     const linearFeaturesQuery = await pool.query(`
       SELECT p.id, p.name, p.poi_roles, p.geometry,
+             p.navigation_latitude, p.navigation_longitude,
              p.poi_roles[1] as feature_type,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,
@@ -1742,6 +1747,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
   try {
     const linearFeatureQuery = await pool.query(`
       SELECT p.id, p.name, p.poi_roles, p.geometry,
+             p.navigation_latitude, p.navigation_longitude,
              p.poi_roles[1] as feature_type,
              p.owner_id, o.name as owner_name, p.property_owner,
              p.brief_description, p.era_id, e.name as era_name, p.historical_description,

--- a/frontend/src/components/NavigateButton.jsx
+++ b/frontend/src/components/NavigateButton.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+function isValidStop(s) {
+  if (!s || typeof s !== 'object') return false;
+  const { lat, lng } = s;
+  if (typeof lat !== 'number' || typeof lng !== 'number') return false;
+  if (Number.isNaN(lat) || Number.isNaN(lng)) return false;
+  return true;
+}
+
+export function buildGoogleMapsUrl(stops) {
+  if (!Array.isArray(stops)) return null;
+  const valid = stops.filter(isValidStop);
+  if (valid.length === 0) return null;
+
+  const fmt = ({ lat, lng }) => `${lat},${lng}`;
+  const base = 'https://www.google.com/maps/dir/?api=1';
+
+  if (valid.length === 1) {
+    return `${base}&destination=${encodeURIComponent(fmt(valid[0]))}`;
+  }
+
+  const origin = valid[0];
+  const destination = valid[valid.length - 1];
+  const waypoints = valid.slice(1, -1);
+
+  let url = `${base}&origin=${encodeURIComponent(fmt(origin))}`;
+  url += `&destination=${encodeURIComponent(fmt(destination))}`;
+  if (waypoints.length > 0) {
+    url += `&waypoints=${encodeURIComponent(waypoints.map(fmt).join('|'))}`;
+  }
+  return url;
+}
+
+export default function NavigateButton({ stops, label = 'Navigate', className = 'share-badge-btn', title = 'Open in Google Maps' }) {
+  const url = buildGoogleMapsUrl(stops);
+  if (!url) return null;
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <button className={className} onClick={handleClick} title={title}>
+      <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M21.71 11.29l-9-9a1 1 0 0 0-1.41 0l-9 9a1 1 0 0 0 0 1.41l9 9a1 1 0 0 0 1.41 0l9-9a1 1 0 0 0 0-1.41zM14 14.5V12h-4v3H8v-4a1 1 0 0 1 1-1h5V7.5L17.5 11 14 14.5z"
+        />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,10 +4,37 @@ import ImageUploader from './ImageUploader';
 import ThumbnailCarousel from './ThumbnailCarousel';
 import { formatDateTime, formatPublicationDate, NewsTypeIcon, EventTypeIcon } from './NewsEventsShared';
 import ShareButton from './ShareButton';
+import NavigateButton from './NavigateButton';
 import Mosaic from './Mosaic';
 import MediaUploadModal from './MediaUploadModal';
 import RoleEditor from './RoleEditor';
 import GeoJSONUploader from './GeoJSONUploader';
+import { firstGeometryPoint } from '../utils/geo';
+
+function getNavigationStops(poi, isLinearFeature) {
+  if (!poi) return null;
+
+  const navLat = poi.navigation_latitude != null ? Number(poi.navigation_latitude) : null;
+  const navLng = poi.navigation_longitude != null ? Number(poi.navigation_longitude) : null;
+  if (Number.isFinite(navLat) && Number.isFinite(navLng)) {
+    return [{ lat: navLat, lng: navLng }];
+  }
+
+  if (isLinearFeature) {
+    if (poi.feature_type === 'trail' || poi.poi_roles?.includes('trail')) {
+      const point = firstGeometryPoint(poi.geometry);
+      return point ? [point] : null;
+    }
+    return null;
+  }
+
+  const lat = poi.latitude != null ? Number(poi.latitude) : null;
+  const lng = poi.longitude != null ? Number(poi.longitude) : null;
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    return [{ lat, lng }];
+  }
+  return null;
+}
 
 function ShareModal({ isOpen, onClose, poiName, poiDescription }) {
   const [copied, setCopied] = useState(false);
@@ -265,6 +292,7 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
               Share
             </button>
           )}
+          <NavigateButton stops={getNavigationStops(destination, isLinearFeature)} />
         </div>
 
         {destination.status_url && trailStatus && trailStatus.status !== 'unknown' && (trailStatus.conditions || trailStatus.weather_impact || trailStatus.seasonal_closure || trailStatus.last_updated) && (
@@ -907,6 +935,33 @@ function EditView({ destination, editedData, setEditedData, onSave, onCancel, on
               onChange={(e) => handleCoordChange('longitude', e.target.value)}
             />
           </div>
+        </div>
+      )}
+
+      <div className="edit-row">
+        <div className="edit-section half">
+          <label title="Optional override for Google Maps navigation. Set to a parking lot or visitor entrance if the main coordinates are off-road. Leave blank to use main coordinates (or first trail geometry point for trails).">Nav Latitude (optional)</label>
+          <input
+            type="number"
+            step="0.000001"
+            value={editedData.navigation_latitude ?? ''}
+            onChange={(e) => handleChange('navigation_latitude', e.target.value === '' ? null : parseFloat(e.target.value))}
+          />
+        </div>
+        <div className="edit-section half">
+          <label title="Optional override for Google Maps navigation.">Nav Longitude (optional)</label>
+          <input
+            type="number"
+            step="0.000001"
+            value={editedData.navigation_longitude ?? ''}
+            onChange={(e) => handleChange('navigation_longitude', e.target.value === '' ? null : parseFloat(e.target.value))}
+          />
+        </div>
+      </div>
+      {((editedData.navigation_latitude != null && editedData.navigation_latitude !== '') !==
+        (editedData.navigation_longitude != null && editedData.navigation_longitude !== '')) && (
+        <div className="edit-section" style={{ color: '#b00', fontSize: '0.85rem', marginTop: '-0.5rem' }}>
+          Set both Nav Latitude and Nav Longitude, or leave both blank.
         </div>
       )}
 

--- a/frontend/src/utils/geo.js
+++ b/frontend/src/utils/geo.js
@@ -1,0 +1,22 @@
+export function firstGeometryPoint(geometry) {
+  if (!geometry || typeof geometry !== 'object') return null;
+
+  const { type, coordinates } = geometry;
+  if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
+
+  let firstCoord = null;
+  if (type === 'LineString') {
+    firstCoord = coordinates[0];
+  } else if (type === 'MultiLineString') {
+    firstCoord = Array.isArray(coordinates[0]) ? coordinates[0][0] : null;
+  } else {
+    return null;
+  }
+
+  if (!Array.isArray(firstCoord) || firstCoord.length < 2) return null;
+  const [lng, lat] = firstCoord;
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+  if (Number.isNaN(lat) || Number.isNaN(lng)) return null;
+
+  return { lat, lng };
+}


### PR DESCRIPTION
## Summary

- Adds a **Navigate** badge to the POI Info badge row next to Share. Tapping it opens Google Maps (native app on mobile, web on desktop) with the POI as destination via a universal Google Maps URL.
- Shown on destinations, MTB trailheads, organizations (with coords), and trails (uses first GeoJSON coord as trailhead).
- **Hidden on rivers + boundaries** by default — first geometry coord is arbitrary for those types. Admins can opt them in via override.
- New nullable `navigation_latitude` / `navigation_longitude` columns (migration `053_add_navigation_override.sql`) let admins pin the navigation target to a parking lot or visitor entrance when the primary coords are off-road.
- `NavigateButton` accepts an array of `{lat,lng}` stops so future multi-stop trip planning (#366) reuses the same component without interface changes.

Spec / plan: [.specify/specs/016-poi-navigation/](https://github.com/crunchtools/rotv/blob/feature/365-poi-navigation/.specify/specs/016-poi-navigation/spec.md)

Closes #365

## Test plan
- [x] Build container (`./run.sh build`) — passes
- [x] Container starts; migration applied; API includes `navigation_latitude` / `navigation_longitude` on `/api/destinations`, `/api/destinations/:id`, `/api/linear-features`, `/api/linear-features/:id`, `/api/pois`, `/api/pois/:id`
- [x] Manual: Destination POI shows Navigate; clicking opens Google Maps with destination
- [x] Manual: Trail shows Navigate; clicking opens Google Maps at trailhead
- [x] Manual: River + Boundary do NOT show Navigate
- [x] Manual: Admin override (Nav Latitude / Nav Longitude) takes precedence over primary coords
- [x] Manual: Partial nav coord (one set, not the other) shows inline warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)