### PR TITLE
feat: newsletter preview send (admin endpoint + Thursday cron)

### DIFF
--- a/backend/migrations/054_add_newsletter_preview_email_setting.sql
+++ b/backend/migrations/054_add_newsletter_preview_email_setting.sql
@@ -1,0 +1,8 @@
+-- 054_add_newsletter_preview_email_setting.sql
+-- Seed the admin setting that controls who receives the Thursday-morning
+-- newsletter preview send. Admins can update this via settings_update.
+-- Empty string disables the cron send (handler short-circuits).
+
+INSERT INTO admin_settings (key, value)
+VALUES ('newsletter_preview_email', 'scott.mccarty@gmail.com')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/newsletter.js
+++ b/backend/routes/newsletter.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { isAdmin } from '../middleware/auth.js';
 import { addSubscriber, getSubscriberCount, testApiKey } from '../services/buttondownClient.js';
 import { triggerDigestManually } from '../services/jobScheduler.js';
+import { sendDigestPreviewTo } from '../services/newsletterDigestService.js';
 
 const router = express.Router();
 
@@ -91,6 +92,21 @@ export function createNewsletterRouter(pool) {
     } catch (error) {
       console.error('Newsletter trigger error:', error);
       res.status(500).json({ error: 'Failed to queue digest' });
+    }
+  });
+
+  router.post('/send-preview-test', isAdmin, async (req, res) => {
+    const { email } = req.body;
+    if (!email || !email.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)) {
+      return res.status(400).json({ error: 'Invalid email address' });
+    }
+    try {
+      const result = await sendDigestPreviewTo(pool, email);
+      res.json(result);
+    } catch (error) {
+      console.error('Newsletter preview send error:', error);
+      const detail = error.response?.data?.detail || error.message;
+      res.status(500).json({ error: detail || 'Failed to send preview' });
     }
   });
 

--- a/backend/routes/newsletter.js
+++ b/backend/routes/newsletter.js
@@ -101,8 +101,8 @@ export function createNewsletterRouter(pool) {
       return res.status(400).json({ error: 'Invalid email address' });
     }
     try {
-      const result = await sendDigestPreviewTo(pool, email);
-      res.json(result);
+      const previewSend = await sendDigestPreviewTo(pool, email);
+      res.json(previewSend);
     } catch (error) {
       console.error('Newsletter preview send error:', error);
       const detail = error.response?.data?.detail || error.message;

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,6 +34,8 @@ import {
   registerNewsletterHandler,
   registerDigestHandler,
   scheduleDigest,
+  registerPreviewHandler,
+  schedulePreview,
   triggerDigestManually,
   registerImageBackupHandler,
   scheduleImageBackup,
@@ -56,7 +58,7 @@ import {
 } from './services/trailStatusService.js';
 import imageServerClient from './services/imageServerClient.js';
 import { startSmtpServer, processNewsletterById } from './services/newsletterService.js';
-import { sendWeeklyDigest } from './services/newsletterDigestService.js';
+import { sendWeeklyDigest, sendDigestPreviewTo } from './services/newsletterDigestService.js';
 import { startMcpServer } from './services/mcpServer.js';
 import { initJobLogger, stopJobLogger } from './services/jobLogger.js';
 
@@ -2699,6 +2701,21 @@ async function start() {
     });
 
     await scheduleDigest('0 8 * * 5');
+
+    await registerPreviewHandler(async (_pgBossJobId, _payload) => {
+      const { rows } = await pool.query(
+        "SELECT value FROM admin_settings WHERE key = 'newsletter_preview_email'"
+      );
+      const email = rows[0]?.value?.trim();
+      if (!email) {
+        console.log('Newsletter preview skipped — newsletter_preview_email setting empty');
+        return;
+      }
+      const result = await sendDigestPreviewTo(pool, email);
+      console.log('Newsletter preview result:', JSON.stringify(result));
+    });
+
+    await schedulePreview('0 8 * * 4');
 
     const getAdminDriveService = async () => {
       const { createDriveServiceWithRefresh } = await import('./services/driveImageService.js');

--- a/backend/server.js
+++ b/backend/server.js
@@ -2711,8 +2711,8 @@ async function start() {
         console.log('Newsletter preview skipped — newsletter_preview_email setting empty');
         return;
       }
-      const result = await sendDigestPreviewTo(pool, email);
-      console.log('Newsletter preview result:', JSON.stringify(result));
+      const previewSend = await sendDigestPreviewTo(pool, email);
+      console.log('Newsletter preview result:', JSON.stringify(previewSend));
     });
 
     await schedulePreview('0 8 * * 4');

--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -204,6 +204,24 @@ export async function sendEmail(subject, htmlBody, pool = null, { existingEmailI
   });
 }
 
