### PR TITLE
feat: day-trip planning (#366)

### DIFF
--- a/.specify/specs/017-day-trip-planning/plan.md
+++ b/.specify/specs/017-day-trip-planning/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: Day-Trip Planning
+
+> **Spec ID:** 017-day-trip-planning
+> **Status:** Planning
+> **Last Updated:** 2026-05-18
+> **Estimated Effort:** L
+
+## Summary
+
+Add a `trips` + `trip_stops` schema, a `/api/trips` route module owning CRUD + featured/duplicate, a React `TripContext` that owns the trip-in-progress with localStorage sync, and four new frontend components (`AddToTripButton`, `TripBuilder`, `MyTripsModal`, `TripPermalink`). The multi-stop Google Maps handoff already works (`NavigateButton.buildGoogleMapsUrl`) — this feature feeds it longer arrays and adds persistence.
+
+---
+
+## Architecture
+
+### Data flow — building a trip
+
+```
+1. User taps "+ Add to Trip" in Sidebar POI Info
+2. AddToTripButton calls TripContext.addStop({poi_id, lat, lng, label})
+3. TripContext appends to in-memory stops + writes localStorage
+4. TripBuilder dock re-renders with the new ordered list
+5. Map re-renders numbered markers from trip.stops
+6. "Open in Google Maps" → buildGoogleMapsUrl(stops) → window.open(url)
+```
+
+### Data flow — saving a trip
+
+```
+1. User taps "Save Trip" in TripBuilder
+2. TripContext.saveTrip() → POST /api/trips with {name, stops, is_public, is_featured}
+3. Server validates, generates slug, inserts trip + trip_stops in a transaction
+4. Returns {id, slug, ...}. TripContext clears localStorage trip-in-progress, holds the saved trip in memory
+5. MyTripsModal (if open) re-fetches /api/trips/mine
+```
+
+### Data flow — opening a Featured Trip
+
+```
+1. User opens MyTripsModal → taps "+ Add Featured Trip"
+2. Modal fetches /api/trips/featured
+3. User selects one → POST /api/trips/:id/duplicate
+4. Server clones into caller's account with is_featured=false, name+" (copy)"
+5. Modal re-fetches /api/trips/mine, shows the new clone
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend
+- [ ] Add `054_add_trips.sql` migration
+- [ ] Add `backend/routes/trips.js` exporting `createTripsRouter(pool)`
+- [ ] Add slug helper (new `backend/utils/slug.js` if no existing util)
+- [ ] Mount router in `backend/server.js`
+- [ ] Add `backend/tests/trips.integration.test.js`
+
+### Phase 2: Frontend foundation
+- [ ] Add `frontend/src/contexts/TripContext.jsx` (state, localStorage sync, API client)
+- [ ] Add a `useTrip()` hook in `frontend/src/hooks/useTrip.js`
+- [ ] Wrap `<App />` (or its children) in `<TripProvider>`
+
+### Phase 3: Frontend components
+- [ ] Add `AddToTripButton.jsx` and insert it into `Sidebar.jsx` after the existing `<NavigateButton />`
+- [ ] Add `TripBuilder.jsx` + CSS; render at App level
+- [ ] Add `MyTripsModal.jsx` + CSS; wire to a new "My Trips" item in the App.jsx user-menu dropdown
+- [ ] Add `TripPermalink.jsx` for `/trip/:slug`; add the route in App.jsx
+- [ ] Render numbered `divIcon` markers in `Map.jsx` for `trip.stops` when active
+
+### Phase 4: Build, verify, ship
+- [ ] `./run.sh build` (must pass)
+- [ ] `./run.sh start`
+- [ ] Walk Scott through the verification checklist in this plan
+- [ ] `./run.sh test`
+- [ ] `git push -u origin feature/366-day-trip-planning`
+- [ ] `gh pr create` (Closes #366)
+- [ ] `./run.sh gatehouse` (fall back to single-shot Gemini Pro on rate-limit)
+- [ ] Triage findings with Scott; fix or justify
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/054_add_trips.sql` | Schema for `trips` + `trip_stops` |
+| `backend/routes/trips.js` | `createTripsRouter(pool)` factory with CRUD + featured + duplicate |
+| `backend/utils/slug.js` | Slug generation helper (if no existing util) |
+| `backend/tests/trips.integration.test.js` | Supertest integration coverage |
+| `frontend/src/contexts/TripContext.jsx` | Current trip-in-progress, localStorage sync, API client |
+| `frontend/src/hooks/useTrip.js` | Hook over `TripContext` |
+| `frontend/src/components/AddToTripButton.jsx` | Badge for POI Info row |
+| `frontend/src/components/TripBuilder.jsx` (+ `.css`) | Slide-up dock |
+| `frontend/src/components/MyTripsModal.jsx` (+ `.css`) | Saved trips + Featured picker |
+| `frontend/src/components/TripPermalink.jsx` | Route handler for `/trip/:slug` |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/server.js` | Mount `app.use('/api/trips', createTripsRouter(pool))` near the other routers (~line 168) |
+| `frontend/src/App.jsx` | Wrap in `<TripProvider>`, render `<TripBuilder />`, add `/trip/:slug` route, add "My Trips" item to the inline user dropdown |
+| `frontend/src/components/Sidebar.jsx` | Add `<AddToTripButton ... />` after `<NavigateButton ... />` at line ~295 |
+| `frontend/src/components/Map.jsx` | Render numbered `divIcon` markers for `trip.stops` when a trip is active |
+
+---
+
+## Reused utilities
+
+| Existing | Used for |
+|---|---|
+| `buildGoogleMapsUrl(stops)` in `NavigateButton.jsx` | Multi-waypoint URL |
+| `getNavigationStops(poi, isLinearFeature)` in `Sidebar.jsx` | Coordinate resolution + nav override fallback for Add-to-Trip eligibility |
+| `useAuth()` (`hooks/useAuth.js`) | Drives Save-Trip enablement, admin-only `Feature this` checkbox |
+| `isAuthenticated`, `isAdmin`, `optionalAuth` middleware (`backend/middleware/auth.js`) | Route authorization |
+| `createFeedbackRouter(pool)` factory pattern (`backend/routes/feedback.js`) | Template for `createTripsRouter` |
+| `divIcon` pattern in `Map.jsx` (~lines 746/756) | Numbered stop markers |
+
+---
+
+## Testing Strategy
+
+### Integration tests (Vitest + Supertest) — `backend/tests/trips.integration.test.js`
+
+- Create a trip; assert response includes slug + stops in order
+- POST as a non-admin with `is_featured: true` → response has `is_featured: false`
+- POST as admin with `is_featured: true` → response has `is_featured: true`
+- GET `/api/trips/featured` returns only `is_featured = true` trips
+- GET `/api/trips/:slug` for a private trip as a non-owner → 404
+- GET `/api/trips/:slug` for a `is_public` trip as an anonymous user → 200
+- PUT owner-only enforcement
+- DELETE owner-only enforcement
+- POST `/api/trips/:id/duplicate` copies stops in order with `is_featured = false`
+- Max stops: 25 accepted, 26 rejected
+- Slug collision: two trips with the same name get distinct slugs
+
+### Manual browser verification
+
+(Same checklist as in spec — Scott walks through in his browser before PR.)
+
+---
+
+## Rollback Plan
+
+If issues are discovered after merge but before deploy:
+1. Revert the merge commit on master
+2. Migration `054_add_trips.sql` is additive (CREATE TABLE IF NOT EXISTS); it can be left in place — leaving empty tables in the DB has no runtime cost
+
+If issues are discovered after deploy:
+1. Revert and redeploy
+2. Optional: `DROP TABLE trip_stops; DROP TABLE trips;` against prod if a re-do migration would conflict (unlikely — only on a major schema change)
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Google Maps URL length exceeds browser limits with 25 stops | Med | Soft warning at 10 stops, hard cap at 25; tested URL ≤ 2KB stays well under |
+| `localStorage` quota or corruption | Low | Trip-in-progress data is < 4 KB; wrap reads in try/catch and clear on parse error |
+| Non-admin sets `is_featured: true` via direct API | Med | Server silently coerces to `false`; integration test covers it |
+| POI deletion orphans trip stops | Low | `ON DELETE SET NULL` on `poi_id`; cached lat/lng + label keep the stop usable |
+| Slug collision | Low | Short random hash suffix on the kebab-case slug; UNIQUE constraint + retry loop on insert |
+| Adding `TripProvider` regresses other rendering paths | Med | Manual verification step covers the main map + existing features; integration test for `headerButtons` already exists |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-18 | Initial plan |

--- a/.specify/specs/017-day-trip-planning/spec.md
+++ b/.specify/specs/017-day-trip-planning/spec.md
@@ -1,0 +1,242 @@
+# Specification: Day-Trip Planning (Advanced Google Maps Navigation)
+
+> **Spec ID:** 017-day-trip-planning
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-18
+> **GitHub Issue:** [#366](https://github.com/crunchtools/rotv/issues/366)
+> **Builds on:** [016-poi-navigation](../016-poi-navigation/spec.md) — reuses the multi-stop `NavigateButton` interface
+
+## Overview
+
+Lets users build an ordered list of POIs into a saved "trip" (a day-trip plan), come back to edit or duplicate it later, and hand the entire route off to Google Maps for turn-by-turn navigation. Admins can flag any trip as **Featured**, surfacing curated routes like the Canalway Scenic Byway that every user can adopt with one tap.
+
+The Google-Maps handoff already works for one stop (PR #374). This feature extends it to many stops, plus the persistence, sharing, and curation that turn it from a one-shot link into trip planning.
+
+---
+
+## User Stories
+
+### Building a Trip (Any Visitor)
+
+**US-017-1: Add a POI to a trip**
+> As a visitor browsing ROTV, I want to tap an "Add to Trip" badge on a POI's Info tab so that I can start collecting stops for a day-trip without losing my place.
+
+Acceptance Criteria:
+- [ ] An `+ Add to Trip` badge appears in the POI Info badge row, right after Share and Navigate
+- [ ] Tapping it adds the POI as a stop in the current trip-in-progress; if no trip is in progress, one is created implicitly
+- [ ] When a POI is already in the current trip, the badge shows `✓ In Trip`; tapping it removes the stop
+- [ ] The badge is hidden when the POI has no coordinates (same eligibility rule as the Navigate badge — reuses `getNavigationStops`)
+
+**US-017-2: See and manage the trip in progress**
+> As a visitor planning a day-trip, I want a persistent dock at the bottom of the map showing my current trip so that I can see what I've added, change the order, or remove stops.
+
+Acceptance Criteria:
+- [ ] A Trip Builder dock appears at the bottom of the map once the trip has at least one stop
+- [ ] Collapsible — collapsed state shows "N stops · Open in Maps ▲"
+- [ ] Expanded state shows: trip name field (editable), ordered list of stops with drag-to-reorder and `×` remove, stop count, action buttons
+- [ ] The map renders numbered Leaflet markers for each stop while the dock is active
+- [ ] An anonymous user's trip-in-progress is preserved across page reloads via `localStorage`
+
+**US-017-3: Open the trip in Google Maps**
+> As a visitor with a trip planned, I want to tap "Open in Google Maps" so that Google Maps opens with all my stops pre-loaded for navigation.
+
+Acceptance Criteria:
+- [ ] Open in Google Maps button uses `buildGoogleMapsUrl(stops)` from `NavigateButton.jsx`
+- [ ] The resulting URL has the first stop as `origin`, the last as `destination`, and the middle stops as `waypoints` in order
+- [ ] On mobile, the Google Maps app opens if installed; web falls back otherwise (inherited behavior)
+- [ ] Stop count of 10+ shows a soft warning; the 26th stop is hard-rejected (Google Maps web ceiling)
+
+### Saving Trips (Logged-In Users)
+
+**US-017-4: Save a trip to my account**
+> As a logged-in user, I want to save my trip so that I can return to it later without re-building.
+
+Acceptance Criteria:
+- [ ] "Save Trip" button is enabled only when authenticated; anonymous users see a "Sign in to save" tooltip
+- [ ] Saving sends `POST /api/trips` with the name, description, public flag, and ordered stops
+- [ ] On success, the trip moves from the localStorage trip-in-progress to the user's saved trips and the dock title changes from "Untitled Trip" to the saved name
+
+**US-017-5: View, edit, duplicate, and delete my trips**
+> As a logged-in user, I want a "My Trips" view so that I can manage all the day-trips I've saved.
+
+Acceptance Criteria:
+- [ ] User-menu dropdown shows a "My Trips" item (visible only when authenticated)
+- [ ] Tapping it opens a modal listing the user's saved trips (name, stop count, last edited)
+- [ ] Each row offers Open, Duplicate, Delete, and Copy share link
+- [ ] Open replaces the current trip-in-progress with the saved trip (with a confirm if the in-progress trip has unsaved stops)
+- [ ] Duplicate creates a new owned trip with " (copy)" suffix and opens it
+- [ ] Delete asks for confirmation; on confirm, removes the trip server-side
+
+**US-017-6: Share a trip with a friend**
+> As a logged-in user, I want to flip a "Make shareable" toggle on a trip so that I can send the link to a friend who isn't necessarily logged in.
+
+Acceptance Criteria:
+- [ ] Each saved trip has an `is_public` toggle in its editor
+- [ ] When enabled, `/trip/<slug>` is reachable by anonymous viewers
+- [ ] Copy share link copies the URL to the clipboard
+- [ ] When `is_public` is off, anonymous access returns 404 and the link does not work
+
+### Featured Trips
+
+**US-017-7: Discover curated trips**
+> As a visitor or logged-in user, I want to browse admin-curated Featured Trips so that I can find suggested day-trips like the Canalway Scenic Byway.
+
+Acceptance Criteria:
+- [ ] Inside the My Trips modal there is an **+ Add Featured Trip** button
+- [ ] Tapping it lists all `is_featured = true` trips with name, description, stop count
+- [ ] Anonymous viewers can view the same list at `/trip/<slug>` for any Featured Trip
+- [ ] Logged-in viewers can clone a Featured Trip into their own My Trips with one tap; the clone has `is_featured = false` and the user's `user_id`
+
+**US-017-8: Admin curates a Featured Trip**
+> As an admin, I want to flag a trip I built as Featured so that all users can find and adopt it — without leaving the same trip editor every user uses.
+
+Acceptance Criteria:
+- [ ] The trip editor shows a **Feature this trip** checkbox only when `user.is_admin = true`
+- [ ] When checked, `is_featured` is set to `true` server-side
+- [ ] Non-admin clients cannot set `is_featured = true`; the server silently ignores the field if the requester isn't admin
+- [ ] Listing under "Add Featured Trip" reflects the change immediately
+
+---
+
+## Data Model
+
+### New Tables
+
+| Table | Description |
+|-------|-------------|
+| `trips` | One row per saved trip. Owned by a user. May be flagged featured (admin only) and/or public (owner choice). |
+| `trip_stops` | Ordered stops belonging to a trip. Stop-position is the ordering key. |
+
+### Migration `054_add_trips.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS trips (
+  id           SERIAL PRIMARY KEY,
+  user_id      INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  name         VARCHAR(200) NOT NULL,
+  description  TEXT,
+  slug         VARCHAR(200) UNIQUE NOT NULL,
+  is_featured  BOOLEAN DEFAULT FALSE,
+  is_public    BOOLEAN DEFAULT FALSE,
+  created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_trips_user_id ON trips(user_id);
+CREATE INDEX IF NOT EXISTS idx_trips_is_featured ON trips(is_featured) WHERE is_featured = TRUE;
+
+CREATE TABLE IF NOT EXISTS trip_stops (
+  trip_id      INTEGER NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  position     INTEGER NOT NULL,
+  poi_id       INTEGER REFERENCES pois(id) ON DELETE SET NULL,
+  label        VARCHAR(200),
+  latitude     DECIMAL(10, 8) NOT NULL,
+  longitude    DECIMAL(11, 8) NOT NULL,
+  PRIMARY KEY (trip_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_stops_poi_id ON trip_stops(poi_id);
+```
+
+Lat/lng are cached on the stop so a trip survives the underlying POI being renamed, moved, or deleted (FK uses `ON DELETE SET NULL`). `poi_id` is a soft link used to render the current POI name when available; `label` is a manual or fallback display name.
+
+---
+
+## API Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/trips/featured` | none | Public list of `is_featured = true` trips |
+| `GET` | `/api/trips/mine` | `isAuthenticated` | Current user's saved trips |
+| `GET` | `/api/trips/:slug` | `optionalAuth` | One trip. Public if `is_featured` or `is_public`; otherwise owner-only |
+| `POST` | `/api/trips` | `isAuthenticated` | Create a trip. `is_featured` silently ignored unless `req.user.is_admin`. Rate-limited (30/hr per user). |
+| `PUT` | `/api/trips/:id` | `isAuthenticated` | Update a trip. Owner-only. Admin can additionally toggle `is_featured`. |
+| `DELETE` | `/api/trips/:id` | `isAuthenticated` | Delete a trip. Owner-only. |
+| `POST` | `/api/trips/:id/duplicate` | `isAuthenticated` | Clone a trip (any trip the caller can read) into the caller's account. New row gets `is_featured = false` and name " (copy)" suffix. |
+
+### Request body (create / update)
+
+```json
+{
+  "name": "Cuyahoga Waterfalls Tour",
+  "description": "Optional",
+  "is_public": false,
+  "is_featured": false,
+  "stops": [
+    { "poi_id": 42, "latitude": 41.27, "longitude": -81.55, "label": "Brandywine Falls" },
+    { "poi_id": 87, "latitude": 41.18, "longitude": -81.58, "label": null }
+  ]
+}
+```
+
+### Validation
+- `name`: required, 1–200 chars
+- `slug`: server-generated from `name` (kebab-case, ≤60 chars, suffixed with short random hash for collision safety). Not accepted in request body.
+- `stops`: required, 1–25 entries (Google Maps web ceiling). Each entry needs valid finite `latitude` / `longitude`.
+- `is_featured`: silently coerced to `false` if requester isn't admin
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+| Component | Purpose |
+|-----------|---------|
+| `AddToTripButton` | Badge in POI Info row; toggles a POI's membership in the current trip-in-progress |
+| `TripBuilder` | Slide-up dock at the bottom of the map showing the trip-in-progress |
+| `MyTripsModal` | Modal listing the user's saved trips + the Add Featured Trip picker |
+| `TripPermalink` | Route handler for `/trip/:slug` |
+| `TripContext` | React context holding the trip-in-progress, with localStorage sync |
+
+### Modified Components
+
+- `Sidebar.jsx` — insert `<AddToTripButton ... />` after the existing `<NavigateButton />` in the POI Info badge row (line ~295)
+- `App.jsx` — wrap children in `<TripProvider>`, render `<TripBuilder />`, add "My Trips" to the inline user-menu dropdown (~line 1609), add a route for `/trip/:slug`
+- `Map.jsx` — render numbered `divIcon` markers for the active trip's stops (reuse existing `divIcon` pattern at lines 746/756). No connecting polyline in v1.
+
+### Map visualization
+
+While a trip-in-progress has stops, the map shows numbered markers (1, 2, 3 …) at each stop's coordinates. No road-following polyline — the real road route is what Google Maps draws after the user taps Open in Google Maps.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-017-1: Anonymous resilience**
+- Trip-in-progress persists across reloads for anonymous users via `localStorage`
+- No server round-trips required to build, modify, or hand off a trip until the user explicitly saves
+
+**NFR-017-2: Rate limiting**
+- Write endpoints (POST/PUT/DELETE/duplicate) limited to 30/hr per authenticated user
+
+**NFR-017-3: Stop limits**
+- Soft warning at > 9 stops (Google Maps web preferred ceiling)
+- Hard reject at > 25 stops, both client- and server-side
+
+**NFR-017-4: Authorization edges**
+- Server silently ignores `is_featured: true` from non-admin requests; never errors
+- `/api/trips/:slug` returns 404 (not 403) for private trips the caller can't see, to avoid leaking existence
+
+---
+
+## Dependencies
+
+- **Depends on:** `016-poi-navigation` (#365) — uses `buildGoogleMapsUrl` and `getNavigationStops`
+- **Blocks:** None known
+
+---
+
+## Open Questions
+
+None — all questions resolved in plan-mode discussion with Scott.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-18 | Initial draft |

--- a/.specify/specs/017-day-trip-planning/spec.md
+++ b/.specify/specs/017-day-trip-planning/spec.md
@@ -44,9 +44,9 @@ Acceptance Criteria:
 
 Acceptance Criteria:
 - [ ] Open in Google Maps button uses `buildGoogleMapsUrl(stops)` from `NavigateButton.jsx`
-- [ ] The resulting URL has the first stop as `origin`, the last as `destination`, and the middle stops as `waypoints` in order
+- [ ] The URL omits `origin` so Google Maps starts from the user's current location; the last stop is `destination` and earlier stops are `waypoints` in order
 - [ ] On mobile, the Google Maps app opens if installed; web falls back otherwise (inherited behavior)
-- [ ] Stop count of 10+ shows a soft warning; the 26th stop is hard-rejected (Google Maps web ceiling)
+- [ ] Stops are hard-capped at 9 (Google Maps URL spec allows 9 waypoints, leaving the origin slot for current location); the Add to Trip badge becomes "Trip full" at the cap
 
 ### Saving Trips (Logged-In Users)
 
@@ -74,20 +74,37 @@ Acceptance Criteria:
 
 Acceptance Criteria:
 - [ ] Each saved trip has an `is_public` toggle in its editor
-- [ ] When enabled, `/trip/<slug>` is reachable by anonymous viewers
+- [ ] When the toggle is first enabled, the trip enters the moderation queue (`is_approved = FALSE`)
+- [ ] My Trips shows "⏳ Pending review" on the row until an admin approves; afterwards it shows "🌐 Shared"
+- [ ] `/trip/<slug>` is reachable by anonymous viewers once approved (or for featured trips, immediately)
 - [ ] Copy share link copies the URL to the clipboard
 - [ ] When `is_public` is off, anonymous access returns 404 and the link does not work
+- [ ] Owner edits to a public trip reset it to `is_approved = FALSE` (must be re-reviewed); admin edits do not reset
+
+### Moderation (Admin)
+
+**US-017-MOD: Review pending public trips**
+> As an admin, I want a queue of user trips awaiting moderation so that I can vet trips before they appear in Find Trips, the same way News, Events, and Photos are reviewed.
+
+Acceptance Criteria:
+- [ ] My Trips modal shows a "Pending Review" entry point only when the user is an admin
+- [ ] The pending list shows trip name, owner, stop count, and submission date
+- [ ] Admin can Preview, Approve, or Reject each trip
+- [ ] Approving sets `is_approved = TRUE` and records `moderated_by` / `moderated_at`; the trip appears in Find Trips
+- [ ] Rejecting sets `is_public = FALSE` (taking it out of the queue); the owner can re-enable sharing to resubmit
+- [ ] Featured trips bypass the queue — admin curation is itself the moderation
 
 ### Featured Trips
 
-**US-017-7: Discover curated trips**
-> As a visitor or logged-in user, I want to browse admin-curated Featured Trips so that I can find suggested day-trips like the Canalway Scenic Byway.
+**US-017-7: Discover shared and curated trips**
+> As a visitor or logged-in user, I want to browse Featured Trips (admin-curated) and trips other users have shared so that I can find suggested day-trips like the Canalway Scenic Byway.
 
 Acceptance Criteria:
-- [ ] Inside the My Trips modal there is an **+ Add Featured Trip** button
-- [ ] Tapping it lists all `is_featured = true` trips with name, description, stop count
-- [ ] Anonymous viewers can view the same list at `/trip/<slug>` for any Featured Trip
-- [ ] Logged-in viewers can clone a Featured Trip into their own My Trips with one tap; the clone has `is_featured = false` and the user's `user_id`
+- [ ] Inside the My Trips modal there is a **Find Trips** button
+- [ ] Tapping it lists every trip where `is_featured = true` OR (`is_public = true` AND `is_approved = true`), excluding the caller's own trips
+- [ ] Each row shows the owner's name (or "⭐ Featured" for admin trips), stop count, and description
+- [ ] Anonymous viewers can view shared/featured trips at `/trip/<slug>`
+- [ ] Logged-in viewers can clone a trip into their own My Trips with one tap; the clone has `is_featured = false`, `is_public = false`, and the user's `user_id`
 
 **US-017-8: Admin curates a Featured Trip**
 > As an admin, I want to flag a trip I built as Featured so that all users can find and adopt it — without leaving the same trip editor every user uses.
@@ -108,6 +125,11 @@ Acceptance Criteria:
 |-------|-------------|
 | `trips` | One row per saved trip. Owned by a user. May be flagged featured (admin only) and/or public (owner choice). |
 | `trip_stops` | Ordered stops belonging to a trip. Stop-position is the ordering key. |
+
+### Migrations
+
+- `054_add_trips.sql` — schema below
+- `055_add_trip_moderation.sql` — adds `is_approved`, `moderated_by`, `moderated_at` to `trips`
 
 ### Migration `054_add_trips.sql`
 
@@ -149,6 +171,9 @@ Lat/lng are cached on the stop so a trip survives the underlying POI being renam
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/api/trips/featured` | none | Public list of `is_featured = true` trips |
+| `GET` | `/api/trips/discover` | `optionalAuth` | Featured + approved-public trips, excluding the caller's own. Powers "Find Trips" |
+| `GET` | `/api/trips/pending` | `isAdmin` | Admin queue of `is_public = true AND is_approved = false` trips |
+| `POST` | `/api/trips/:id/moderate` | `isAdmin` | Approve (`is_approved = true`) or reject (`is_public = false`) a pending trip |
 | `GET` | `/api/trips/mine` | `isAuthenticated` | Current user's saved trips |
 | `GET` | `/api/trips/:slug` | `optionalAuth` | One trip. Public if `is_featured` or `is_public`; otherwise owner-only |
 | `POST` | `/api/trips` | `isAuthenticated` | Create a trip. `is_featured` silently ignored unless `req.user.is_admin`. Rate-limited (30/hr per user). |
@@ -174,7 +199,7 @@ Lat/lng are cached on the stop so a trip survives the underlying POI being renam
 ### Validation
 - `name`: required, 1–200 chars
 - `slug`: server-generated from `name` (kebab-case, ≤60 chars, suffixed with short random hash for collision safety). Not accepted in request body.
-- `stops`: required, 1–25 entries (Google Maps web ceiling). Each entry needs valid finite `latitude` / `longitude`.
+- `stops`: required, 1–9 entries. The cap matches the Google Maps URL spec (≤9 waypoints) so the trip handoff can use the user's current location as origin. Each entry needs valid finite `latitude` / `longitude`.
 - `is_featured`: silently coerced to `false` if requester isn't admin
 
 ---
@@ -213,8 +238,8 @@ While a trip-in-progress has stops, the map shows numbered markers (1, 2, 3 …)
 - Write endpoints (POST/PUT/DELETE/duplicate) limited to 30/hr per authenticated user
 
 **NFR-017-3: Stop limits**
-- Soft warning at > 9 stops (Google Maps web preferred ceiling)
-- Hard reject at > 25 stops, both client- and server-side
+- Hard cap of 9 stops, enforced both client- and server-side
+- Matches Google Maps URL spec (≤9 waypoints), leaving the origin slot for the user's current location
 
 **NFR-017-4: Authorization edges**
 - Server silently ignores `is_featured: true` from non-admin requests; never errors

--- a/backend/migrations/054_add_trips.sql
+++ b/backend/migrations/054_add_trips.sql
@@ -1,0 +1,35 @@
+-- 054_add_trips.sql
+-- Day-trip planning (issue #366). One trip = an ordered list of POI stops
+-- a user has saved for handoff to Google Maps navigation. Admin-curated
+-- "Featured Trips" live in the same table with is_featured = true.
+
+CREATE TABLE IF NOT EXISTS trips (
+  id           SERIAL PRIMARY KEY,
+  user_id      INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  name         VARCHAR(200) NOT NULL,
+  description  TEXT,
+  slug         VARCHAR(220) UNIQUE NOT NULL,
+  is_featured  BOOLEAN DEFAULT FALSE,
+  is_public    BOOLEAN DEFAULT FALSE,
+  created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_trips_user_id ON trips(user_id);
+CREATE INDEX IF NOT EXISTS idx_trips_is_featured ON trips(is_featured) WHERE is_featured = TRUE;
+
+-- trip_stops caches lat/lng so a trip remains usable if the referenced
+-- POI is renamed, moved, or deleted (ON DELETE SET NULL). poi_id is a
+-- soft link used to render the current POI name when present; label is
+-- a manual override or fallback display name.
+CREATE TABLE IF NOT EXISTS trip_stops (
+  trip_id      INTEGER NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  position     INTEGER NOT NULL,
+  poi_id       INTEGER REFERENCES pois(id) ON DELETE SET NULL,
+  label        VARCHAR(200),
+  latitude     DECIMAL(10, 8) NOT NULL,
+  longitude    DECIMAL(11, 8) NOT NULL,
+  PRIMARY KEY (trip_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_stops_poi_id ON trip_stops(poi_id);

--- a/backend/migrations/055_add_trip_moderation.sql
+++ b/backend/migrations/055_add_trip_moderation.sql
@@ -1,0 +1,13 @@
+-- 055_add_trip_moderation.sql
+-- Public user trips (is_public = TRUE) go through a moderation queue before
+-- becoming visible in the "Find Trips" picker, mirroring how News, Events,
+-- and Photos are reviewed. Featured trips (is_featured = TRUE, admin-set)
+-- bypass approval because the admin curating them is the moderator.
+
+ALTER TABLE trips ADD COLUMN IF NOT EXISTS is_approved  BOOLEAN DEFAULT FALSE;
+ALTER TABLE trips ADD COLUMN IF NOT EXISTS moderated_by INTEGER REFERENCES users(id);
+ALTER TABLE trips ADD COLUMN IF NOT EXISTS moderated_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_trips_pending
+  ON trips(is_public, is_approved)
+  WHERE is_public = TRUE AND is_approved = FALSE;

--- a/backend/migrations/056_add_trip_tutorial_content.sql
+++ b/backend/migrations/056_add_trip_tutorial_content.sql
@@ -1,0 +1,10 @@
+-- 056_add_trip_tutorial_content.sql
+-- Seed markdown content for the new Trip Planning tutorial on the
+-- About → Tutorials page. Admins can edit through the standard about-content
+-- editor once seeded.
+
+INSERT INTO admin_settings (key, value) VALUES
+('about_trip_tutorial_md', '## Plan a Day Trip
+
+Build a multi-stop itinerary across the valley, save it to your account, and hand the whole route off to Google Maps starting from your current location. Featured Routes curated by admins are available too, and you can share your own trips with friends after a quick review.')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/trips.js
+++ b/backend/routes/trips.js
@@ -1,0 +1,483 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { isAuthenticated, optionalAuth } from '../middleware/auth.js';
+import { slugifyWithSuffix } from '../utils/slug.js';
+
+// Cap at 9 so the user's current location can be the Google Maps origin.
+// We send 8 waypoints + 1 destination and let Maps default origin to GPS.
+const MAX_STOPS = 9;
+
+const tripWriteLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 30,
+  message: { error: 'Too many trip changes. Please try again later.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => (req.user && req.user.id ? `user:${req.user.id}` : req.ip)
+});
+
+function isFiniteNumber(v) {
+  const n = typeof v === 'string' ? Number(v) : v;
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+function validateStops(stops) {
+  if (!Array.isArray(stops) || stops.length === 0) {
+    return 'stops must be a non-empty array';
+  }
+  if (stops.length > MAX_STOPS) {
+    return `stops cannot exceed ${MAX_STOPS} entries`;
+  }
+  for (const [i, s] of stops.entries()) {
+    if (!s || typeof s !== 'object') return `stop ${i + 1} is invalid`;
+    if (!isFiniteNumber(s.latitude) || !isFiniteNumber(s.longitude)) {
+      return `stop ${i + 1} requires numeric latitude/longitude`;
+    }
+    const lat = Number(s.latitude);
+    const lng = Number(s.longitude);
+    if (lat < -90 || lat > 90) return `stop ${i + 1} latitude out of range`;
+    if (lng < -180 || lng > 180) return `stop ${i + 1} longitude out of range`;
+  }
+  return null;
+}
+
+function isAdminUser(user) {
+  return !!(user && (user.is_admin || user.role === 'admin'));
+}
+
+async function loadTripBySlug(pool, slug) {
+  const tripResult = await pool.query(
+    `SELECT id, user_id, name, description, slug, is_featured, is_public,
+            is_approved, moderated_by, moderated_at,
+            created_at, updated_at
+       FROM trips WHERE slug = $1`,
+    [slug]
+  );
+  if (tripResult.rows.length === 0) return null;
+  const trip = tripResult.rows[0];
+  const stops = await pool.query(
+    `SELECT ts.position, ts.poi_id, ts.label, ts.latitude, ts.longitude,
+            p.name AS poi_name
+       FROM trip_stops ts
+       LEFT JOIN pois p ON p.id = ts.poi_id
+      WHERE ts.trip_id = $1
+      ORDER BY ts.position ASC`,
+    [trip.id]
+  );
+  trip.stops = stops.rows;
+  return trip;
+}
+
+async function loadTripById(pool, id) {
+  const tripResult = await pool.query(
+    `SELECT id, user_id, name, description, slug, is_featured, is_public,
+            is_approved, moderated_by, moderated_at,
+            created_at, updated_at
+       FROM trips WHERE id = $1`,
+    [id]
+  );
+  if (tripResult.rows.length === 0) return null;
+  const trip = tripResult.rows[0];
+  const stops = await pool.query(
+    `SELECT ts.position, ts.poi_id, ts.label, ts.latitude, ts.longitude,
+            p.name AS poi_name
+       FROM trip_stops ts
+       LEFT JOIN pois p ON p.id = ts.poi_id
+      WHERE ts.trip_id = $1
+      ORDER BY ts.position ASC`,
+    [trip.id]
+  );
+  trip.stops = stops.rows;
+  return trip;
+}
+
+async function insertStops(client, tripId, stops) {
+  for (const [i, s] of stops.entries()) {
+    await client.query(
+      `INSERT INTO trip_stops (trip_id, position, poi_id, label, latitude, longitude)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        tripId,
+        i + 1,
+        s.poi_id || null,
+        s.label || null,
+        Number(s.latitude),
+        Number(s.longitude)
+      ]
+    );
+  }
+}
+
+async function insertTripWithSlugRetry(client, fields, maxAttempts = 5) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const slug = slugifyWithSuffix(fields.name);
+    try {
+      const result = await client.query(
+        `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING *`,
+        [fields.user_id, fields.name, fields.description, slug, fields.is_featured, fields.is_public]
+      );
+      return result.rows[0];
+    } catch (err) {
+      if (err.code === '23505' && err.constraint && err.constraint.includes('slug')) {
+        continue; // unique violation on slug → retry with new suffix
+      }
+      throw err;
+    }
+  }
+  throw new Error('slug collision after retries');
+}
+
+export function createTripsRouter(pool) {
+  const router = express.Router();
+
+  // ---- Featured (public) ----
+  router.get('/featured', async (_req, res) => {
+    try {
+      const result = await pool.query(
+        `SELECT id, user_id, name, description, slug, is_featured, is_public,
+                is_approved, created_at, updated_at,
+                (SELECT COUNT(*) FROM trip_stops WHERE trip_id = trips.id) AS stop_count
+           FROM trips
+          WHERE is_featured = TRUE
+          ORDER BY updated_at DESC`
+      );
+      res.json(result.rows);
+    } catch (err) {
+      console.error('GET /api/trips/featured failed:', err);
+      res.status(500).json({ error: 'Failed to load featured trips' });
+    }
+  });
+
+  // ---- Discover (featured + approved public from others) ----
+  router.get('/discover', optionalAuth, async (req, res) => {
+    try {
+      const currentUserId = req.user && req.user.id ? req.user.id : 0;
+      const result = await pool.query(
+        `SELECT t.id, t.user_id, t.name, t.description, t.slug, t.is_featured,
+                t.is_public, t.is_approved, t.created_at, t.updated_at,
+                u.name AS owner_name,
+                (SELECT COUNT(*) FROM trip_stops WHERE trip_id = t.id) AS stop_count
+           FROM trips t
+           LEFT JOIN users u ON u.id = t.user_id
+          WHERE (t.is_featured = TRUE
+                 OR (t.is_public = TRUE AND t.is_approved = TRUE))
+            AND (t.user_id IS NULL OR t.user_id <> $1)
+          ORDER BY t.is_featured DESC, t.updated_at DESC`,
+        [currentUserId]
+      );
+      res.json(result.rows);
+    } catch (err) {
+      console.error('GET /api/trips/discover failed:', err);
+      res.status(500).json({ error: 'Failed to load trips' });
+    }
+  });
+
+  // ---- Pending moderation (admin only) ----
+  router.get('/pending', isAuthenticated, async (req, res) => {
+    if (!isAdminUser(req.user)) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+    try {
+      const result = await pool.query(
+        `SELECT t.id, t.user_id, t.name, t.description, t.slug, t.is_featured,
+                t.is_public, t.is_approved, t.created_at, t.updated_at,
+                u.name AS owner_name, u.email AS owner_email,
+                (SELECT COUNT(*) FROM trip_stops WHERE trip_id = t.id) AS stop_count
+           FROM trips t
+           LEFT JOIN users u ON u.id = t.user_id
+          WHERE t.is_public = TRUE AND t.is_approved = FALSE
+          ORDER BY t.updated_at ASC`
+      );
+      res.json(result.rows);
+    } catch (err) {
+      console.error('GET /api/trips/pending failed:', err);
+      res.status(500).json({ error: 'Failed to load pending trips' });
+    }
+  });
+
+  // ---- Moderate (admin only) ----
+  router.post('/:id/moderate', isAuthenticated, async (req, res) => {
+    if (!isAdminUser(req.user)) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'invalid id' });
+    }
+    const { action } = req.body || {};
+    if (action !== 'approve' && action !== 'reject') {
+      return res.status(400).json({ error: "action must be 'approve' or 'reject'" });
+    }
+    try {
+      const existing = await pool.query('SELECT id FROM trips WHERE id = $1', [id]);
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: 'Trip not found' });
+      }
+      if (action === 'approve') {
+        await pool.query(
+          `UPDATE trips
+              SET is_approved = TRUE,
+                  moderated_by = $1,
+                  moderated_at = CURRENT_TIMESTAMP,
+                  updated_at = CURRENT_TIMESTAMP
+            WHERE id = $2`,
+          [req.user.id, id]
+        );
+      } else {
+        // reject: take the trip off the public list. Owner can re-enable.
+        await pool.query(
+          `UPDATE trips
+              SET is_public = FALSE,
+                  is_approved = FALSE,
+                  moderated_by = $1,
+                  moderated_at = CURRENT_TIMESTAMP,
+                  updated_at = CURRENT_TIMESTAMP
+            WHERE id = $2`,
+          [req.user.id, id]
+        );
+      }
+      const fresh = await loadTripById(pool, id);
+      res.json(fresh);
+    } catch (err) {
+      console.error('POST /api/trips/:id/moderate failed:', err);
+      res.status(500).json({ error: 'Failed to moderate trip' });
+    }
+  });
+
+  // ---- Mine (auth required) ----
+  router.get('/mine', isAuthenticated, async (req, res) => {
+    try {
+      const result = await pool.query(
+        `SELECT id, user_id, name, description, slug, is_featured, is_public,
+                is_approved, created_at, updated_at,
+                (SELECT COUNT(*) FROM trip_stops WHERE trip_id = trips.id) AS stop_count
+           FROM trips
+          WHERE user_id = $1
+          ORDER BY updated_at DESC`,
+        [req.user.id]
+      );
+      res.json(result.rows);
+    } catch (err) {
+      console.error('GET /api/trips/mine failed:', err);
+      res.status(500).json({ error: 'Failed to load your trips' });
+    }
+  });
+
+  // ---- One by slug or numeric id (public if featured/public, else owner-only) ----
+  router.get('/:idOrSlug', optionalAuth, async (req, res) => {
+    try {
+      const param = req.params.idOrSlug;
+      const asNumber = Number(param);
+      const trip = Number.isInteger(asNumber) && asNumber > 0 && String(asNumber) === param
+        ? await loadTripById(pool, asNumber)
+        : await loadTripBySlug(pool, param);
+      if (!trip) return res.status(404).json({ error: 'Trip not found' });
+      const isOwner = req.user && req.user.id === trip.user_id;
+      const canView = trip.is_featured || trip.is_public || isOwner;
+      if (!canView) return res.status(404).json({ error: 'Trip not found' });
+      res.json(trip);
+    } catch (err) {
+      console.error('GET /api/trips/:idOrSlug failed:', err);
+      res.status(500).json({ error: 'Failed to load trip' });
+    }
+  });
+
+  // ---- Create ----
+  router.post('/', isAuthenticated, tripWriteLimiter, async (req, res) => {
+    const { name, description, is_public, is_featured, stops } = req.body || {};
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    if (name.length > 200) {
+      return res.status(400).json({ error: 'name must be 200 characters or fewer' });
+    }
+    const stopsError = validateStops(stops);
+    if (stopsError) return res.status(400).json({ error: stopsError });
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const created = await insertTripWithSlugRetry(client, {
+        user_id: req.user.id,
+        name: name.trim(),
+        description: description || null,
+        is_featured: !!is_featured && isAdminUser(req.user),
+        is_public: !!is_public
+      });
+      await insertStops(client, created.id, stops);
+      await client.query('COMMIT');
+      const fresh = await loadTripById(pool, created.id);
+      res.status(201).json(fresh);
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      console.error('POST /api/trips failed:', err);
+      res.status(500).json({ error: 'Failed to create trip' });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ---- Update ----
+  router.put('/:id', isAuthenticated, tripWriteLimiter, async (req, res) => {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'invalid id' });
+    }
+    const { name, description, is_public, is_featured, stops } = req.body || {};
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const existing = await client.query(
+        'SELECT user_id FROM trips WHERE id = $1 FOR UPDATE',
+        [id]
+      );
+      if (existing.rows.length === 0) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Trip not found' });
+      }
+      if (existing.rows[0].user_id !== req.user.id) {
+        await client.query('ROLLBACK');
+        return res.status(403).json({ error: 'Not your trip' });
+      }
+
+      const updates = [];
+      const values = [];
+      let i = 1;
+
+      if (name !== undefined) {
+        if (typeof name !== 'string' || name.trim().length === 0 || name.length > 200) {
+          await client.query('ROLLBACK');
+          return res.status(400).json({ error: 'invalid name' });
+        }
+        updates.push(`name = $${i++}`);
+        values.push(name.trim());
+      }
+      if (description !== undefined) {
+        updates.push(`description = $${i++}`);
+        values.push(description || null);
+      }
+      if (is_public !== undefined) {
+        updates.push(`is_public = $${i++}`);
+        values.push(!!is_public);
+      }
+      if (is_featured !== undefined && isAdminUser(req.user)) {
+        updates.push(`is_featured = $${i++}`);
+        values.push(!!is_featured);
+      }
+      // Owner edits send a public trip back through moderation. Admins
+      // editing their own trips skip this — admin == implicit moderator.
+      if (!isAdminUser(req.user)) {
+        updates.push(`is_approved = FALSE`);
+      }
+      updates.push(`updated_at = CURRENT_TIMESTAMP`);
+
+      if (updates.length > 1 || values.length > 0) {
+        values.push(id);
+        await client.query(
+          `UPDATE trips SET ${updates.join(', ')} WHERE id = $${i}`,
+          values
+        );
+      }
+
+      if (stops !== undefined) {
+        const stopsError = validateStops(stops);
+        if (stopsError) {
+          await client.query('ROLLBACK');
+          return res.status(400).json({ error: stopsError });
+        }
+        await client.query('DELETE FROM trip_stops WHERE trip_id = $1', [id]);
+        await insertStops(client, id, stops);
+      }
+
+      await client.query('COMMIT');
+      const fresh = await loadTripById(pool, id);
+      res.json(fresh);
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      console.error('PUT /api/trips/:id failed:', err);
+      res.status(500).json({ error: 'Failed to update trip' });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ---- Delete ----
+  router.delete('/:id', isAuthenticated, tripWriteLimiter, async (req, res) => {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'invalid id' });
+    }
+    try {
+      const existing = await pool.query('SELECT user_id FROM trips WHERE id = $1', [id]);
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: 'Trip not found' });
+      }
+      if (existing.rows[0].user_id !== req.user.id) {
+        return res.status(403).json({ error: 'Not your trip' });
+      }
+      await pool.query('DELETE FROM trips WHERE id = $1', [id]);
+      res.status(204).end();
+    } catch (err) {
+      console.error('DELETE /api/trips/:id failed:', err);
+      res.status(500).json({ error: 'Failed to delete trip' });
+    }
+  });
+
+  // ---- Duplicate ----
+  router.post('/:id/duplicate', isAuthenticated, tripWriteLimiter, async (req, res) => {
+    const sourceId = Number(req.params.id);
+    if (!Number.isInteger(sourceId) || sourceId <= 0) {
+      return res.status(400).json({ error: 'invalid id' });
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const source = await client.query(
+        `SELECT id, user_id, name, description, is_featured, is_public
+           FROM trips WHERE id = $1`,
+        [sourceId]
+      );
+      if (source.rows.length === 0) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Trip not found' });
+      }
+      const src = source.rows[0];
+      const canRead = src.is_featured || src.is_public || src.user_id === req.user.id;
+      if (!canRead) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Trip not found' });
+      }
+
+      const created = await insertTripWithSlugRetry(client, {
+        user_id: req.user.id,
+        name: `${src.name} (copy)`.substring(0, 200),
+        description: src.description,
+        is_featured: false,
+        is_public: false
+      });
+
+      const stops = await client.query(
+        `SELECT position, poi_id, label, latitude, longitude
+           FROM trip_stops WHERE trip_id = $1 ORDER BY position ASC`,
+        [sourceId]
+      );
+      await insertStops(client, created.id, stops.rows);
+
+      await client.query('COMMIT');
+      const fresh = await loadTripById(pool, created.id);
+      res.status(201).json(fresh);
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      console.error('POST /api/trips/:id/duplicate failed:', err);
+      res.status(500).json({ error: 'Failed to duplicate trip' });
+    } finally {
+      client.release();
+    }
+  });
+
+  return router;
+}

