### PR TITLE
fix: inject POI OG tags for bare-path permalinks (/:slug)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2405,11 +2405,24 @@ async function resolvePoiOgImage(poiId, baseUrl) {
   return `${baseUrl}${OG_FALLBACK_IMAGE}`;
 }
 
-// OG-tag injection for ?poi= deep links. MUST be mounted before express.static
-// so it can intercept "/" before the static index.html is served.
+// OG-tag injection for POI deep links: ?poi=slug (query) and /:slug (path
+// permalink — the form share buttons produce). MUST be mounted before
+// express.static so it can intercept the request before index.html is served.
+const OG_RESERVED_PATHS = new Set(['results', 'news', 'events', 'settings', 'about', 'mtb-trail-status']);
 app.use(async (req, res, next) => {
+  let poiSlug = null;
+  let canonicalPath = null;
   if (req.path === '/' && req.query.poi) {
-    const poiSlug = req.query.poi;
+    poiSlug = req.query.poi;
+    canonicalPath = `/?poi=${poiSlug}`;
+  } else {
+    const match = req.path.match(/^\/([a-z0-9-]+)\/?$/);
+    if (match && !OG_RESERVED_PATHS.has(match[1])) {
+      poiSlug = match[1];
+      canonicalPath = `/${poiSlug}`;
+    }
+  }
+  if (poiSlug) {
     try {
       const poisQuery = await pool.query(`
         SELECT id, name, poi_roles, brief_description
@@ -2421,7 +2434,7 @@ app.use(async (req, res, next) => {
 
       if (poi) {
         const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
-        const appUrl = `${baseUrl}/?poi=${poiSlug}`;
+        const appUrl = `${baseUrl}${canonicalPath}`;
         const imageUrl = await resolvePoiOgImage(poi.id, baseUrl);
         const description = poi.brief_description || `Explore ${poi.name} at Cuyahoga Valley National Park`;
         // Fix: HTML-escape interpolated content (PR #382 review)

--- a/backend/tests/ogShareImages.integration.test.js
+++ b/backend/tests/ogShareImages.integration.test.js
@@ -49,6 +49,26 @@ describe('Open Graph share images', () => {
     expect(ogImages.length).toBe(1);
   }, 15000);
 
+  it('injects POI og:image for the bare-path permalink', async () => {
+    const poi = poiWithPhoto || pois[0];
+    const slug = generateSlug(poi.name);
+    const res = await request(BASE_URL).get(`/${slug}`).expect(200);
+
+    const ogImages = metaContent(res.text, 'property', 'og:image');
+    expect(ogImages.length).toBe(1);
+    const [ogUrl] = metaContent(res.text, 'property', 'og:url');
+    expect(ogUrl.endsWith(`/${slug}`)).toBe(true);
+    if (poiWithPhoto) {
+      expect(ogImages[0]).toMatch(new RegExp(`/api/pois/${poiWithPhoto.id}/thumbnail\\?size=large$`));
+    }
+  }, 15000);
+
+  it('does not hijack reserved single-segment routes', async () => {
+    const res = await request(BASE_URL).get('/about').expect(200);
+    const [ogUrl] = metaContent(res.text, 'property', 'og:url');
+    expect(ogUrl.endsWith('/about')).toBe(false);
+  }, 15000);
+
   it('uses the POI primary photo at size=large when a photo exists', async () => {
     if (!poiWithPhoto) {
       console.warn('[og-share] No POI with a photo in seed — skipping primary-photo assertion');


### PR DESCRIPTION
## Summary
Follow-up to #382. That PR fixed OG images for `?poi=` deep links and news/event permalinks, but the POI permalink that share buttons actually emit is the **bare path** `/:slug` (e.g. `/summit-lake-northshore-park`). That form had no server-side OG injection, so a shared POI link unfurled with the generic site card.

Confirmed via the Facebook Sharing Debugger: sharing `/summit-lake-northshore-park` resolved `og:url` to `/` and showed the generic image.

## Changes
- Extend the POI OG middleware to match **both** `?poi=slug` and the bare path `/:slug`.
- Skip reserved single-segment routes (`results`, `news`, `events`, `settings`, `about`, `mtb-trail-status`) and anything that doesn't match a real POI slug — non-POI paths fall through to the SPA catch-all unchanged.
- `og:url` is set to the canonical shared form.
- Tests: bare-path permalink emits one `og:image` (POI photo at `size=large`); reserved routes are not hijacked.

News and event permalinks were already correct (verified live) and are unchanged.

## Test plan
- [ ] `backend/tests/ogShareImages.integration.test.js` passes in CI
- [ ] After deploy: Facebook Sharing Debugger re-scrapes `/summit-lake-northshore-park` and shows the POI photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)