### PR TITLE
Anonymous user settings + tutorial accessibility (#379)

### DIFF
--- a/.specify/specs/018-anon-user-settings/plan.md
+++ b/.specify/specs/018-anon-user-settings/plan.md
@@ -1,0 +1,204 @@
+# Implementation Plan: Anonymous User Settings & Tour Accessibility
+
+> **Spec ID:** 018-anon-user-settings
+> **Status:** Planning
+> **Last Updated:** 2026-05-19
+> **Estimated Effort:** L (large — single bundled PR, ~10–15h focused work)
+
+## Summary
+
+Ungate `/settings` for anon visitors, render a reduced `UserSettings` (timezone, newsletter) for them, back the newsletter email and Trip Planner saved trips with `localStorage`, and add a single `/api/user/settings/sync` endpoint that flushes any local state to the backend on first successful login (server-wins for non-empty fields). The GuidedTour `useEffect` refactor (already committed locally) fixes the step-3 flicker for both the main tour and the trip tour.
+
+---
+
+## Architecture
+
+### Data flow — anon visitor
+
+```
+[Anon visitor]
+    │
+    ├─ /settings → render <UserSettings user=null />
+    │                  ├─ General: timezone (already localStorage)
+    │                  └─ Newsletter: email field (localStorage), POST /api/newsletter/subscribe (anon OK)
+    │
+    ├─ + Add to Trip → tripStore in-memory state (unchanged)
+    │
+    └─ Save trip → write to localStorage["rotv-saved-trips"]
+                   (My Trips menu visible when ≥1 local trip)
+```
+
+### Data flow — anon visitor signs up
+
+```
+OAuth redirect /?auth=success
+    │
+AuthContext fetchUser() succeeds
+    │
+    ▼
+syncAnonSettings() (new helper)
+    │
+    ├─ POST /api/user/settings/sync { timezone, newsletter, trips }
+    │
+    ▼
+Backend `/api/user/settings/sync` (server-wins, fill gaps):
+    │  • users.timezone IS NULL → set
+    │  • newsletter_subscriptions: insert if not exists
+    │  • trips: insert (per-trip) if no existing trip with same slug for user
+    │
+    ▼
+Client clears synced localStorage keys
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1 — GuidedTour flicker (already done)
+- [x] Refactor `GuidedTour.jsx` useEffect to use refs for `step`, `onStepAction`, `applyPosition`. Effect deps reduce to `[currentStep, isMobile]`. Fixes step-3 flicker for both tours.
+
+### Phase 2 — Ungate /settings & reduce UserSettings for anon
+- [ ] Remove the `useEffect` in `App.jsx` (~line 402) that bounces anon users off `/settings` to `/view`.
+- [ ] Keep the existing `isAdmin ? <admin nav> : <UserSettings>` branch — anon users now render `<UserSettings user={null} />`.
+- [ ] `UserSettings.jsx` — wrap the General-tab Profile section (email field, Privacy Policy link) in `{user && (...)}`. Timezone selector remains; it already reads/writes localStorage.
+
+### Phase 3 — Newsletter email persistence
+- [ ] Add `frontend/src/utils/anonSettings.js` — `readEmail()`, `writeEmail(v)`, `clearEmail()`, `readSubscribed()`, `writeSubscribed(b)`. All wrap `localStorage` with try/catch (private mode safe).
+- [ ] `UserSettings.jsx` Newsletter form — init email from `user?.email ?? anonSettings.readEmail()`. On change, if no user, call `anonSettings.writeEmail()`. On successful subscribe, call `anonSettings.writeSubscribed(true)`.
+
+### Phase 4 — LocalStorage saved trips
+- [ ] Extend `anonSettings.js` with `readTrips()`, `writeTrips(arr)`, `addTrip(t)`, `removeTrip(slug)`, `clearTrips()`.
+- [ ] `TripBuilder.jsx` (handleSave at line 35):
+  - When `isAuthenticated`: existing POST `/api/trips` flow.
+  - When anon: persist to `anonSettings.addTrip({ name, description, slug, stops })` and show same success UX. Remove the `disabled={!isAuthenticated || saving}` gate (keep saving disable). Update tooltip copy.
+- [ ] `MyTripsModal.jsx`: when anon, source trip list from `anonSettings.readTrips()` instead of `GET /api/trips`. Hide "Find Trips" (public/featured) tab for anon — or keep but read-only; pick the smaller surface.
+- [ ] `App.jsx` user-menu rendering (~line 1764): show `.my-trips-menu-item` whenever `isAuthenticated || anonSettings.readTrips().length > 0`. Trip-tour step 5 selector remains valid.
+
+### Phase 5 — Backend sync endpoint
+- [ ] Migration `057_add_user_timezone.sql`: `ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT;`
+- [ ] New route `backend/routes/userSettings.js`: `POST /api/user/settings/sync` (requires auth via existing middleware). Server-wins fill-gaps for `timezone`; idempotent `INSERT INTO newsletter_subscriptions ... ON CONFLICT DO NOTHING`; per-trip insert only if no trip with that slug exists for this user.
+- [ ] Wire into `server.js` (mirroring trips/newsletter routes).
+
+### Phase 6 — Sync-on-signup hook
+- [ ] `frontend/src/contexts/AuthContext.jsx`:
+  - In the `?auth=success` handler (line 36), after `fetchUser()` resolves with a user, call `syncAnonSettings()`.
+  - `syncAnonSettings()` lives in `anonSettings.js`. Gathers all localStorage state, POSTs to `/api/user/settings/sync`, clears synced keys on success. Idempotent — calling on a user with no anon data is a no-op.
+
+### Phase 7 — Build, browser verify, commit, review
+- [ ] `./run.sh build`
+- [ ] Browser verify: incognito → main tour to step 11, trip tour to step 5, build a trip → sign in → confirm trip & email subscription synced.
+- [ ] Browser verify: existing logged-in user — no regressions in UserSettings, TripBuilder, MyTripsModal.
+- [ ] Commit per phase OR one bundled commit (Scott's preference noted in memory: bundled PRs preferred for refactors in this area).
+- [ ] Gatehouse / Gemini review; fix findings.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `.specify/specs/018-anon-user-settings/spec.md` | This spec (done) |
+| `.specify/specs/018-anon-user-settings/plan.md` | This plan (done) |
+| `frontend/src/utils/anonSettings.js` | localStorage helpers + `syncAnonSettings()` |
+| `backend/routes/userSettings.js` | `/api/user/settings/sync` endpoint |
+| `backend/migrations/057_add_user_timezone.sql` | timezone column on users |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/App.jsx` | Remove anon→/view redirect; tweak my-trips-menu-item visibility |
+| `frontend/src/components/UserSettings.jsx` | Hide Profile section for anon; use anonSettings for email |
+| `frontend/src/components/TripBuilder.jsx` | Anon Save → localStorage; remove auth gate on Save button |
+| `frontend/src/components/MyTripsModal.jsx` | Read local trips when anon |
+| `frontend/src/components/GuidedTour.jsx` | Already done — useEffect refs (flicker fix) |
+| `frontend/src/contexts/AuthContext.jsx` | Call `syncAnonSettings()` after auth=success |
+| `backend/server.js` | Mount new userSettings router |
+
+---
+
+## Database Migrations
+
+```sql
+-- 057_add_user_timezone.sql
+-- Per-user timezone preference. Anon visitors set this in localStorage; on
+-- first sign-in, the sync endpoint fills this column if currently NULL
+-- (server-wins on subsequent syncs).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT;
+```
+
+No trip schema changes needed — the existing `trips` + `trip_stops` schema already accepts a `user_id`-scoped insert. The anon-trip JSON shape mirrors what `POST /api/trips` already accepts.
+
+---
+
+## API Implementation
+
+### `POST /api/user/settings/sync` (Auth required)
+
+**Request:**
+```json
+{
+  "timezone": "America/New_York",
+  "newsletter": { "email": "user@example.com", "subscribed": true },
+  "trips": [
+    { "name": "Towpath Highlights", "slug": "towpath-highlights-...",
+      "description": null,
+      "stops": [ { "position": 1, "poi_id": 123, "label": null,
+                   "latitude": 41.27, "longitude": -81.55 }, ... ] }
+  ]
+}
+```
+
+**Response:** `200 OK` with `{ synced: { timezone: bool, newsletter: bool, trips: number } }`.
+
+**Logic (server-wins fill-gaps):**
+1. If `timezone` provided AND `users.timezone IS NULL`: update.
+2. If `newsletter.email` provided: existing newsletter subscribe path (idempotent server-side).
+3. For each trip: lookup `SELECT id FROM trips WHERE user_id = $1 AND slug = $2`. If none, INSERT the trip + its trip_stops. If found, skip (don't overwrite).
+
+---
+
+## Testing Strategy
+
+### Manual (Mandatory)
+1. Incognito → main tour end-to-end → step 11 lands on `/settings` newsletter, no flicker on step 3.
+2. Incognito → trip tour end-to-end → save a trip → My Trips shows the local trip.
+3. Incognito → reload after typing email → email persists.
+4. Incognito → sign in → newsletter subscription and saved trip appear server-side.
+5. Logged-in user (regression) → /settings, TripBuilder save, MyTripsModal — no behavior changes.
+6. Re-sync (no-op) → sign out, sign back in → no duplicate trips, no errors.
+7. Conflict test → set timezone server-side, then sign in with a different timezone in localStorage → server value wins.
+
+### Automated
+- Skip for this PR (per project pattern — `/deploy` runs the test suite post-merge). Manual verification is the gate.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Sync clobbers existing user data | High | Server-wins fill-gaps semantics: never overwrite non-null fields; trip dedup by slug |
+| LocalStorage quota errors | Low | All anonSettings writes are try/catch; saved trips are small JSON |
+| Anon trip with stale POI references | Medium | trip_stops already caches lat/lng (`ON DELETE SET NULL` on poi_id); UI handles unlinked stops |
+| Sync runs twice on rapid re-login | Low | Endpoint is idempotent; localStorage cleared on first success |
+| Existing logged-in user regression | Medium | UserSettings for `user` truthy path is unchanged; TripBuilder anon branch only fires when `!isAuthenticated` |
+
+---
+
+## Rollback Plan
+
+If issues post-deploy:
+1. Revert the merge commit (single PR).
+2. Database: migration is additive (`ADD COLUMN IF NOT EXISTS`) — no rollback needed.
+3. LocalStorage data persists harmlessly until next session.
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-19 | Initial plan; OQs from spec resolved (OQ-1=full localStorage trips, OQ-3=auth callback, OQ-4=server-wins, OQ-5=keep copy). OQ-2 resolved by inspection — existing trips schema is reusable. |

--- a/.specify/specs/018-anon-user-settings/spec.md
+++ b/.specify/specs/018-anon-user-settings/spec.md
@@ -1,0 +1,194 @@
+# Specification: Anonymous User Settings & Tour Accessibility
+
+> **Spec ID:** 018-anon-user-settings
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-19
+
+## Overview
+
+Anonymous (non-logged-in) visitors hit dead-ends in both guided tutorials and in the settings UI. The main tour's Newsletter step and the Trip Planner tour's "My Trips"/"Save" steps point at controls that only render when authenticated, so the tour spotlights a missing DOM target. The `/settings` route itself is gated and redirects anon users back to the map.
+
+This spec makes user-level customizations — timezone, newsletter subscription, saved trips — usable without an account by backing them with `localStorage`. When a visitor eventually creates an account, any locally-held state is pushed to the backend so it follows them across devices. Tour steps for both tutorials become navigable from a fresh incognito session.
+
+Out of scope: admin-only settings (Themes, Activities, Icons, Moderation, etc.) remain gated.
+
+Closes #379.
+
+---
+
+## User Stories
+
+### Anonymous Tour Completion
+
+**US-018-01: First-time visitor finishes the main tutorial**
+> As a first-time, not-logged-in visitor, I want to step through the welcome tour from end to end so that I understand the app without needing to sign up first.
+
+Acceptance Criteria:
+- [ ] Step 3 (Browse Results) draws the spotlight once with no flicker
+- [ ] Step 11 (Newsletter) lands on a visible newsletter signup form and highlights the subscribe button
+- [ ] Tour does not abandon, fail, or spotlight an empty region on any step
+
+**US-018-02: First-time visitor finishes the Trip Planner tour**
+> As a first-time, not-logged-in visitor, I want to step through the Trip Planner tutorial so that I learn how trip building works before deciding whether to create an account.
+
+Acceptance Criteria:
+- [ ] All five trip-tour steps render correctly without authentication
+- [ ] Step 4 (Navigate · Save · My Trips) and Step 5 (My Trips Anywhere) point at controls that exist for anonymous users
+- [ ] Where saving requires signup (depending on Open Question OQ-1), the tour clearly says so
+
+### Anonymous Customization
+
+**US-018-03: Anon visitor sets their timezone**
+> As a not-logged-in visitor, I want to set my timezone so that news and event dates display correctly to me.
+
+Acceptance Criteria:
+- [ ] `/settings` is accessible without authentication
+- [ ] General tab renders for anon visitors; timezone selector saves to `localStorage` (already today's behavior — confirm)
+- [ ] Profile section (read-only email from auth provider) is hidden for anon users
+
+**US-018-04: Anon visitor subscribes to the newsletter**
+> As a not-logged-in visitor, I want to subscribe to the newsletter from the in-app settings so that I don't have to sign up to receive the weekly digest.
+
+Acceptance Criteria:
+- [ ] Newsletter tab in `/settings` renders for anon visitors
+- [ ] Email field persists to `localStorage` so a reload before submitting doesn't lose input
+- [ ] `POST /api/newsletter/subscribe` accepts the request anonymously (no backend change — endpoint already allows it)
+- [ ] On success, the success message displays the same as for logged-in users
+
+**US-018-05: Anon visitor builds and saves a trip locally**
+> As a not-logged-in visitor, I want to build a day-trip and save it locally so that I can come back to it later, even before creating an account.
+
+Acceptance Criteria:
+- [ ] Add-to-Trip works for anon visitors (current behavior — confirm)
+- [ ] Save action persists the trip to `localStorage` for anon visitors *(Pending OQ-1 decision)*
+- [ ] My Trips menu item is visible (or has an anon equivalent) when there is at least one locally-saved trip *(Pending OQ-1)*
+
+### Sync on Sign-up
+
+**US-018-06: Locally-held state follows me when I create an account**
+> As a returning anon visitor who decides to sign up, I want my timezone, newsletter subscription, and saved trips to follow me onto my new account so that I don't have to re-enter them.
+
+Acceptance Criteria:
+- [ ] On first successful login or account creation, the client POSTs any local settings/trips to backend sync endpoints
+- [ ] Backend stores the synced state under the new user
+- [ ] After successful sync, `localStorage` keys for synced fields are cleared (or marked synced)
+- [ ] Sync is idempotent — replaying it does not duplicate trips or re-subscribe
+
+---
+
+## Data Model
+
+### Schema Changes
+
+```sql
+-- Per-user timezone preference (currently only client-side)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT;
+
+-- Per-user saved trips: depends on OQ-2
+-- (If new table needed, add 018_create_saved_trips.sql)
+```
+
+### LocalStorage Keys (canonical)
+
+| Key | Type | Lifetime | Notes |
+|-----|------|----------|-------|
+| `rotv-tour-seen` | bool flag | permanent | already used |
+| `app-timezone` | string | until cleared on sync | already used |
+| `rotv-newsletter-email` | string | until cleared on sync | new — preserves input across reloads |
+| `rotv-newsletter-subscribed` | bool | permanent for anon | new — suppresses re-prompts |
+| `rotv-saved-trips` | JSON array | until cleared on sync | new, pending OQ-1 |
+
+---
+
+## API Endpoints
+
+### New / Changed Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/user/settings/sync` | Bulk-upsert anon settings on first login | Authenticated |
+| POST | `/api/newsletter/subscribe` | (existing) accepts anonymous emails | None |
+| POST | `/api/trips` | (existing) create saved trip — anon variant TBD | Auth or anon (OQ-1) |
+
+`/api/user/settings/sync` request body:
+```json
+{
+  "timezone": "America/New_York",
+  "newsletter": { "email": "user@example.com", "subscribed": true },
+  "trips": [ { "name": "...", "stops": [...] } ]
+}
+```
+
+---
+
+## UI/UX Requirements
+
+### Changes to existing components
+
+- `App.jsx` — Remove the `useEffect` that bounces anon users off `/settings` (lines ~402–406). Settings tab visible in nav for anon users too.
+- `App.jsx` settings panel — keep current `isAdmin ? <admin nav> : <UserSettings>` branch. `UserSettings` is rendered for both authed regular users and anon users; it conditionally hides the Profile/Email section when there is no `user`.
+- `UserSettings.jsx` — hide General-tab Profile section when no user; everything else (timezone, newsletter) works as today.
+- `GuidedTour.jsx` — already fixed: stabilized `useEffect` so step 3 no longer flickers on re-render. The Newsletter step (main tour) and the Trip Save/My Trips steps (trip tour) become reachable thanks to the settings ungating; no step-array changes required if OQ-1 resolves toward localStorage trips.
+- New helper `frontend/src/utils/anonSettings.js` — small read/write/sync helpers around the localStorage keys above.
+- Auth post-login hook — when `useAuth()` transitions from anon → authed, invoke the sync helper to flush `localStorage` to `/api/user/settings/sync`.
+
+### Wireframes
+
+Settings page for anon user (desktop):
+```
++----------------------------------------------------+
+| [Settings]                                         |
+|                                                    |
+|  General | Newsletter                              |
+|  --------                                          |
+|                                                    |
+|  🕐 Timezone                                       |
+|  [select: America/New_York v]                      |
+|  [Save]                                            |
+|                                                    |
++----------------------------------------------------+
+```
+
+(Profile section is hidden — the Newsletter tab renders the same `<NewsletterSignup>` form used by the existing UserSettings newsletter tab.)
+
+---
+
+## Non-Functional Requirements
+
+**NFR-018-01: Privacy**
+- LocalStorage data stays on-device until the user explicitly creates an account.
+- Sync endpoint is authenticated; anon visitors cannot push state on someone else's behalf.
+
+**NFR-018-02: Backward compatibility**
+- Existing logged-in users see no UI changes (their settings tab renders unchanged).
+- Existing `app-timezone` localStorage key keeps the same name and semantics.
+
+**NFR-018-03: Idempotency**
+- Sync is safe to retry. Newsletter resubscribe is already idempotent server-side. Trip sync uses dedup by name + stops hash *(detail in plan)*.
+
+---
+
+## Dependencies
+
+- Depends on: nothing (uses existing newsletter, trip APIs as starting point)
+- Blocks: future personalization features that require auth-aware preferences
+
+---
+
+## Resolved Questions
+
+1. **OQ-1 (Trip Planner anon flow):** Full localStorage-backed Save + My Trips, with sync on signup.
+2. **OQ-2 (Saved-trips backend shape):** Existing `trips`/`trip_stops` schema is reused as-is; no new table needed. See plan §API.
+3. **OQ-3 (Sync trigger):** First successful auth callback (`?auth=success` in `AuthContext.jsx`).
+4. **OQ-4 (Conflict resolution):** Server-wins fill-gaps — never overwrite non-null server values; local entries only fill gaps.
+5. **OQ-5 (Step 11 copy):** Keep existing wording.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-19 | Initial draft. Closes #379. |

--- a/backend/migrations/057_add_user_timezone.sql
+++ b/backend/migrations/057_add_user_timezone.sql
@@ -1,0 +1,7 @@
+-- 057_add_user_timezone.sql
+-- Per-user timezone preference (spec 018-anon-user-settings, issue #379).
+-- Anonymous visitors set this in localStorage (key 'app-timezone'); on first
+-- sign-in the /api/user/settings/sync endpoint fills this column when it is
+-- still NULL (server-wins on subsequent syncs — never overwrites a value
+-- already set from another device).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT;

--- a/backend/routes/trips.js
+++ b/backend/routes/trips.js
@@ -19,7 +19,7 @@ function isFiniteNumber(v) {
   return typeof n === 'number' && Number.isFinite(n);
 }
 
-function validateStops(stops) {
+export function validateStops(stops) {
   if (!Array.isArray(stops) || stops.length === 0) {
     return 'stops must be a non-empty array';
   }
@@ -66,7 +66,7 @@ async function loadTripById(pool, id) {
   return trip;
 }
 
-async function insertStops(client, tripId, stops) {
+export async function insertStops(client, tripId, stops) {
   for (const [i, s] of stops.entries()) {
     await client.query(
       `INSERT INTO trip_stops (trip_id, position, poi_id, label, latitude, longitude)
@@ -83,9 +83,11 @@ async function insertStops(client, tripId, stops) {
   }
 }
 
-async function insertTripWithSlugRetry(client, fields, maxAttempts = 5) {
+export async function insertTripWithSlugRetry(client, fields, maxAttempts = 5) {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const slug = slugifyWithSuffix(fields.name);
+    const slug = (attempt === 0 && fields.preferredSlug)
+      ? fields.preferredSlug
+      : slugifyWithSuffix(fields.name);
     try {
       const inserted = await client.query(
         `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)

--- a/backend/routes/userSettings.js
+++ b/backend/routes/userSettings.js
@@ -1,0 +1,134 @@
+import express from 'express';
+import { isAuthenticated } from '../middleware/auth.js';
+import { slugifyWithSuffix } from '../utils/slug.js';
+import { addSubscriber } from '../services/buttondownClient.js';
+
+const MAX_STOPS = 9;
+const MAX_SYNC_TRIPS = 50;
+
+function isFiniteNumber(v) {
+  const n = typeof v === 'string' ? Number(v) : v;
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+function validStops(stops) {
+  if (!Array.isArray(stops) || stops.length === 0 || stops.length > MAX_STOPS) {
+    return false;
+  }
+  return stops.every(s => s && typeof s === 'object'
+    && isFiniteNumber(s.latitude) && isFiniteNumber(s.longitude));
+}
+
+async function insertTripWithStops(client, userId, trip) {
+  let inserted = null;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const slug = slugifyWithSuffix(trip.name);
+    try {
+      const row = await client.query(
+        `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)
+         VALUES ($1, $2, $3, $4, FALSE, FALSE)
+         RETURNING id`,
+        [userId, trip.name, trip.description || null, slug]
+      );
+      inserted = row.rows[0];
+      break;
+    } catch (err) {
+      if (err.code === '23505' && err.constraint && err.constraint.includes('slug')) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  if (!inserted) throw new Error('slug collision after retries');
+
+  for (const [i, s] of trip.stops.entries()) {
+    await client.query(
+      `INSERT INTO trip_stops (trip_id, position, poi_id, label, latitude, longitude)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [inserted.id, i + 1, s.poi_id || null, s.label || null, Number(s.latitude), Number(s.longitude)]
+    );
+  }
+  return inserted.id;
+}
+
+// POST /api/user/settings/sync
+// Flushes a freshly-signed-in user's anonymous localStorage state to the
+// backend. Server-wins fill-gaps: timezone only set when currently NULL,
+// newsletter subscribe is idempotent server-side, trips inserted only when
+// the user has no trip with a matching name (avoids duplicates on re-sync).
+export function createUserSettingsRouter(pool) {
+  const router = express.Router();
+
+  router.post('/sync', isAuthenticated, async (req, res) => {
+    const { timezone, newsletter, trips } = req.body || {};
+    const synced = { timezone: false, newsletter: false, trips: 0 };
+
+    try {
+      // Timezone — only fill when not already set on the account.
+      if (typeof timezone === 'string' && timezone.trim()) {
+        const result = await pool.query(
+          `UPDATE users SET timezone = $1
+            WHERE id = $2 AND (timezone IS NULL OR timezone = '')`,
+          [timezone.trim(), req.user.id]
+        );
+        synced.timezone = result.rowCount > 0;
+      }
+
+      // Newsletter — idempotent subscribe (Buttondown handles already-subscribed).
+      if (newsletter && newsletter.subscribed && typeof newsletter.email === 'string'
+          && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newsletter.email)) {
+        try {
+          await addSubscriber(newsletter.email, pool);
+          await pool.query(
+            `INSERT INTO newsletter_subscriptions (email, source) VALUES ($1, $2)`,
+            [newsletter.email, 'web']
+          ).catch(err => {
+            if (!err.message?.includes('duplicate key')) throw err;
+          });
+          synced.newsletter = true;
+        } catch (err) {
+          // Newsletter is best-effort during sync; don't fail the whole call.
+          console.error('settings/sync newsletter failed:', err.message);
+        }
+      }
+
+      // Trips — insert only those without a same-named trip for this user.
+      if (Array.isArray(trips) && trips.length > 0) {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          let count = 0;
+          for (const trip of trips.slice(0, MAX_SYNC_TRIPS)) {
+            if (!trip || typeof trip.name !== 'string' || !trip.name.trim()) continue;
+            if (!validStops(trip.stops)) continue;
+            const existing = await client.query(
+              `SELECT id FROM trips WHERE user_id = $1 AND name = $2 LIMIT 1`,
+              [req.user.id, trip.name.trim().substring(0, 200)]
+            );
+            if (existing.rows.length > 0) continue;
+            await insertTripWithStops(client, req.user.id, {
+              name: trip.name.trim().substring(0, 200),
+              description: trip.description,
+              stops: trip.stops
+            });
+            count++;
+          }
+          await client.query('COMMIT');
+          synced.trips = count;
+        } catch (err) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw err;
+        } finally {
+          client.release();
+        }
+      }
+
+      res.json({ synced });
+    } catch (err) {
+      console.error('POST /api/user/settings/sync failed:', err);
+      res.status(500).json({ error: 'Failed to sync settings' });
+    }
+  });
+
+  return router;
+}

--- a/backend/routes/userSettings.js
+++ b/backend/routes/userSettings.js
@@ -4,6 +4,9 @@ import { slugifyWithSuffix } from '../utils/slug.js';
 import { addSubscriber } from '../services/buttondownClient.js';
 
 const MAX_STOPS = 9;
+// Upper bound on trips accepted in a single sign-in sync, to bound work and
+// guard against a tampered/oversized localStorage payload. Generous — a real
+// anonymous session won't approach it.
 const MAX_SYNC_TRIPS = 50;
 
 function isFiniteNumber(v) {
@@ -20,9 +23,14 @@ function validStops(stops) {
 }
 
 async function insertTripWithStops(client, userId, trip) {
+  // Prefer the client-provided slug on the first attempt so re-syncs dedup
+  // reliably by slug. Fall back to a freshly generated slug on collision
+  // (the trips.slug column is globally unique).
   let inserted = null;
   for (let attempt = 0; attempt < 5; attempt++) {
-    const slug = slugifyWithSuffix(trip.name);
+    const slug = (attempt === 0 && typeof trip.slug === 'string' && trip.slug.trim())
+      ? trip.slug.trim().substring(0, 220)
+      : slugifyWithSuffix(trip.name);
     try {
       const row = await client.query(
         `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)
@@ -83,7 +91,8 @@ export function createUserSettingsRouter(pool) {
             `INSERT INTO newsletter_subscriptions (email, source) VALUES ($1, $2)`,
             [newsletter.email, 'web']
           ).catch(err => {
-            if (!err.message?.includes('duplicate key')) throw err;
+            // 23505 = unique_violation (already subscribed) — ignore.
+            if (err.code !== '23505') throw err;
           });
           synced.newsletter = true;
         } catch (err) {
@@ -92,7 +101,9 @@ export function createUserSettingsRouter(pool) {
         }
       }
 
-      // Trips — insert only those without a same-named trip for this user.
+      // Trips — insert only those this user doesn't already have. Dedup by
+      // slug (the client persists a stable slug per trip), which is reliable
+      // across re-syncs; insertTripWithStops reuses that slug server-side.
       if (Array.isArray(trips) && trips.length > 0) {
         const client = await pool.connect();
         try {
@@ -101,14 +112,17 @@ export function createUserSettingsRouter(pool) {
           for (const trip of trips.slice(0, MAX_SYNC_TRIPS)) {
             if (!trip || typeof trip.name !== 'string' || !trip.name.trim()) continue;
             if (!validStops(trip.stops)) continue;
-            const existing = await client.query(
-              `SELECT id FROM trips WHERE user_id = $1 AND name = $2 LIMIT 1`,
-              [req.user.id, trip.name.trim().substring(0, 200)]
-            );
-            if (existing.rows.length > 0) continue;
+            if (typeof trip.slug === 'string' && trip.slug.trim()) {
+              const existing = await client.query(
+                `SELECT id FROM trips WHERE user_id = $1 AND slug = $2 LIMIT 1`,
+                [req.user.id, trip.slug.trim().substring(0, 220)]
+              );
+              if (existing.rows.length > 0) continue;
+            }
             await insertTripWithStops(client, req.user.id, {
               name: trip.name.trim().substring(0, 200),
               description: trip.description,
+              slug: trip.slug,
               stops: trip.stops
             });
             count++;

--- a/backend/routes/userSettings.js
+++ b/backend/routes/userSettings.js
@@ -1,69 +1,21 @@
 import express from 'express';
 import { isAuthenticated } from '../middleware/auth.js';
-import { slugifyWithSuffix } from '../utils/slug.js';
+import { validateStops, insertStops, insertTripWithSlugRetry } from './trips.js';
 import { addSubscriber } from '../services/buttondownClient.js';
 
-const MAX_STOPS = 9;
-// Upper bound on trips accepted in a single sign-in sync, to bound work and
-// guard against a tampered/oversized localStorage payload. Generous — a real
-// anonymous session won't approach it.
 const MAX_SYNC_TRIPS = 50;
 
-function isFiniteNumber(v) {
-  const n = typeof v === 'string' ? Number(v) : v;
-  return typeof n === 'number' && Number.isFinite(n);
-}
-
-function validStops(stops) {
-  if (!Array.isArray(stops) || stops.length === 0 || stops.length > MAX_STOPS) {
-    return false;
-  }
-  return stops.every(s => s && typeof s === 'object'
-    && isFiniteNumber(s.latitude) && isFiniteNumber(s.longitude));
-}
-
-async function insertTripWithStops(client, userId, trip) {
-  // Prefer the client-provided slug on the first attempt so re-syncs dedup
-  // reliably by slug. Fall back to a freshly generated slug on collision
-  // (the trips.slug column is globally unique).
-  let inserted = null;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const slug = (attempt === 0 && typeof trip.slug === 'string' && trip.slug.trim())
-      ? trip.slug.trim().substring(0, 220)
-      : slugifyWithSuffix(trip.name);
-    try {
-      const row = await client.query(
-        `INSERT INTO trips (user_id, name, description, slug, is_featured, is_public)
-         VALUES ($1, $2, $3, $4, FALSE, FALSE)
-         RETURNING id`,
-        [userId, trip.name, trip.description || null, slug]
-      );
-      inserted = row.rows[0];
-      break;
-    } catch (err) {
-      if (err.code === '23505' && err.constraint && err.constraint.includes('slug')) {
-        continue;
-      }
-      throw err;
-    }
-  }
-  if (!inserted) throw new Error('slug collision after retries');
-
-  for (const [i, s] of trip.stops.entries()) {
-    await client.query(
-      `INSERT INTO trip_stops (trip_id, position, poi_id, label, latitude, longitude)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [inserted.id, i + 1, s.poi_id || null, s.label || null, Number(s.latitude), Number(s.longitude)]
-    );
-  }
-  return inserted.id;
-}
-
-// POST /api/user/settings/sync
-// Flushes a freshly-signed-in user's anonymous localStorage state to the
-// backend. Server-wins fill-gaps: timezone only set when currently NULL,
-// newsletter subscribe is idempotent server-side, trips inserted only when
-// the user has no trip with a matching name (avoids duplicates on re-sync).
+/**
+ * Router for /api/user/settings/sync.
+ *
+ * Flushes a freshly-signed-in user's anonymous localStorage state to the
+ * backend. Server-wins fill-gaps semantics: timezone is set only when the
+ * account's value is still NULL/empty; newsletter subscribe is idempotent
+ * server-side; a trip is inserted only when the user has no trip with the
+ * same slug, so re-syncs never duplicate. The client persists a stable slug
+ * per trip and it is reused server-side via insertTripWithSlugRetry's
+ * preferredSlug, keeping client and server slugs aligned for dedup.
+ */
 export function createUserSettingsRouter(pool) {
   const router = express.Router();
 
@@ -72,17 +24,15 @@ export function createUserSettingsRouter(pool) {
     const synced = { timezone: false, newsletter: false, trips: 0 };
 
     try {
-      // Timezone — only fill when not already set on the account.
       if (typeof timezone === 'string' && timezone.trim()) {
-        const result = await pool.query(
+        const tzUpdate = await pool.query(
           `UPDATE users SET timezone = $1
             WHERE id = $2 AND (timezone IS NULL OR timezone = '')`,
           [timezone.trim(), req.user.id]
         );
-        synced.timezone = result.rowCount > 0;
+        synced.timezone = tzUpdate.rowCount > 0;
       }
 
-      // Newsletter — idempotent subscribe (Buttondown handles already-subscribed).
       if (newsletter && newsletter.subscribed && typeof newsletter.email === 'string'
           && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newsletter.email)) {
         try {
@@ -91,19 +41,14 @@ export function createUserSettingsRouter(pool) {
             `INSERT INTO newsletter_subscriptions (email, source) VALUES ($1, $2)`,
             [newsletter.email, 'web']
           ).catch(err => {
-            // 23505 = unique_violation (already subscribed) — ignore.
             if (err.code !== '23505') throw err;
           });
           synced.newsletter = true;
         } catch (err) {
-          // Newsletter is best-effort during sync; don't fail the whole call.
           console.error('settings/sync newsletter failed:', err.message);
         }
       }
 
-      // Trips — insert only those this user doesn't already have. Dedup by
-      // slug (the client persists a stable slug per trip), which is reliable
-      // across re-syncs; insertTripWithStops reuses that slug server-side.
       if (Array.isArray(trips) && trips.length > 0) {
         const client = await pool.connect();
         try {
@@ -111,20 +56,26 @@ export function createUserSettingsRouter(pool) {
           let count = 0;
           for (const trip of trips.slice(0, MAX_SYNC_TRIPS)) {
             if (!trip || typeof trip.name !== 'string' || !trip.name.trim()) continue;
-            if (!validStops(trip.stops)) continue;
-            if (typeof trip.slug === 'string' && trip.slug.trim()) {
+            if (validateStops(trip.stops)) continue;
+            const slug = (typeof trip.slug === 'string' && trip.slug.trim())
+              ? trip.slug.trim().substring(0, 220)
+              : null;
+            if (slug) {
               const existing = await client.query(
                 `SELECT id FROM trips WHERE user_id = $1 AND slug = $2 LIMIT 1`,
-                [req.user.id, trip.slug.trim().substring(0, 220)]
+                [req.user.id, slug]
               );
               if (existing.rows.length > 0) continue;
             }
-            await insertTripWithStops(client, req.user.id, {
+            const created = await insertTripWithSlugRetry(client, {
+              user_id: req.user.id,
               name: trip.name.trim().substring(0, 200),
-              description: trip.description,
-              slug: trip.slug,
-              stops: trip.stops
+              description: trip.description || null,
+              is_featured: false,
+              is_public: false,
+              preferredSlug: slug
             });
+            await insertStops(client, created.id, trip.stops);
             count++;
           }
           await client.query('COMMIT');

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ import { createAdminRouter } from './routes/admin.js';
 import { createNewsletterRouter } from './routes/newsletter.js';
 import { createFeedbackRouter } from './routes/feedback.js';
 import { createTripsRouter } from './routes/trips.js';
+import { createUserSettingsRouter } from './routes/userSettings.js';
 import { isAuthenticated } from './middleware/auth.js';
 import {
   initJobScheduler,
@@ -170,6 +171,7 @@ app.use('/api/admin', createAdminRouter(pool, invalidateMosaicCache));
 app.use('/api/newsletter', createNewsletterRouter(pool));
 app.use('/api/feedback', createFeedbackRouter(pool));
 app.use('/api/trips', createTripsRouter(pool));
+app.use('/api/user/settings', createUserSettingsRouter(pool));
 
 async function importGeoJSONFeatures(client) {
   const staticPath = process.env.STATIC_PATH || path.join(__dirname, '../frontend/public');

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -348,6 +348,16 @@ body {
   color: #333;
 }
 
+.my-trips-menu-item {
+  color: #333;
+}
+
+.tab-dropdown-divider {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: #eee;
+}
+
 /* Filter Bar */
 .filter-bar {
   background: white;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -265,7 +265,11 @@ function AppContent() {
       latitude: 41.276,
       longitude: -81.538
     });
-    tripSetShowBuilder(true);
+    // Keep the builder collapsed at step 1 so the expanded panel (a bottom
+    // sheet on mobile) doesn't cover the "+ Add to Trip" badge the step
+    // highlights. addStop auto-expands, so collapse explicitly. Step 2's
+    // tripTourExpandBuilder action expands it. Fix: #379
+    tripSetShowBuilder(false);
     isProgrammaticNavigationRef.current = true;
     navigate('/');
   }, [navigate, tripClear, tripAddStop, tripSetShowBuilder]);
@@ -358,14 +362,13 @@ function AppContent() {
         break;
       }
       case 'showNewsletter': {
-        if (isAuthenticated) {
-          setActiveTab('settings');
-          if (isAdmin) {
-            setSettingsTab('newsletter');
-          }
-          isProgrammaticNavigationRef.current = true;
-          navigate('/settings');
-        }
+        // Works for anon, regular users, and admins. Admin nav uses
+        // settingsTab='newsletter' to show the admin NewsletterSettings;
+        // UserSettings reads the same value to open its Newsletter tab.
+        setActiveTab('settings');
+        setSettingsTab('newsletter');
+        isProgrammaticNavigationRef.current = true;
+        navigate('/settings');
         break;
       }
       case 'tripTourAddDemoStop': {
@@ -388,9 +391,15 @@ function AppContent() {
         break;
       }
       case 'tripTourEndDemo': {
-        // Open the user dropdown so the My Trips item is spotlight-able.
+        // Open the menu holding the My Trips item so it is spotlight-able.
+        // Anon visitors get it in the Login dropdown; authed users in the
+        // account dropdown.
         setSelectedDestination(null);
-        setShowUserDropdown(true);
+        if (isAuthenticated) {
+          setShowUserDropdown(true);
+        } else {
+          setShowLoginDropdown(true);
+        }
         break;
       }
     }
@@ -474,11 +483,8 @@ function AppContent() {
     }
   }, [role]);
 
-  useEffect(() => {
-    if (!isAuthenticated && activeTab === 'settings') {
-      setActiveTab('view');
-    }
-  }, [isAuthenticated, activeTab]);
+  // Anonymous visitors can use /settings for user-level preferences (timezone,
+  // newsletter, saved trips). Spec: 018-anon-user-settings. Issue: #379.
 
   useEffect(() => {
     const handleEscape = (e) => {
@@ -1821,6 +1827,19 @@ function AppContent() {
                       items[next]?.focus();
                     }
                   }}>
+                    <button
+                      className="dropdown-item-inline my-trips-menu-item"
+                      onClick={() => { setShowLoginDropdown(false); setShowMyTrips(true); }}
+                    >
+                      My Trips
+                    </button>
+                    <button
+                      className="dropdown-item-inline settings-item-inline"
+                      onClick={() => { setShowLoginDropdown(false); handleTabChange('settings'); }}
+                    >
+                      Settings
+                    </button>
+                    <div className="tab-dropdown-divider" />
                     <button className="oauth-btn-inline google-btn" onClick={loginWithGoogle}>
                       <svg viewBox="0 0 24 24" width="18" height="18">
                         <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -2104,7 +2123,7 @@ function AppContent() {
             </div>
             </>
             ) : (
-              <UserSettings user={user} />
+              <UserSettings user={user} initialTab={settingsTab === 'newsletter' ? 'newsletter' : 'general'} />
             )}
           </div>
         </main>
@@ -2184,6 +2203,7 @@ function AppContent() {
         />
 
         <Sidebar
+          tourActive={tourActive}
           destination={newPOI || newOrganization || selectedDestination}
           isNewPOI={!!newPOI}
           newOrganization={newOrganization}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -265,10 +265,6 @@ function AppContent() {
       latitude: 41.276,
       longitude: -81.538
     });
-    // Keep the builder collapsed at step 1 so the expanded panel (a bottom
-    // sheet on mobile) doesn't cover the "+ Add to Trip" badge the step
-    // highlights. addStop auto-expands, so collapse explicitly. Step 2's
-    // tripTourExpandBuilder action expands it. Fix: #379
     tripSetShowBuilder(false);
     isProgrammaticNavigationRef.current = true;
     navigate('/');
@@ -362,9 +358,6 @@ function AppContent() {
         break;
       }
       case 'showNewsletter': {
-        // Works for anon, regular users, and admins. Admin nav uses
-        // settingsTab='newsletter' to show the admin NewsletterSettings;
-        // UserSettings reads the same value to open its Newsletter tab.
         setActiveTab('settings');
         setSettingsTab('newsletter');
         isProgrammaticNavigationRef.current = true;
@@ -391,9 +384,6 @@ function AppContent() {
         break;
       }
       case 'tripTourEndDemo': {
-        // Open the menu holding the My Trips item so it is spotlight-able.
-        // Anon visitors get it in the Login dropdown; authed users in the
-        // account dropdown.
         setSelectedDestination(null);
         if (isAuthenticated) {
           setShowUserDropdown(true);
@@ -483,8 +473,6 @@ function AppContent() {
     }
   }, [role]);
 
-  // Anonymous visitors can use /settings for user-level preferences (timezone,
-  // newsletter, saved trips). Spec: 018-anon-user-settings. Issue: #379.
 
   useEffect(() => {
     const handleEscape = (e) => {

--- a/frontend/src/components/AddToTripButton.jsx
+++ b/frontend/src/components/AddToTripButton.jsx
@@ -9,7 +9,7 @@ export default function AddToTripButton({ poi, stops, className = 'share-badge-b
   if (!primary || typeof primary.lat !== 'number' || typeof primary.lng !== 'number') return null;
 
   const poiId = poi && poi.id ? poi.id : null;
-  const inTrip = poiId ? hasStop(poiId) : false;
+  const inTrip = !!poiId && hasStop(poiId);
   const atLimit = trip.stops.length >= MAX_STOPS;
 
   const handleClick = (e) => {

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -375,20 +375,34 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
     setMobilePositionAbove(result.mobilePositionAbove);
   }, [isMobile]);
 
+  // Keep latest values in refs so the step-change effect doesn't re-run on
+  // every parent render. Parent renders (e.g., showResults navigating tabs)
+  // used to retrigger the effect, reset the spotlight, and re-poll — causing
+  // visible flicker on step 3. Fix: #379
+  const stepRef = useRef(step);
+  const onStepActionRef = useRef(onStepAction);
+  const applyPositionRef = useRef(applyPosition);
   useEffect(() => {
-    if (!step) return;
+    stepRef.current = step;
+    onStepActionRef.current = onStepAction;
+    applyPositionRef.current = applyPosition;
+  });
+
+  useEffect(() => {
+    const s = stepRef.current;
+    if (!s) return;
     let cancelled = false;
     const timers = [];
 
     if (prevStepRef.current !== currentStep) {
       prevStepRef.current = currentStep;
 
-      if (step.action && onStepAction) {
-        onStepAction(step.action);
+      if (s.action && onStepActionRef.current) {
+        onStepActionRef.current(s.action);
       }
     }
 
-    if (step.delay) {
+    if (s.delay) {
       setStepReady(false);
       setSpotlightRect(null);
 
@@ -397,7 +411,8 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
       let stableCount = 0;
       const poll = () => {
         if (cancelled) return;
-        const targetSelector = step.spotlightSelector || step.selector;
+        const cur = stepRef.current;
+        const targetSelector = cur.spotlightSelector || cur.selector;
         const el = document.querySelector(targetSelector);
         if (el) {
           const rect = el.getBoundingClientRect();
@@ -408,7 +423,7 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
           }
           lastTop = rect.top;
           if (stableCount >= 2) {
-            applyPosition(step);
+            applyPositionRef.current(cur);
             setStepReady(true);
             return;
           }
@@ -417,31 +432,35 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
           retryCount++;
           timers.push(setTimeout(poll, 50));
         } else {
-          applyPosition(step);
+          applyPositionRef.current(stepRef.current);
           setStepReady(true);
         }
       };
-      timers.push(setTimeout(poll, step.delay));
+      timers.push(setTimeout(poll, s.delay));
     } else {
       setStepReady(true);
-      applyPosition(step);
+      applyPositionRef.current(s);
     }
 
     const handleResize = () => {
       setIsMobile(window.innerWidth < 768);
       if (resizeRef.current) cancelAnimationFrame(resizeRef.current);
-      resizeRef.current = requestAnimationFrame(() => applyPosition(step));
+      resizeRef.current = requestAnimationFrame(() => {
+        if (!cancelled) applyPositionRef.current(stepRef.current);
+      });
     };
     window.addEventListener('resize', handleResize);
 
     const handleScroll = () => {
       if (resizeRef.current) cancelAnimationFrame(resizeRef.current);
-      resizeRef.current = requestAnimationFrame(() => applyPosition(step));
+      resizeRef.current = requestAnimationFrame(() => {
+        if (!cancelled) applyPositionRef.current(stepRef.current);
+      });
     };
     window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
 
     const repositionInterval = setInterval(() => {
-      if (!cancelled) applyPosition(step);
+      if (!cancelled) applyPositionRef.current(stepRef.current);
     }, 250);
 
     return () => {
@@ -452,7 +471,7 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
       window.removeEventListener('scroll', handleScroll, { capture: true });
       if (resizeRef.current) cancelAnimationFrame(resizeRef.current);
     };
-  }, [currentStep, step, onStepAction, applyPosition, isMobile]);
+  }, [currentStep, isMobile]);
 
   useEffect(() => {
     const handleKeyDown = (e) => {

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -57,9 +57,6 @@ export const TRIP_TOUR_STEPS = [
     action: 'tripTourEndDemo',
     spotlightSelector: '.my-trips-menu-item',
     delay: 400,
-    // The My Trips item lives in a dropdown near the top of the screen, so on
-    // mobile the tooltip must dock below it — positioning above would clamp to
-    // the top edge and overlap the spotlight. Fix: #379
     mobile: { position: 'bottom' }
   }
 ];
@@ -378,10 +375,6 @@ function GuidedTour({ onEnd, currentStep, setCurrentStep, onStepAction, steps: s
     setMobilePositionAbove(result.mobilePositionAbove);
   }, [isMobile]);
 
-  // Keep latest values in refs so the step-change effect doesn't re-run on
-  // every parent render. Parent renders (e.g., showResults navigating tabs)
-  // used to retrigger the effect, reset the spotlight, and re-poll — causing
-  // visible flicker on step 3. Fix: #379
   const stepRef = useRef(step);
   const onStepActionRef = useRef(onStepAction);
   const applyPositionRef = useRef(applyPosition);

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -57,7 +57,10 @@ export const TRIP_TOUR_STEPS = [
     action: 'tripTourEndDemo',
     spotlightSelector: '.my-trips-menu-item',
     delay: 400,
-    mobile: { position: 'top', mobilePositionAbove: true }
+    // The My Trips item lives in a dropdown near the top of the screen, so on
+    // mobile the tooltip must dock below it — positioning above would clamp to
+    // the top edge and overlap the spotlight. Fix: #379
+    mobile: { position: 'bottom' }
   }
 ];
 

--- a/frontend/src/components/MyTripsModal.css
+++ b/frontend/src/components/MyTripsModal.css
@@ -128,6 +128,15 @@
   font-style: italic;
 }
 
+.my-trips-anon-hint {
+  margin: 0 0 0.75rem 0;
+  padding: 0.5rem 0.75rem;
+  background: #f1f8e9;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #33691e;
+}
+
 .my-trips-section-heading {
   margin: 0.75rem 0 0.4rem 0;
   font-size: 0.95rem;

--- a/frontend/src/components/MyTripsModal.jsx
+++ b/frontend/src/components/MyTripsModal.jsx
@@ -33,7 +33,6 @@ export default function MyTripsModal({ open, onClose }) {
   const [copiedId, setCopiedId] = useState(null);
 
   const refreshMine = useCallback(async () => {
-    // Anonymous visitors: trips live in localStorage, not the backend.
     if (!isAuthenticated) {
       setMine(readLocalTrips().map(t => ({
         ...t,

--- a/frontend/src/components/MyTripsModal.jsx
+++ b/frontend/src/components/MyTripsModal.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTrip } from '../hooks/useTrip';
 import { useAuth } from '../hooks/useAuth';
+import { readTrips as readLocalTrips, removeTrip as removeLocalTrip } from '../utils/anonSettings';
 import './MyTripsModal.css';
 
 function formatDate(iso) {
@@ -22,7 +23,7 @@ function shareStatusLabel(trip) {
 
 export default function MyTripsModal({ open, onClose }) {
   const { trip: activeTrip, loadTrip, clear } = useTrip();
-  const { isAdmin } = useAuth();
+  const { isAdmin, isAuthenticated } = useAuth();
   const [mine, setMine] = useState([]);
   const [discover, setDiscover] = useState([]);
   const [pending, setPending] = useState([]);
@@ -32,6 +33,15 @@ export default function MyTripsModal({ open, onClose }) {
   const [copiedId, setCopiedId] = useState(null);
 
   const refreshMine = useCallback(async () => {
+    // Anonymous visitors: trips live in localStorage, not the backend.
+    if (!isAuthenticated) {
+      setMine(readLocalTrips().map(t => ({
+        ...t,
+        stop_count: t.stops?.length || 0,
+        updated_at: t.savedAt
+      })));
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -43,7 +53,7 @@ export default function MyTripsModal({ open, onClose }) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isAuthenticated]);
 
   const refreshDiscover = useCallback(async () => {
     setLoading(true);
@@ -82,6 +92,16 @@ export default function MyTripsModal({ open, onClose }) {
   if (!open) return null;
 
   const handleOpen = async (slug) => {
+    if (!isAuthenticated) {
+      const local = readLocalTrips().find(t => t.slug === slug);
+      if (local) {
+        loadTrip(local);
+        onClose();
+      } else {
+        setError('Could not load trip');
+      }
+      return;
+    }
     try {
       const res = await fetch(`/api/trips/${encodeURIComponent(slug)}`, { credentials: 'include' });
       if (!res.ok) throw new Error('Could not load trip');
@@ -113,6 +133,13 @@ export default function MyTripsModal({ open, onClose }) {
     } catch (err) {
       setError(err.message);
     }
+  };
+
+  const handleDeleteLocal = (slug) => {
+    if (!window.confirm('Delete this trip?')) return;
+    removeLocalTrip(slug);
+    if (activeTrip && activeTrip.slug === slug) clear();
+    refreshMine();
   };
 
   const handleCopyLink = async (trip) => {
@@ -188,13 +215,20 @@ export default function MyTripsModal({ open, onClose }) {
             <>
               <div className="my-trips-actions-row">
                 <button className="primary" onClick={() => { clear(); onClose(); }}>+ New Trip</button>
-                <button onClick={() => { setView('discover'); refreshDiscover(); }}>Find Trips</button>
+                {isAuthenticated && (
+                  <button onClick={() => { setView('discover'); refreshDiscover(); }}>Find Trips</button>
+                )}
                 {isAdmin && (
                   <button onClick={() => { setView('pending'); refreshPending(); }}>
                     Pending Review
                   </button>
                 )}
               </div>
+              {!isAuthenticated && mine.length > 0 && (
+                <p className="my-trips-anon-hint">
+                  These trips are saved to this browser. Sign in to keep them on your account and share them.
+                </p>
+              )}
               {loading ? (
                 <div className="my-trips-empty">Loading…</div>
               ) : mine.length === 0 ? (
@@ -204,24 +238,32 @@ export default function MyTripsModal({ open, onClose }) {
                   {mine.map(trip => {
                     const status = shareStatusLabel(trip);
                     return (
-                      <li key={trip.id} className="my-trips-row">
+                      <li key={trip.id || trip.slug} className="my-trips-row">
                         <div className="my-trips-row-info">
                           <span className="my-trips-row-name">
                             {trip.name}{status ? ` · ${status}` : ''}
                           </span>
                           <span className="my-trips-row-meta">
-                            {trip.stop_count} stop{Number(trip.stop_count) === 1 ? '' : 's'} · edited {formatDate(trip.updated_at)}
+                            {trip.stop_count} stop{Number(trip.stop_count) === 1 ? '' : 's'}
+                            {trip.updated_at ? ` · edited ${formatDate(trip.updated_at)}` : ''}
                           </span>
                         </div>
                         <div className="my-trips-row-actions">
                           <button onClick={() => handleOpen(trip.slug)}>Open</button>
-                          <button onClick={() => handleDuplicate(trip.id)}>Duplicate</button>
-                          {(trip.is_featured || trip.is_public) && (
+                          {isAuthenticated && (
+                            <button onClick={() => handleDuplicate(trip.id)}>Duplicate</button>
+                          )}
+                          {isAuthenticated && (trip.is_featured || trip.is_public) && (
                             <button onClick={() => handleCopyLink(trip)}>
                               {copiedId === trip.id ? 'Copied!' : 'Copy link'}
                             </button>
                           )}
-                          <button className="danger" onClick={() => handleDelete(trip.id)}>Delete</button>
+                          <button
+                            className="danger"
+                            onClick={() => isAuthenticated ? handleDelete(trip.id) : handleDeleteLocal(trip.slug)}
+                          >
+                            Delete
+                          </button>
                         </div>
                       </li>
                     );

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2390,7 +2390,7 @@ const SIDEBAR_TAB_LABELS = {
   associations: 'Associations',
 };
 
-function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, onClose, isAdmin, user, editMode, onDestinationUpdate, onDestinationDelete, onSaveNewPOI, onCancelNewPOI, onSaveNewOrganization, onCancelNewOrganization, previewCoords, onPreviewCoordsChange, linearFeature, onLinearFeatureUpdate, onLinearFeatureDelete, onNavigate, currentIndex, totalCount, poiNavigationList, associations, allDestinations, allLinearFeatures, allVirtualPois, onSelectDestination, onSelectLinearFeature, onAssociationsChanged, onStartDrawingAssociations, isInMtbMode, selectedFromMtbList, mtbTrailsList, currentMtbIndex, onNavigateMtbTrail, onBackToMtbList, permalinkInfo, onSetPermalink, onClearPermalink, initialSidebarTab, onSidebarTabChange }) {
+function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrganization, onClose, isAdmin, user, editMode, onDestinationUpdate, onDestinationDelete, onSaveNewPOI, onCancelNewPOI, onSaveNewOrganization, onCancelNewOrganization, previewCoords, onPreviewCoordsChange, linearFeature, onLinearFeatureUpdate, onLinearFeatureDelete, onNavigate, currentIndex, totalCount, poiNavigationList, associations, allDestinations, allLinearFeatures, allVirtualPois, onSelectDestination, onSelectLinearFeature, onAssociationsChanged, onStartDrawingAssociations, isInMtbMode, selectedFromMtbList, mtbTrailsList, currentMtbIndex, onNavigateMtbTrail, onBackToMtbList, permalinkInfo, onSetPermalink, onClearPermalink, initialSidebarTab, onSidebarTabChange }) {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
   const [editedData, setEditedData] = useState({});
@@ -3011,7 +3011,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
         onTouchMove={isMobile && onNavigate ? handleTouchMove : undefined}
         onTouchEnd={isMobile && onNavigate ? handleTouchEnd : undefined}
       >
-        {isMobile && onNavigate && poiNavigationList && poiNavigationList.length > 0 && (
+        {isMobile && !tourActive && onNavigate && poiNavigationList && poiNavigationList.length > 0 && (
           <ThumbnailCarousel
             pois={poiNavigationList}
             currentIndex={currentIndex}
@@ -3300,7 +3300,7 @@ function Sidebar({ destination, isNewPOI, newOrganization, isNewOrganization, on
       onTouchMove={isMobile && onNavigate ? handleTouchMove : undefined}
       onTouchEnd={isMobile && onNavigate ? handleTouchEnd : undefined}
     >
-      {isMobile && onNavigate && poiNavigationList && poiNavigationList.length > 0 && (
+      {isMobile && !tourActive && onNavigate && poiNavigationList && poiNavigationList.length > 0 && (
         <ThumbnailCarousel
           pois={poiNavigationList}
           currentIndex={currentIndex}

--- a/frontend/src/components/TripBuilder.jsx
+++ b/frontend/src/components/TripBuilder.jsx
@@ -175,8 +175,8 @@ export default function TripBuilder({ onOpenMyTrips }) {
               type="button"
               className="primary"
               onClick={handleSave}
-              disabled={!isAuthenticated || saving}
-              title={isAuthenticated ? '' : 'Sign in to save this trip'}
+              disabled={saving}
+              title={isAuthenticated ? '' : 'Saved to this browser until you sign in'}
             >
               {saving ? 'Saving…' : 'Save'}
             </button>

--- a/frontend/src/components/UserSettings.jsx
+++ b/frontend/src/components/UserSettings.jsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import GeneralSettings from './GeneralSettings';
+import { readEmail, writeEmail, writeSubscribed } from '../utils/anonSettings';
 
-function UserSettings({ user }) {
-  const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState('general');
-  const [email, setEmail] = useState('');
+function UserSettings({ user, initialTab }) {
+  const [activeTab, setActiveTab] = useState(initialTab || 'general');
+
+  useEffect(() => {
+    if (initialTab) setActiveTab(initialTab);
+  }, [initialTab]);
+  const [email, setEmail] = useState(() => user?.email || readEmail());
   const [status, setStatus] = useState('idle');
   const [message, setMessage] = useState('');
 
@@ -13,6 +17,15 @@ function UserSettings({ user }) {
       setEmail(user.email);
     }
   }, [user]);
+
+  const handleEmailChange = (e) => {
+    const value = e.target.value;
+    setEmail(value);
+    // Persist anon input so a reload before submit doesn't lose it.
+    if (!user?.email) {
+      writeEmail(value);
+    }
+  };
 
   const handleSubscribe = async (e) => {
     e.preventDefault();
@@ -32,6 +45,9 @@ function UserSettings({ user }) {
       if (res.ok) {
         setStatus('success');
         setMessage(data.message);
+        if (!user?.email) {
+          writeSubscribed(true);
+        }
       } else {
         setStatus('error');
         setMessage(data.error || 'Subscription failed');
@@ -61,35 +77,36 @@ function UserSettings({ user }) {
 
       <div className="settings-tab-content">
         {activeTab === 'general' && (
-          <div className="settings-section">
-            <h3>👤 Profile</h3>
-            <p className="settings-description">
-              Manage your account preferences.
-            </p>
-            <div className="settings-field">
-              <label>Email</label>
-              <input
-                type="email"
-                value={user?.email || ''}
-                disabled
-                style={{ backgroundColor: '#f5f5f5', cursor: 'not-allowed' }}
-              />
-              <p className="field-hint">
-                Your email is managed through your authentication provider
-              </p>
-            </div>
-            <div className="settings-divider"></div>
-            <div className="settings-field">
-              <label>Legal</label>
-              <a
-                href="/privacy"
-                className="settings-link"
-                onClick={(e) => { e.preventDefault(); navigate('/privacy'); }}
-              >
-                Privacy Policy
-              </a>
-            </div>
-          </div>
+          <>
+            {user ? (
+              <div className="settings-section">
+                <h3>👤 Profile</h3>
+                <p className="settings-description">
+                  Manage your account preferences.
+                </p>
+                <div className="settings-field">
+                  <label>Email</label>
+                  <input
+                    type="email"
+                    value={user.email || ''}
+                    disabled
+                    style={{ backgroundColor: '#f5f5f5', cursor: 'not-allowed' }}
+                  />
+                  <p className="field-hint">
+                    Your email is managed through your authentication provider
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="settings-section">
+                <p className="settings-description">
+                  Your timezone and newsletter preferences are saved to this
+                  browser and will follow you onto your account when you sign in.
+                </p>
+              </div>
+            )}
+            <GeneralSettings />
+          </>
         )}
 
         {activeTab === 'newsletter' && (
@@ -100,77 +117,77 @@ function UserSettings({ user }) {
             </p>
 
             <form onSubmit={handleSubscribe} className="newsletter-form">
-          <div className="settings-field">
-            <label htmlFor="email">Email Address</label>
-            <input
-              id="email"
-              type="email"
-              placeholder="your@email.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={status === 'loading'}
-              required
-            />
-            <p className="field-hint">
-              You'll receive a confirmation email from Buttondown to complete your subscription
-            </p>
-          </div>
+              <div className="settings-field">
+                <label htmlFor="email">Email Address</label>
+                <input
+                  id="email"
+                  type="email"
+                  placeholder="your@email.com"
+                  value={email}
+                  onChange={handleEmailChange}
+                  disabled={status === 'loading'}
+                  required
+                />
+                <p className="field-hint">
+                  You'll receive a confirmation email from Buttondown to complete your subscription
+                </p>
+              </div>
 
-          <div className="settings-actions">
-            <button
-              type="submit"
-              disabled={status === 'loading'}
-              className="save-settings-btn"
-            >
-              {status === 'loading' ? '📨 Subscribing...' : '📨 Subscribe to Weekly Digest'}
-            </button>
-          </div>
+              <div className="settings-actions">
+                <button
+                  type="submit"
+                  disabled={status === 'loading'}
+                  className="save-settings-btn"
+                >
+                  {status === 'loading' ? '📨 Subscribing...' : '📨 Subscribe to Weekly Digest'}
+                </button>
+              </div>
 
-          {status === 'success' && (
-            <div style={{
-              marginTop: '12px',
-              padding: '10px 14px',
-              borderRadius: '6px',
-              backgroundColor: '#d4edda',
-              color: '#155724',
-              border: '1px solid #c3e6cb',
-              fontSize: '0.9rem',
-              maxWidth: '600px'
-            }}>
-              ✓ {message}
+              {status === 'success' && (
+                <div style={{
+                  marginTop: '12px',
+                  padding: '10px 14px',
+                  borderRadius: '6px',
+                  backgroundColor: '#d4edda',
+                  color: '#155724',
+                  border: '1px solid #c3e6cb',
+                  fontSize: '0.9rem',
+                  maxWidth: '600px'
+                }}>
+                  ✓ {message}
+                </div>
+              )}
+              {status === 'error' && (
+                <div style={{
+                  marginTop: '12px',
+                  padding: '10px 14px',
+                  borderRadius: '6px',
+                  backgroundColor: '#f8d7da',
+                  color: '#721c24',
+                  border: '1px solid #f5c6cb',
+                  fontSize: '0.9rem',
+                  maxWidth: '600px'
+                }}>
+                  ✗ {message}
+                </div>
+              )}
+            </form>
+
+            <div className="settings-divider"></div>
+
+            <div className="settings-info-box">
+              <div className="info-box-header">
+                <span className="info-icon">ℹ️</span>
+                <strong>What's in the Newsletter?</strong>
+              </div>
+              <ul className="info-list">
+                <li>Events happening this weekend (Friday-Sunday)</li>
+                <li>Recent news from the past week</li>
+                <li>Trail status updates (when available)</li>
+                <li>Sent every Friday at 8 AM EST</li>
+              </ul>
             </div>
-          )}
-          {status === 'error' && (
-            <div style={{
-              marginTop: '12px',
-              padding: '10px 14px',
-              borderRadius: '6px',
-              backgroundColor: '#f8d7da',
-              color: '#721c24',
-              border: '1px solid #f5c6cb',
-              fontSize: '0.9rem',
-              maxWidth: '600px'
-            }}>
-              ✗ {message}
-            </div>
-          )}
-        </form>
-
-        <div className="settings-divider"></div>
-
-        <div className="settings-info-box">
-          <div className="info-box-header">
-            <span className="info-icon">ℹ️</span>
-            <strong>What's in the Newsletter?</strong>
           </div>
-          <ul className="info-list">
-            <li>Events happening this weekend (Friday-Sunday)</li>
-            <li>Recent news from the past week</li>
-            <li>Trail status updates (when available)</li>
-            <li>Sent every Friday at 8 AM EST</li>
-          </ul>
-        </div>
-      </div>
         )}
       </div>
     </>

--- a/frontend/src/components/UserSettings.jsx
+++ b/frontend/src/components/UserSettings.jsx
@@ -21,7 +21,6 @@ function UserSettings({ user, initialTab }) {
   const handleEmailChange = (e) => {
     const value = e.target.value;
     setEmail(value);
-    // Persist anon input so a reload before submit doesn't lose it.
     if (!user?.email) {
       writeEmail(value);
     }

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -36,9 +36,6 @@ export function AuthProvider({ children }) {
     const params = new URLSearchParams(window.location.search);
     const authStatus = params.get('auth');
     if (authStatus === 'success') {
-      // Flush any anonymous localStorage settings (timezone, newsletter,
-      // saved trips) to the backend now that a session exists. Spec
-      // 018-anon-user-settings. Best-effort; failure is a no-op.
       fetchUser().then(() => syncAnonSettings());
       window.history.replaceState({}, '', window.location.pathname);
     } else if (authStatus === 'failed') {

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useEffect, useCallback } from 'react';
+import { syncAnonSettings } from '../utils/anonSettings';
 
 export const AuthContext = createContext(null);
 
@@ -35,7 +36,10 @@ export function AuthProvider({ children }) {
     const params = new URLSearchParams(window.location.search);
     const authStatus = params.get('auth');
     if (authStatus === 'success') {
-      fetchUser();
+      // Flush any anonymous localStorage settings (timezone, newsletter,
+      // saved trips) to the backend now that a session exists. Spec
+      // 018-anon-user-settings. Best-effort; failure is a no-op.
+      fetchUser().then(() => syncAnonSettings());
       window.history.replaceState({}, '', window.location.pathname);
     } else if (authStatus === 'failed') {
       setError('Authentication failed. Please try again.');

--- a/frontend/src/contexts/TripContext.jsx
+++ b/frontend/src/contexts/TripContext.jsx
@@ -1,6 +1,16 @@
 import React, { createContext, useState, useEffect, useCallback, useRef } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { addTrip as addLocalTrip } from '../utils/anonSettings';
 
 export const TripContext = createContext(null);
+
+function generateAnonSlug(name) {
+  const base = (name || 'untitled-trip')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${base || 'untitled-trip'}-${Date.now().toString(36)}`;
+}
 
 const STORAGE_KEY = 'rotv.tripInProgress.v1';
 export const MAX_STOPS = 9;
@@ -42,6 +52,7 @@ function stopKey(s) {
 }
 
 export function TripProvider({ children }) {
+  const { isAuthenticated } = useAuth();
   const [trip, setTrip] = useState(() => loadFromStorage());
   const [showBuilder, setShowBuilder] = useState(false);
   const persistTimer = useRef(null);
@@ -141,6 +152,25 @@ export function TripProvider({ children }) {
       is_featured: trip.is_featured,
       stops: trip.stops
     };
+
+    // Anonymous visitors save trips to localStorage. On first successful
+    // sign-in, syncAnonSettings flushes these to /api/trips. See spec
+    // 018-anon-user-settings.
+    if (!isAuthenticated) {
+      const slug = trip.slug || generateAnonSlug(payload.name);
+      const localTrip = {
+        ...payload,
+        id: null,
+        slug,
+        is_public: false,
+        is_featured: false,
+        isAnonymous: true
+      };
+      addLocalTrip(localTrip);
+      loadTrip(localTrip);
+      return localTrip;
+    }
+
     const url = trip.id ? `/api/trips/${trip.id}` : '/api/trips';
     const method = trip.id ? 'PUT' : 'POST';
     const res = await fetch(url, {
@@ -156,7 +186,7 @@ export function TripProvider({ children }) {
     const saved = await res.json();
     loadTrip(saved);
     return saved;
-  }, [trip, loadTrip]);
+  }, [trip, loadTrip, isAuthenticated]);
 
   const hasStop = useCallback((poi_id) => {
     if (!poi_id) return false;

--- a/frontend/src/contexts/TripContext.jsx
+++ b/frontend/src/contexts/TripContext.jsx
@@ -153,9 +153,6 @@ export function TripProvider({ children }) {
       stops: trip.stops
     };
 
-    // Anonymous visitors save trips to localStorage. On first successful
-    // sign-in, syncAnonSettings flushes these to /api/trips. See spec
-    // 018-anon-user-settings.
     if (!isAuthenticated) {
       const slug = trip.slug || generateAnonSlug(payload.name);
       const localTrip = {

--- a/frontend/src/utils/anonSettings.js
+++ b/frontend/src/utils/anonSettings.js
@@ -110,9 +110,11 @@ export async function syncAnonSettings() {
     });
     if (!res.ok) return { synced: false, status: res.status };
 
-    // Clear synced keys. Timezone is intentionally retained because the
-    // logged-in client still reads it from the same key for now (server
-    // column is canonical, but client doesn't refetch yet).
+    // Clear synced keys for newsletter and trips. The timezone key
+    // ('app-timezone') is intentionally NOT cleared: the logged-in client
+    // (GeneralSettings) still reads timezone from localStorage. The server
+    // column is canonical for future cross-device use, but the client does
+    // not yet refetch it, so clearing here would drop the user's timezone.
     if (email && subscribed) {
       safeRemove(KEY_NEWSLETTER_EMAIL);
       safeRemove(KEY_NEWSLETTER_SUBSCRIBED);

--- a/frontend/src/utils/anonSettings.js
+++ b/frontend/src/utils/anonSettings.js
@@ -1,0 +1,128 @@
+// LocalStorage-backed customizations for anonymous (not-logged-in) visitors.
+// On first successful sign-in, syncAnonSettings() POSTs accumulated state to
+// /api/user/settings/sync (server-wins fill-gaps) and clears synced keys.
+// See .specify/specs/018-anon-user-settings/ for the architecture.
+
+const KEY_TIMEZONE = 'app-timezone';
+const KEY_NEWSLETTER_EMAIL = 'rotv-newsletter-email';
+const KEY_NEWSLETTER_SUBSCRIBED = 'rotv-newsletter-subscribed';
+const KEY_SAVED_TRIPS = 'rotv-saved-trips';
+
+function safeRead(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeWrite(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage may be unavailable (private mode, quota); ignore
+  }
+}
+
+function safeRemove(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function readTimezone() {
+  return safeRead(KEY_TIMEZONE);
+}
+
+export function readEmail() {
+  return safeRead(KEY_NEWSLETTER_EMAIL) || '';
+}
+
+export function writeEmail(value) {
+  safeWrite(KEY_NEWSLETTER_EMAIL, value);
+}
+
+export function readSubscribed() {
+  return safeRead(KEY_NEWSLETTER_SUBSCRIBED) === 'true';
+}
+
+export function writeSubscribed(value) {
+  safeWrite(KEY_NEWSLETTER_SUBSCRIBED, value ? 'true' : 'false');
+}
+
+export function readTrips() {
+  const raw = safeRead(KEY_SAVED_TRIPS);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeTrips(trips) {
+  safeWrite(KEY_SAVED_TRIPS, JSON.stringify(trips));
+}
+
+export function addTrip(trip) {
+  const trips = readTrips();
+  // Dedup by slug — overwrites a same-slug local trip (last-write-wins locally)
+  const filtered = trips.filter(t => t.slug !== trip.slug);
+  filtered.push({ ...trip, savedAt: new Date().toISOString() });
+  writeTrips(filtered);
+}
+
+export function removeTrip(slug) {
+  writeTrips(readTrips().filter(t => t.slug !== slug));
+}
+
+// Flushes all accumulated anonymous state to the backend on first successful
+// sign-in. Server-wins semantics: backend only fills NULL timezone, only
+// inserts newsletter subscriptions/trips that don't already exist for the
+// user. Safe to call repeatedly — no-op when no anon state is present.
+export async function syncAnonSettings() {
+  const timezone = readTimezone();
+  const email = readEmail();
+  const subscribed = readSubscribed();
+  const trips = readTrips();
+
+  const hasState =
+    timezone ||
+    (email && subscribed) ||
+    trips.length > 0;
+
+  if (!hasState) return { synced: false };
+
+  const payload = {};
+  if (timezone) payload.timezone = timezone;
+  if (email && subscribed) payload.newsletter = { email, subscribed };
+  if (trips.length > 0) payload.trips = trips;
+
+  try {
+    const res = await fetch('/api/user/settings/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) return { synced: false, status: res.status };
+
+    // Clear synced keys. Timezone is intentionally retained because the
+    // logged-in client still reads it from the same key for now (server
+    // column is canonical, but client doesn't refetch yet).
+    if (email && subscribed) {
+      safeRemove(KEY_NEWSLETTER_EMAIL);
+      safeRemove(KEY_NEWSLETTER_SUBSCRIBED);
+    }
+    if (trips.length > 0) {
+      safeRemove(KEY_SAVED_TRIPS);
+    }
+
+    return { synced: true };
+  } catch {
+    return { synced: false };
+  }
+}

--- a/frontend/src/utils/anonSettings.js
+++ b/frontend/src/utils/anonSettings.js
@@ -1,7 +1,9 @@
-// LocalStorage-backed customizations for anonymous (not-logged-in) visitors.
-// On first successful sign-in, syncAnonSettings() POSTs accumulated state to
-// /api/user/settings/sync (server-wins fill-gaps) and clears synced keys.
-// See .specify/specs/018-anon-user-settings/ for the architecture.
+/**
+ * LocalStorage-backed customizations for anonymous (not-logged-in) visitors.
+ * On first successful sign-in, syncAnonSettings() POSTs accumulated state to
+ * /api/user/settings/sync (server-wins fill-gaps) and clears synced keys.
+ * See .specify/specs/018-anon-user-settings/ for the architecture.
+ */
 
 const KEY_TIMEZONE = 'app-timezone';
 const KEY_NEWSLETTER_EMAIL = 'rotv-newsletter-email';
@@ -20,7 +22,7 @@ function safeWrite(key, value) {
   try {
     localStorage.setItem(key, value);
   } catch {
-    // localStorage may be unavailable (private mode, quota); ignore
+    return;
   }
 }
 
@@ -28,12 +30,8 @@ function safeRemove(key) {
   try {
     localStorage.removeItem(key);
   } catch {
-    // ignore
+    return;
   }
-}
-
-export function readTimezone() {
-  return safeRead(KEY_TIMEZONE);
 }
 
 export function readEmail() {
@@ -42,10 +40,6 @@ export function readEmail() {
 
 export function writeEmail(value) {
   safeWrite(KEY_NEWSLETTER_EMAIL, value);
-}
-
-export function readSubscribed() {
-  return safeRead(KEY_NEWSLETTER_SUBSCRIBED) === 'true';
 }
 
 export function writeSubscribed(value) {
@@ -68,32 +62,33 @@ export function writeTrips(trips) {
 }
 
 export function addTrip(trip) {
-  const trips = readTrips();
-  // Dedup by slug — overwrites a same-slug local trip (last-write-wins locally)
-  const filtered = trips.filter(t => t.slug !== trip.slug);
-  filtered.push({ ...trip, savedAt: new Date().toISOString() });
-  writeTrips(filtered);
+  const trips = readTrips().filter(t => t.slug !== trip.slug);
+  trips.push({ ...trip, savedAt: new Date().toISOString() });
+  writeTrips(trips);
 }
 
 export function removeTrip(slug) {
   writeTrips(readTrips().filter(t => t.slug !== slug));
 }
 
-// Flushes all accumulated anonymous state to the backend on first successful
-// sign-in. Server-wins semantics: backend only fills NULL timezone, only
-// inserts newsletter subscriptions/trips that don't already exist for the
-// user. Safe to call repeatedly — no-op when no anon state is present.
+/**
+ * Flush accumulated anonymous state to the backend on first successful
+ * sign-in. Server-wins semantics: the backend only fills a NULL timezone and
+ * only inserts newsletter subscriptions / trips that don't already exist for
+ * the user. Safe to call repeatedly — a no-op when no anon state is present.
+ *
+ * The timezone key is intentionally NOT cleared after sync: the logged-in
+ * client (GeneralSettings) still reads timezone from localStorage. The server
+ * column is canonical for future cross-device use, but the client does not yet
+ * refetch it, so clearing here would drop the user's timezone.
+ */
 export async function syncAnonSettings() {
-  const timezone = readTimezone();
-  const email = readEmail();
-  const subscribed = readSubscribed();
+  const timezone = safeRead(KEY_TIMEZONE);
+  const email = safeRead(KEY_NEWSLETTER_EMAIL) || '';
+  const subscribed = safeRead(KEY_NEWSLETTER_SUBSCRIBED) === 'true';
   const trips = readTrips();
 
-  const hasState =
-    timezone ||
-    (email && subscribed) ||
-    trips.length > 0;
-
+  const hasState = timezone || (email && subscribed) || trips.length > 0;
   if (!hasState) return { synced: false };
 
   const payload = {};
@@ -110,11 +105,6 @@ export async function syncAnonSettings() {
     });
     if (!res.ok) return { synced: false, status: res.status };
 
-    // Clear synced keys for newsletter and trips. The timezone key
-    // ('app-timezone') is intentionally NOT cleared: the logged-in client
-    // (GeneralSettings) still reads timezone from localStorage. The server
-    // column is canonical for future cross-device use, but the client does
-    // not yet refetch it, so clearing here would drop the user's timezone.
     if (email && subscribed) {
       safeRemove(KEY_NEWSLETTER_EMAIL);
       safeRemove(KEY_NEWSLETTER_SUBSCRIBED);


### PR DESCRIPTION
## Summary

Lets non-logged-in visitors use **timezone**, **newsletter**, and **saved-trip** features, backed by `localStorage` and synced to the backend on first sign-in. Also fixes the tutorial bugs from #379 that left anonymous visitors stranded.

Spec: `.specify/specs/018-anon-user-settings/`

### User-facing settings (anon)
- `/settings` is no longer gated — anon visitors get timezone (already localStorage-backed) + newsletter signup.
- `UserSettings` hides the Profile/email section when signed out; renders the shared `GeneralSettings` (timezone) for everyone.
- Newsletter email persists across reloads; `POST /api/newsletter/subscribe` already accepts anon requests.
- Trips: anon visitors Save to `localStorage`; `MyTripsModal` and the Login dropdown surface local trips; Save button no longer auth-gated.

### Sync on sign-in
- `anonSettings.syncAnonSettings()` flushes timezone/newsletter/trips to `POST /api/user/settings/sync` after the `?auth=success` callback.
- Server-wins fill-gaps: only fills NULL timezone, idempotent newsletter subscribe, inserts only trips not already present (dedup by name). Verified idempotent + server-wins via curl.

### Tutorial fixes
- **Step 3 flicker:** `GuidedTour` main `useEffect` now reads `step`/`onStepAction`/`applyPosition` from refs, so parent re-renders during `showResults` no longer reset the spotlight. Benefits both tours.
- **Trip tour step 1 (mobile):** Trip Builder stays collapsed so the bottom sheet doesn't cover the highlighted "+ Add to Trip" badge.
- **Trip tour step 5 (mobile):** tooltip docks below the spotlight instead of above.
- **Carousel:** mobile thumbnail carousel suppressed while a tour is active (no empty spotlight on step 1).

### Backend
- `POST /api/user/settings/sync` (auth required) in new `routes/userSettings.js`.
- Migration `057_add_user_timezone.sql` adds `users.timezone`.

Closes #379.

## Test plan
- [x] Build passes (`./run.sh build`)
- [x] Sync endpoint: timezone fill, idempotent re-sync, server-wins, trip dedup (curl)
- [x] Migration applies (timezone column present)
- [x] Manual browser: anon tour to step 11, anon trip save + My Trips, signed-in regression, mobile trip tour steps 1 & 5
- [ ] Post-merge: GHA build + `/deploy` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)