### PR TITLE
feat: show newsletter preview cron in Jobs dashboard

### DIFF
--- a/backend/routes/newsletter.js
+++ b/backend/routes/newsletter.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { isAdmin } from '../middleware/auth.js';
 import { addSubscriber, getSubscriberCount, testApiKey } from '../services/buttondownClient.js';
-import { triggerDigestManually } from '../services/jobScheduler.js';
+import { triggerDigestManually, triggerPreviewManually } from '../services/jobScheduler.js';
 import { sendDigestPreviewTo } from '../services/newsletterDigestService.js';
 
 const router = express.Router();
@@ -92,6 +92,16 @@ export function createNewsletterRouter(pool) {
     } catch (error) {
       console.error('Newsletter trigger error:', error);
       res.status(500).json({ error: 'Failed to queue digest' });
+    }
+  });
+
+  router.post('/trigger-preview', isAdmin, async (_req, res) => {
+    try {
+      const jobId = await triggerPreviewManually();
+      res.json({ success: true, message: 'Newsletter preview queued', jobId });
+    } catch (error) {
+      console.error('Newsletter preview trigger error:', error);
+      res.status(500).json({ error: 'Failed to queue preview' });
     }
   });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -2702,7 +2702,7 @@ async function start() {
 
     await scheduleDigest('0 8 * * 5');
 
-    await registerPreviewHandler(async (_pgBossJobId, _payload) => {
+    await registerPreviewHandler(async (pgBossJobId, _payload) => {
       const { rows } = await pool.query(
         "SELECT value FROM admin_settings WHERE key = 'newsletter_preview_email'"
       );
@@ -2711,7 +2711,7 @@ async function start() {
         console.log('Newsletter preview skipped — newsletter_preview_email setting empty');
         return;
       }
-      const previewSend = await sendDigestPreviewTo(pool, email);
+      const previewSend = await sendDigestPreviewTo(pool, email, 'America/New_York', pgBossJobId);
       console.log('Newsletter preview result:', JSON.stringify(previewSend));
     });
 

--- a/backend/services/collection/registry.js
+++ b/backend/services/collection/registry.js
@@ -103,8 +103,8 @@ export const COLLECTION_TYPES = [
   },
   {
     id: 'newsletter_digest',
-    label: 'Newsletter Digest',
-    description: 'Weekly email digest sent every Friday at 8 AM',
+    label: 'Newsletter Digest (Production)',
+    description: 'Weekly email digest sent every Friday at 8 AM to all subscribers',
     icon: '\u{1F4E7}',
     promptKeys: [],
     scheduleJobName: 'newsletter-digest',
@@ -112,6 +112,20 @@ export const COLLECTION_TYPES = [
     statusTable: null,
     historyTypes: ['newsletter-digest'],
     triggerEndpoint: '/api/newsletter/send-digest',
+    manualTriggerMethod: 'POST',
+    hasPrompt: false
+  },
+  {
+    id: 'newsletter_preview',
+    label: 'Newsletter Digest (Preview)',
+    description: 'Thursday morning preview to the admin email in newsletter_preview_email — same content as Friday production send, 24 hours earlier',
+    icon: '\u{1F4E7}',
+    promptKeys: [],
+    scheduleJobName: 'newsletter-preview',
+    schedule: '0 8 * * 4',
+    statusTable: null,
+    historyTypes: ['newsletter-preview'],
+    triggerEndpoint: '/api/newsletter/trigger-preview',
     manualTriggerMethod: 'POST',
     hasPrompt: false
   },

--- a/backend/services/jobScheduler.js
+++ b/backend/services/jobScheduler.js
@@ -521,6 +521,18 @@ export async function triggerDigestManually() {
   return jobId;
 }
 
+export async function triggerPreviewManually() {
+  const scheduler = getJobScheduler();
+
+  const jobId = await scheduler.send(JOB_NAMES.NEWSLETTER_PREVIEW, {
+    triggeredManually: true,
+    triggeredAt: new Date().toISOString()
+  });
+
+  console.log('Manual preview send triggered, job ID:', jobId);
+  return jobId;
+}
+
 export async function stopJobScheduler() {
   if (boss) {
     await boss.stop();

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -373,19 +373,68 @@ function escapeHtml(text) {
     .replace(/'/g, '&#039;');
 }
 
-export async function sendDigestPreviewTo(pool, email, tz = 'America/New_York') {
-  const asOf = upcomingFridayISO(tz);
-  const html = await generateDigest(pool, tz, asOf);
+export async function sendDigestPreviewTo(pool, email, tz = 'America/New_York', pgBossJobId = null) {
+  // job_logs.job_id is int32 — hash the pg-boss UUID into that range (mirrors sendWeeklyDigest)
+  let jobId = 0;
+  if (pgBossJobId) {
+    let hash = 0;
+    for (let i = 0; i < pgBossJobId.length; i++) {
+      hash = ((hash << 5) - hash) + pgBossJobId.charCodeAt(i);
+      hash = hash & 0x7FFFFFFF;
+    }
+    jobId = hash;
+  }
+  const jobType = 'newsletter-preview';
 
-  if (!html) {
-    return { success: true, skipped: true, reason: 'No content for upcoming Friday', asOf };
+  if (jobId > 0) {
+    await pool.query(
+      'INSERT INTO job_logs (job_id, job_type, level, message) VALUES ($1, $2, $3, $4)',
+      [jobId, jobType, 'info', `Starting newsletter preview for ${email}`]
+    );
   }
 
-  const previewDate = new Date(asOf).toLocaleDateString('en-US', {
-    month: 'long', day: 'numeric', year: 'numeric', timeZone: tz
-  });
-  const subject = `What's Happening in the Valley This Weekend - ${previewDate}`;
+  try {
+    const asOf = upcomingFridayISO(tz);
+    const html = await generateDigest(pool, tz, asOf);
 
-  const { emailId } = await sendDraftToRecipients(subject, html, [email], pool);
-  return { success: true, emailId, asOf, recipient: email };
+    if (!html) {
+      if (jobId > 0) {
+        await pool.query(
+          `INSERT INTO job_logs (job_id, job_type, level, message, details)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [jobId, jobType, 'info', 'No content available for preview',
+           JSON.stringify({ completed: true, skipped: true, asOf })]
+        );
+      }
+      return { success: true, skipped: true, reason: 'No content for upcoming Friday', asOf };
+    }
+
+    const previewDate = new Date(asOf).toLocaleDateString('en-US', {
+      month: 'long', day: 'numeric', year: 'numeric', timeZone: tz
+    });
+    const subject = `What's Happening in the Valley This Weekend - ${previewDate}`;
+
+    const { emailId } = await sendDraftToRecipients(subject, html, [email], pool);
+
+    if (jobId > 0) {
+      await pool.query(
+        `INSERT INTO job_logs (job_id, job_type, level, message, details)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [jobId, jobType, 'info', `Preview sent to ${email}`,
+         JSON.stringify({ completed: true, skipped: false, asOf, buttondownEmailId: emailId, recipient: email })]
+      );
+    }
+
+    return { success: true, emailId, asOf, recipient: email };
+  } catch (error) {
+    if (jobId > 0) {
+      await pool.query(
+        `INSERT INTO job_logs (job_id, job_type, level, message, details)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [jobId, jobType, 'error', error.message || 'Failed to send preview',
+         JSON.stringify({ completed: false, error: error.message, recipient: email })]
+      );
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

The Thursday newsletter preview cron from PR #376 is firing correctly, but the Settings → Jobs sub-tab didn't show it. The dashboard only renders cards for entries in `COLLECTION_TYPES`; the new cron wasn't registered there.

- **Register `newsletter_preview` in `registry.js`** as a sibling card to the existing digest. Both relabeled for clarity:
  - `Newsletter Digest` → `Newsletter Digest (Production)`
  - new `Newsletter Digest (Preview)`
- **`POST /api/newsletter/trigger-preview`** + new `triggerPreviewManually()` so the dashboard's `Run Now` button works (mirrors the existing `triggerDigestManually` / `/send-digest` pattern).
- **`sendDigestPreviewTo` now writes `job_logs` entries** with `job_type='newsletter-preview'` (Starting / Preview sent to `<email>` / No content / errors). Without this, the "Recent Runs" section would stay empty even after the cron ran — same logging shape as `sendWeeklyDigest`.

The pre-existing admin-only `send-preview-test` endpoint (with explicit `{ email }` body) is untouched.

## Files

- `backend/services/collection/registry.js` — new card + relabel
- `backend/services/jobScheduler.js` — `triggerPreviewManually`
- `backend/routes/newsletter.js` — `POST /trigger-preview`
- `backend/services/newsletterDigestService.js` — job_logs logging
- `backend/server.js` — pass `pgBossJobId` through to `sendDigestPreviewTo`

## Test plan

- [ ] After deploy, refresh Settings → Jobs — expect two newsletter cards: "Newsletter Digest (Production)" and "Newsletter Digest (Preview)"
- [ ] Click "Run Now" on the Preview card — should fire the queue and a Buttondown preview should land in `scott.mccarty@gmail.com`
- [ ] Confirm the run appears under "Recent Runs" with status `completed`
- [ ] Confirm the Production card still works unchanged
- [ ] Naming check: "Preview" or do you want it changed to "Development"?

🤖 Generated with [Claude Code](https://claude.com/claude-code)