### PR TITLE
feat: newsletter & moderation hardening (excluded-POI sweep, content blocklist, deterministic digest)

### DIFF
--- a/backend/migrations/060_rename_trusted_event_paths.sql
+++ b/backend/migrations/060_rename_trusted_event_paths.sql
@@ -1,0 +1,9 @@
+-- Rename the trusted_event_paths admin setting to trusted_content_paths as part
+-- of unifying the News & Events filter lists. Preserves the existing value.
+INSERT INTO admin_settings (key, value, updated_at)
+SELECT 'trusted_content_paths', value, CURRENT_TIMESTAMP
+FROM admin_settings
+WHERE key = 'trusted_event_paths'
+ON CONFLICT (key) DO NOTHING;
+
+DELETE FROM admin_settings WHERE key = 'trusted_event_paths';

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -529,7 +529,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'blocklist_urls',
       'event_content_blocklist',
       'moderation_trusted_domains',
-      'trusted_event_paths',
+      'trusted_content_paths',
       'github_api_token',
       'about_story_md',
       'about_tutorial_md',

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -527,6 +527,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'page_delay_ms',
       'news_collection_excluded_pois',
       'blocklist_urls',
+      'event_content_blocklist',
       'moderation_trusted_domains',
       'trusted_event_paths',
       'github_api_token',

--- a/backend/services/filterLists.js
+++ b/backend/services/filterLists.js
@@ -1,0 +1,95 @@
+// Unified handling for the admin-managed filter lists (mirrors the frontend's
+// single News & Events Filters section). One place to load a list setting, and
+// a data-driven registry of the hard-reject "deny lists" that drive both the
+// per-item moderation check and the retroactive sweep. Adding a deny list is a
+// single registry entry. Domain reputation (trusted/blocklist domains) and the
+// crawler's content paths are deliberately NOT here — they're scoring/crawling
+// mechanisms, not hard rejects.
+
+// Load a JSON-array admin setting. Returns [] when unset or malformed.
+export async function loadListSetting(pool, key) {
+  const res = await pool.query('SELECT value FROM admin_settings WHERE key = $1', [key]);
+  if (!res.rows.length || !res.rows[0].value) return [];
+  try {
+    const parsed = JSON.parse(res.rows[0].value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (e) {
+    console.error(`[filterLists] Failed to parse ${key}:`, e.message);
+    return [];
+  }
+}
+
+// Registry of hard-reject deny lists, applied during moderation.
+// - matches(row, values): per-item test.
+// - sweepFragment(values, textCols): SQL WHERE fragment for the retroactive
+//   bulk reject, built against a given table's text columns (null = skip).
+// - contentTypes: which moderation content types the list applies to.
+export const DENY_LISTS = [
+  {
+    key: 'news_collection_excluded_pois',
+    reason: 'Rejected: POI is on the deny list',
+    contentTypes: ['news', 'event', 'photo'],
+    matches: (row, ids) => ids.includes(row.poi_id),
+    sweepFragment: (ids) => ({ sql: 'poi_id = ANY($1)', params: [ids] })
+  },
+  {
+    key: 'event_content_blocklist',
+    reason: 'Rejected: matches content deny list',
+    contentTypes: ['news', 'event'],
+    matches: (row, phrases) => {
+      const haystack = [row.title, row.description, row.summary, row.location_details]
+        .filter(Boolean).join(' ').toLowerCase();
+      return phrases.some(p => typeof p === 'string' && p.trim() && haystack.includes(p.trim().toLowerCase()));
+    },
+    sweepFragment: (phrases, textCols) => {
+      const valid = phrases.filter(p => typeof p === 'string' && p.trim());
+      if (!valid.length) return null;
+      const conds = valid.flatMap((_, i) => textCols.map(c => `${c} ILIKE $${i + 1}`)).join(' OR ');
+      return { sql: `(${conds})`, params: valid.map(p => `%${p.trim()}%`) };
+    }
+  }
+];
+
+// Per-item moderation check. Returns a rejection reason string, or null.
+export async function denyReason(pool, contentType, row) {
+  for (const list of DENY_LISTS) {
+    if (!list.contentTypes.includes(contentType)) continue;
+    const values = await loadListSetting(pool, list.key);
+    if (values.length && list.matches(row, values)) return list.reason;
+  }
+  return null;
+}
+
+// Retroactive sweep: reject any stored (non-rejected) news/event matching a deny
+// list, so adding to a list cleans up already-approved items. Returns counts.
+export async function sweepDenyLists(pool, { runId, logInfo } = {}) {
+  const tables = [
+    { name: 'poi_events', textCols: ['title', 'description'] },
+    { name: 'poi_news', textCols: ['title', 'summary'] }
+  ];
+  let events = 0;
+  let news = 0;
+  for (const list of DENY_LISTS) {
+    const values = await loadListSetting(pool, list.key);
+    if (!values.length) continue;
+    for (const table of tables) {
+      const frag = list.sweepFragment(values, table.textCols);
+      if (!frag) continue;
+      const reasonIdx = frag.params.length + 1;
+      const res = await pool.query(
+        `UPDATE ${table.name} SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $${reasonIdx}
+         WHERE moderation_status <> 'rejected' AND ${frag.sql}`,
+        [...frag.params, list.reason]
+      );
+      if (table.name === 'poi_events') events += res.rowCount;
+      else news += res.rowCount;
+    }
+  }
+  if ((events + news) > 0) {
+    console.log(`[Moderation] Deny-list sweep rejected ${events} events, ${news} news`);
+    if (runId != null && logInfo) {
+      logInfo(runId, 'moderation', null, null, `Deny-list sweep: rejected ${events} events, ${news} news`);
+    }
+  }
+  return { events, news };
+}

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -288,6 +288,39 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       }
     }
 
