### PR TITLE
fix: YouTube Shorts support + stop hiding lone gallery media

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1099,15 +1099,7 @@ app.get('/api/pois/:id/media', async (req, res) => {
       allMedia.push(item);
     }
 
-    // A lone gallery item alongside a primary is usually a migration duplicate — show hero only
-    const primaryItems = allMedia.filter(m => m.role === 'primary');
-    const galleryItems = allMedia.filter(m => m.role !== 'primary');
-    let mosaic;
-    if (primaryItems.length > 0 && galleryItems.length <= 1) {
-      mosaic = primaryItems.slice(0, 1);
-    } else {
-      mosaic = allMedia.slice(0, 3);
-    }
+    const mosaic = allMedia.slice(0, 3);
 
     const response = {
       mosaic,
@@ -1530,7 +1522,7 @@ app.get('/api/assets/:assetId/original', assetProxyLimiter, async (req, res) => 
 
 function extractYouTubeId(url) {
   const patterns = [
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/|youtube\.com\/shorts\/)([^&\n?#]+)/,
     /^([a-zA-Z0-9_-]{11})$/
   ];
 


### PR DESCRIPTION
## Summary
- `extractYouTubeId()` now matches `youtube.com/shorts/` URLs, so YouTube Shorts can be added to a POI instead of being rejected with "Invalid YouTube URL".
- Removed the "migration duplicate" heuristic in `/api/pois/:id/media` that hid a lone gallery item whenever a primary existed.

## Why
Two reported bugs:
1. Deep Lock Quarry's YouTube video never appeared in the mosaic.
2. A YouTube Short (`https://www.youtube.com/shorts/MeRMBeP_CVA`) was rejected when adding to a POI.

Production data investigation found **zero** actual duplicate rows (no image asset is reused across rows). The heuristic only ever suppressed legitimately added media — 4 POIs' YouTube videos (Deep Lock Quarry, Detroit Superior Bridge, Terra Vista, William Mathers) and Blue Hen Falls' second image. So the safe fix is to remove it; the mosaic now always shows up to 3 items.

## Test plan
- [x] `./run.sh build` passes
- [x] API: `/api/pois/5520/media` returns the YouTube video in the mosaic
- [x] `extractYouTubeId` parses Shorts URLs (with and without query params) and still parses watch/youtu.be/embed
- [x] Verified in browser at localhost:8081

🤖 Generated with [Claude Code](https://claude.com/claude-code)