--- a/backend/routes/trips.js
+++ b/backend/routes/trips.js
@@ -3,8 +3,6 @@ import rateLimit from 'express-rate-limit';
 import { isAuthenticated, optionalAuth } from '../middleware/auth.js';
 import { slugifyWithSuffix } from '../utils/slug.js';
 
-// Cap at 9 so the user's current location can be the Google Maps origin.
-// We send 8 waypoints + 1 destination and let Maps default origin to GPS.
 const MAX_STOPS = 9;
 
 const tripWriteLimiter = rateLimit({
@@ -45,40 +43,17 @@ function isAdminUser(user) {
   return !!(user && (user.is_admin || user.role === 'admin'));
 }
 
-async function loadTripBySlug(pool, slug) {
-  const tripResult = await pool.query(
-    `SELECT id, user_id, name, description, slug, is_featured, is_public,
-            is_approved, moderated_by, moderated_at,
-            created_at, updated_at
-       FROM trips WHERE slug = $1`,
-    [slug]
-  );
-  if (tripResult.rows.length === 0) return null;
-  const trip = tripResult.rows[0];
-  const stops = await pool.query(
-    `SELECT ts.position, ts.poi_id, ts.label, ts.latitude, ts.longitude,
-            p.name AS poi_name
-       FROM trip_stops ts
-       LEFT JOIN pois p ON p.id = ts.poi_id
-      WHERE ts.trip_id = $1
-      ORDER BY ts.position ASC`,
-    [trip.id]
-  );
-  trip.stops = stops.rows;
-  return trip;
-}
-
 async function loadTripById(pool, id) {
-  const tripResult = await pool.query(
+  const tripRows = await pool.query(
     `SELECT id, user_id, name, description, slug, is_featured, is_public,
             is_approved, moderated_by, moderated_at,
             created_at, updated_at
        FROM trips WHERE id = $1`,
     [id]
   );
-  if (tripResult.rows.length === 0) return null;
-  const trip = tripResult.rows[0];
-  const stops = await pool.query(
+  if (tripRows.rows.length === 0) return null;
+  const trip = tripRows.rows[0];
+  const stopRows = await pool.query(
     `SELECT ts.position, ts.poi_id, ts.label, ts.latitude, ts.longitude,
             p.name AS poi_name
        FROM trip_stops ts
@@ -87,7 +62,7 @@ async function loadTripById(pool, id) {
       ORDER BY ts.position ASC`,
     [trip.id]
   );
-  trip.stops = stops.rows;
+  trip.stops = stopRows.rows;
   return trip;
 }
 
@@ -112,16 +87,16 @@ async function insertTripWithSlugRetry(client, fields, maxAttempts = 5) {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const slug = slugifyWithSuffix(fields.name);
     try {
-      const result = await client.query(
+      const inserted = await client.query(
         `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)
          VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING *`,
         [fields.user_id, fields.name, fields.description, slug, fields.is_featured, fields.is_public]
       );
-      return result.rows[0];
+      return inserted.rows[0];
     } catch (err) {
       if (err.code === '23505' && err.constraint && err.constraint.includes('slug')) {
-        continue; // unique violation on slug → retry with new suffix
+        continue;
       }
       throw err;
     }
@@ -132,10 +107,9 @@ async function insertTripWithSlugRetry(client, fields, maxAttempts = 5) {
 export function createTripsRouter(pool) {
   const router = express.Router();
 
-  // ---- Featured (public) ----
   router.get('/featured', async (_req, res) => {
     try {
-      const result = await pool.query(
+      const featuredRows = await pool.query(
         `SELECT id, user_id, name, description, slug, is_featured, is_public,
                 is_approved, created_at, updated_at,
                 (SELECT COUNT(*) FROM trip_stops WHERE trip_id = trips.id) AS stop_count
@@ -143,18 +117,17 @@ export function createTripsRouter(pool) {
           WHERE is_featured = TRUE
           ORDER BY updated_at DESC`
       );
-      res.json(result.rows);
+      res.json(featuredRows.rows);
     } catch (err) {
       console.error('GET /api/trips/featured failed:', err);
       res.status(500).json({ error: 'Failed to load featured trips' });
     }
   });
 
-  // ---- Discover (featured + approved public from others) ----
   router.get('/discover', optionalAuth, async (req, res) => {
     try {
       const currentUserId = req.user && req.user.id ? req.user.id : 0;
-      const result = await pool.query(
+      const discoverRows = await pool.query(
         `SELECT t.id, t.user_id, t.name, t.description, t.slug, t.is_featured,
                 t.is_public, t.is_approved, t.created_at, t.updated_at,
                 u.name AS owner_name,
@@ -167,20 +140,19 @@ export function createTripsRouter(pool) {
           ORDER BY t.is_featured DESC, t.updated_at DESC`,
         [currentUserId]
       );
-      res.json(result.rows);
+      res.json(discoverRows.rows);
     } catch (err) {
       console.error('GET /api/trips/discover failed:', err);
       res.status(500).json({ error: 'Failed to load trips' });
     }
   });
 
-  // ---- Pending moderation (admin only) ----
   router.get('/pending', isAuthenticated, async (req, res) => {
     if (!isAdminUser(req.user)) {
       return res.status(403).json({ error: 'Admin access required' });
     }
     try {
-      const result = await pool.query(
+      const pendingRows = await pool.query(
         `SELECT t.id, t.user_id, t.name, t.description, t.slug, t.is_featured,
                 t.is_public, t.is_approved, t.created_at, t.updated_at,
                 u.name AS owner_name, u.email AS owner_email,
@@ -190,14 +162,13 @@ export function createTripsRouter(pool) {
           WHERE t.is_public = TRUE AND t.is_approved = FALSE
           ORDER BY t.updated_at ASC`
       );
-      res.json(result.rows);
+      res.json(pendingRows.rows);
     } catch (err) {
       console.error('GET /api/trips/pending failed:', err);
       res.status(500).json({ error: 'Failed to load pending trips' });
     }
   });
 
-  // ---- Moderate (admin only) ----
   router.post('/:id/moderate', isAuthenticated, async (req, res) => {
     if (!isAdminUser(req.user)) {
       return res.status(403).json({ error: 'Admin access required' });
@@ -226,7 +197,6 @@ export function createTripsRouter(pool) {
           [req.user.id, id]
         );
       } else {
-        // reject: take the trip off the public list. Owner can re-enable.
         await pool.query(
           `UPDATE trips
               SET is_public = FALSE,
@@ -246,10 +216,9 @@ export function createTripsRouter(pool) {
     }
   });
 
-  // ---- Mine (auth required) ----
   router.get('/mine', isAuthenticated, async (req, res) => {
     try {
-      const result = await pool.query(
+      const mineRows = await pool.query(
         `SELECT id, user_id, name, description, slug, is_featured, is_public,
                 is_approved, created_at, updated_at,
                 (SELECT COUNT(*) FROM trip_stops WHERE trip_id = trips.id) AS stop_count
@@ -258,21 +227,26 @@ export function createTripsRouter(pool) {
           ORDER BY updated_at DESC`,
         [req.user.id]
       );
-      res.json(result.rows);
+      res.json(mineRows.rows);
     } catch (err) {
       console.error('GET /api/trips/mine failed:', err);
       res.status(500).json({ error: 'Failed to load your trips' });
     }
   });
 
-  // ---- One by slug or numeric id (public if featured/public, else owner-only) ----
   router.get('/:idOrSlug', optionalAuth, async (req, res) => {
     try {
       const param = req.params.idOrSlug;
       const asNumber = Number(param);
-      const trip = Number.isInteger(asNumber) && asNumber > 0 && String(asNumber) === param
-        ? await loadTripById(pool, asNumber)
-        : await loadTripBySlug(pool, param);
+      let id;
+      if (Number.isInteger(asNumber) && asNumber > 0 && String(asNumber) === param) {
+        id = asNumber;
+      } else {
+        const slugLookup = await pool.query('SELECT id FROM trips WHERE slug = $1', [param]);
+        if (slugLookup.rows.length === 0) return res.status(404).json({ error: 'Trip not found' });
+        id = slugLookup.rows[0].id;
+      }
+      const trip = await loadTripById(pool, id);
       if (!trip) return res.status(404).json({ error: 'Trip not found' });
       const isOwner = req.user && req.user.id === trip.user_id;
       const canView = trip.is_featured || trip.is_public || isOwner;
@@ -284,7 +258,6 @@ export function createTripsRouter(pool) {
     }
   });
 
-  // ---- Create ----
   router.post('/', isAuthenticated, tripWriteLimiter, async (req, res) => {
     const { name, description, is_public, is_featured, stops } = req.body || {};
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -319,7 +292,6 @@ export function createTripsRouter(pool) {
     }
   });
 
-  // ---- Update ----
   router.put('/:id', isAuthenticated, tripWriteLimiter, async (req, res) => {
     const id = Number(req.params.id);
     if (!Number.isInteger(id) || id <= 0) {
@@ -367,8 +339,6 @@ export function createTripsRouter(pool) {
         updates.push(`is_featured = $${i++}`);
         values.push(!!is_featured);
       }
-      // Owner edits send a public trip back through moderation. Admins
-      // editing their own trips skip this — admin == implicit moderator.
       if (!isAdminUser(req.user)) {
         updates.push(`is_approved = FALSE`);
       }
@@ -404,7 +374,6 @@ export function createTripsRouter(pool) {
     }
   });
 
-  // ---- Delete ----
   router.delete('/:id', isAuthenticated, tripWriteLimiter, async (req, res) => {
     const id = Number(req.params.id);
     if (!Number.isInteger(id) || id <= 0) {
@@ -426,7 +395,6 @@ export function createTripsRouter(pool) {
     }
   });
 
-  // ---- Duplicate ----
   router.post('/:id/duplicate', isAuthenticated, tripWriteLimiter, async (req, res) => {
     const sourceId = Number(req.params.id);
     if (!Number.isInteger(sourceId) || sourceId <= 0) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ import authRoutes from './routes/auth.js';
 import { createAdminRouter } from './routes/admin.js';
 import { createNewsletterRouter } from './routes/newsletter.js';
 import { createFeedbackRouter } from './routes/feedback.js';
+import { createTripsRouter } from './routes/trips.js';
 import { isAuthenticated } from './middleware/auth.js';
 import {
   initJobScheduler,
@@ -166,6 +167,7 @@ app.use('/auth', authRoutes);
 app.use('/api/admin', createAdminRouter(pool, invalidateMosaicCache));
 app.use('/api/newsletter', createNewsletterRouter(pool));
 app.use('/api/feedback', createFeedbackRouter(pool));
+app.use('/api/trips', createTripsRouter(pool));
 
 async function importGeoJSONFeatures(client) {
   const staticPath = process.env.STATIC_PATH || path.join(__dirname, '../frontend/public');
@@ -831,7 +833,7 @@ async function initDatabase() {
 app.get('/api/about-content', async (req, res) => {
   try {
     const aboutSettings = await pool.query(
-      `SELECT key, value FROM admin_settings WHERE key IN ('about_story_md', 'about_tutorial_md', 'about_privacy_md')`
+      `SELECT key, value FROM admin_settings WHERE key IN ('about_story_md', 'about_tutorial_md', 'about_trip_tutorial_md', 'about_privacy_md')`
     );
     const content = {};
     for (const row of aboutSettings.rows) {

--- a/backend/tests/slug.unit.test.js
+++ b/backend/tests/slug.unit.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { slugify, slugifyWithSuffix } from '../utils/slug.js';
+
+describe('slugify', () => {
+  it('lowercases, strips punctuation, replaces spaces with hyphens', () => {
+    expect(slugify('Cuyahoga Waterfalls Tour!')).toBe('cuyahoga-waterfalls-tour');
+  });
+
+  it('collapses repeated whitespace and hyphens', () => {
+    expect(slugify('  Cuyahoga   Valley  ---  Tour ')).toBe('cuyahoga-valley-tour');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugify('---trail---')).toBe('trail');
+  });
+
+  it('returns empty string for null or empty input', () => {
+    expect(slugify('')).toBe('');
+    expect(slugify(null)).toBe('');
+    expect(slugify(undefined)).toBe('');
+  });
+
+  it('caps the slug at 60 characters', () => {
+    const long = 'a'.repeat(120);
+    expect(slugify(long).length).toBe(60);
+  });
+
+  it('strips characters that arent alphanumeric or spaces or hyphens', () => {
+    expect(slugify('Towpath: River & Trail @ Stop #1')).toBe('towpath-river-trail-stop-1');
+  });
+});
+
+describe('slugifyWithSuffix', () => {
+  it('appends a hex suffix after the base slug', () => {
+    const s = slugifyWithSuffix('Brandywine Falls');
+    expect(s).toMatch(/^brandywine-falls-[0-9a-f]{8}$/);
+  });
+
+  it('falls back to "trip" when name is empty', () => {
+    const s = slugifyWithSuffix('');
+    expect(s).toMatch(/^trip-[0-9a-f]{8}$/);
+  });
+
+  it('produces distinct slugs for the same input on repeated calls', () => {
+    const a = slugifyWithSuffix('Brandywine Falls');
+    const b = slugifyWithSuffix('Brandywine Falls');
+    expect(a).not.toBe(b);
+  });
+});

--- a/backend/tests/slug.unit.test.js
+++ b/backend/tests/slug.unit.test.js
@@ -1,44 +1,41 @@
 import { describe, it, expect } from 'vitest';
-import { slugify, slugifyWithSuffix } from '../utils/slug.js';
+import { slugifyWithSuffix } from '../utils/slug.js';
 
-describe('slugify', () => {
+const HEX_SUFFIX = /-[0-9a-f]{8}$/;
+function baseOf(slug) {
+  return slug.replace(HEX_SUFFIX, '');
+}
+
+describe('slugifyWithSuffix', () => {
   it('lowercases, strips punctuation, replaces spaces with hyphens', () => {
-    expect(slugify('Cuyahoga Waterfalls Tour!')).toBe('cuyahoga-waterfalls-tour');
+    expect(baseOf(slugifyWithSuffix('Cuyahoga Waterfalls Tour!'))).toBe('cuyahoga-waterfalls-tour');
   });
 
   it('collapses repeated whitespace and hyphens', () => {
-    expect(slugify('  Cuyahoga   Valley  ---  Tour ')).toBe('cuyahoga-valley-tour');
+    expect(baseOf(slugifyWithSuffix('  Cuyahoga   Valley  ---  Tour '))).toBe('cuyahoga-valley-tour');
   });
 
   it('trims leading and trailing hyphens', () => {
-    expect(slugify('---trail---')).toBe('trail');
+    expect(baseOf(slugifyWithSuffix('---trail---'))).toBe('trail');
   });
 
-  it('returns empty string for null or empty input', () => {
-    expect(slugify('')).toBe('');
-    expect(slugify(null)).toBe('');
-    expect(slugify(undefined)).toBe('');
+  it('falls back to "trip" for null or empty input', () => {
+    expect(baseOf(slugifyWithSuffix(''))).toBe('trip');
+    expect(baseOf(slugifyWithSuffix(null))).toBe('trip');
+    expect(baseOf(slugifyWithSuffix(undefined))).toBe('trip');
   });
 
-  it('caps the slug at 60 characters', () => {
+  it('caps the base slug at 60 characters', () => {
     const long = 'a'.repeat(120);
-    expect(slugify(long).length).toBe(60);
+    expect(baseOf(slugifyWithSuffix(long)).length).toBe(60);
   });
 
   it('strips characters that arent alphanumeric or spaces or hyphens', () => {
-    expect(slugify('Towpath: River & Trail @ Stop #1')).toBe('towpath-river-trail-stop-1');
-  });
-});
-
-describe('slugifyWithSuffix', () => {
-  it('appends a hex suffix after the base slug', () => {
-    const s = slugifyWithSuffix('Brandywine Falls');
-    expect(s).toMatch(/^brandywine-falls-[0-9a-f]{8}$/);
+    expect(baseOf(slugifyWithSuffix('Towpath: River & Trail @ Stop #1'))).toBe('towpath-river-trail-stop-1');
   });
 
-  it('falls back to "trip" when name is empty', () => {
-    const s = slugifyWithSuffix('');
-    expect(s).toMatch(/^trip-[0-9a-f]{8}$/);
+  it('appends an 8-character hex suffix', () => {
+    expect(slugifyWithSuffix('Brandywine Falls')).toMatch(/^brandywine-falls-[0-9a-f]{8}$/);
   });
 
   it('produces distinct slugs for the same input on repeated calls', () => {

--- a/backend/utils/slug.js
+++ b/backend/utils/slug.js
@@ -1,21 +1,13 @@
 import crypto from 'crypto';
 
-// Must match the frontend slugify logic (frontend/src/utils/slug.js).
-export function slugify(name) {
-  if (!name) return '';
-  return name
+export function slugifyWithSuffix(name) {
+  const base = (name || '')
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
-    .substring(0, 60);
-}
-
-// kebab-cased name (≤60 chars) plus a short random hash suffix. Cheap
-// collision avoidance for a UNIQUE column; callers retry on UniqueViolation.
-export function slugifyWithSuffix(name) {
-  const base = slugify(name) || 'trip';
+    .substring(0, 60) || 'trip';
   const suffix = crypto.randomBytes(4).toString('hex');
   return `${base}-${suffix}`;
 }

--- a/backend/utils/slug.js
+++ b/backend/utils/slug.js
@@ -1,0 +1,21 @@
+import crypto from 'crypto';
+
+// Must match the frontend slugify logic (frontend/src/utils/slug.js).
+export function slugify(name) {
+  if (!name) return '';
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 60);
+}
+
+// kebab-cased name (≤60 chars) plus a short random hash suffix. Cheap
+// collision avoidance for a UNIQUE column; callers retry on UniqueViolation.
+export function slugifyWithSuffix(name) {
+  const base = slugify(name) || 'trip';
+  const suffix = crypto.randomBytes(4).toString('hex');
+  return `${base}-${suffix}`;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14411,6 +14411,12 @@ button.feedback-link-inline {
   background: #1b4332;
 }
 
+.about-tutorial + .about-tutorial {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
 /* Markdown-rendered content inherits about-story styles */
 .about-story .markdown-content h2 {
   color: #2d6a4f;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import { TripProvider } from './contexts/TripContext';
 import { useAuth } from './hooks/useAuth';
+import { useTrip } from './hooks/useTrip';
+import TripBuilder from './components/TripBuilder';
+import MyTripsModal from './components/MyTripsModal';
 import useSeasonalTheme from './hooks/useSeasonalTheme';
 import Map from './components/Map';
 import Sidebar from './components/Sidebar';
@@ -27,7 +31,7 @@ import EventPermalink from './components/EventPermalink';
 import PrivacyPolicy from './components/PrivacyPolicy';
 import FeedbackForm from './components/FeedbackForm';
 import AboutPage from './components/AboutPage';
-import GuidedTour from './components/GuidedTour';
+import GuidedTour, { TRIP_TOUR_STEPS } from './components/GuidedTour';
 import TourPrompt from './components/TourPrompt';
 import { handleRovingKeyDown } from './utils/a11yUtils';
 
@@ -111,6 +115,14 @@ function AppContent() {
 
   const [showLoginDropdown, setShowLoginDropdown] = useState(false);
   const [showUserDropdown, setShowUserDropdown] = useState(false);
+  const [showMyTrips, setShowMyTrips] = useState(false);
+  const [tourVariant, setTourVariant] = useState('default');
+  const {
+    loadFromSlug: loadTripFromSlug,
+    addStop: tripAddStop,
+    clear: tripClear,
+    setShowBuilder: tripSetShowBuilder
+  } = useTrip();
 
   const [kbdFocusIndex, setKbdFocusIndex] = useState(null);
 
@@ -195,6 +207,15 @@ function AppContent() {
   }, [location.pathname, destinations]);
 
   useEffect(() => {
+    if (!location.pathname.startsWith('/trip/')) return;
+    const slug = location.pathname.split('/')[2];
+    if (!slug) return;
+    loadTripFromSlug(slug)
+      .catch(() => {})
+      .finally(() => navigate('/', { replace: true }));
+  }, [location.pathname, loadTripFromSlug, navigate]);
+
+  useEffect(() => {
     if (location.pathname.startsWith('/organizations')) {
       const pathParts = location.pathname.split('/');
       const orgSlug = pathParts[2]; // /organizations/org-name -> 'org-name'
@@ -215,6 +236,7 @@ function AppContent() {
   const startTour = useCallback(() => {
     setShowTourPrompt(false);
     setTourStep(0);
+    setTourVariant('default');
     setTourActive(true);
     localStorage.setItem('rotv-tour-seen', 'true');
     setActiveTab('view');
@@ -224,15 +246,43 @@ function AppContent() {
     navigate('/');
   }, [navigate]);
 
+  const startTripTour = useCallback(() => {
+    setShowTourPrompt(false);
+    setTourStep(0);
+    setTourVariant('trips');
+    setTourActive(true);
+    setActiveTab('view');
+    setSelectedDestination(null);
+    setSelectedLinearFeature(null);
+    // Pre-populate a demo trip so the Trip Builder dock is mounted in the
+    // DOM before steps 2-4 poll for it. Using a label without a poi_id so
+    // the VC selected in step 1 still shows "+ Add to Trip" rather than
+    // "✓ In Trip" (hasStop() matches by poi_id).
+    tripClear();
+    tripAddStop({
+      poi_id: null,
+      label: 'Brandywine Falls',
+      latitude: 41.276,
+      longitude: -81.538
+    });
+    tripSetShowBuilder(true);
+    isProgrammaticNavigationRef.current = true;
+    navigate('/');
+  }, [navigate, tripClear, tripAddStop, tripSetShowBuilder]);
+
   const endTour = useCallback(() => {
     setTourActive(false);
     setTourStep(0);
     setActiveTab('view');
     setSelectedDestination(null);
     setSelectedLinearFeature(null);
+    if (tourVariant === 'trips') {
+      tripClear();
+    }
+    setTourVariant('default');
     isProgrammaticNavigationRef.current = true;
     navigate('/');
-  }, [navigate]);
+  }, [navigate, tourVariant, tripClear]);
 
   const handleTourStepAction = useCallback((action) => {
     switch (action) {
@@ -318,8 +368,33 @@ function AppContent() {
         }
         break;
       }
+      case 'tripTourAddDemoStop': {
+        // Demo a stop so the Trip Builder appears for the next steps.
+        // Coords are Boston Mill Visitor Center (picked by selectVisitorCenter).
+        const vc = destinations.find(d => d.name === 'Boston Mill Visitor Center');
+        const lat = vc && vc.latitude != null ? Number(vc.latitude) : 41.273;
+        const lng = vc && vc.longitude != null ? Number(vc.longitude) : -81.566;
+        tripAddStop({
+          poi_id: vc ? vc.id : null,
+          label: vc ? vc.name : 'Sample Stop',
+          latitude: lat,
+          longitude: lng
+        });
+        tripSetShowBuilder(true);
+        break;
+      }
+      case 'tripTourExpandBuilder': {
+        tripSetShowBuilder(true);
+        break;
+      }
+      case 'tripTourEndDemo': {
+        // Open the user dropdown so the My Trips item is spotlight-able.
+        setSelectedDestination(null);
+        setShowUserDropdown(true);
+        break;
+      }
     }
-  }, [destinations, isAuthenticated, isAdmin, navigate]);
+  }, [destinations, isAuthenticated, isAdmin, navigate, tripAddStop, tripSetShowBuilder]);
 
   const handleTabChange = useCallback((newTab) => {
     const previousActiveTab = activeTab;
@@ -1686,6 +1761,12 @@ function AppContent() {
                       {isAdmin && <span className="admin-badge-inline">Admin</span>}
                     </div>
                     <button
+                      className="dropdown-item-inline my-trips-menu-item"
+                      onClick={() => { setShowUserDropdown(false); setShowMyTrips(true); }}
+                    >
+                      My Trips
+                    </button>
+                    <button
                       className="dropdown-item-inline settings-item-inline"
                       onClick={() => { setShowUserDropdown(false); handleTabChange('settings'); }}
                     >
@@ -1860,7 +1941,7 @@ function AppContent() {
 
       {activeTab === 'about' && (
         <main id="main-content" className="main-content-full" tabIndex="-1">
-          <AboutPage onStartTour={startTour} aboutTab={aboutTab} onTabChange={setAboutTab} isAdmin={isAdmin} editMode={editMode} />
+          <AboutPage onStartTour={startTour} onStartTripTour={startTripTour} aboutTab={aboutTab} onTabChange={setAboutTab} isAdmin={isAdmin} editMode={editMode} />
         </main>
       )}
 
@@ -2197,6 +2278,9 @@ function AppContent() {
         <FeedbackForm onClose={() => setShowFeedbackForm(false)} />
       )}
 
+      <TripBuilder onOpenMyTrips={() => setShowMyTrips(true)} />
+      <MyTripsModal open={showMyTrips} onClose={() => setShowMyTrips(false)} />
+
       {showTourPrompt && (
         <TourPrompt
           onStartTour={startTour}
@@ -2213,6 +2297,7 @@ function AppContent() {
           currentStep={tourStep}
           setCurrentStep={setTourStep}
           onStepAction={handleTourStepAction}
+          steps={tourVariant === 'trips' ? TRIP_TOUR_STEPS : undefined}
         />
       )}
     </div>
@@ -2222,7 +2307,9 @@ function AppContent() {
 function App() {
   return (
     <AuthProvider>
-      <AppContent />
+      <TripProvider>
+        <AppContent />
+      </TripProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/components/AboutPage.jsx
+++ b/frontend/src/components/AboutPage.jsx
@@ -100,7 +100,7 @@ function AboutStory({ content, isAdmin, editMode }) {
   );
 }
 
-function AboutTutorial({ onStartTour, content, isAdmin, editMode }) {
+function AboutTutorial({ onStartTour, content, contentKey = 'about_tutorial_md', buttonLabel = 'Take a Tour', isAdmin, editMode }) {
   const [editing, setEditing] = useState(false);
   const [localContent, setLocalContent] = useState(content);
 
@@ -119,18 +119,18 @@ function AboutTutorial({ onStartTour, content, isAdmin, editMode }) {
         <button className="about-edit-btn" onClick={() => setEditing(true)}>Edit</button>
       )}
       {editing ? (
-        <AboutEditor contentKey="about_tutorial_md" content={localContent} onSave={handleSave} />
+        <AboutEditor contentKey={contentKey} content={localContent} onSave={handleSave} />
       ) : (
         <MarkdownRenderer content={localContent} className="about-tutorial-content" />
       )}
       <button className="about-tour-btn" onClick={onStartTour}>
-        Take a Tour
+        {buttonLabel}
       </button>
     </div>
   );
 }
 
-function AboutPage({ onStartTour, aboutTab, onTabChange, isAdmin, editMode }) {
+function AboutPage({ onStartTour, onStartTripTour, aboutTab, onTabChange, isAdmin, editMode }) {
   const [aboutContent, setAboutContent] = useState({});
 
   useEffect(() => {
@@ -160,7 +160,7 @@ function AboutPage({ onStartTour, aboutTab, onTabChange, isAdmin, editMode }) {
             role="tab"
             aria-selected={aboutTab === 'tutorial'}
           >
-            Tutorial
+            Tutorials
           </button>
           <button
             className={`settings-tab-btn about-tab-btn ${aboutTab === 'feedback' ? 'active' : ''}`}
@@ -188,7 +188,24 @@ function AboutPage({ onStartTour, aboutTab, onTabChange, isAdmin, editMode }) {
           <AboutStory content={aboutContent.about_story_md} isAdmin={isAdmin} editMode={editMode} />
         )}
         {aboutTab === 'tutorial' && (
-          <AboutTutorial onStartTour={onStartTour} content={aboutContent.about_tutorial_md} isAdmin={isAdmin} editMode={editMode} />
+          <>
+            <AboutTutorial
+              onStartTour={onStartTour}
+              content={aboutContent.about_tutorial_md}
+              contentKey="about_tutorial_md"
+              buttonLabel="Take a Tour"
+              isAdmin={isAdmin}
+              editMode={editMode}
+            />
+            <AboutTutorial
+              onStartTour={onStartTripTour}
+              content={aboutContent.about_trip_tutorial_md}
+              contentKey="about_trip_tutorial_md"
+              buttonLabel="Take the Trip Planning Tour"
+              isAdmin={isAdmin}
+              editMode={editMode}
+            />
+          </>
         )}
         {aboutTab === 'feedback' && <FeedbackForm inline />}
         {aboutTab === 'privacy' && (

--- a/frontend/src/components/AddToTripButton.jsx
+++ b/frontend/src/components/AddToTripButton.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useTrip } from '../hooks/useTrip';
+
+export default function AddToTripButton({ poi, stops, className = 'share-badge-btn add-to-trip-btn' }) {
+  const { trip, addStop, removeStopByPoi, hasStop, MAX_STOPS } = useTrip();
+
+  if (!Array.isArray(stops) || stops.length === 0) return null;
+  const primary = stops[0];
+  if (!primary || typeof primary.lat !== 'number' || typeof primary.lng !== 'number') return null;
+
+  const poiId = poi && poi.id ? poi.id : null;
+  const inTrip = poiId ? hasStop(poiId) : false;
+  const atLimit = trip.stops.length >= MAX_STOPS;
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+    if (inTrip && poiId) {
+      removeStopByPoi(poiId);
+      return;
+    }
+    if (atLimit) return;
+    addStop({
+      poi_id: poiId,
+      label: poi && poi.name ? poi.name : null,
+      latitude: primary.lat,
+      longitude: primary.lng
+    });
+  };
+
+  if (!inTrip && atLimit) {
+    return (
+      <button className={className} disabled title={`Trip is at the ${MAX_STOPS}-stop maximum`}>
+        Trip full
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className={className}
+      onClick={handleClick}
+      title={inTrip ? 'Remove from trip' : 'Add this stop to your day-trip'}
+    >
+      <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+        {inTrip ? (
+          <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+        ) : (
+          <path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z" />
+        )}
+      </svg>
+      {inTrip ? 'In Trip' : 'Add to Trip'}
+    </button>
+  );
+}

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -1,5 +1,66 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
+export const TRIP_TOUR_STEPS = [
+  {
+    selector: '.add-to-trip-btn',
+    title: 'Add to Trip',
+    description: 'Open any point of interest and look for the "+ Add to Trip" badge next to Share and Navigate. Tap it to drop the stop into a new day-trip.',
+    position: 'left',
+    action: 'selectVisitorCenter',
+    delay: 450,
+    spotlightSelector: '.add-to-trip-btn',
+    mobile: {
+      action: 'collapseLegendThenSelectVisitorCenter',
+      delay: 700,
+      position: 'top',
+      mobilePositionAbove: true
+    }
+  },
+  {
+    selector: '.trip-builder',
+    title: 'Trip Builder',
+    description: 'When you add a stop, a small card appears at the bottom with your trip. Tap the chevron on the left to expand or collapse it without losing your stops. The × on the right discards the trip.',
+    position: 'top',
+    action: 'tripTourExpandBuilder',
+    delay: 300,
+    spotlightSelector: '.trip-builder',
+    tooltipHeight: 260,
+    mobile: { mobilePositionAbove: true }
+  },
+  {
+    selector: '.trip-stop-row',
+    title: 'Stops in Order',
+    description: 'Reorder with ▲/▼ or remove a stop with ×. Trips are capped at 9 stops so Google Maps can start the route from your current location.',
+    position: 'top',
+    action: 'tripTourExpandBuilder',
+    spotlightSelector: '.trip-stop-row',
+    delay: 300,
+    tooltipHeight: 240,
+    mobile: { mobilePositionAbove: true }
+  },
+  {
+    selector: '.trip-builder-actions-primary',
+    title: 'Navigate · Save · My Trips',
+    description: 'Three green buttons: Navigate hands the route to Google Maps. Save stores the trip to your account. My Trips opens your library and Find Trips — Featured Routes from admins and trips other users have shared.',
+    position: 'top',
+    action: 'tripTourExpandBuilder',
+    spotlightSelector: '.trip-builder-actions-primary',
+    delay: 200,
+    tooltipHeight: 260,
+    mobile: { mobilePositionAbove: true }
+  },
+  {
+    selector: '.my-trips-menu-item',
+    title: 'My Trips Anywhere',
+    description: 'Your trip library is reachable any time from the user menu too. Sign in to save trips, share them publicly (after a quick review), or — if you’re an admin — feature them for everyone.',
+    position: 'left',
+    action: 'tripTourEndDemo',
+    spotlightSelector: '.my-trips-menu-item',
+    delay: 400,
+    mobile: { position: 'top', mobilePositionAbove: true }
+  }
+];
+
 const TOUR_STEPS = [
   {
     selector: '.leaflet-container',
@@ -125,8 +186,8 @@ function getEffectiveStep(step, isMobile) {
   return { ...step, ...step.mobile };
 }
 
-function getActiveSteps(isMobile) {
-  return TOUR_STEPS.filter(s => {
+function getActiveSteps(isMobile, allSteps = TOUR_STEPS) {
+  return allSteps.filter(s => {
     if (s.mobileOnly && !isMobile) return false;
     if (s.desktopOnly && isMobile) return false;
     return true;
@@ -187,7 +248,11 @@ function placeTooltip(placement, spotlight, tooltipWidth, tooltipHeight, gap, vw
 }
 
 function computePosition(step, el, isMobile) {
-  const isHidden = el && (el.offsetParent === null || (el.getBoundingClientRect().width === 0 && el.getBoundingClientRect().height === 0));
+  // offsetParent is null for position:fixed elements in Chrome even when
+  // they're fully visible (this broke the .trip-builder spotlight). Use
+  // dimensions as the visibility signal instead.
+  const elRectForHidden = el ? el.getBoundingClientRect() : null;
+  const isHidden = el && elRectForHidden.width === 0 && elRectForHidden.height === 0;
   if (!el || isHidden) {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
@@ -226,7 +291,12 @@ function computePosition(step, el, isMobile) {
   }
 
   const tooltipWidth = isMobile ? Math.min(300, vw - 40) : 300;
-  const tooltipHeight = isMobile ? 220 : 180;
+  // Per-step override lets steps with long descriptions reserve enough
+  // space so placeTooltip doesn't position the tooltip overlapping the
+  // spotlight. Default values match short-description steps.
+  const tooltipHeight = step.tooltipHeight !== undefined
+    ? step.tooltipHeight
+    : (isMobile ? 220 : 180);
   const gap = 16;
 
   if (isMobile) {
@@ -289,7 +359,7 @@ function computePosition(step, el, isMobile) {
   };
 }
 
-function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction }) {
+function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: stepsProp }) {
   const [spotlightRect, setSpotlightRect] = useState(null);
   const [tooltipStyle, setTooltipStyle] = useState({});
   const [stepReady, setStepReady] = useState(true);
@@ -298,7 +368,7 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction }) {
   const resizeRef = useRef(null);
   const prevStepRef = useRef(-1);
 
-  const activeSteps = useMemo(() => getActiveSteps(isMobile), [isMobile]);
+  const activeSteps = useMemo(() => getActiveSteps(isMobile, stepsProp || TOUR_STEPS), [isMobile, stepsProp]);
   const baseStep = activeSteps[currentStep];
   const step = useMemo(() => getEffectiveStep(baseStep, isMobile), [baseStep, isMobile]);
 
@@ -418,7 +488,7 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction }) {
         <div
           className="guided-tour-backdrop"
           style={{
-            boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 0 2px rgba(255, 255, 255, 0.3) inset',
+            boxShadow: '0 0 0 4px rgba(45, 106, 79, 1), 0 0 16px 6px rgba(45, 106, 79, 0.55), 0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 0 2px rgba(255, 255, 255, 0.4) inset',
             position: 'fixed',
             top: `${spotlightRect.top}px`,
             left: `${spotlightRect.left}px`,

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -248,9 +248,6 @@ function placeTooltip(placement, spotlight, tooltipWidth, tooltipHeight, gap, vw
 }
 
 function computePosition(step, el, isMobile) {
-  // offsetParent is null for position:fixed elements in Chrome even when
-  // they're fully visible (this broke the .trip-builder spotlight). Use
-  // dimensions as the visibility signal instead.
   const elRectForHidden = el ? el.getBoundingClientRect() : null;
   const isHidden = el && elRectForHidden.width === 0 && elRectForHidden.height === 0;
   if (!el || isHidden) {
@@ -291,9 +288,6 @@ function computePosition(step, el, isMobile) {
   }
 
   const tooltipWidth = isMobile ? Math.min(300, vw - 40) : 300;
-  // Per-step override lets steps with long descriptions reserve enough
-  // space so placeTooltip doesn't position the tooltip overlapping the
-  // spotlight. Default values match short-description steps.
   const tooltipHeight = step.tooltipHeight !== undefined
     ? step.tooltipHeight
     : (isMobile ? 220 : 180);

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -3,6 +3,34 @@ import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents
 import L from 'leaflet';
 import VirtualPoiCreator from './VirtualPoiCreator';
 import { getDestinationIconTypeFromConfig } from '../utils/iconUtils';
+import { useTrip } from '../hooks/useTrip';
+
+function createTripStopIcon(n) {
+  return L.divIcon({
+    className: 'trip-stop-icon',
+    html: `<div class="trip-stop-marker">${n}</div>`,
+    iconSize: [28, 28],
+    iconAnchor: [14, 14]
+  });
+}
+
+function TripStopMarkers() {
+  const { trip } = useTrip();
+  if (!trip || !Array.isArray(trip.stops) || trip.stops.length === 0) return null;
+  return (
+    <>
+      {trip.stops.map((stop, i) => (
+        <Marker
+          key={`trip-stop-${i}`}
+          position={[Number(stop.latitude), Number(stop.longitude)]}
+          icon={createTripStopIcon(i + 1)}
+          interactive={false}
+          zIndexOffset={1000}
+        />
+      ))}
+    </>
+  );
+}
 
 const createIcon = (iconUrl) => L.icon({
   iconUrl,
@@ -1487,6 +1515,7 @@ function Map({ destinations, selectedDestination, onSelectDestination, isAdmin, 
             }}
           />
         )}
+        <TripStopMarkers />
       </MapContainer>
 
       <button

--- a/frontend/src/components/MyTripsModal.css
+++ b/frontend/src/components/MyTripsModal.css
@@ -1,0 +1,144 @@
+.my-trips-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.my-trips-modal {
+  background: white;
+  border-radius: 8px;
+  max-width: 640px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+}
+
+.my-trips-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.my-trips-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.my-trips-close-btn {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.my-trips-body {
+  padding: 0.75rem 1rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.my-trips-actions-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.my-trips-actions-row button {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: white;
+  border-radius: 4px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.my-trips-actions-row button.primary {
+  background: var(--accent, #2d6a4f);
+  color: white;
+  border-color: var(--accent, #2d6a4f);
+}
+
+.my-trips-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.my-trips-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #f7f7f7;
+  border-radius: 4px;
+}
+
+.my-trips-row-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.my-trips-row-name {
+  font-weight: 600;
+}
+
+.my-trips-row-meta {
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.my-trips-row-actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.my-trips-row-actions button {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: white;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.my-trips-row-actions button.danger {
+  border-color: rgba(220, 53, 69, 0.4);
+  color: #dc3545;
+}
+
+.my-trips-empty {
+  padding: 0.75rem 0;
+  color: rgba(0, 0, 0, 0.55);
+  font-style: italic;
+}
+
+.my-trips-section-heading {
+  margin: 0.75rem 0 0.4rem 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.my-trips-error {
+  background: rgba(220, 53, 69, 0.08);
+  border: 1px solid rgba(220, 53, 69, 0.3);
+  color: #dc3545;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/components/MyTripsModal.jsx
+++ b/frontend/src/components/MyTripsModal.jsx
@@ -108,7 +108,6 @@ export default function MyTripsModal({ open, onClose }) {
     try {
       const res = await fetch(`/api/trips/${id}`, { method: 'DELETE', credentials: 'include' });
       if (!res.ok) throw new Error('Could not delete trip');
-      // If the trip currently open in the dock just got deleted, drop it.
       if (activeTrip && activeTrip.id === id) clear();
       await refreshMine();
     } catch (err) {
@@ -124,7 +123,6 @@ export default function MyTripsModal({ open, onClose }) {
         await navigator.clipboard.writeText(url);
         ok = true;
       } else {
-        // Fallback for non-secure contexts (clipboard API unavailable)
         const ta = document.createElement('textarea');
         ta.value = url;
         ta.style.position = 'fixed';

--- a/frontend/src/components/MyTripsModal.jsx
+++ b/frontend/src/components/MyTripsModal.jsx
@@ -1,0 +1,304 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTrip } from '../hooks/useTrip';
+import { useAuth } from '../hooks/useAuth';
+import './MyTripsModal.css';
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+function shareStatusLabel(trip) {
+  if (trip.is_featured) return '⭐ Featured';
+  if (trip.is_public && trip.is_approved) return '🌐 Shared';
+  if (trip.is_public && !trip.is_approved) return '⏳ Pending review';
+  return null;
+}
+
+export default function MyTripsModal({ open, onClose }) {
+  const { trip: activeTrip, loadTrip, clear } = useTrip();
+  const { isAdmin } = useAuth();
+  const [mine, setMine] = useState([]);
+  const [discover, setDiscover] = useState([]);
+  const [pending, setPending] = useState([]);
+  const [view, setView] = useState('mine');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [copiedId, setCopiedId] = useState(null);
+
+  const refreshMine = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/trips/mine', { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load trips');
+      setMine(await res.json());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refreshDiscover = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/trips/discover', { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load trips');
+      setDiscover(await res.json());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refreshPending = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/trips/pending', { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load pending trips');
+      setPending(await res.json());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setView('mine');
+    refreshMine();
+  }, [open, refreshMine]);
+
+  if (!open) return null;
+
+  const handleOpen = async (slug) => {
+    try {
+      const res = await fetch(`/api/trips/${encodeURIComponent(slug)}`, { credentials: 'include' });
+      if (!res.ok) throw new Error('Could not load trip');
+      const data = await res.json();
+      loadTrip(data);
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDuplicate = async (id) => {
+    try {
+      const res = await fetch(`/api/trips/${id}/duplicate`, { method: 'POST', credentials: 'include' });
+      if (!res.ok) throw new Error('Could not duplicate trip');
+      await refreshMine();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this trip?')) return;
+    try {
+      const res = await fetch(`/api/trips/${id}`, { method: 'DELETE', credentials: 'include' });
+      if (!res.ok) throw new Error('Could not delete trip');
+      // If the trip currently open in the dock just got deleted, drop it.
+      if (activeTrip && activeTrip.id === id) clear();
+      await refreshMine();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCopyLink = async (trip) => {
+    const url = `${window.location.origin}/trip/${trip.slug}`;
+    let ok = false;
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(url);
+        ok = true;
+      } else {
+        // Fallback for non-secure contexts (clipboard API unavailable)
+        const ta = document.createElement('textarea');
+        ta.value = url;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try { ok = document.execCommand('copy'); } catch { ok = false; }
+        document.body.removeChild(ta);
+      }
+    } catch {
+      ok = false;
+    }
+    if (ok) {
+      setCopiedId(trip.id);
+      setTimeout(() => setCopiedId(prev => (prev === trip.id ? null : prev)), 1800);
+    } else {
+      window.prompt('Copy this link:', url);
+    }
+  };
+
+  const handleClone = async (id) => {
+    try {
+      const res = await fetch(`/api/trips/${id}/duplicate`, { method: 'POST', credentials: 'include' });
+      if (!res.ok) throw new Error('Could not add trip to your list');
+      setView('mine');
+      await refreshMine();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleModerate = async (id, action) => {
+    try {
+      const res = await fetch(`/api/trips/${id}/moderate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ action })
+      });
+      if (!res.ok) throw new Error(`Could not ${action} trip`);
+      await refreshPending();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="my-trips-overlay" role="dialog" aria-modal="true" onClick={onClose}>
+      <div className="my-trips-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="my-trips-header">
+          <h2>
+            {view === 'mine' && 'My Trips'}
+            {view === 'discover' && 'Find Trips'}
+            {view === 'pending' && 'Pending Public Trips'}
+          </h2>
+          <button className="my-trips-close-btn" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        <div className="my-trips-body">
+          {error && <div className="my-trips-error">{error}</div>}
+
+          {view === 'mine' && (
+            <>
+              <div className="my-trips-actions-row">
+                <button className="primary" onClick={() => { clear(); onClose(); }}>+ New Trip</button>
+                <button onClick={() => { setView('discover'); refreshDiscover(); }}>Find Trips</button>
+                {isAdmin && (
+                  <button onClick={() => { setView('pending'); refreshPending(); }}>
+                    Pending Review
+                  </button>
+                )}
+              </div>
+              {loading ? (
+                <div className="my-trips-empty">Loading…</div>
+              ) : mine.length === 0 ? (
+                <div className="my-trips-empty">No saved trips yet. Plan one on the map, then tap Save.</div>
+              ) : (
+                <ul className="my-trips-list">
+                  {mine.map(trip => {
+                    const status = shareStatusLabel(trip);
+                    return (
+                      <li key={trip.id} className="my-trips-row">
+                        <div className="my-trips-row-info">
+                          <span className="my-trips-row-name">
+                            {trip.name}{status ? ` · ${status}` : ''}
+                          </span>
+                          <span className="my-trips-row-meta">
+                            {trip.stop_count} stop{Number(trip.stop_count) === 1 ? '' : 's'} · edited {formatDate(trip.updated_at)}
+                          </span>
+                        </div>
+                        <div className="my-trips-row-actions">
+                          <button onClick={() => handleOpen(trip.slug)}>Open</button>
+                          <button onClick={() => handleDuplicate(trip.id)}>Duplicate</button>
+                          {(trip.is_featured || trip.is_public) && (
+                            <button onClick={() => handleCopyLink(trip)}>
+                              {copiedId === trip.id ? 'Copied!' : 'Copy link'}
+                            </button>
+                          )}
+                          <button className="danger" onClick={() => handleDelete(trip.id)}>Delete</button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
+
+          {view === 'discover' && (
+            <>
+              {loading ? (
+                <div className="my-trips-empty">Loading…</div>
+              ) : discover.length === 0 ? (
+                <div className="my-trips-empty">No shared trips yet.</div>
+              ) : (
+                <ul className="my-trips-list">
+                  {discover.map(trip => (
+                    <li key={trip.id} className="my-trips-row">
+                      <div className="my-trips-row-info">
+                        <span className="my-trips-row-name">
+                          {trip.name}
+                          {trip.is_featured ? ' · ⭐ Featured' : (trip.owner_name ? ` · by ${trip.owner_name}` : '')}
+                        </span>
+                        <span className="my-trips-row-meta">
+                          {trip.stop_count} stop{Number(trip.stop_count) === 1 ? '' : 's'}
+                          {trip.description ? ` · ${trip.description}` : ''}
+                        </span>
+                      </div>
+                      <div className="my-trips-row-actions">
+                        <button onClick={() => handleClone(trip.id)}>Add to my trips</button>
+                        <button onClick={() => handleOpen(trip.slug)}>Preview</button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div style={{ marginTop: '0.75rem' }}>
+                <button onClick={() => setView('mine')}>&larr; Back to My Trips</button>
+              </div>
+            </>
+          )}
+
+          {view === 'pending' && isAdmin && (
+            <>
+              {loading ? (
+                <div className="my-trips-empty">Loading…</div>
+              ) : pending.length === 0 ? (
+                <div className="my-trips-empty">No trips awaiting review.</div>
+              ) : (
+                <ul className="my-trips-list">
+                  {pending.map(trip => (
+                    <li key={trip.id} className="my-trips-row">
+                      <div className="my-trips-row-info">
+                        <span className="my-trips-row-name">{trip.name}</span>
+                        <span className="my-trips-row-meta">
+                          {trip.stop_count} stop{Number(trip.stop_count) === 1 ? '' : 's'} · by {trip.owner_name || trip.owner_email || 'unknown'} · submitted {formatDate(trip.updated_at)}
+                        </span>
+                      </div>
+                      <div className="my-trips-row-actions">
+                        <button onClick={() => handleOpen(trip.slug)}>Preview</button>
+                        <button className="primary" onClick={() => handleModerate(trip.id, 'approve')}>Approve</button>
+                        <button className="danger" onClick={() => handleModerate(trip.id, 'reject')}>Reject</button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div style={{ marginTop: '0.75rem' }}>
+                <button onClick={() => setView('mine')}>&larr; Back to My Trips</button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/NavigateButton.jsx
+++ b/frontend/src/components/NavigateButton.jsx
@@ -16,9 +16,6 @@ export function buildGoogleMapsUrl(stops) {
   const fmt = ({ lat, lng }) => `${lat},${lng}`;
   const base = 'https://www.google.com/maps/dir/?api=1';
 
-  // Omit &origin= so Google Maps starts from the user's current location.
-  // The last stop is the destination; everything before it is a waypoint.
-  // Google Maps URL spec supports up to 9 waypoints.
   const destination = valid[valid.length - 1];
   const waypoints = valid.slice(0, -1);
 

--- a/frontend/src/components/NavigateButton.jsx
+++ b/frontend/src/components/NavigateButton.jsx
@@ -16,16 +16,13 @@ export function buildGoogleMapsUrl(stops) {
   const fmt = ({ lat, lng }) => `${lat},${lng}`;
   const base = 'https://www.google.com/maps/dir/?api=1';
 
-  if (valid.length === 1) {
-    return `${base}&destination=${encodeURIComponent(fmt(valid[0]))}`;
-  }
-
-  const origin = valid[0];
+  // Omit &origin= so Google Maps starts from the user's current location.
+  // The last stop is the destination; everything before it is a waypoint.
+  // Google Maps URL spec supports up to 9 waypoints.
   const destination = valid[valid.length - 1];
-  const waypoints = valid.slice(1, -1);
+  const waypoints = valid.slice(0, -1);
 
-  let url = `${base}&origin=${encodeURIComponent(fmt(origin))}`;
-  url += `&destination=${encodeURIComponent(fmt(destination))}`;
+  let url = `${base}&destination=${encodeURIComponent(fmt(destination))}`;
   if (waypoints.length > 0) {
     url += `&waypoints=${encodeURIComponent(waypoints.map(fmt).join('|'))}`;
   }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -5,6 +5,7 @@ import ThumbnailCarousel from './ThumbnailCarousel';
 import { formatDateTime, formatPublicationDate, NewsTypeIcon, EventTypeIcon } from './NewsEventsShared';
 import ShareButton from './ShareButton';
 import NavigateButton from './NavigateButton';
+import AddToTripButton from './AddToTripButton';
 import Mosaic from './Mosaic';
 import MediaUploadModal from './MediaUploadModal';
 import RoleEditor from './RoleEditor';
@@ -293,6 +294,7 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
             </button>
           )}
           <NavigateButton stops={getNavigationStops(destination, isLinearFeature)} />
+          <AddToTripButton poi={destination} stops={getNavigationStops(destination, isLinearFeature)} />
         </div>
 
         {destination.status_url && trailStatus && trailStatus.status !== 'unknown' && (trailStatus.conditions || trailStatus.weather_impact || trailStatus.seasonal_closure || trailStatus.last_updated) && (

--- a/frontend/src/components/TripBuilder.css
+++ b/frontend/src/components/TripBuilder.css
@@ -1,0 +1,244 @@
+.trip-builder {
+  position: fixed;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1100;
+  width: min(480px, calc(100vw - 16px));
+  background: var(--surface, #ffffff);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.trip-builder-handle {
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
+  align-items: center;
+  padding: 0.5rem 0.5rem;
+  background: var(--surface-strong, #f5f5f5);
+  user-select: none;
+}
+
+.trip-builder-handle-summary {
+  font-weight: 600;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.trip-builder-close {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.2rem 0.4rem;
+  color: rgba(0, 0, 0, 0.55);
+  border-radius: 4px;
+  justify-self: end;
+}
+
+.trip-builder-close:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #dc3545;
+}
+
+.trip-builder-close.confirming {
+  color: #dc3545;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.4rem;
+}
+
+.trip-builder-toggle {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.2rem 0.4rem;
+  color: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
+  justify-self: start;
+}
+
+.trip-builder-toggle:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.trip-builder-body {
+  padding: 0.75rem;
+  max-height: min(50vh, 360px);
+  overflow-y: auto;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.trip-name-input {
+  width: 100%;
+  font-size: 1rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  background: white;
+}
+
+.trip-stops-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trip-stop-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  background: var(--surface-strong, #f5f5f5);
+  border-radius: 4px;
+}
+
+.trip-stop-position {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent, #2d6a4f);
+  color: white;
+  font-weight: 700;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.trip-stop-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trip-stop-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.trip-stop-action-btn {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: white;
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.trip-stop-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.trip-stop-remove-btn {
+  border: 1px solid rgba(220, 53, 69, 0.4);
+  background: white;
+  color: #dc3545;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.trip-builder-limit-hint {
+  font-size: 0.78rem;
+  color: rgba(0, 0, 0, 0.55);
+  margin: 0 0 0.5rem 0;
+}
+
+.trip-builder-warning {
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.4);
+  border-radius: 4px;
+  padding: 0.4rem 0.5rem;
+  margin: 0.5rem 0;
+  font-size: 0.85rem;
+}
+
+.trip-builder-actions-primary {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.trip-builder-actions-primary button,
+.trip-builder-actions-primary a {
+  flex: 1;
+  text-align: center;
+  background: var(--accent, #2d6a4f);
+  color: white;
+  border: 1px solid var(--accent, #2d6a4f);
+  border-radius: 4px;
+  padding: 0.5rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.trip-builder-actions-primary button:disabled,
+.trip-builder-actions-primary a.disabled,
+.trip-builder-actions-primary a[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.trip-builder-toggles {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.trip-builder-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+}
+
+.trip-stop-icon {
+  background: transparent;
+  border: none;
+}
+
+.trip-stop-marker {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2d6a4f;
+  color: white;
+  font-weight: 700;
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  font-size: 0.85rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/frontend/src/components/TripBuilder.jsx
+++ b/frontend/src/components/TripBuilder.jsx
@@ -1,0 +1,226 @@
+import React, { useState, useEffect } from 'react';
+import { useTrip } from '../hooks/useTrip';
+import { useAuth } from '../hooks/useAuth';
+import { buildGoogleMapsUrl } from './NavigateButton';
+import './TripBuilder.css';
+
+function stopDisplayName(stop, index) {
+  return stop.label || stop.poi_name || `Stop ${index + 1}`;
+}
+
+export default function TripBuilder({ onOpenMyTrips }) {
+  const {
+    trip, showBuilder, setShowBuilder,
+    removeStop, moveStop, clear,
+    setName, setIsPublic, setIsFeatured, saveTrip,
+    MAX_STOPS
+  } = useTrip();
+  const { isAuthenticated, isAdmin } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  // The dock is *visible as a handle* whenever a trip has any stops.
+  // The body inside the dock is *expanded* per showBuilder. Adding a
+  // stop expands automatically (set in TripContext.addStop); the user
+  // can collapse with the chevron without losing the trip.
+  useEffect(() => {
+    if (trip.stops.length === 0) setConfirmClear(false);
+  }, [trip.stops.length]);
+
+  if (trip.stops.length === 0) return null;
+
+  const expanded = !!showBuilder;
+  const googleMapsUrl = buildGoogleMapsUrl(
+    trip.stops.map(s => ({ lat: Number(s.latitude), lng: Number(s.longitude) }))
+  );
+  const atLimit = trip.stops.length >= MAX_STOPS;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await saveTrip();
+    } catch (err) {
+      setSaveError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = () => {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      setTimeout(() => setConfirmClear(false), 4000);
+      return;
+    }
+    clear();
+    setConfirmClear(false);
+  };
+
+  // Saved trips (have an id) live in My Trips, so X just clears the
+  // current view. Unsaved trips need a confirm — losing them is destructive.
+  const handleClose = () => {
+    if (trip.id) {
+      clear();
+      return;
+    }
+    if (!confirmClear) {
+      setConfirmClear(true);
+      setTimeout(() => setConfirmClear(false), 4000);
+      return;
+    }
+    clear();
+    setConfirmClear(false);
+  };
+
+  return (
+    <div className="trip-builder" role="region" aria-label="Trip Builder">
+      <div className="trip-builder-handle">
+        <button
+          type="button"
+          className="trip-builder-toggle"
+          onClick={() => setShowBuilder(!expanded)}
+          aria-label={expanded ? 'Collapse trip builder' : 'Expand trip builder'}
+          title={expanded ? 'Collapse' : 'Expand'}
+        >
+          {expanded ? '▾' : '▴'}
+        </button>
+        <span
+          className="trip-builder-handle-summary"
+          onClick={() => setShowBuilder(!expanded)}
+          role="button"
+          tabIndex={0}
+          aria-expanded={expanded}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setShowBuilder(!expanded);
+            }
+          }}
+        >
+          {trip.name || 'Untitled Trip'} · {trip.stops.length} stop{trip.stops.length === 1 ? '' : 's'}
+        </span>
+        <button
+          type="button"
+          className={`trip-builder-close${confirmClear ? ' confirming' : ''}`}
+          onClick={handleClose}
+          aria-label={confirmClear ? 'Tap again to discard trip' : 'Close trip'}
+          title={confirmClear ? 'Tap again to discard' : (trip.id ? 'Close' : 'Discard trip')}
+        >
+          {confirmClear ? 'Discard?' : '×'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="trip-builder-body">
+          <input
+            type="text"
+            className="trip-name-input"
+            placeholder="Untitled Trip"
+            value={trip.name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={200}
+          />
+
+          <ol className="trip-stops-list">
+            {trip.stops.map((stop, i) => (
+              <li key={`${i}:${stop.poi_id || stop.latitude}`} className="trip-stop-row">
+                <span className="trip-stop-position">{i + 1}</span>
+                <span className="trip-stop-label">{stopDisplayName(stop, i)}</span>
+                <div className="trip-stop-actions">
+                  <button
+                    type="button"
+                    className="trip-stop-action-btn"
+                    onClick={() => moveStop(i, i - 1)}
+                    disabled={i === 0}
+                    aria-label="Move up"
+                    title="Move up"
+                  >▲</button>
+                  <button
+                    type="button"
+                    className="trip-stop-action-btn"
+                    onClick={() => moveStop(i, i + 1)}
+                    disabled={i === trip.stops.length - 1}
+                    aria-label="Move down"
+                    title="Move down"
+                  >▼</button>
+                  <button
+                    type="button"
+                    className="trip-stop-remove-btn"
+                    onClick={() => removeStop(i)}
+                    aria-label="Remove stop"
+                    title="Remove stop"
+                  >×</button>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <p className="trip-builder-limit-hint">
+            {trip.stops.length} of {MAX_STOPS} stops · Starts from your current location in Google Maps.
+            {atLimit && ' Trip is full.'}
+          </p>
+
+          {saveError && (
+            <div className="trip-builder-warning" role="alert">{saveError}</div>
+          )}
+
+          <div className="trip-builder-actions-primary">
+            <a
+              href={googleMapsUrl || '#'}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`primary${googleMapsUrl ? '' : ' disabled'}`}
+              onClick={(e) => { if (!googleMapsUrl) e.preventDefault(); }}
+              aria-disabled={!googleMapsUrl}
+            >
+              Navigate
+            </a>
+            <button
+              type="button"
+              className="primary"
+              onClick={handleSave}
+              disabled={!isAuthenticated || saving}
+              title={isAuthenticated ? '' : 'Sign in to save this trip'}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              className="primary"
+              onClick={onOpenMyTrips}
+            >
+              My Trips
+            </button>
+          </div>
+
+          {(isAuthenticated || isAdmin) && (
+            <div className="trip-builder-toggles">
+              {isAuthenticated && (
+                <label className="trip-builder-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={trip.is_public}
+                    onChange={(e) => setIsPublic(e.target.checked)}
+                  />
+                  Public
+                </label>
+              )}
+              {isAdmin && (
+                <label className="trip-builder-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={trip.is_featured}
+                    onChange={(e) => setIsFeatured(e.target.checked)}
+                  />
+                  Featured
+                </label>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TripBuilder.jsx
+++ b/frontend/src/components/TripBuilder.jsx
@@ -20,10 +20,6 @@ export default function TripBuilder({ onOpenMyTrips }) {
   const [saveError, setSaveError] = useState(null);
   const [confirmClear, setConfirmClear] = useState(false);
 
-  // The dock is *visible as a handle* whenever a trip has any stops.
-  // The body inside the dock is *expanded* per showBuilder. Adding a
-  // stop expands automatically (set in TripContext.addStop); the user
-  // can collapse with the chevron without losing the trip.
   useEffect(() => {
     if (trip.stops.length === 0) setConfirmClear(false);
   }, [trip.stops.length]);
@@ -58,8 +54,6 @@ export default function TripBuilder({ onOpenMyTrips }) {
     setConfirmClear(false);
   };
 
-  // Saved trips (have an id) live in My Trips, so X just clears the
-  // current view. Unsaved trips need a confirm — losing them is destructive.
   const handleClose = () => {
     if (trip.id) {
       clear();

--- a/frontend/src/contexts/TripContext.jsx
+++ b/frontend/src/contexts/TripContext.jsx
@@ -3,9 +3,6 @@ import React, { createContext, useState, useEffect, useCallback, useRef } from '
 export const TripContext = createContext(null);
 
 const STORAGE_KEY = 'rotv.tripInProgress.v1';
-// Cap at 9 so the user's current location can be the starting point.
-// Google Maps' URL spec allows up to 9 waypoints; we send 8 waypoints +
-// 1 destination and let Maps default the origin to current location.
 export const MAX_STOPS = 9;
 
 function loadFromStorage() {

--- a/frontend/src/contexts/TripContext.jsx
+++ b/frontend/src/contexts/TripContext.jsx
@@ -1,0 +1,190 @@
+import React, { createContext, useState, useEffect, useCallback, useRef } from 'react';
+
+export const TripContext = createContext(null);
+
+const STORAGE_KEY = 'rotv.tripInProgress.v1';
+// Cap at 9 so the user's current location can be the starting point.
+// Google Maps' URL spec allows up to 9 waypoints; we send 8 waypoints +
+// 1 destination and let Maps default the origin to current location.
+export const MAX_STOPS = 9;
+
+function loadFromStorage() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyTrip();
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.stops)) return emptyTrip();
+    return {
+      id: parsed.id || null,
+      slug: parsed.slug || null,
+      name: typeof parsed.name === 'string' ? parsed.name : '',
+      description: typeof parsed.description === 'string' ? parsed.description : '',
+      is_public: !!parsed.is_public,
+      is_featured: !!parsed.is_featured,
+      stops: parsed.stops.filter(isValidStop)
+    };
+  } catch {
+    return emptyTrip();
+  }
+}
+
+function emptyTrip() {
+  return { id: null, slug: null, name: '', description: '', is_public: false, is_featured: false, stops: [] };
+}
+
+function isValidStop(s) {
+  if (!s || typeof s !== 'object') return false;
+  const lat = Number(s.latitude);
+  const lng = Number(s.longitude);
+  return Number.isFinite(lat) && Number.isFinite(lng);
+}
+
+function stopKey(s) {
+  if (s.poi_id != null) return `poi:${s.poi_id}`;
+  return `coord:${s.latitude},${s.longitude}`;
+}
+
+export function TripProvider({ children }) {
+  const [trip, setTrip] = useState(() => loadFromStorage());
+  const [showBuilder, setShowBuilder] = useState(false);
+  const persistTimer = useRef(null);
+
+  useEffect(() => {
+    if (persistTimer.current) clearTimeout(persistTimer.current);
+    persistTimer.current = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(trip));
+      } catch (err) {
+        console.warn('Could not persist trip-in-progress:', err.message);
+      }
+    }, 200);
+    return () => {
+      if (persistTimer.current) clearTimeout(persistTimer.current);
+    };
+  }, [trip]);
+
+  const addStop = useCallback((stop) => {
+    if (!isValidStop(stop)) return;
+    setTrip(prev => {
+      if (prev.stops.length >= MAX_STOPS) return prev;
+      const key = stopKey(stop);
+      if (prev.stops.some(s => stopKey(s) === key)) return prev;
+      return { ...prev, stops: [...prev.stops, {
+        poi_id: stop.poi_id || null,
+        label: stop.label || null,
+        latitude: Number(stop.latitude),
+        longitude: Number(stop.longitude)
+      }] };
+    });
+    setShowBuilder(true);
+  }, []);
+
+  const removeStop = useCallback((index) => {
+    setTrip(prev => ({ ...prev, stops: prev.stops.filter((_, i) => i !== index) }));
+  }, []);
+
+  const removeStopByPoi = useCallback((poi_id) => {
+    setTrip(prev => ({ ...prev, stops: prev.stops.filter(s => s.poi_id !== poi_id) }));
+  }, []);
+
+  const moveStop = useCallback((from, to) => {
+    setTrip(prev => {
+      if (from === to || from < 0 || to < 0 || from >= prev.stops.length || to >= prev.stops.length) {
+        return prev;
+      }
+      const next = [...prev.stops];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return { ...prev, stops: next };
+    });
+  }, []);
+
+  const setName = useCallback((name) => setTrip(prev => ({ ...prev, name })), []);
+  const setDescription = useCallback((description) => setTrip(prev => ({ ...prev, description })), []);
+  const setIsPublic = useCallback((is_public) => setTrip(prev => ({ ...prev, is_public })), []);
+  const setIsFeatured = useCallback((is_featured) => setTrip(prev => ({ ...prev, is_featured })), []);
+
+  const clear = useCallback(() => {
+    setTrip(emptyTrip());
+    setShowBuilder(false);
+  }, []);
+
+  const loadTrip = useCallback((next) => {
+    if (!next) return;
+    setTrip({
+      id: next.id || null,
+      slug: next.slug || null,
+      name: next.name || '',
+      description: next.description || '',
+      is_public: !!next.is_public,
+      is_featured: !!next.is_featured,
+      stops: (next.stops || []).map(s => ({
+        poi_id: s.poi_id || null,
+        label: s.label || s.poi_name || null,
+        latitude: Number(s.latitude),
+        longitude: Number(s.longitude)
+      })).filter(isValidStop)
+    });
+    setShowBuilder(true);
+  }, []);
+
+  const loadFromSlug = useCallback(async (slug) => {
+    const res = await fetch(`/api/trips/${encodeURIComponent(slug)}`, { credentials: 'include' });
+    if (!res.ok) throw new Error(res.status === 404 ? 'Trip not found' : 'Failed to load trip');
+    const data = await res.json();
+    loadTrip(data);
+    return data;
+  }, [loadTrip]);
+
+  const saveTrip = useCallback(async () => {
+    const payload = {
+      name: trip.name || 'Untitled Trip',
+      description: trip.description || null,
+      is_public: trip.is_public,
+      is_featured: trip.is_featured,
+      stops: trip.stops
+    };
+    const url = trip.id ? `/api/trips/${trip.id}` : '/api/trips';
+    const method = trip.id ? 'PUT' : 'POST';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ error: 'Save failed' }));
+      throw new Error(error.error || 'Save failed');
+    }
+    const saved = await res.json();
+    loadTrip(saved);
+    return saved;
+  }, [trip, loadTrip]);
+
+  const hasStop = useCallback((poi_id) => {
+    if (!poi_id) return false;
+    return trip.stops.some(s => s.poi_id === poi_id);
+  }, [trip.stops]);
+
+  const value = {
+    trip,
+    showBuilder,
+    setShowBuilder,
+    addStop,
+    removeStop,
+    removeStopByPoi,
+    moveStop,
+    setName,
+    setDescription,
+    setIsPublic,
+    setIsFeatured,
+    clear,
+    loadTrip,
+    loadFromSlug,
+    saveTrip,
+    hasStop,
+    MAX_STOPS
+  };
+
+  return <TripContext.Provider value={value}>{children}</TripContext.Provider>;
+}

--- a/frontend/src/hooks/useTrip.js
+++ b/frontend/src/hooks/useTrip.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { TripContext } from '../contexts/TripContext';
+
+export function useTrip() {
+  const ctx = useContext(TripContext);
+  if (!ctx) throw new Error('useTrip must be used within a TripProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary

Users build multi-stop trips across the valley, save them to their account, optionally share publicly (after admin review), and hand the whole route off to Google Maps starting from their current location. Admins curate Featured Trips (e.g. Canalway Scenic Byway) through the same UI users use, just with a Featured checkbox.

- **Trip Builder dock** — centered card (~480px) at the bottom of the map; chevron expand/collapse on the left, × discard on the right
- **Three primary actions**: Navigate · Save · My Trips (green buttons)
- **My Trips modal** under the user menu — My Trips list, Find Trips picker (Featured + shared user trips), Pending Review queue for admins
- **Moderation** mirrors News/Events/Photos: public user trips need admin approval before they appear in Find Trips; rejection sets is_public=false
- **Permalinks**: `/trip/<id>` or `/trip/<slug>` both work
- **Tutorial** added: About → Tutorials → "Take the Trip Planning Tour" (5 steps)

## Notable GuidedTour fixes (incidental but important)

- Dropped `el.offsetParent === null` from the `isHidden` check — Chrome returns null for position:fixed elements even when fully visible, which was breaking the trip-builder spotlight.
- Per-step `tooltipHeight` override so long-description tooltips don't underestimate their height and overlap the spotlight.
- 4px green ring + glow on the spotlight so it's visible against white backgrounds (the prior white inset was invisible on the trip-builder).

## Data model

- `trips` (migration 054): id, user_id, name, description, slug (unique), is_featured, is_public, timestamps
- `trip_stops` (054): trip_id, position, poi_id (ON DELETE SET NULL — cached lat/lng + label keep trips usable if a POI is deleted), latitude, longitude, label
- `trips` moderation columns (055): is_approved, moderated_by, moderated_at
- About tutorial markdown seeded (056): `about_trip_tutorial_md`

## API

- `GET /api/trips/featured` (public)
- `GET /api/trips/discover` (featured + approved-public-from-others, excludes caller's own)
- `GET /api/trips/pending` (admin only — moderation queue)
- `GET /api/trips/mine` (auth)
- `GET /api/trips/:idOrSlug` (public if featured or public; else owner-only)
- `POST /api/trips` (auth; is_featured silently ignored unless admin; 30/hr per user)
- `PUT /api/trips/:id` (owner-only; admin can toggle is_featured; owner edits reset is_approved to false)
- `DELETE /api/trips/:id` (owner-only)
- `POST /api/trips/:id/duplicate` (auth — clones any readable trip into caller's account, is_featured=false)
- `POST /api/trips/:id/moderate` (admin — `{ action: 'approve' | 'reject' }`)

Stops are hard-capped at 9 (client + server) so the Google Maps URL can leave `&origin=` blank and start from the user's current location.

Closes #366

## Test plan

- [x] Container build passes
- [x] Slug unit tests pass
- [x] Backend end-to-end via curl: create / discover / mine / approve / duplicate / 10-stop reject / 9-stop accept
- [x] Manual browser verification — Trip Builder dock, Navigate hand-off, Save, My Trips list, Find Trips, Pending Review (admin), Featured toggle (admin), permalinks, moderation flow
- [x] Trip Planning Tour: all 5 steps highlight correct elements with tooltip placement avoiding spotlight overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)