+// Create a draft and immediately fan it out to a small recipient list via
+// Buttondown's send-draft endpoint. Used for admin preview sends — does NOT
+// schedule the draft to subscribers like sendEmail() does.
+export async function sendDraftToRecipients(subject, htmlBody, recipients, pool = null) {
+  const apiKey = await getApiKey(pool);
+  const client = createClient(apiKey);
+
+  const createResponse = await client.post('/v1/emails', {
+    subject,
+    body: htmlBody,
+    email_type: 'public'
+  });
+  const emailId = createResponse.data.id;
+
+  await client.post(`/v1/emails/${emailId}/send-draft`, { recipients });
+  return { emailId };
+}
+
 export async function testApiKey(pool = null) {
   const apiKey = await getApiKey(pool);
   const client = createClient(apiKey);

--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -204,9 +204,6 @@ export async function sendEmail(subject, htmlBody, pool = null, { existingEmailI
   });
 }
 
-// Create a draft and immediately fan it out to a small recipient list via
-// Buttondown's send-draft endpoint. Used for admin preview sends — does NOT
-// schedule the draft to subscribers like sendEmail() does.
 export async function sendDraftToRecipients(subject, htmlBody, recipients, pool = null) {
   const apiKey = await getApiKey(pool);
   const client = createClient(apiKey);

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -15,6 +15,7 @@ const JOB_NAMES = {
   CONTENT_MODERATION_SWEEP: 'content-moderation-sweep',
   NEWSLETTER_PROCESS: 'newsletter-process',
   NEWSLETTER_DIGEST: 'newsletter-digest',
+  NEWSLETTER_PREVIEW: 'newsletter-preview',
   IMAGE_BACKUP: 'image-backup',
   DATABASE_BACKUP: 'database-backup'
 };
@@ -469,6 +470,43 @@ export async function scheduleDigest(cronExpression = '0 8 * * 5') {
   });
 
   console.log(`Newsletter digest scheduled with cron: ${cronExpression}`);
