### PR TITLE
feat: image in news/event/POI detail views with fallback chain

### DIFF
--- a/frontend/src/components/EventPermalink.jsx
+++ b/frontend/src/components/EventPermalink.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatDateWithWeekday, EventTypeIcon } from './NewsEventsShared';
+import { formatDateWithWeekday, EventTypeIcon, DetailImage } from './NewsEventsShared';
 import ShareButton from './ShareButton';
 
 function generateSlug(name) {
@@ -61,6 +61,8 @@ export default function EventPermalink({ poiSlug, titleSlug }) {
             &larr; Back to Map
           </button>
         </div>
+
+        <DetailImage imageUrl={item.image_url} poiId={item.poi_id} alt={item.title} />
 
         <div className="permalink-header">
           <EventTypeIcon type={item.event_type} />

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -76,6 +76,39 @@ export const EVENT_TYPES = {
   'alert': { icon: '!', label: 'Alert', color: '#f44336' }
 };
 
+export function DetailImage({ imageUrl, poiId, alt }) {
+  const sources = [];
+  if (imageUrl) sources.push(imageUrl);
+  if (poiId) sources.push(`/api/pois/${poiId}/thumbnail?size=large`);
+  sources.push('/brand/rotv-logo.png');
+
+  const [idx, setIdx] = React.useState(0);
+  React.useEffect(() => { setIdx(0); }, [imageUrl, poiId]);
+
+  const isLogo = idx === sources.length - 1;
+  return (
+    <div style={{
+      width: '100%', height: '180px', marginBottom: '12px', borderRadius: '8px',
+      overflow: 'hidden', background: '#eef2ea', display: 'flex',
+      alignItems: 'center', justifyContent: 'center'
+    }}>
+      <img
+        src={sources[idx]}
+        alt={alt || ''}
+        loading="lazy"
+        onError={() => setIdx(i => (i < sources.length - 1 ? i + 1 : i))}
+        style={{
+          width: isLogo ? 'auto' : '100%',
+          height: '100%',
+          objectFit: isLogo ? 'contain' : 'cover',
+          padding: isLogo ? '28px' : 0,
+          boxSizing: 'border-box'
+        }}
+      />
+    </div>
+  );
+}
+
 export function NewsTypeIcon({ type }) {
   const config = NEWS_TYPES[type] || NEWS_TYPES.general;
   return (

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -77,8 +77,9 @@ export const EVENT_TYPES = {
 };
 
 export function DetailImage({ imageUrl, poiId, alt }) {
+  const isSafeUrl = (u) => typeof u === 'string' && (/^https?:\/\//i.test(u) || u.startsWith('/'));
   const sources = [];
-  if (imageUrl) sources.push(imageUrl);
+  if (isSafeUrl(imageUrl)) sources.push(imageUrl);
   if (poiId) sources.push(`/api/pois/${poiId}/thumbnail?size=large`);
   sources.push('/brand/rotv-logo.png');
 

--- a/frontend/src/components/NewsPermalink.jsx
+++ b/frontend/src/components/NewsPermalink.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatPublicationDate, NewsTypeIcon } from './NewsEventsShared';
+import { formatPublicationDate, NewsTypeIcon, DetailImage } from './NewsEventsShared';
 import ShareButton from './ShareButton';
 
 function generateSlug(name) {
@@ -61,6 +61,8 @@ export default function NewsPermalink({ poiSlug, titleSlug }) {
             &larr; Back to Map
           </button>
         </div>
+
+        <DetailImage imageUrl={item.image_url} poiId={item.poi_id} alt={item.title} />
 
         <div className="permalink-header">
           <NewsTypeIcon type={item.news_type} />

--- a/frontend/src/components/ResultsTile.jsx
+++ b/frontend/src/components/ResultsTile.jsx
@@ -8,16 +8,7 @@ const ResultsTile = memo(function ResultsTile({ poi, poiKey, isLinear, isVirtual
 
   const isMtbTrailhead = !isLinear && !isVirtual && (poi.poi_roles?.includes('mtb_trail') || (poi.status_url && poi.status_url.trim() !== ''));
 
-  const getDefaultThumbnail = () => {
-    if (isVirtual) return '/icons/thumbnails/virtual.svg';
-    if (isLinear) {
-      if (poi.feature_type === 'river') return '/icons/thumbnails/river.svg';
-      if (poi.feature_type === 'boundary') return '/icons/thumbnails/boundary.svg';
-      return '/icons/thumbnails/trail.svg';
-    }
-    if (isMtbTrailhead) return '/icons/thumbnails/mtb.svg';
-    return '/icons/thumbnails/destination.svg';
-  };
+  const getDefaultThumbnail = () => '/brand/rotv-logo.png';
 
   const getPoiType = () => {
     if (isVirtual) return 'virtual';

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ImageUploader from './ImageUploader';
 import ThumbnailCarousel from './ThumbnailCarousel';
-import { formatDateTime, formatPublicationDate, NewsTypeIcon, EventTypeIcon } from './NewsEventsShared';
+import { formatDateTime, formatPublicationDate, NewsTypeIcon, EventTypeIcon, DetailImage } from './NewsEventsShared';
 import ShareButton from './ShareButton';
 import NavigateButton from './NavigateButton';
 import AddToTripButton from './AddToTripButton';
@@ -1321,7 +1321,7 @@ function PoiNews({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectNew
   );
 }
 
-function ContentDetail({ permalinkInfo, onBack }) {
+function ContentDetail({ permalinkInfo, onBack, onItemLoaded }) {
   const [item, setItem] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -1335,9 +1335,9 @@ function ContentDetail({ permalinkInfo, onBack }) {
         if (!res.ok) throw new Error(res.status === 404 ? 'Not found' : 'Failed to load');
         return res.json();
       })
-      .then(data => { setItem(data); setLoading(false); })
+      .then(data => { setItem(data); setLoading(false); if (onItemLoaded) onItemLoaded(data); })
       .catch(err => { setError(err.message); setLoading(false); });
-  }, [permalinkInfo]);
+  }, [permalinkInfo, onItemLoaded]);
 
   if (loading) return <div className="sidebar-tab-loading">Loading...</div>;
   if (error || !item) return (
@@ -2397,8 +2397,10 @@ function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrga
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [sidebarTab, setSidebarTab] = useState(initialSidebarTab || 'view');
+  const [permalinkItem, setPermalinkItem] = useState(null);
 
   useEffect(() => {
+    setPermalinkItem(null);
     if (permalinkInfo) {
       setSidebarTab(permalinkInfo.type === 'event' ? 'events' : 'news');
     }
@@ -3114,7 +3116,7 @@ function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrga
             </div>
           ) : null}
 
-          {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
+          {isMobile && !isEditing && !permalinkInfo && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
             <>
               {currentIndex > 0 && (
                 <button
@@ -3365,7 +3367,13 @@ function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrga
       </div>
 
       <div style={{ position: 'relative' }}>
-        {isEditing && destination?.id ? (
+        {permalinkInfo && (sidebarTab === 'news' || sidebarTab === 'events') ? (
+          permalinkItem ? (
+            <DetailImage key={permalinkItem.id} imageUrl={permalinkItem.image_url} poiId={permalinkItem.poi_id} alt={permalinkItem.title} />
+          ) : (
+            <div style={{ height: '180px', marginBottom: '12px' }} />
+          )
+        ) : isEditing && destination?.id ? (
           <ImageUploader
             destinationId={destination.id}
             hasImage={!!destination.has_primary_image}
@@ -3391,7 +3399,7 @@ function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrga
           </div>
         ) : null}
 
-        {isMobile && !isEditing && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
+        {isMobile && !isEditing && !permalinkInfo && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
           <>
             {currentIndex > 0 && (
               <button
@@ -3485,6 +3493,7 @@ function Sidebar({ tourActive, destination, isNewPOI, newOrganization, isNewOrga
         {permalinkInfo && (sidebarTab === 'news' || sidebarTab === 'events') && (
           <ContentDetail
             permalinkInfo={permalinkInfo}
+            onItemLoaded={setPermalinkItem}
             onBack={() => {
               if (onClearPermalink) onClearPermalink();
               const subTab = permalinkInfo?.type === 'event' ? 'events' : 'news';


### PR DESCRIPTION
## Summary
Show a representative image in the detail views, mirroring the social-share fallback logic.

- **News/Events** (sidebar detail + full permalink pages): `source article image → POI primary photo → ROTV logo`. The image renders in the sidebar's standard top image slot (where the POI photo normally sits), and resets cleanly when navigating between items.
- **Results list**: photo-less POIs now show the **ROTV logo** instead of the type-specific glyphs.
- **Map tooltips**: unchanged — still no image when a POI has no primary photo.

Frontend-only — the `image_url` and `poi_id` were already returned by the news/event permalink endpoints (#385). No backend or DB change.

## Implementation
- New `DetailImage` component (NewsEventsShared.jsx) walks the candidate chain via `onError`.
- Sidebar lifts the selected article into the parent so the image occupies the top slot; keyed per item so it resets on navigation.
- ResultsTile fallback → `/brand/rotv-logo.png`.

## Test plan
- [ ] Sidebar: open a news item — image shows in the top slot; Back + reopen keeps it consistent
- [ ] News with source image → article image; without → POI photo; neither → logo
- [ ] Results tab: trails/photo-less POIs show the ROTV logo
- [ ] Map tooltip: photo-less POI shows no image

🤖 Generated with [Claude Code](https://claude.com/claude-code)