+    // Content blocklist: reject items whose text matches a blocked phrase — e.g.
+    // an organization that isn't (and shouldn't be) a POI, like "Cuyahoga Valley
+    // Art Center", whose events otherwise attach to whatever venue POI they're
+    // hosted at. Lets us stop recurring leaks without excluding the venue POI.
+    if (contentType === 'news' || contentType === 'event') {
+      const blocklistSetting = await pool.query(
+        "SELECT value FROM admin_settings WHERE key = 'event_content_blocklist'"
+      );
+      if (blocklistSetting.rows.length > 0 && blocklistSetting.rows[0].value) {
+        try {
+          const phrases = JSON.parse(blocklistSetting.rows[0].value);
+          if (Array.isArray(phrases) && phrases.length > 0) {
+            const haystack = [row.title, row.description, row.summary, row.location_details]
+              .filter(Boolean).join(' ').toLowerCase();
+            const hit = phrases.find(
+              (p) => typeof p === 'string' && p.trim() && haystack.includes(p.trim().toLowerCase())
+            );
+            if (hit) {
+              await pool.query(
+                `UPDATE ${table} SET moderation_processed = true, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
+                [`Rejected: matches content blocklist ("${hit}")`, contentId]
+              );
+              console.log(`[Moderation] ${contentType} #${contentId}: rejected (content blocklist "${hit}")`);
+              logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: content blocklist "${hit}"`, { completed: true });
+              return;
+            }
+          }
+        } catch (e) {
+          console.error('[Moderation] Failed to parse event_content_blocklist:', e.message);
+        }
+      }
+    }
+
     // Per-POI threshold only applies when item came from the POI's configured URL
     const poiConfigUrl = contentType === 'news' ? row.news_url : row.events_url;
     const poiThreshold = contentType === 'news' ? row.news_score_threshold : row.events_score_threshold;
@@ -475,6 +508,35 @@ export async function processPendingItems(pool) {
   if (enabledQuery.rows.length && enabledQuery.rows[0].value === 'false') {
     console.log('[Moderation] Moderation disabled, skipping sweep');
     return { processed: 0 };
+  }
+
+  // Retroactively reject any stored item whose POI is on the excluded list, not
+  // just newly-collected ones. Exclusion used to be forward-only, so items
+  // collected before a POI was excluded kept leaking into the digest.
+  try {
+    const excl = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
+    );
+    const excludedIds = excl.rows[0]?.value ? JSON.parse(excl.rows[0].value) : [];
+    if (Array.isArray(excludedIds) && excludedIds.length > 0) {
+      const reason = 'Rejected: POI is on the excluded list';
+      const ev = await pool.query(
+        `UPDATE poi_events SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $2
+         WHERE poi_id = ANY($1) AND moderation_status <> 'rejected'`,
+        [excludedIds, reason]
+      );
+      const nw = await pool.query(
+        `UPDATE poi_news SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $2
+         WHERE poi_id = ANY($1) AND moderation_status <> 'rejected'`,
+        [excludedIds, reason]
+      );
+      if (ev.rowCount + nw.rowCount > 0) {
+        console.log(`[Moderation] Excluded-POI sweep rejected ${ev.rowCount} events, ${nw.rowCount} news`);
+        logInfo(runId, 'moderation', null, null, `Excluded-POI sweep: rejected ${ev.rowCount} events, ${nw.rowCount} news`);
+      }
+    }
+  } catch (e) {
+    console.error('[Moderation] Excluded-POI sweep failed:', e.message);
   }
 
   const pendingNews = await pool.query(

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -4,6 +4,7 @@ import { deepCrawlForArticle, isGenericUrl } from './deepCrawler.js';
 import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 import { parseDate, parseDateTime, localToUTC, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
 import { scoreDate, normalizeRenderUrl, normalizeTitle } from './newsService.js';
+import { denyReason, sweepDenyLists } from './filterLists.js';
 
 function sameOrigin(urlA, urlB) {
   try { return new URL(urlA).origin === new URL(urlB).origin; }
@@ -268,57 +269,16 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       return;
     }
 
-    const excludedSetting = await pool.query(
-      "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
-    );
-    if (excludedSetting.rows.length > 0 && excludedSetting.rows[0].value) {
-      try {
-        const excludedIds = JSON.parse(excludedSetting.rows[0].value);
-        if (Array.isArray(excludedIds) && excludedIds.includes(row.poi_id)) {
-          await pool.query(
-            `UPDATE ${table} SET moderation_processed = true, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
-            [`Rejected: POI is on the excluded list`, contentId]
-          );
-          console.log(`[Moderation] ${contentType} #${contentId}: rejected (excluded POI ${row.poi_id})`);
-          logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: excluded POI ${row.poi_id}`, { completed: true });
-          return;
-        }
-      } catch (e) {
-        console.error('[Moderation] Failed to parse news_collection_excluded_pois:', e.message);
-      }
-    }
-
-    // Content blocklist: reject items whose text matches a blocked phrase — e.g.
-    // an organization that isn't (and shouldn't be) a POI, like "Cuyahoga Valley
-    // Art Center", whose events otherwise attach to whatever venue POI they're
-    // hosted at. Lets us stop recurring leaks without excluding the venue POI.
-    if (contentType === 'news' || contentType === 'event') {
-      const blocklistSetting = await pool.query(
-        "SELECT value FROM admin_settings WHERE key = 'event_content_blocklist'"
+    // Hard-reject deny lists (POI deny list, content deny list) — see filterLists.js.
+    const reason = await denyReason(pool, contentType, row);
+    if (reason) {
+      await pool.query(
+        `UPDATE ${table} SET moderation_processed = true, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
+        [reason, contentId]
       );
-      if (blocklistSetting.rows.length > 0 && blocklistSetting.rows[0].value) {
-        try {
-          const phrases = JSON.parse(blocklistSetting.rows[0].value);
-          if (Array.isArray(phrases) && phrases.length > 0) {
-            const haystack = [row.title, row.description, row.summary, row.location_details]
-              .filter(Boolean).join(' ').toLowerCase();
-            const hit = phrases.find(
-              (p) => typeof p === 'string' && p.trim() && haystack.includes(p.trim().toLowerCase())
-            );
-            if (hit) {
-              await pool.query(
-                `UPDATE ${table} SET moderation_processed = true, ai_reasoning = $1, moderation_status = 'rejected' WHERE id = $2`,
-                [`Rejected: matches content blocklist ("${hit}")`, contentId]
-              );
-              console.log(`[Moderation] ${contentType} #${contentId}: rejected (content blocklist "${hit}")`);
-              logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: content blocklist "${hit}"`, { completed: true });
-              return;
-            }
-          }
-        } catch (e) {
-          console.error('[Moderation] Failed to parse event_content_blocklist:', e.message);
-        }
-      }
+      console.log(`[Moderation] ${contentType} #${contentId}: ${reason}`);
+      logInfo(itemRunId, 'moderation', null, row.title, `Rejected ${contentType} #${contentId}: ${reason}`, { completed: true });
+      return;
     }
 
     // Per-POI threshold only applies when item came from the POI's configured URL
@@ -510,66 +470,12 @@ export async function processPendingItems(pool) {
     return { processed: 0 };
   }
 
-  // Retroactively reject any stored item whose POI is on the excluded list, not
-  // just newly-collected ones. Exclusion used to be forward-only, so items
-  // collected before a POI was excluded kept leaking into the digest.
+  // Retroactively reject stored items matching any deny list (POI, content), so
+  // adding to a list cleans up already-approved items, not just new ones.
   try {
-    const excl = await pool.query(
-      "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
-    );
-    const excludedIds = excl.rows[0]?.value ? JSON.parse(excl.rows[0].value) : [];
-    if (Array.isArray(excludedIds) && excludedIds.length > 0) {
-      const reason = 'Rejected: POI is on the excluded list';
-      const ev = await pool.query(
-        `UPDATE poi_events SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $2
-         WHERE poi_id = ANY($1) AND moderation_status <> 'rejected'`,
-        [excludedIds, reason]
-      );
-      const nw = await pool.query(
-        `UPDATE poi_news SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $2
-         WHERE poi_id = ANY($1) AND moderation_status <> 'rejected'`,
-        [excludedIds, reason]
-      );
-      if (ev.rowCount + nw.rowCount > 0) {
-        console.log(`[Moderation] Excluded-POI sweep rejected ${ev.rowCount} events, ${nw.rowCount} news`);
-        logInfo(runId, 'moderation', null, null, `Excluded-POI sweep: rejected ${ev.rowCount} events, ${nw.rowCount} news`);
-      }
-    }
+    await sweepDenyLists(pool, { runId, logInfo });
   } catch (e) {
-    console.error('[Moderation] Excluded-POI sweep failed:', e.message);
-  }
-
-  // Retroactively reject stored items matching the content blocklist, so adding
-  // a phrase cleans up already-approved items too (parity with the POI sweep).
-  try {
-    const cb = await pool.query(
-      "SELECT value FROM admin_settings WHERE key = 'event_content_blocklist'"
-    );
-    const phrases = (cb.rows[0]?.value ? JSON.parse(cb.rows[0].value) : [])
-      .filter((p) => typeof p === 'string' && p.trim());
-    if (phrases.length > 0) {
-      const reason = 'Rejected: matches content blocklist';
-      const params = phrases.map((p) => `%${p.trim()}%`);
-      const eventConds = phrases.map((_, i) => `title ILIKE $${i + 1} OR description ILIKE $${i + 1}`).join(' OR ');
-      const newsConds = phrases.map((_, i) => `title ILIKE $${i + 1} OR summary ILIKE $${i + 1}`).join(' OR ');
-      const reasonIdx = phrases.length + 1;
-      const ev = await pool.query(
-        `UPDATE poi_events SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $${reasonIdx}
-         WHERE moderation_status <> 'rejected' AND (${eventConds})`,
-        [...params, reason]
-      );
-      const nw = await pool.query(
-        `UPDATE poi_news SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $${reasonIdx}
-         WHERE moderation_status <> 'rejected' AND (${newsConds})`,
-        [...params, reason]
-      );
-      if (ev.rowCount + nw.rowCount > 0) {
-        console.log(`[Moderation] Content-blocklist sweep rejected ${ev.rowCount} events, ${nw.rowCount} news`);
-        logInfo(runId, 'moderation', null, null, `Content-blocklist sweep: rejected ${ev.rowCount} events, ${nw.rowCount} news`);
-      }
-    }
-  } catch (e) {
-    console.error('[Moderation] Content-blocklist sweep failed:', e.message);
+    console.error('[Moderation] Deny-list sweep failed:', e.message);
   }
 
   const pendingNews = await pool.query(

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -539,6 +539,39 @@ export async function processPendingItems(pool) {
     console.error('[Moderation] Excluded-POI sweep failed:', e.message);
   }
 
+  // Retroactively reject stored items matching the content blocklist, so adding
+  // a phrase cleans up already-approved items too (parity with the POI sweep).
+  try {
+    const cb = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'event_content_blocklist'"
+    );
+    const phrases = (cb.rows[0]?.value ? JSON.parse(cb.rows[0].value) : [])
+      .filter((p) => typeof p === 'string' && p.trim());
+    if (phrases.length > 0) {
+      const reason = 'Rejected: matches content blocklist';
+      const params = phrases.map((p) => `%${p.trim()}%`);
+      const eventConds = phrases.map((_, i) => `title ILIKE $${i + 1} OR description ILIKE $${i + 1}`).join(' OR ');
+      const newsConds = phrases.map((_, i) => `title ILIKE $${i + 1} OR summary ILIKE $${i + 1}`).join(' OR ');
+      const reasonIdx = phrases.length + 1;
+      const ev = await pool.query(
+        `UPDATE poi_events SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $${reasonIdx}
+         WHERE moderation_status <> 'rejected' AND (${eventConds})`,
+        [...params, reason]
+      );
+      const nw = await pool.query(
+        `UPDATE poi_news SET moderation_status = 'rejected', moderation_processed = true, ai_reasoning = $${reasonIdx}
+         WHERE moderation_status <> 'rejected' AND (${newsConds})`,
+        [...params, reason]
+      );
+      if (ev.rowCount + nw.rowCount > 0) {
+        console.log(`[Moderation] Content-blocklist sweep rejected ${ev.rowCount} events, ${nw.rowCount} news`);
+        logInfo(runId, 'moderation', null, null, `Content-blocklist sweep: rejected ${ev.rowCount} events, ${nw.rowCount} news`);
+      }
+    }
+  } catch (e) {
+    console.error('[Moderation] Content-blocklist sweep failed:', e.message);
+  }
+
   const pendingNews = await pool.query(
     `SELECT id FROM poi_news WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT 20`
   );

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -118,6 +118,7 @@ export class BrowserOverloadError extends Error {
 }
 import { searchNewsUrls } from './serperService.js';
 import { getDomainReputation } from './moderationService.js';
+import { loadListSetting } from './filterLists.js';
 import fs from 'fs';
 
 function debugLog(message) {
@@ -646,14 +647,7 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
 
   let trustedEventPaths = [];
   if (contentType === 'event') {
-    try {
-      const tepResult = await pool.query(
-        "SELECT value FROM admin_settings WHERE key = 'trusted_content_paths'"
-      );
-      if (tepResult.rows.length) {
-        trustedEventPaths = JSON.parse(tepResult.rows[0].value);
-      }
-    } catch { /* use empty list */ }
+    trustedEventPaths = await loadListSetting(pool, 'trusted_content_paths');
   }
 
   async function processLevel(urls, depth) {
@@ -1787,18 +1781,8 @@ function checkDomainOwnership(sourceUrl, currentPoiId, domainMap) {
 }
 
 export async function getAllPoisForCollection(pool) {
-  const settingResult = await pool.query(
-    "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
-  );
-  let excludedIds = [];
-  if (settingResult.rows.length > 0 && settingResult.rows[0].value) {
-    try {
-      const parsed = JSON.parse(settingResult.rows[0].value);
-      excludedIds = Array.isArray(parsed) ? parsed.filter(id => Number.isInteger(id)) : [];
-    } catch (e) {
-      console.error('[newsService] Failed to parse news_collection_excluded_pois:', e.message);
-    }
-  }
+  const excludedIds = (await loadListSetting(pool, 'news_collection_excluded_pois'))
+    .filter(id => Number.isInteger(id));
 
   const collectionPoiRows = await pool.query(
     `SELECT id FROM pois
@@ -1818,18 +1802,8 @@ export async function getAllPoisForCollection(pool) {
 }
 
 export async function getPoisForTierCollection(pool, tier) {
-  const settingResult = await pool.query(
-    "SELECT value FROM admin_settings WHERE key = 'news_collection_excluded_pois'"
-  );
-  let excludedIds = [];
-  if (settingResult.rows.length > 0 && settingResult.rows[0].value) {
-    try {
-      const parsed = JSON.parse(settingResult.rows[0].value);
-      excludedIds = Array.isArray(parsed) ? parsed.filter(id => Number.isInteger(id)) : [];
-    } catch (e) {
-      console.error('[newsService] Failed to parse news_collection_excluded_pois:', e.message);
-    }
-  }
+  const excludedIds = (await loadListSetting(pool, 'news_collection_excluded_pois'))
+    .filter(id => Number.isInteger(id));
 
   const validTiers = ['daily', 'weekly', 'monthly'];
   if (!validTiers.includes(tier)) {

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -648,7 +648,7 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
   if (contentType === 'event') {
     try {
       const tepResult = await pool.query(
-        "SELECT value FROM admin_settings WHERE key = 'trusted_event_paths'"
+        "SELECT value FROM admin_settings WHERE key = 'trusted_content_paths'"
       );
       if (tepResult.rows.length) {
         trustedEventPaths = JSON.parse(tepResult.rows[0].value);

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -23,8 +23,8 @@ async function fetchDigestContent(pool, tz, asOfDate) {
     WHERE (e.start_date AT TIME ZONE $1)::date >= (COALESCE($2::timestamptz, CURRENT_TIMESTAMP) AT TIME ZONE $1)::date
       AND (e.start_date AT TIME ZONE $1)::date <= (COALESCE($2::timestamptz, CURRENT_TIMESTAMP) AT TIME ZONE $1)::date + 2
       AND e.moderation_status IN ('published', 'auto_approved')
-    ORDER BY e.start_date ASC
-    LIMIT 10
+    ORDER BY e.start_date ASC, e.id ASC
+    LIMIT 15
   `;
 
   const newsQuery = `
@@ -34,7 +34,7 @@ async function fetchDigestContent(pool, tz, asOfDate) {
     JOIN pois p ON n.poi_id = p.id
     WHERE n.moderation_status IN ('published', 'auto_approved')
       AND COALESCE(n.publication_date, n.collection_date) > COALESCE($1::timestamptz, NOW()) - INTERVAL '7 days'
-    ORDER BY COALESCE(n.publication_date, n.collection_date) DESC
+    ORDER BY COALESCE(n.publication_date, n.collection_date) DESC, n.id DESC
     LIMIT 5
   `;
 
@@ -390,6 +390,25 @@ export async function sendDigestPreviewTo(pool, email, tz = 'America/New_York', 
     jobId = hash;
   }
   const jobType = 'newsletter-preview';
+
+  // Idempotency for scheduled/triggered previews: don't send the same recipient
+  // a preview twice in one day. Manual test sends (send-preview-test, no
+  // pgBossJobId) are exempt so admins can re-send on demand. Fixes the duplicate
+  // preview emails caused by the job firing more than once.
+  if (pgBossJobId) {
+    const today = new Date().toISOString().split('T')[0];
+    const alreadySent = await pool.query(
+      `SELECT id FROM job_logs
+       WHERE job_type = $1 AND level = 'info' AND message = $2
+         AND created_at::date = $3::date
+       LIMIT 1`,
+      [jobType, `Preview sent to ${email}`, today]
+    );
+    if (alreadySent.rows.length > 0) {
+      console.log(`Preview already sent to ${email} today, skipping duplicate`);
+      return { success: true, skipped: true, reason: 'already_sent_today', recipient: email };
+    }
+  }
 
   if (jobId > 0) {
     await pool.query(

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import PoiSearchSelect from './PoiSearchSelect';
+import FilterList, { FilterChip, FILTER_COLORS } from './FilterList';
 
 function DataCollectionSettings() {
   const [result, setResult] = useState(null);
@@ -52,18 +53,16 @@ function DataCollectionSettings() {
 
   const [domainLists, setDomainLists] = useState({ trusted: [], competitor: [] });
   const [domainListsLoading, setDomainListsLoading] = useState(true);
-  const [domainListsSaving, setDomainListsSaving] = useState(false);
+  const [filtersSaving, setFiltersSaving] = useState(false);
   const [newTrustedDomain, setNewTrustedDomain] = useState('');
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
   const [contentBlocklist, setContentBlocklist] = useState([]);
   const [newContentPhrase, setNewContentPhrase] = useState('');
-  const [contentBlocklistSaving, setContentBlocklistSaving] = useState(false);
   const [trustedEventPaths, setTrustedEventPaths] = useState([]);
   const [newTrustedEventPath, setNewTrustedEventPath] = useState('');
 
   const [excludedPois, setExcludedPois] = useState([]);
   const [excludedPoisLoading, setExcludedPoisLoading] = useState(true);
-  const [excludedPoisSaving, setExcludedPoisSaving] = useState(false);
   const [allPois, setAllPois] = useState([]);
   const [selectedPoiId, setSelectedPoiId] = useState('');
 
@@ -411,7 +410,7 @@ function DataCollectionSettings() {
         const settings = await response.json();
         const trusted = settings.moderation_trusted_domains?.value || '[]';
         const blocklist = settings.blocklist_urls?.value || '[]';
-        const eventPaths = settings.trusted_event_paths?.value || '[]';
+        const eventPaths = settings.trusted_content_paths?.value || '[]';
         const contentBlock = settings.event_content_blocklist?.value || '[]';
         try {
           const parsedTrusted = JSON.parse(trusted);
@@ -436,13 +435,17 @@ function DataCollectionSettings() {
     finally { setDomainListsLoading(false); }
   };
 
-  const handleSaveDomainLists = async () => {
-    setDomainListsSaving(true); setResult(null);
+  // Single save for the unified News & Events Filters section — persists all
+  // five allow/block lists in one click.
+  const handleSaveAllFilters = async () => {
+    setFiltersSaving(true); setResult(null);
     try {
       const settings = [
         { key: 'moderation_trusted_domains', value: JSON.stringify(domainLists.trusted) },
         { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) },
-        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) }
+        { key: 'trusted_content_paths', value: JSON.stringify(trustedEventPaths) },
+        { key: 'news_collection_excluded_pois', value: JSON.stringify(excludedPois.map(p => p.id)) },
+        { key: 'event_content_blocklist', value: JSON.stringify(contentBlocklist) }
       ];
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
@@ -451,9 +454,9 @@ function DataCollectionSettings() {
         });
         if (!response.ok) { const error = await response.json(); throw new Error(error.error || 'Failed to save setting'); }
       }
-      setResult({ type: 'success', message: 'Domain lists saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save domain lists: ${err.message}` }); }
-    finally { setDomainListsSaving(false); }
+      setResult({ type: 'success', message: 'Filters saved' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save filters: ${err.message}` }); }
+    finally { setFiltersSaving(false); }
   };
 
   const handleAddTrustedDomain = () => {
@@ -505,19 +508,6 @@ function DataCollectionSettings() {
     setContentBlocklist(contentBlocklist.filter(p => p !== phrase));
   };
 
-  const handleSaveContentBlocklist = async () => {
-    setContentBlocklistSaving(true); setResult(null);
-    try {
-      const response = await fetch('/api/admin/settings/event_content_blocklist', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: JSON.stringify(contentBlocklist) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Content blocklist saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save content blocklist: ${err.message}` }); }
-    finally { setContentBlocklistSaving(false); }
-  };
-
   const handleAddTrustedEventPath = () => {
     const path = newTrustedEventPath.trim().toLowerCase();
     if (!path) return;
@@ -558,19 +548,6 @@ function DataCollectionSettings() {
       }
     } catch (err) { console.error('Error fetching excluded POIs:', err); }
     finally { setExcludedPoisLoading(false); }
-  };
-
-  const handleSaveExcludedPois = async () => {
-    setExcludedPoisSaving(true); setResult(null);
-    try {
-      const response = await fetch('/api/admin/settings/news_collection_excluded_pois', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: JSON.stringify(excludedPois.map(p => p.id)) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Excluded POIs saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save excluded POIs: ${err.message}` }); }
-    finally { setExcludedPoisSaving(false); }
   };
 
   const handleAddExcludedPoi = () => {
@@ -1060,237 +1037,86 @@ function DataCollectionSettings() {
 
 
       <div className="ai-config-section">
-        <h4>Quality Filter Domain Lists</h4>
-        <p className="settings-description">Manage trusted domains and blocklist URLs for quality filtering in moderation and phase 2 collection.</p>
-        {domainListsLoading ? <p>Loading domain lists...</p> : (
+        <h4>News &amp; Events Filters</h4>
+        <p className="settings-description">Allow lists (green) and block lists (red) that govern what gets collected and what passes moderation. Add to each list independently, then Save Filters once to apply everything.</p>
+        {(domainListsLoading || excludedPoisLoading) ? <p>Loading filters...</p> : (
           <>
+            <FilterList
+              title="Domain Allow List"
+              type="allow"
+              hint="Trusted source domains. Items from these bypass quality penalties in moderation and phase 2 collection."
+              items={domainLists.trusted}
+              value={newTrustedDomain}
+              onValueChange={setNewTrustedDomain}
+              onAdd={handleAddTrustedDomain}
+              onRemove={handleRemoveTrustedDomain}
+              placeholder="example.com"
+              disabled={filtersSaving}
+            />
+            <FilterList
+              title="URL Block List"
+              type="block"
+              hint="Source domains or URLs that are rejected during moderation and skipped in phase 2 collection."
+              items={domainLists.competitor}
+              value={newCompetitorDomain}
+              onValueChange={setNewCompetitorDomain}
+              onAdd={handleAddCompetitorDomain}
+              onRemove={handleRemoveCompetitorDomain}
+              placeholder="scam-site.com"
+              disabled={filtersSaving}
+            />
+            <FilterList
+              title="Content Path Allow List"
+              type="allow"
+              hint="URL path patterns the content crawler may follow beyond the listing page (e.g., /event, /events, iteminfo.html)."
+              items={trustedEventPaths}
+              value={newTrustedEventPath}
+              onValueChange={setNewTrustedEventPath}
+              onAdd={handleAddTrustedEventPath}
+              onRemove={handleRemoveTrustedEventPath}
+              placeholder="/event"
+              disabled={filtersSaving}
+            />
+
             <div style={{ marginBottom: '1.5rem' }}>
-              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#28a745' }}>Trusted Domains</h5>
-              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>These domains are considered reliable news sources and receive no penalty.</p>
+              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: FILTER_COLORS.block.heading }}>POI Block List</h5>
+              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>POIs skipped during collection. Any news or events from them are rejected on every moderation run. Use for broad geographic entities (e.g. Cuyahoga County) whose feeds pull in irrelevant content.</p>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-                {domainLists.trusted.map(domain => (
-                  <span key={domain} style={{
-                    padding: '0.25rem 0.5rem',
-                    backgroundColor: '#d4edda',
-                    color: '#155724',
-                    borderRadius: '4px',
-                    fontSize: '0.85rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem'
-                  }}>
-                    {domain}
-                    <button onClick={() => handleRemoveTrustedDomain(domain)}
-                      style={{
-                        background: 'none',
-                        border: 'none',
-                        color: '#155724',
-                        cursor: 'pointer',
-                        padding: '0',
-                        fontSize: '1rem',
-                        lineHeight: '1'
-                      }}>×</button>
-                  </span>
+                {excludedPois.length === 0 && (
+                  <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>No POIs blocked.</p>
+                )}
+                {excludedPois.map(poi => (
+                  <FilterChip key={poi.id} label={poi.name} type="block" onRemove={() => handleRemoveExcludedPoi(poi.id)} />
                 ))}
               </div>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
-                <input
-                  type="text"
-                  value={newTrustedDomain}
-                  onChange={e => setNewTrustedDomain(e.target.value)}
-                  onKeyPress={e => e.key === 'Enter' && handleAddTrustedDomain()}
-                  placeholder="example.com"
-                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
-                  disabled={domainListsSaving}
+                <PoiSearchSelect
+                  pois={allPois.filter(p => !excludedPois.some(e => e.id === p.id))}
+                  value={selectedPoiId}
+                  onChange={(id) => setSelectedPoiId(id || '')}
+                  placeholder="Search POIs to block..."
+                  disabled={filtersSaving}
+                  style={{ flex: 1 }}
                 />
-                <button className="action-btn secondary" onClick={handleAddTrustedDomain} disabled={domainListsSaving || !newTrustedDomain.trim()}>Add</button>
+                <button className="action-btn secondary" onClick={handleAddExcludedPoi} disabled={filtersSaving || !selectedPoiId}>Add</button>
               </div>
             </div>
 
-            <div style={{ marginBottom: '1.5rem' }}>
-              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#dc3545' }}>Blocklist URLs</h5>
-              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>These domains receive a severe penalty (×0.3 confidence score).</p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-                {domainLists.competitor.map(domain => (
-                  <span key={domain} style={{
-                    padding: '0.25rem 0.5rem',
-                    backgroundColor: '#f8d7da',
-                    color: '#721c24',
-                    borderRadius: '4px',
-                    fontSize: '0.85rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem'
-                  }}>
-                    {domain}
-                    <button onClick={() => handleRemoveCompetitorDomain(domain)}
-                      style={{
-                        background: 'none',
-                        border: 'none',
-                        color: '#721c24',
-                        cursor: 'pointer',
-                        padding: '0',
-                        fontSize: '1rem',
-                        lineHeight: '1'
-                      }}>×</button>
-                  </span>
-                ))}
-              </div>
-              <div style={{ display: 'flex', gap: '0.5rem' }}>
-                <input
-                  type="text"
-                  value={newCompetitorDomain}
-                  onChange={e => setNewCompetitorDomain(e.target.value)}
-                  onKeyPress={e => e.key === 'Enter' && handleAddCompetitorDomain()}
-                  placeholder="scam-site.com"
-                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
-                  disabled={domainListsSaving}
-                />
-                <button className="action-btn secondary" onClick={handleAddCompetitorDomain} disabled={domainListsSaving || !newCompetitorDomain.trim()}>Add</button>
-              </div>
-            </div>
+            <FilterList
+              title="Content Block List"
+              type="block"
+              hint="Reject any news or event whose title or description contains one of these phrases. Use for organizations that are not POIs (e.g., Cuyahoga Valley Art Center) whose events attach to the venue POI. Applied on every moderation run."
+              items={contentBlocklist}
+              value={newContentPhrase}
+              onValueChange={setNewContentPhrase}
+              onAdd={handleAddContentPhrase}
+              onRemove={handleRemoveContentPhrase}
+              placeholder="Cuyahoga Valley Art Center"
+              disabled={filtersSaving}
+            />
 
-            <div style={{ marginBottom: '1.5rem' }}>
-              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#17a2b8' }}>Trusted Event Paths</h5>
-              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>URL path patterns the events crawler can follow beyond the listing page path (e.g., /event, /events, iteminfo.html).</p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-                {trustedEventPaths.map(path => (
-                  <span key={path} style={{
-                    padding: '0.25rem 0.5rem',
-                    backgroundColor: '#d1ecf1',
-                    color: '#0c5460',
-                    borderRadius: '4px',
-                    fontSize: '0.85rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem'
-                  }}>
-                    {path}
-                    <button onClick={() => handleRemoveTrustedEventPath(path)}
-                      style={{
-                        background: 'none',
-                        border: 'none',
-                        color: '#0c5460',
-                        cursor: 'pointer',
-                        padding: '0',
-                        fontSize: '1rem',
-                        lineHeight: '1'
-                      }}>×</button>
-                  </span>
-                ))}
-              </div>
-              <div style={{ display: 'flex', gap: '0.5rem' }}>
-                <input
-                  type="text"
-                  value={newTrustedEventPath}
-                  onChange={e => setNewTrustedEventPath(e.target.value)}
-                  onKeyPress={e => e.key === 'Enter' && handleAddTrustedEventPath()}
-                  placeholder="/event"
-                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
-                  disabled={domainListsSaving}
-                />
-                <button className="action-btn secondary" onClick={handleAddTrustedEventPath} disabled={domainListsSaving || !newTrustedEventPath.trim()}>Add</button>
-              </div>
-            </div>
-
-            <button className="action-btn primary" onClick={handleSaveDomainLists} disabled={domainListsSaving}>
-              {domainListsSaving ? 'Saving...' : 'Save Domain Lists'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="ai-config-section">
-        <h4>Excluded POIs from News and Events</h4>
-        <p className="settings-description">POIs in this list are skipped during automated news collection, and any news or events from these POIs are automatically rejected during moderation. Use for broad geographic entities (e.g. Cuyahoga County, Cleveland) whose feeds pull in irrelevant content.</p>
-        {excludedPoisLoading ? <p>Loading...</p> : (
-          <>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-              {excludedPois.length === 0 && (
-                <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>No POIs excluded.</p>
-              )}
-              {excludedPois.map(poi => (
-                <span key={poi.id} style={{
-                  padding: '0.25rem 0.5rem',
-                  backgroundColor: '#fff3cd',
-                  color: '#856404',
-                  borderRadius: '4px',
-                  fontSize: '0.85rem',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}>
-                  {poi.name}
-                  <button onClick={() => handleRemoveExcludedPoi(poi.id)}
-                    style={{ background: 'none', border: 'none', color: '#856404', cursor: 'pointer', padding: '0', fontSize: '1rem', lineHeight: '1' }}>×</button>
-                </span>
-              ))}
-            </div>
-            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-              <PoiSearchSelect
-                pois={allPois.filter(p => !excludedPois.some(e => e.id === p.id))}
-                value={selectedPoiId}
-                onChange={(id) => setSelectedPoiId(id || '')}
-                placeholder="Search POIs to exclude..."
-                disabled={excludedPoisSaving}
-                style={{ flex: 1 }}
-              />
-              <button className="action-btn secondary" onClick={handleAddExcludedPoi} disabled={excludedPoisSaving || !selectedPoiId}>Add</button>
-            </div>
-            <button className="action-btn primary" onClick={handleSaveExcludedPois} disabled={excludedPoisSaving}>
-              {excludedPoisSaving ? 'Saving...' : 'Save Excluded POIs'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="ai-config-section">
-        <h4>Content Blocklist for News and Events</h4>
-        <p className="settings-description">Reject any news or event whose title or description contains one of these phrases. Use it for organizations that aren&apos;t POIs (e.g., &quot;Cuyahoga Valley Art Center&quot;) whose events otherwise attach to whatever venue POI hosts them. Case-insensitive substring match, applied on every moderation run.</p>
-        {domainListsLoading ? <p>Loading content blocklist...</p> : (
-          <>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-              {contentBlocklist.map(phrase => (
-                <span key={phrase} style={{
-                  padding: '0.25rem 0.5rem',
-                  backgroundColor: '#f8d7da',
-                  color: '#721c24',
-                  borderRadius: '4px',
-                  fontSize: '0.85rem',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}>
-                  {phrase}
-                  <button onClick={() => handleRemoveContentPhrase(phrase)}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      color: '#721c24',
-                      cursor: 'pointer',
-                      padding: '0',
-                      fontSize: '1rem',
-                      lineHeight: '1'
-                    }}>×</button>
-                </span>
-              ))}
-            </div>
-            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
-              <input
-                type="text"
-                value={newContentPhrase}
-                onChange={e => setNewContentPhrase(e.target.value)}
-                onKeyPress={e => e.key === 'Enter' && handleAddContentPhrase()}
-                placeholder="Cuyahoga Valley Art Center"
-                style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
-                disabled={contentBlocklistSaving}
-              />
-              <button className="action-btn secondary" onClick={handleAddContentPhrase} disabled={contentBlocklistSaving || !newContentPhrase.trim()}>Add</button>
-            </div>
-            <button className="action-btn primary" onClick={handleSaveContentBlocklist} disabled={contentBlocklistSaving}>
-              {contentBlocklistSaving ? 'Saving...' : 'Save Content Blocklist'}
+            <button className="action-btn primary" onClick={handleSaveAllFilters} disabled={filtersSaving}>
+              {filtersSaving ? 'Saving...' : 'Save Filters'}
             </button>
           </>
         )}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -1038,7 +1038,7 @@ function DataCollectionSettings() {
 
       <div className="ai-config-section">
         <h4>News &amp; Events Filters</h4>
-        <p className="settings-description">Allow lists (green) and block lists (red) that govern what gets collected and what passes moderation. Add to each list independently, then Save Filters once to apply everything.</p>
+        <p className="settings-description">Allow lists (green) and deny lists (red) that govern what gets collected and what passes moderation. Add to each list independently, then Save Filters once to apply everything.</p>
         {(domainListsLoading || excludedPoisLoading) ? <p>Loading filters...</p> : (
           <>
             <FilterList
@@ -1054,18 +1054,6 @@ function DataCollectionSettings() {
               disabled={filtersSaving}
             />
             <FilterList
-              title="URL Block List"
-              type="block"
-              hint="Source domains or URLs that are rejected during moderation and skipped in phase 2 collection."
-              items={domainLists.competitor}
-              value={newCompetitorDomain}
-              onValueChange={setNewCompetitorDomain}
-              onAdd={handleAddCompetitorDomain}
-              onRemove={handleRemoveCompetitorDomain}
-              placeholder="scam-site.com"
-              disabled={filtersSaving}
-            />
-            <FilterList
               title="Content Path Allow List"
               type="allow"
               hint="URL path patterns the content crawler may follow beyond the listing page (e.g., /event, /events, iteminfo.html)."
@@ -1077,16 +1065,28 @@ function DataCollectionSettings() {
               placeholder="/event"
               disabled={filtersSaving}
             />
+            <FilterList
+              title="URL Deny List"
+              type="deny"
+              hint="Source domains or URLs that are rejected during moderation and skipped in phase 2 collection."
+              items={domainLists.competitor}
+              value={newCompetitorDomain}
+              onValueChange={setNewCompetitorDomain}
+              onAdd={handleAddCompetitorDomain}
+              onRemove={handleRemoveCompetitorDomain}
+              placeholder="scam-site.com"
+              disabled={filtersSaving}
+            />
 
             <div style={{ marginBottom: '1.5rem' }}>
-              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: FILTER_COLORS.block.heading }}>POI Block List</h5>
+              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: FILTER_COLORS.deny.heading }}>POI Deny List</h5>
               <p className="config-hint" style={{ marginBottom: '0.75rem' }}>POIs skipped during collection. Any news or events from them are rejected on every moderation run. Use for broad geographic entities (e.g. Cuyahoga County) whose feeds pull in irrelevant content.</p>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
                 {excludedPois.length === 0 && (
-                  <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>No POIs blocked.</p>
+                  <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>No POIs denied.</p>
                 )}
                 {excludedPois.map(poi => (
-                  <FilterChip key={poi.id} label={poi.name} type="block" onRemove={() => handleRemoveExcludedPoi(poi.id)} />
+                  <FilterChip key={poi.id} label={poi.name} type="deny" onRemove={() => handleRemoveExcludedPoi(poi.id)} />
                 ))}
               </div>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
@@ -1094,7 +1094,7 @@ function DataCollectionSettings() {
                   pois={allPois.filter(p => !excludedPois.some(e => e.id === p.id))}
                   value={selectedPoiId}
                   onChange={(id) => setSelectedPoiId(id || '')}
-                  placeholder="Search POIs to block..."
+                  placeholder="Search POIs to deny..."
                   disabled={filtersSaving}
                   style={{ flex: 1 }}
                 />
@@ -1103,8 +1103,8 @@ function DataCollectionSettings() {
             </div>
 
             <FilterList
-              title="Content Block List"
-              type="block"
+              title="Content Deny List"
+              type="deny"
               hint="Reject any news or event whose title or description contains one of these phrases. Use for organizations that are not POIs (e.g., Cuyahoga Valley Art Center) whose events attach to the venue POI. Applied on every moderation run."
               items={contentBlocklist}
               value={newContentPhrase}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -57,6 +57,7 @@ function DataCollectionSettings() {
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
   const [contentBlocklist, setContentBlocklist] = useState([]);
   const [newContentPhrase, setNewContentPhrase] = useState('');
+  const [contentBlocklistSaving, setContentBlocklistSaving] = useState(false);
   const [trustedEventPaths, setTrustedEventPaths] = useState([]);
   const [newTrustedEventPath, setNewTrustedEventPath] = useState('');
 
@@ -441,8 +442,7 @@ function DataCollectionSettings() {
       const settings = [
         { key: 'moderation_trusted_domains', value: JSON.stringify(domainLists.trusted) },
         { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) },
-        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) },
-        { key: 'event_content_blocklist', value: JSON.stringify(contentBlocklist) }
+        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) }
       ];
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
@@ -503,6 +503,19 @@ function DataCollectionSettings() {
 
   const handleRemoveContentPhrase = (phrase) => {
     setContentBlocklist(contentBlocklist.filter(p => p !== phrase));
+  };
+
+  const handleSaveContentBlocklist = async () => {
+    setContentBlocklistSaving(true); setResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/event_content_blocklist', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: JSON.stringify(contentBlocklist) })
+      });
+      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
+      setResult({ type: 'success', message: 'Content blocklist saved' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save content blocklist: ${err.message}` }); }
+    finally { setContentBlocklistSaving(false); }
   };
 
   const handleAddTrustedEventPath = () => {
@@ -1180,49 +1193,6 @@ function DataCollectionSettings() {
               </div>
             </div>
 
-            <div style={{ marginBottom: '1.5rem' }}>
-              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#dc3545' }}>Content Blocklist</h5>
-              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>Reject any news/event whose title or description contains one of these phrases — use for organizations that aren&apos;t POIs (e.g., &quot;Cuyahoga Valley Art Center&quot;) whose events otherwise attach to the venue POI. Case-insensitive substring match.</p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
-                {contentBlocklist.map(phrase => (
-                  <span key={phrase} style={{
-                    padding: '0.25rem 0.5rem',
-                    backgroundColor: '#f8d7da',
-                    color: '#721c24',
-                    borderRadius: '4px',
-                    fontSize: '0.85rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem'
-                  }}>
-                    {phrase}
-                    <button onClick={() => handleRemoveContentPhrase(phrase)}
-                      style={{
-                        background: 'none',
-                        border: 'none',
-                        color: '#721c24',
-                        cursor: 'pointer',
-                        padding: '0',
-                        fontSize: '1rem',
-                        lineHeight: '1'
-                      }}>×</button>
-                  </span>
-                ))}
-              </div>
-              <div style={{ display: 'flex', gap: '0.5rem' }}>
-                <input
-                  type="text"
-                  value={newContentPhrase}
-                  onChange={e => setNewContentPhrase(e.target.value)}
-                  onKeyPress={e => e.key === 'Enter' && handleAddContentPhrase()}
-                  placeholder="Cuyahoga Valley Art Center"
-                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
-                  disabled={domainListsSaving}
-                />
-                <button className="action-btn secondary" onClick={handleAddContentPhrase} disabled={domainListsSaving || !newContentPhrase.trim()}>Add</button>
-              </div>
-            </div>
-
             <button className="action-btn primary" onClick={handleSaveDomainLists} disabled={domainListsSaving}>
               {domainListsSaving ? 'Saving...' : 'Save Domain Lists'}
             </button>
@@ -1270,6 +1240,57 @@ function DataCollectionSettings() {
             </div>
             <button className="action-btn primary" onClick={handleSaveExcludedPois} disabled={excludedPoisSaving}>
               {excludedPoisSaving ? 'Saving...' : 'Save Excluded POIs'}
+            </button>
+          </>
+        )}
+      </div>
+
+
+      <div className="ai-config-section">
+        <h4>Content Blocklist for News and Events</h4>
+        <p className="settings-description">Reject any news or event whose title or description contains one of these phrases. Use it for organizations that aren&apos;t POIs (e.g., &quot;Cuyahoga Valley Art Center&quot;) whose events otherwise attach to whatever venue POI hosts them. Case-insensitive substring match, applied on every moderation run.</p>
+        {domainListsLoading ? <p>Loading content blocklist...</p> : (
+          <>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
+              {contentBlocklist.map(phrase => (
+                <span key={phrase} style={{
+                  padding: '0.25rem 0.5rem',
+                  backgroundColor: '#f8d7da',
+                  color: '#721c24',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem'
+                }}>
+                  {phrase}
+                  <button onClick={() => handleRemoveContentPhrase(phrase)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#721c24',
+                      cursor: 'pointer',
+                      padding: '0',
+                      fontSize: '1rem',
+                      lineHeight: '1'
+                    }}>×</button>
+                </span>
+              ))}
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+              <input
+                type="text"
+                value={newContentPhrase}
+                onChange={e => setNewContentPhrase(e.target.value)}
+                onKeyPress={e => e.key === 'Enter' && handleAddContentPhrase()}
+                placeholder="Cuyahoga Valley Art Center"
+                style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
+                disabled={contentBlocklistSaving}
+              />
+              <button className="action-btn secondary" onClick={handleAddContentPhrase} disabled={contentBlocklistSaving || !newContentPhrase.trim()}>Add</button>
+            </div>
+            <button className="action-btn primary" onClick={handleSaveContentBlocklist} disabled={contentBlocklistSaving}>
+              {contentBlocklistSaving ? 'Saving...' : 'Save Content Blocklist'}
             </button>
           </>
         )}

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -55,6 +55,8 @@ function DataCollectionSettings() {
   const [domainListsSaving, setDomainListsSaving] = useState(false);
   const [newTrustedDomain, setNewTrustedDomain] = useState('');
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
+  const [contentBlocklist, setContentBlocklist] = useState([]);
+  const [newContentPhrase, setNewContentPhrase] = useState('');
   const [trustedEventPaths, setTrustedEventPaths] = useState([]);
   const [newTrustedEventPath, setNewTrustedEventPath] = useState('');
 
@@ -409,10 +411,13 @@ function DataCollectionSettings() {
         const trusted = settings.moderation_trusted_domains?.value || '[]';
         const blocklist = settings.blocklist_urls?.value || '[]';
         const eventPaths = settings.trusted_event_paths?.value || '[]';
+        const contentBlock = settings.event_content_blocklist?.value || '[]';
         try {
           const parsedTrusted = JSON.parse(trusted);
           const parsedBlocklist = JSON.parse(blocklist);
           const parsedEventPaths = JSON.parse(eventPaths);
+          const parsedContentBlock = JSON.parse(contentBlock);
+          setContentBlocklist(Array.isArray(parsedContentBlock) ? parsedContentBlock.filter(p => typeof p === 'string') : []);
           setDomainLists({
             trusted: Array.isArray(parsedTrusted) ? parsedTrusted.filter(d => typeof d === 'string') : [],
             competitor: Array.isArray(parsedBlocklist) ? parsedBlocklist.filter(d => typeof d === 'string') : []
@@ -436,7 +441,8 @@ function DataCollectionSettings() {
       const settings = [
         { key: 'moderation_trusted_domains', value: JSON.stringify(domainLists.trusted) },
         { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) },
-        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) }
+        { key: 'trusted_event_paths', value: JSON.stringify(trustedEventPaths) },
+        { key: 'event_content_blocklist', value: JSON.stringify(contentBlocklist) }
       ];
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
@@ -484,6 +490,19 @@ function DataCollectionSettings() {
 
   const handleRemoveCompetitorDomain = (domain) => {
     setDomainLists({ ...domainLists, competitor: domainLists.competitor.filter(d => d !== domain) });
+  };
+
+  const handleAddContentPhrase = () => {
+    const phrase = newContentPhrase.trim();
+    if (!phrase) return;
+    if (!contentBlocklist.some(p => p.toLowerCase() === phrase.toLowerCase())) {
+      setContentBlocklist([...contentBlocklist, phrase]);
+      setNewContentPhrase('');
+    }
+  };
+
+  const handleRemoveContentPhrase = (phrase) => {
+    setContentBlocklist(contentBlocklist.filter(p => p !== phrase));
   };
 
   const handleAddTrustedEventPath = () => {
@@ -1158,6 +1177,49 @@ function DataCollectionSettings() {
                   disabled={domainListsSaving}
                 />
                 <button className="action-btn secondary" onClick={handleAddTrustedEventPath} disabled={domainListsSaving || !newTrustedEventPath.trim()}>Add</button>
+              </div>
+            </div>
+
+            <div style={{ marginBottom: '1.5rem' }}>
+              <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: '#dc3545' }}>Content Blocklist</h5>
+              <p className="config-hint" style={{ marginBottom: '0.75rem' }}>Reject any news/event whose title or description contains one of these phrases — use for organizations that aren&apos;t POIs (e.g., &quot;Cuyahoga Valley Art Center&quot;) whose events otherwise attach to the venue POI. Case-insensitive substring match.</p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
+                {contentBlocklist.map(phrase => (
+                  <span key={phrase} style={{
+                    padding: '0.25rem 0.5rem',
+                    backgroundColor: '#f8d7da',
+                    color: '#721c24',
+                    borderRadius: '4px',
+                    fontSize: '0.85rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem'
+                  }}>
+                    {phrase}
+                    <button onClick={() => handleRemoveContentPhrase(phrase)}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        color: '#721c24',
+                        cursor: 'pointer',
+                        padding: '0',
+                        fontSize: '1rem',
+                        lineHeight: '1'
+                      }}>×</button>
+                  </span>
+                ))}
+              </div>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={newContentPhrase}
+                  onChange={e => setNewContentPhrase(e.target.value)}
+                  onKeyPress={e => e.key === 'Enter' && handleAddContentPhrase()}
+                  placeholder="Cuyahoga Valley Art Center"
+                  style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
+                  disabled={domainListsSaving}
+                />
+                <button className="action-btn secondary" onClick={handleAddContentPhrase} disabled={domainListsSaving || !newContentPhrase.trim()}>Add</button>
               </div>
             </div>
 

--- a/frontend/src/components/FilterList.jsx
+++ b/frontend/src/components/FilterList.jsx
@@ -1,8 +1,8 @@
 // Shared editor for the News & Events filter lists. `type` drives the color:
-// allow lists are green, block lists are red, consistently across the section.
+// allow lists are green, deny lists are red, consistently across the section.
 export const FILTER_COLORS = {
   allow: { heading: '#28a745', chipBg: '#d4edda', chipText: '#155724' },
-  block: { heading: '#dc3545', chipBg: '#f8d7da', chipText: '#721c24' }
+  deny: { heading: '#dc3545', chipBg: '#f8d7da', chipText: '#721c24' }
 };
 
 export function FilterChip({ label, type, onRemove }) {

--- a/frontend/src/components/FilterList.jsx
+++ b/frontend/src/components/FilterList.jsx
@@ -1,0 +1,55 @@
+// Shared editor for the News & Events filter lists. `type` drives the color:
+// allow lists are green, block lists are red, consistently across the section.
+export const FILTER_COLORS = {
+  allow: { heading: '#28a745', chipBg: '#d4edda', chipText: '#155724' },
+  block: { heading: '#dc3545', chipBg: '#f8d7da', chipText: '#721c24' }
+};
+
+export function FilterChip({ label, type, onRemove }) {
+  const c = FILTER_COLORS[type];
+  return (
+    <span style={{
+      padding: '0.25rem 0.5rem',
+      backgroundColor: c.chipBg,
+      color: c.chipText,
+      borderRadius: '4px',
+      fontSize: '0.85rem',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.5rem'
+    }}>
+      {label}
+      <button onClick={onRemove} style={{
+        background: 'none', border: 'none', color: c.chipText,
+        cursor: 'pointer', padding: '0', fontSize: '1rem', lineHeight: '1'
+      }}>×</button>
+    </span>
+  );
+}
+
+export default function FilterList({ title, type, hint, items, value, onValueChange, onAdd, onRemove, placeholder, disabled }) {
+  const c = FILTER_COLORS[type];
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem', color: c.heading }}>{title}</h5>
+      <p className="config-hint" style={{ marginBottom: '0.75rem' }}>{hint}</p>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.75rem' }}>
+        {items.map(item => (
+          <FilterChip key={item} label={item} type={type} onRemove={() => onRemove(item)} />
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <input
+          type="text"
+          value={value}
+          onChange={e => onValueChange(e.target.value)}
+          onKeyPress={e => e.key === 'Enter' && onAdd()}
+          placeholder={placeholder}
+          style={{ flex: 1, padding: '0.5rem', fontSize: '0.85rem' }}
+          disabled={disabled}
+        />
+        <button className="action-btn secondary" onClick={onAdd} disabled={disabled || !value.trim()}>Add</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes several newsletter/moderation issues found while reviewing the weekly preview.

- **Excluded-POI retroactive sweep** — `processPendingItems` now rejects any *stored* news/event whose POI is on `news_collection_excluded_pois` on every moderation run, not just newly-collected items. Exclusion was forward-only, so items collected before a POI was excluded kept leaking into the digest (e.g. Cuyahoga County).
- **Content blocklist** — new `event_content_blocklist` admin setting + admin UI. Moderation rejects news/events whose title/description matches a blocked phrase. Stops events from organizations that aren't POIs (e.g. *Cuyahoga Valley Art Center*) which otherwise attach to the venue POI (Gorge Metro Park, M.D. Garage).
- **Deterministic digest** — added `id` tiebreakers to the event/news `ORDER BY` and bumped the event `LIMIT` 10→15. Previously, ties on `start_date` made *which 10 events* non-deterministic, so two preview runs produced different items.
- **Preview idempotency** — scheduled/triggered previews won't double-send the same recipient within a day (manual `send-preview-test` sends remain unrestricted). This is why two previews arrived ~1 min apart.

## Notes
- Prod data was already cleaned manually (Cuyahoga County, CVAC, and a stray NPS news item rejected).
- **Deploy step:** seed `event_content_blocklist = ["Cuyahoga Valley Art Center"]`.

## Test plan
- [ ] CI: build + Application Tests (incl. moderationService) + Gourmand
- [ ] Admin UI: Content Blocklist editor renders + saves in Data Collection settings
- [ ] After deploy: trigger a preview twice → identical content, single email; collect a CVAC event → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)