+}
+
+export async function registerPreviewHandler(handler) {
+  const scheduler = getJobScheduler();
+
+  try {
+    await scheduler.createQueue(JOB_NAMES.NEWSLETTER_PREVIEW);
+    console.log(`Queue '${JOB_NAMES.NEWSLETTER_PREVIEW}' created`);
+  } catch (error) {
+    if (!error.message?.includes('already exists')) {
+      console.log(`Queue '${JOB_NAMES.NEWSLETTER_PREVIEW}' may already exist`);
+    }
+  }
+
+  await scheduler.work(JOB_NAMES.NEWSLETTER_PREVIEW, async (jobs) => {
+    const jobList = Array.isArray(jobs) ? jobs : [jobs];
+    for (const job of jobList) {
+      console.log('Starting newsletter preview job:', job.id);
+      try {
+        await handler(job.id, job.data);
+        console.log('Newsletter preview sent successfully:', job.id);
+      } catch (error) {
+        console.error('Newsletter preview job failed:', error);
+        throw error;
+      }
+    }
+  });
+}
+
+export async function schedulePreview(cronExpression = '0 8 * * 4') {
+  const scheduler = getJobScheduler();
+
+  await scheduler.schedule(JOB_NAMES.NEWSLETTER_PREVIEW, cronExpression, {}, {
+    tz: 'America/New_York'
+  });
+
+  console.log(`Newsletter preview scheduled with cron: ${cronExpression}`);
 }
 
 export async function triggerDigestManually() {

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -1,9 +1,5 @@
 import { sendEmail, sendDraftToRecipients } from './buttondownClient.js';
 
-// Return the upcoming Friday in the target TZ as an ISO timestamp.
-// If today is Friday, returns today. Otherwise the next Friday after today.
-// Used so admin preview sends always reflect the same query bounds the
-// production cron will hit on Friday morning.
 export function upcomingFridayISO(tz = 'America/New_York') {
   const now = new Date();
   const weekdayShort = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' }).format(now);
@@ -377,9 +373,6 @@ function escapeHtml(text) {
     .replace(/'/g, '&#039;');
 }
 
-// Generate the digest as it will appear for the upcoming Friday and send it
-// via Buttondown's send-draft endpoint to a single recipient (admin preview),
-// instead of scheduling to all subscribers like sendWeeklyDigest.
 export async function sendDigestPreviewTo(pool, email, tz = 'America/New_York') {
   const asOf = upcomingFridayISO(tz);
   const html = await generateDigest(pool, tz, asOf);

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -1,13 +1,27 @@
-import { sendEmail } from './buttondownClient.js';
+import { sendEmail, sendDraftToRecipients } from './buttondownClient.js';
 
-export async function generateDigest(pool, tz = 'America/New_York') {
+// Return the upcoming Friday in the target TZ as an ISO timestamp.
+// If today is Friday, returns today. Otherwise the next Friday after today.
+// Used so admin preview sends always reflect the same query bounds the
+// production cron will hit on Friday morning.
+export function upcomingFridayISO(tz = 'America/New_York') {
+  const now = new Date();
+  const weekdayShort = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' }).format(now);
+  const dayMap = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const today = dayMap[weekdayShort];
+  const daysAhead = today === 5 ? 0 : (5 - today + 7) % 7;
+  return new Date(now.getTime() + daysAhead * 86400000).toISOString();
+}
+
+export async function generateDigest(pool, tz = 'America/New_York', asOfDate = null) {
+  // asOfDate overrides CURRENT_TIMESTAMP in the date filters. NULL → use real now.
   const eventsQuery = `
     SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
            e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles
     FROM poi_events e
     JOIN pois p ON e.poi_id = p.id
-    WHERE (e.start_date AT TIME ZONE $1)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
-      AND (e.start_date AT TIME ZONE $1)::date <= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date + 2
+    WHERE (e.start_date AT TIME ZONE $1)::date >= (COALESCE($2::timestamptz, CURRENT_TIMESTAMP) AT TIME ZONE $1)::date
+      AND (e.start_date AT TIME ZONE $1)::date <= (COALESCE($2::timestamptz, CURRENT_TIMESTAMP) AT TIME ZONE $1)::date + 2
       AND e.moderation_status IN ('published', 'auto_approved')
     ORDER BY e.start_date ASC
     LIMIT 10
@@ -19,14 +33,14 @@ export async function generateDigest(pool, tz = 'America/New_York') {
     FROM poi_news n
     JOIN pois p ON n.poi_id = p.id
     WHERE n.moderation_status IN ('published', 'auto_approved')
-      AND COALESCE(n.publication_date, n.collection_date) > NOW() - INTERVAL '7 days'
+      AND COALESCE(n.publication_date, n.collection_date) > COALESCE($1::timestamptz, NOW()) - INTERVAL '7 days'
     ORDER BY COALESCE(n.publication_date, n.collection_date) DESC
     LIMIT 5
   `;
 
   const [eventsResult, newsResult] = await Promise.all([
-    pool.query(eventsQuery, [tz]),
-    pool.query(newsQuery)
+    pool.query(eventsQuery, [tz, asOfDate]),
+    pool.query(newsQuery, [asOfDate])
   ]);
 
   const events = eventsResult.rows;
@@ -361,4 +375,24 @@ function escapeHtml(text) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+// Generate the digest as it will appear for the upcoming Friday and send it
+// via Buttondown's send-draft endpoint to a single recipient (admin preview),
+// instead of scheduling to all subscribers like sendWeeklyDigest.
+export async function sendDigestPreviewTo(pool, email, tz = 'America/New_York') {
+  const asOf = upcomingFridayISO(tz);
+  const html = await generateDigest(pool, tz, asOf);
+
+  if (!html) {
+    return { success: true, skipped: true, reason: 'No content for upcoming Friday', asOf };
+  }
+
+  const previewDate = new Date(asOf).toLocaleDateString('en-US', {
+    month: 'long', day: 'numeric', year: 'numeric', timeZone: tz
+  });
+  const subject = `What's Happening in the Valley This Weekend - ${previewDate}`;
+
+  const { emailId } = await sendDraftToRecipients(subject, html, [email], pool);
+  return { success: true, emailId, asOf, recipient: email };
 }


### PR DESCRIPTION
## Summary

Adds two ways to preview the upcoming Friday's digest without scheduling to the subscriber list — one admin-triggered, one automatic — plus the underlying date-parameterization that both rely on.

### What changed

- **`generateDigest()` takes optional `asOfDate`.** SQL uses it in place of `CURRENT_TIMESTAMP`/`NOW()` so the preview reflects exactly the date range the Friday cron will query at send time, not whenever the preview happens to run. Production cron passes nothing (behavior unchanged).
- **`POST /api/newsletter/send-preview-test`** (admin-only). Body: `{ email }`. Generates the upcoming-Friday digest and uses Buttondown's `send-draft` endpoint to deliver to that single address. Does **not** schedule to subscribers.
- **`newsletter-preview` pg-boss schedule.** Fires Thursdays at 8 AM EDT, reads the recipient from `admin_settings.newsletter_preview_email`, and runs the same preview path. Empty setting short-circuits the cron.
- **Migration 054** seeds `newsletter_preview_email = scott.mccarty@gmail.com`.

### Files

- `backend/services/newsletterDigestService.js` — `asOfDate` param, `upcomingFridayISO()` helper, `sendDigestPreviewTo()` export
- `backend/services/buttondownClient.js` — `sendDraftToRecipients()` (create draft + POST `/send-draft`)
- `backend/services/jobScheduler.js` — `NEWSLETTER_PREVIEW` job, `registerPreviewHandler`, `schedulePreview`
- `backend/routes/newsletter.js` — `POST /send-preview-test`
- `backend/server.js` — wires preview handler + Thursday schedule
- `backend/migrations/054_add_newsletter_preview_email_setting.sql`

## Test plan

- [ ] After deploy, verify migration 054 ran (`SELECT * FROM admin_settings WHERE key='newsletter_preview_email'`)
- [ ] Verify `newsletter-preview` queue exists (`SELECT name FROM pgboss.schedule WHERE name='newsletter-preview'`) with cron `0 8 * * 4`
- [ ] Hit `POST /api/newsletter/send-preview-test` with `{email: "scott.mccarty@gmail.com"}` — expect a Buttondown send-draft preview reflecting Fri 5/22 – Sun 5/24
- [ ] Confirm preview body shows next weekend's events, not today's
- [ ] Confirm production Friday digest (`scheduleDigest`) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)