### PR TITLE
Unify newsletter extraction into the collection pipeline (spec 020)

### DIFF
--- a/.specify/specs/020-unify-collection-extraction/spec.md
+++ b/.specify/specs/020-unify-collection-extraction/spec.md
@@ -1,0 +1,131 @@
+# Specification: Unify Newsletter Extraction into the Collection Pipeline
+
+> **Spec ID:** 020-unify-collection-extraction
+> **Status:** Draft
+> **Version:** 0.2.0
+> **Author:** Scott McCarty (with Josui)
+> **Date:** 2026-05-21
+
+## Overview
+
+Newsletter ingestion (`newsletterService.js`) and AI collection (`newsService.js`) extract content through two divergent code paths. The newsletter path asks Gemini to produce structured items **including `source_url` and dates in one shot**, while the collection path forbids Gemini from setting URLs/dates and derives them deterministically. This divergence is the root cause of the newsletter "homepage link" bug (Gemini fabricated `akronzoo.org/` instead of using the real per-item links) and means newsletter events skip the date-consensus scoring every other event gets.
+
+This spec unifies the two: a newsletter is tied to **one POI** (the sending organization), its **"view in browser" page is crawled as the entry page**, and the existing classifier decides **listing vs. detail** — after which the standard crawl → extract → score → save pipeline does everything. `newsletterService.js` shrinks to *ingest + resolve POI + hand off*.
+
+---
+
+## Background: why they differ today
+
+| Concern | Collection path (`newsService.js`) | Newsletter path (`newsletterService.js`) |
+|---------|-----------------------------------|------------------------------------------|
+| URL selection | Deterministic — `item.source_url = url` (rendered page's URL). Prompt: *"Do NOT include date or source_url fields"* | **Gemini emits `source_url`** → hallucinated the homepage |
+| Dates | Separate date-scoring pipeline (`date_consensus_score`, `date_signals`) | **Gemini emits dates** → no consensus scoring, past-dated noise |
+| Link/page handling | Render URL → classify listing/detail → `isNoiseLink` + dedup + redirect resolution | One-shot Gemini extraction over whole-email markdown; bespoke `resolveItemUrls` |
+| POI assignment | Job is scoped to one known POI | `matchItemsToPois` by name-substring over all POIs |
+| Item extraction | `processPage` per rendered detail page | Single Gemini call over the email |
+
+The collection path embodies **"Gemini classifies/extracts content; everything structural (URLs, dates) is deterministic."** Unification makes the newsletter obey the same principle by reusing the same pipeline.
+
+---
+
+## Resolved Design Decisions (2026-05-21)
+
+**D1 — One newsletter = one POI.** A newsletter comes from a specific organization (e.g., Akron Zoo → POI 5753), so the whole email is scoped to that POI, exactly like a collection job. This replaces per-item name-matching. Requires a **sender → POI mapping** (see Data Model). Unmapped senders are quarantined for one-click admin assignment (which creates the mapping for next time).
+
+**D2 — Crawl the "view in browser" page as the entry page.** Most newsletters include a "View in browser / View as webpage" link that renders the full newsletter as a normal web page. Extract that link from the email and feed it into the standard pipeline as the entry URL for the POI. Fallback when absent: render the stored email HTML (`newsletter_emails.body_html`) as the entry page.
+
+**D3 — Classify the entry page as listing vs. detail, then reuse everything.** The existing classifier decides: *listing* → extract detail links, crawl them, extract items; *detail* → extract the single item. From there the standard `processPage` → date-scoring → dedup → save path runs unchanged, tagged `content_source='newsletter'`. "Everything else just works."
+
+Net effect: `newsletterService.js` keeps only the SMTP receiver, `newsletter_emails` logging, POI resolution, and entry-URL selection. It **drops** the bespoke extraction prompt, `matchItemsToPois`, and `resolveItemUrls`.
+
+---
+
+## User Stories
+
+**US-001: Newsletter bound to its organization's POI**
+> As a maintainer, I want each newsletter routed to the single POI for its sending organization, so its items attach to the right place without per-item guessing.
+
+Acceptance Criteria:
+- [ ] A sender → POI mapping resolves the Akron Zoo newsletter to POI 5753.
+- [ ] An unmapped sender is quarantined with an admin action to assign a POI (persisting the mapping).
+- [ ] All items from one newsletter attach to that one POI.
+
+**US-002: Single extraction pipeline, deterministic deep links**
+> As a maintainer, I want newsletters to flow through the same crawl/extract/score/save code as collection.
+
+Acceptance Criteria:
+- [ ] Newsletter items are produced by the shared `processPage`/save path (no parallel Gemini prompt emitting URLs/dates).
+- [ ] `source_url` comes from the resolved destination page, never inferred by Gemini; re-processing the Akron Zoo "Renaissance Faire" email links to `akronzoo.org/renaissance-faire`, not `akronzoo.org/`.
+- [ ] `newsletterService.js` no longer contains a bespoke item-extraction prompt, `matchItemsToPois`, or `resolveItemUrls`.
+
+**US-003: Consistent dates and dedup**
+> As a moderator, I want newsletter events scored and deduped like collected events.
+
+Acceptance Criteria:
+- [ ] Newsletter events populate `date_consensus_score`/`date_signals`.
+- [ ] Newsletter items dedup against existing `poi_news`/`poi_events` via the shared dedup.
+
+---
+
+## Data Model
+
+New mapping table (admin-managed):
+
+```sql
+CREATE TABLE IF NOT EXISTS poi_newsletter_sources (
+  id           SERIAL PRIMARY KEY,
+  poi_id       INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
+  from_pattern TEXT NOT NULL,   -- match against the email From: (e.g. 'info-akronzoo.org@shared1.ccsend.com' or '%akronzoo.org%')
+  created_at   TIMESTAMPTZ DEFAULT now()
+);
+```
+
+Notes:
+- Constant Contact relays from `…@shared1.ccsend.com`, so the org identity often lives in the From local-part / `List-Unsubscribe` header / body, not the sending domain — `from_pattern` is matched as a LIKE/regex against the stored `from_address`.
+- No other schema change; `content_source='newsletter'` already exists. Newsletter events will now also populate `date_consensus_score`, `date_signals`, `rendered_content` (previously null).
+- `newsletter_emails` remains the ingestion log/entry point.
+
+---
+
+## Processing Flow (target)
+
+1. SMTP receiver stores raw email in `newsletter_emails`, queues a job (unchanged).
+2. Resolve POI via `poi_newsletter_sources` against `from_address`. No match → quarantine (status on `newsletter_emails`) + admin assignment.
+3. Select entry URL: "view in browser" link if present, else render stored `body_html`.
+4. Hand `(entryUrl|html, poi)` to the standard pipeline as a single-POI job.
+5. Standard classify (listing/detail) → crawl → extract → date-score → dedup → save with `content_source='newsletter'`.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Cost / performance** — crawling links is heavier than one-shot email extraction. Apply the same per-job page caps as collection and reuse `renderPage` caching (see `docs/NEWS_COLLECTION_INEFFICIENCIES.md`).
+
+**NFR-002: Graceful degradation** — a link/page that won't render must not fail the whole newsletter; skip that item. If the entry page itself won't render, fall back to the stored email HTML.
+
+**NFR-003: No ingestion regression** — SMTP receiver, `newsletter_emails` logging, and `newsletter_reprocess` keep working.
+
+---
+
+## Dependencies
+
+- Depends on: `newsService.js` crawl/extract/save being invocable for a single POI given an entry URL or raw HTML (not only DB-driven POI jobs).
+- Supersedes: the interim prompt band-aid `fix: extract source_url verbatim from newsletters` (branch `fix/collection-url-and-grounding`). The Serper "floor grounding to Ohio" fix on that branch is independent and should ship regardless.
+- Related: `docs/NEWS_COLLECTION_INEFFICIENCIES.md` (cost controls to respect).
+
+---
+
+## Open Questions
+
+1. **Sender mapping admin UX:** new admin screen for `poi_newsletter_sources`, or fold "assign POI" into the existing newsletter admin view as a one-click action on a quarantined email?
+2. **Entry-page rendering of stored HTML:** does the pipeline accept a raw HTML string as a "page", or do we always prefer a real URL ("view in browser") and only fall back to HTML when present? (Affects how much of `crawlPage` needs a non-URL entry mode.)
+3. **Exhibit-announcement event/news split** (Primate Passage / DinoTrek): orthogonal; fold in here or leave to the classifier?
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-21 | Initial draft |
+| 0.2.0 | 2026-05-21 | Resolved POI mapping (one newsletter = one POI + `poi_newsletter_sources`), "view in browser" entry page, and listing/detail classification per Scott's direction |

--- a/backend/migrations/060_add_poi_newsletter_sources.sql
+++ b/backend/migrations/060_add_poi_newsletter_sources.sql
@@ -1,0 +1,18 @@
+-- 060_add_poi_newsletter_sources.sql
+-- Maps an inbound newsletter sender to the POI it belongs to (spec 020).
+-- A newsletter comes from one organization (e.g. Akron Zoo), so the whole
+-- email is scoped to one POI and crawled through the standard collection
+-- pipeline. from_pattern is matched (case-insensitive substring) against
+-- newsletter_emails.from_address. Unmapped senders are quarantined until an
+-- admin assigns a POI, which inserts a row here. Re-runs every container
+-- start, so all statements are idempotent.
+
+CREATE TABLE IF NOT EXISTS poi_newsletter_sources (
+  poi_id       INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
+  from_pattern TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (poi_id, from_pattern)
+);
+
+CREATE INDEX IF NOT EXISTS idx_poi_newsletter_sources_pattern
+  ON poi_newsletter_sources (LOWER(from_pattern));

--- a/backend/routes/newsletter.js
+++ b/backend/routes/newsletter.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { isAdmin } from '../middleware/auth.js';
 import { addSubscriber, getSubscriberCount, testApiKey } from '../services/buttondownClient.js';
-import { triggerDigestManually, triggerPreviewManually } from '../services/jobScheduler.js';
+import { triggerDigestManually, triggerPreviewManually, queueNewsletterJob } from '../services/jobScheduler.js';
 import { sendDigestPreviewTo } from '../services/newsletterDigestService.js';
 
 const router = express.Router();
@@ -135,6 +135,66 @@ export function createNewsletterRouter(pool) {
         success: false,
         error: error.message || 'API key validation failed'
       });
+    }
+  });
+
+  router.get('/inbound', isAdmin, async (req, res) => {
+    try {
+      const limit = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
+      const rows = await pool.query(
+        `SELECT e.id, e.from_address, e.subject, e.received_at, e.processed, e.processed_at,
+                e.error_message, e.news_extracted, e.events_extracted,
+                s.poi_id, p.name AS poi_name
+         FROM newsletter_emails e
+         LEFT JOIN LATERAL (
+           SELECT src.poi_id FROM poi_newsletter_sources src
+           WHERE POSITION(LOWER(src.from_pattern) IN LOWER(e.from_address)) > 0
+           ORDER BY LENGTH(src.from_pattern) DESC LIMIT 1
+         ) s ON TRUE
+         LEFT JOIN pois p ON p.id = s.poi_id
+         ORDER BY e.received_at DESC
+         LIMIT $1`,
+        [limit]
+      );
+      res.json(rows.rows);
+    } catch (error) {
+      console.error('Inbound newsletter list error:', error);
+      res.status(500).json({ error: 'Failed to list inbound newsletters' });
+    }
+  });
+
+  router.post('/inbound/:id/reprocess', isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      await pool.query('UPDATE newsletter_emails SET processed = FALSE, error_message = NULL WHERE id = $1', [id]);
+      await queueNewsletterJob(id);
+      res.json({ success: true, message: `Email #${id} queued for reprocessing` });
+    } catch (error) {
+      console.error('Inbound newsletter reprocess error:', error);
+      res.status(500).json({ error: 'Failed to reprocess' });
+    }
+  });
+
+  router.post('/inbound/:id/assign-poi', isAdmin, async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    const { poi_id, from_pattern } = req.body;
+    if (!poi_id) return res.status(400).json({ error: 'poi_id required' });
+    try {
+      const emailRow = await pool.query('SELECT from_address FROM newsletter_emails WHERE id = $1', [id]);
+      if (emailRow.rows.length === 0) return res.status(404).json({ error: 'Not found' });
+      const pattern = (from_pattern && from_pattern.trim()) || emailRow.rows[0].from_address;
+      if (!pattern) return res.status(400).json({ error: 'No sender pattern available' });
+      await pool.query(
+        `INSERT INTO poi_newsletter_sources (poi_id, from_pattern)
+         VALUES ($1, $2) ON CONFLICT (poi_id, from_pattern) DO NOTHING`,
+        [poi_id, pattern]
+      );
+      await pool.query('UPDATE newsletter_emails SET processed = FALSE, error_message = NULL WHERE id = $1', [id]);
+      await queueNewsletterJob(id);
+      res.json({ success: true, message: `Mapped "${pattern}" → POI ${poi_id}` });
+    } catch (error) {
+      console.error('Inbound newsletter assign-poi error:', error);
+      res.status(500).json({ error: 'Failed to assign POI' });
     }
   });
 

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -563,6 +563,34 @@ function registerTools(server, pool, boss) {
   );
 
   server.tool(
+    'newsletter_assign_poi',
+    'Map a newsletter sender to a POI so its emails are scoped to that POI, then reprocess the email',
+    {
+      id: z.number().describe('Newsletter email ID'),
+      poi_id: z.number().describe('POI id to attribute this sender to'),
+      from_pattern: z.string().optional().describe("Sender match pattern (substring of From:). Defaults to the email's full from_address.")
+    },
+    async ({ id, poi_id, from_pattern }) => {
+      const emailRow = await pool.query('SELECT from_address FROM newsletter_emails WHERE id = $1', [id]);
+      if (emailRow.rows.length === 0) {
+        return { content: [{ type: 'text', text: 'Newsletter email not found' }], isError: true };
+      }
+      const pattern = (from_pattern && from_pattern.trim()) || emailRow.rows[0].from_address;
+      if (!pattern) {
+        return { content: [{ type: 'text', text: 'No sender pattern available to map' }], isError: true };
+      }
+      await pool.query(
+        `INSERT INTO poi_newsletter_sources (poi_id, from_pattern)
+         VALUES ($1, $2) ON CONFLICT (poi_id, from_pattern) DO NOTHING`,
+        [poi_id, pattern]
+      );
+      await pool.query(`UPDATE newsletter_emails SET processed = FALSE, error_message = NULL WHERE id = $1`, [id]);
+      await queueNewsletterJob(id);
+      return { content: [{ type: 'text', text: `Mapped "${pattern}" → POI ${poi_id}; queued email #${id} for reprocessing` }] };
+    }
+  );
+
+  server.tool(
     'settings_list',
     'View all admin settings (moderation thresholds, toggles)',
     {},

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -346,7 +346,7 @@ Return ONLY valid JSON:
   }
 }
 
-function filterDetailLinks(detailLinks, sourceUrl, basePath = null, trustedEventPaths = []) {
+function filterDetailLinks(detailLinks, sourceUrl, basePath = null, trustedEventPaths = [], allowedDomains = null) {
   if (!detailLinks?.length) return [];
   let sourceOrigin;
   try { sourceOrigin = new URL(sourceUrl).origin; } catch { return []; }
@@ -361,7 +361,9 @@ function filterDetailLinks(detailLinks, sourceUrl, basePath = null, trustedEvent
         parsed.pathname.includes(pattern)
       );
       if (parsed.origin !== sourceOrigin) {
-        if (!matchesTrusted) return false;
+        const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+        const ownDomain = allowedDomains && allowedDomains.has(host);
+        if (!matchesTrusted && !ownDomain) return false;
       } else if (basePath && !parsed.pathname.startsWith(basePath)) {
         if (!matchesTrusted) return false;
       }
@@ -655,6 +657,13 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
     }
   } catch { /* use empty list */ }
 
+  const allowedDomains = new Set();
+  for (const u of [poi.more_info_link, poi.news_url, poi.events_url]) {
+    try {
+      if (u) allowedDomains.add(new URL(u).hostname.replace(/^www\./, '').toLowerCase());
+    } catch { /* skip unparseable */ }
+  }
+
   async function processLevel(urls, depth) {
     if (depth > maxDepth || totalPagesRendered >= maxPages || collectedPages.length >= maxDetailPages) return;
 
@@ -695,7 +704,7 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
         if (extracted.pageType === 'listing') {
           const resolvedCachedLinks = await resolveTrackerLinks((extracted.links || []).map(l => l.url));
           classification.detailLinks = shortestUrlDedup(filterDetailLinks(
-            resolvedCachedLinks, url, basePath, trustedEventPaths
+            resolvedCachedLinks, url, basePath, trustedEventPaths, allowedDomains
           ));
         }
       } else {
@@ -709,7 +718,7 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
         collectedPages.push({ url, markdown: extracted.markdown, rawText: extracted.rawText, ogDates: extracted.ogDates, ogImage: extracted.ogImage, title: extracted.title, itemCountNews: extracted.itemCountNews, itemCountEvents: extracted.itemCountEvents });
       } else if (classification.pageType === 'listing') {
         const resolvedLinks = await resolveTrackerLinks(classification.detailLinks);
-        const validLinks = shortestUrlDedup(filterDetailLinks(resolvedLinks, url, basePath, trustedEventPaths));
+        const validLinks = shortestUrlDedup(filterDetailLinks(resolvedLinks, url, basePath, trustedEventPaths, allowedDomains));
         updateProgress(poi.id, { phase: 'crawl', message: `${validLinks.length} links from ${url}` });
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Crawl] Following ${validLinks.length} detail links from ${url}`);
         await processLevel(validLinks, depth + 1);

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -356,12 +356,13 @@ function filterDetailLinks(detailLinks, sourceUrl, basePath = null, trustedEvent
   }).filter(link => {
     try {
       const parsed = new URL(link);
-      if (parsed.origin !== sourceOrigin) return false;
       if (isNoiseLink(link, sourceUrl)) return false;
-      if (basePath && !parsed.pathname.startsWith(basePath)) {
-        const matchesTrusted = trustedEventPaths.some(pattern =>
-          parsed.pathname.includes(pattern)
-        );
+      const matchesTrusted = trustedEventPaths.some(pattern =>
+        parsed.pathname.includes(pattern)
+      );
+      if (parsed.origin !== sourceOrigin) {
+        if (!matchesTrusted) return false;
+      } else if (basePath && !parsed.pathname.startsWith(basePath)) {
         if (!matchesTrusted) return false;
       }
       if (seen.has(link)) return false;
@@ -645,16 +646,14 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
   }
 
   let trustedEventPaths = [];
-  if (contentType === 'event') {
-    try {
-      const tepResult = await pool.query(
-        "SELECT value FROM admin_settings WHERE key = 'trusted_event_paths'"
-      );
-      if (tepResult.rows.length) {
-        trustedEventPaths = JSON.parse(tepResult.rows[0].value);
-      }
-    } catch { /* use empty list */ }
-  }
+  try {
+    const tepResult = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'trusted_event_paths'"
+    );
+    if (tepResult.rows.length) {
+      trustedEventPaths = JSON.parse(tepResult.rows[0].value);
+    }
+  } catch { /* use empty list */ }
 
   async function processLevel(urls, depth) {
     if (depth > maxDepth || totalPagesRendered >= maxPages || collectedPages.length >= maxDetailPages) return;
@@ -694,8 +693,9 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
         classification = { pageType: extracted.pageType, detailLinks: [], reasoning: 'cached' };
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Cache] Classify skip — already ${extracted.pageType}: ${url}`);
         if (extracted.pageType === 'listing') {
+          const resolvedCachedLinks = await resolveTrackerLinks((extracted.links || []).map(l => l.url));
           classification.detailLinks = shortestUrlDedup(filterDetailLinks(
-            (extracted.links || []).map(l => l.url), url, basePath, trustedEventPaths
+            resolvedCachedLinks, url, basePath, trustedEventPaths
           ));
         }
       } else {
@@ -708,7 +708,8 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
       if (classification.pageType === 'detail') {
         collectedPages.push({ url, markdown: extracted.markdown, rawText: extracted.rawText, ogDates: extracted.ogDates, ogImage: extracted.ogImage, title: extracted.title, itemCountNews: extracted.itemCountNews, itemCountEvents: extracted.itemCountEvents });
       } else if (classification.pageType === 'listing') {
-        const validLinks = shortestUrlDedup(filterDetailLinks(classification.detailLinks, url, basePath, trustedEventPaths));
+        const resolvedLinks = await resolveTrackerLinks(classification.detailLinks);
+        const validLinks = shortestUrlDedup(filterDetailLinks(resolvedLinks, url, basePath, trustedEventPaths));
         updateProgress(poi.id, { phase: 'crawl', message: `${validLinks.length} links from ${url}` });
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Crawl] Following ${validLinks.length} detail links from ${url}`);
         await processLevel(validLinks, depth + 1);
@@ -722,7 +723,8 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
   return { pages: collectedPages, totalPagesRendered, totalDetailPages: collectedPages.length };
 }
 
-export async function collectPoi(pool, poi, sheets = null, timezone = 'America/New_York', collectionType = 'both', onProgress = null) {
+export async function collectPoi(pool, poi, sheets = null, timezone = 'America/New_York', collectionType = 'both', onProgress = null, options = {}) {
+  const { skipPhaseTwo = false } = options;
   const collectibleRoles = ['point', 'organization', 'river'];
   const poiRoles = poi.poi_roles || [];
   if (!poiRoles.some(r => collectibleRoles.includes(r))) {
@@ -919,7 +921,7 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
       return Number.isFinite(val) ? Math.min(20, Math.max(1, val)) : 10;
     })();
 
-    if (collectionType !== 'events') {
+    if (collectionType !== 'events' && !skipPhaseTwo) {
       try {
         updateProgress(poi.id, {
           phase: 'search',
@@ -1016,7 +1018,7 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
       }
     }
 
-    if (collectionType !== 'news') {
+    if (collectionType !== 'news' && !skipPhaseTwo) {
       try {
         updateProgress(poi.id, {
           phase: 'search',
@@ -1163,7 +1165,8 @@ async function resolveRedirectUrl(url) {
 
   const isRedirect = url.includes('grounding-api-redirect') ||
                      url.includes('redirect') ||
-                     url.includes('vertexaisearch.cloud.google.com');
+                     url.includes('vertexaisearch.cloud.google.com') ||
+                     /\.rs6\.net\//i.test(url);
 
   if (!isRedirect) {
     return url; // Not a redirect, return direct URL as-is
@@ -1189,6 +1192,18 @@ async function resolveRedirectUrl(url) {
     console.log(`[Search] ✗ Failed to resolve: ${url.substring(0, 50)}... (${error.message})`);
     return null; // Don't save broken redirects
   }
+}
+
+const TRACKER_LINK_RE = /\.rs6\.net\//i;
+
+async function resolveTrackerLinks(urls) {
+  return Promise.all((urls || []).map(async (u) => {
+    if (typeof u === 'string' && TRACKER_LINK_RE.test(u)) {
+      const resolved = await resolveRedirectUrl(u);
+      return resolved || u;
+    }
+    return u;
+  }));
 }
 
 export function normalizeTitle(title) {
@@ -1221,7 +1236,7 @@ function normalizeUrl(url) {
 export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
-  const { log = null, domainOwnershipMap = null } = options;
+  const { log = null, domainOwnershipMap = null, contentSource = 'ai' } = options;
 
   for (const item of newsItems) {
     try {
@@ -1290,8 +1305,8 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 
       const dateScore = item.date_consensus_score || 0;
       await pool.query(`
-        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals, image_url)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals, image_url, content_source)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       `, [
         effectivePoiId,
         item.title,
@@ -1304,7 +1319,8 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
         'pending',
         item.rendered_content || null,
         item.date_signals ? JSON.stringify(item.date_signals) : null,
-        item.image_url || null
+        item.image_url || null,
+        contentSource
       ]);
       savedCount++;
       if (log) log(`[Save] Saved (pending): "${item.title}" (${item.published_date || 'no date'}, score=${dateScore}) → ${resolvedUrl}`);
@@ -1320,7 +1336,7 @@ export async function saveNewsItems(pool, poiId, newsItems, options = {}) {
 export async function saveEventItems(pool, poiId, eventItems, options = {}) {
   let savedCount = 0;
   let duplicateCount = 0;
-  const { log = null, domainOwnershipMap = null } = options;
+  const { log = null, domainOwnershipMap = null, contentSource = 'ai' } = options;
 
   for (const item of eventItems) {
     try {
@@ -1407,8 +1423,8 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
 
       const dateScore = item.date_consensus_score || 0;
       await pool.query(`
-        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals, image_url)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, date_consensus_score, moderation_status, rendered_content, date_signals, image_url, content_source)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
       `, [
         effectivePoiId,
         item.title,
@@ -1423,7 +1439,8 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
         'pending',
         item.rendered_content || null,
         item.date_signals ? JSON.stringify(item.date_signals) : null,
-        item.image_url || null
+        item.image_url || null,
+        contentSource
       ]);
       savedCount++;
       if (log) log(`[Save] Saved event (pending): "${item.title}" (${item.start_date}, score=${dateScore}) → ${resolvedUrl}`);

--- a/backend/services/newsletterService.js
+++ b/backend/services/newsletterService.js
@@ -1,7 +1,9 @@
 /**
  * Newsletter Ingestion Service
- * Receives inbound emails via built-in SMTP server (port 25).
- * Extracts news/events using Gemini, matches to POIs, inserts into moderation queue.
+ * Receives inbound emails via the built-in SMTP server (port 25), maps the
+ * sender to a POI, and runs the email through the standard collection pipeline
+ * (collectPoi) twice — once for news, once for events — so URLs, dates, POI
+ * matching and dedup are handled identically to Phase I/II collection (spec 020).
  */
 
 import { SMTPServer } from 'smtp-server';
@@ -9,10 +11,9 @@ import { simpleParser } from 'mailparser';
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import nodemailer from 'nodemailer';
-import { GoogleGenerativeAI } from '@google/generative-ai';
-import { GEMINI_MODEL } from './geminiService.js';
+import { collectPoi, saveNewsItems, saveEventItems } from './newsService.js';
 import { queueNewsletterJob } from './jobScheduler.js';
-import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
+import { logInfo, flush as flushJobLogs } from './jobLogger.js';
 
 const turndown = new TurndownService({
   headingStyle: 'atx',
@@ -60,339 +61,55 @@ export function extractContentFromEmail(html, text) {
   return text || '';
 }
 
-/**
- * Match extracted items to POIs by name/keyword overlap
- * @param {Pool} pool - Database pool
- * @param {Array} items - Items with title and description
- * @returns {Array} Items with poi_id added where matched
- */
-export async function matchItemsToPois(pool, items) {
-  if (!items || items.length === 0) return [];
-
-  const poiRows = await pool.query(`
-    SELECT id, name FROM pois
-    WHERE (deleted IS NULL OR deleted = FALSE)
-    ORDER BY name
-  `);
-  const pois = poiRows.rows;
-
-  return items.map(item => {
-    const searchText = `${item.title || ''} ${item.description || ''} ${item.summary || ''} ${item.location_details || ''}`.toLowerCase();
-
-    const sortedPois = [...pois].sort((a, b) => b.name.length - a.name.length);
-
-    for (const poi of sortedPois) {
-      if (searchText.includes(poi.name.toLowerCase())) {
-        return { ...item, poi_id: poi.id };
-      }
-    }
-
-    return { ...item, poi_id: null };
-  });
-}
+const VIEW_IN_BROWSER_RE = /view\s+(this\s+)?(email\s+)?(as\s+a\s+)?(web\s?page|in\s+(your\s+)?browser|online)|having\s+trouble\s+viewing/i;
 
 /**
- * Follow a URL via HEAD request with redirect: follow.
- * @param {string} url - URL to follow
- * @returns {string|null} Final URL after HTTP redirects, or null on failure
+ * Parse a newsletter email into the shape the collection pipeline consumes:
+ * the cleaned markdown, every absolute anchor, and the "view in browser" link.
+ * Links/VIB are read from the raw HTML (no noise removal) so the preheader
+ * "view as webpage" link survives.
+ * @param {string} html - Raw email HTML
+ * @returns {{markdown: string, links: Array<{url: string, text: string}>, viewInBrowserUrl: string|null}}
  */
-async function followRedirects(url) {
+function extractEmailParts(html) {
+  const markdown = extractContentFromEmail(html, '');
+  if (!html) return { markdown, links: [], viewInBrowserUrl: null };
+
+  let doc;
   try {
-    const response = await fetch(url, {
-      method: 'HEAD',
-      redirect: 'follow',
-      signal: AbortSignal.timeout(10000)
-    });
-    return response.url || url;
-  } catch (error) {
-    console.log(`[Newsletter] HEAD failed for ${url.substring(0, 60)}... (${error.message})`);
-    return null;
+    doc = new JSDOM(html).window.document;
+  } catch {
+    return { markdown, links: [], viewInBrowserUrl: null };
   }
+
+  const anchors = [...doc.querySelectorAll('a[href]')];
+  let viewInBrowserUrl = null;
+  for (const a of anchors) {
+    if (/^https?:/i.test(a.href) && VIEW_IN_BROWSER_RE.test((a.textContent || '').trim())) {
+      viewInBrowserUrl = a.href;
+      break;
+    }
+  }
+
+  const links = anchors
+    .map(a => ({ url: a.href, text: (a.textContent || '').trim() }))
+    .filter(l => /^https?:/i.test(l.url));
+
+  return { markdown, links, viewInBrowserUrl };
 }
 
 /**
- * Resolve all source URLs in extracted items, following redirect chains
- * and stripping tracking parameters.
- * @param {Array} items - Items with source_url fields
- * @returns {Array} Items with resolved source URLs
- */
-async function resolveItemUrls(items) {
-  if (!items || items.length === 0) return [];
-
-  const trackingPrefixes = ['utm_', 'h_sid', 'h_slt', 'h_', 'mc_', 'fbclid', 'gclid', 'ref', 'trk'];
-
-  const resolved = [];
-  for (const item of items) {
-    if (!item.source_url) {
-      resolved.push(item);
-      continue;
-    }
-
-    let dest = await followRedirects(item.source_url);
-    if (!dest) {
-      resolved.push({ ...item, source_url: null });
-      continue;
-    }
-
-    try {
-      const parsed = new URL(dest);
-      if (parsed.pathname.includes('js-redirect') || parsed.pathname.includes('js_redirect')) {
-        const nextUrl = parsed.searchParams.get('next_url')
-          || parsed.searchParams.get('next')
-          || parsed.searchParams.get('url')
-          || parsed.searchParams.get('redirect_url');
-        if (nextUrl) {
-          new URL(nextUrl);
-          console.log(`[Newsletter] JS redirect hop: ${dest.substring(0, 50)}... -> ${nextUrl.substring(0, 80)}`);
-          dest = nextUrl;
-        }
-      }
-    } catch { /* expected */ }
-
-    if (dest !== item.source_url) {
-      const finalHop = await followRedirects(dest);
-      if (finalHop && finalHop !== dest) {
-        console.log(`[Newsletter] Final hop: ${dest.substring(0, 50)}... -> ${finalHop.substring(0, 80)}`);
-        dest = finalHop;
-      }
-    }
-
-    try {
-      const parsed = new URL(dest);
-      const host = parsed.hostname.toLowerCase();
-      if ((host === 'www.google.com' || host === 'google.com') && (parsed.pathname === '/' || parsed.pathname === '')) {
-        console.log(`[Newsletter] Dead-end URL dropped: ${dest.substring(0, 80)}`);
-        resolved.push({ ...item, source_url: null });
-        continue;
-      }
-      if (host.includes('hive.co') || host.includes('mail-tracking.')) {
-        console.log(`[Newsletter] Dead-end URL dropped: ${dest.substring(0, 80)}`);
-        resolved.push({ ...item, source_url: null });
-        continue;
-      }
-
-      const keysToRemove = [];
-      for (const key of parsed.searchParams.keys()) {
-        if (trackingPrefixes.some(prefix => key.startsWith(prefix))) {
-          keysToRemove.push(key);
-        }
-      }
-      for (const key of keysToRemove) {
-        parsed.searchParams.delete(key);
-      }
-      dest = parsed.toString();
-    } catch { /* expected */ }
-
-    if (dest !== item.source_url) {
-      console.log(`[Newsletter] URL resolved: ${item.source_url.substring(0, 50)}... -> ${dest.substring(0, 80)}`);
-    }
-
-    resolved.push({ ...item, source_url: dest });
-  }
-  return resolved;
-}
-
-/**
- * Main newsletter processing function.
- * Called by the webhook endpoint.
- * @param {Pool} pool - Database pool
- * @param {Object} emailData - { from, subject, html, text, raw, receivedAt }
- * @returns {Object} Processing result summary
- */
-export async function processNewsletter(pool, emailData) {
-  const { from, subject, html, text, receivedAt } = emailData;
-
-  console.log(`[Newsletter] Processing: "${subject}" from ${from}`);
-
-  const markdown = extractContentFromEmail(html, text);
-
-  if (!markdown || markdown.length < 50) {
-    console.log('[Newsletter] Insufficient content, skipping');
-
-    await pool.query(`
-      INSERT INTO newsletter_emails (from_address, subject, body_html, body_text, body_markdown, processed, error_message, received_at)
-      VALUES ($1, $2, $3, $4, $5, TRUE, 'Insufficient content', $6)
-    `, [from, subject, html || null, text || null, markdown, receivedAt || new Date()]);
-
-    return { success: false, error: 'Insufficient content', newsExtracted: 0, eventsExtracted: 0 };
-  }
-
-  const emailInsert = await pool.query(`
-    INSERT INTO newsletter_emails (from_address, subject, body_html, body_text, body_markdown, received_at)
-    VALUES ($1, $2, $3, $4, $5, $6)
-    RETURNING id
-  `, [from, subject, html || null, text || null, markdown, receivedAt || new Date()]);
-
-  const emailId = emailInsert.rows[0].id;
-
-  try {
-    const apiKeyRow = await pool.query(
-      "SELECT value FROM admin_settings WHERE key = 'gemini_api_key'"
-    );
-    const apiKey = apiKeyRow.rows[0]?.value || process.env.GOOGLE_AI_API_KEY;
-    if (!apiKey) {
-      throw new Error('No Gemini API key configured');
-    }
-
-    const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({
-      model: GEMINI_MODEL,
-      generationConfig: { temperature: 0 }
-    });
-
-    const prompt = `You are a content curator for Roots of The Valley, a guide to Cuyahoga Valley National Park and surrounding communities in Northeast Ohio.
-
-Extract news items and events from this newsletter that are relevant to the Cuyahoga Valley region.
-
-Newsletter subject: "${subject}"
-
-Newsletter content:
-${markdown.substring(0, 30000)}
-
-RELEVANCE CRITERIA:
-- Nature, trails, outdoor recreation, conservation
-- Local history, ecology, wildlife
-- Community stewardship, scenic railroads, canal towpath heritage
-- Arts/culture organizations that serve the valley
-- Events at or near Cuyahoga Valley National Park
-- Skip generic urban news, restaurant openings, unrelated entertainment
-
-Return a JSON object with this exact structure:
-{
-  "news": [
-    {
-      "title": "News headline",
-      "summary": "2-3 sentence summary",
-      "source_name": "Newsletter name or organization",
-      "source_url": "URL if mentioned in newsletter, or null",
-      "published_date": "YYYY-MM-DD if known, or null",
-      "news_type": "general|alert|wildlife|infrastructure|community"
-    }
-  ],
-  "events": [
-    {
-      "title": "Event name",
-      "description": "Brief description",
-      "start_date": "YYYY-MM-DD",
-      "end_date": "YYYY-MM-DD or null",
-      "event_type": "hike|race|concert|festival|program|volunteer|arts|community|alert",
-      "location_details": "Venue or location name",
-      "source_url": "URL if available, or null"
-    }
-  ]
-}
-
-IMPORTANT:
-- Only include items relevant to the Cuyahoga Valley region
-- All dates in ISO 8601 format (YYYY-MM-DD)
-- Skip past events — only include upcoming/current events
-- Return {"news": [], "events": []} if nothing relevant found
-- Return ONLY the JSON, no additional text`;
-
-    const generation = await model.generateContent(prompt);
-    const response = generation.response.text();
-
-    const jsonMatch = response.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      console.log('[Newsletter] No JSON in Gemini response');
-      return { success: true, emailId, newsExtracted: 0, eventsExtracted: 0 };
-    }
-
-    const extracted = JSON.parse(jsonMatch[0]);
-    console.log(`[Newsletter] Gemini extracted: ${extracted.news?.length || 0} news, ${extracted.events?.length || 0} events`);
-
-    const resolvedNews = await resolveItemUrls(extracted.news || []);
-    const resolvedEvents = await resolveItemUrls(extracted.events || []);
-
-    const matchedNews = await matchItemsToPois(pool, resolvedNews);
-    const matchedEvents = await matchItemsToPois(pool, resolvedEvents);
-
-    let newsInserted = 0;
-    let eventsInserted = 0;
-
-    for (const item of matchedNews) {
-      try {
-        const newsInsert = await pool.query(`
-          INSERT INTO poi_news (poi_id, title, summary, source_url, source_name, news_type, publication_date,
-                                moderation_status, content_source)
-          VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', 'newsletter')
-          RETURNING id
-        `, [
-          item.poi_id, item.title, item.summary,
-          item.source_url || null, item.source_name || null,
-          item.news_type || 'general', item.published_date || null
-        ]);
-
-        newsInserted++;
-      } catch (err) {
-        console.error(`[Newsletter] Failed to insert news "${item.title}":`, err.message);
-      }
-    }
-
-    for (const item of matchedEvents) {
-      if (!item.start_date) continue;
-
-      try {
-        const eventInsert = await pool.query(`
-          INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type,
-                                  location_details, source_url, moderation_status, content_source)
-          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', 'newsletter')
-          RETURNING id
-        `, [
-          item.poi_id, item.title, item.description,
-          item.start_date, item.end_date || null,
-          item.event_type || null, item.location_details || null,
-          item.source_url || null
-        ]);
-
-        eventsInserted++;
-      } catch (err) {
-        console.error(`[Newsletter] Failed to insert event "${item.title}":`, err.message);
-      }
-    }
-
-    await pool.query(`
-      UPDATE newsletter_emails
-      SET processed = TRUE, news_extracted = $1, events_extracted = $2, processed_at = CURRENT_TIMESTAMP
-      WHERE id = $3
-    `, [newsInserted, eventsInserted, emailId]);
-
-    console.log(`[Newsletter] Complete: ${newsInserted} news, ${eventsInserted} events inserted from "${subject}"`);
-    logInfo(emailId, 'newsletter', null, null, `${newsInserted} news, ${eventsInserted} events extracted from "${subject}"`, { from, news_inserted: newsInserted, events_inserted: eventsInserted });
-    await flushJobLogs();
-
-    return {
-      success: true,
-      emailId,
-      newsExtracted: newsInserted,
-      eventsExtracted: eventsInserted,
-      unmatchedNews: matchedNews.filter(n => !n.poi_id).length,
-      unmatchedEvents: matchedEvents.filter(e => !e.poi_id).length
-    };
-  } catch (error) {
-    console.error(`[Newsletter] Processing failed for email #${emailId}:`, error);
-
-    await pool.query(`
-      UPDATE newsletter_emails
-      SET processed = TRUE, error_message = $1, processed_at = CURRENT_TIMESTAMP
-      WHERE id = $2
-    `, [error.message, emailId]);
-
-    logError(emailId, 'newsletter', null, null, `Processing failed: ${error.message}`, { from, subject });
-    await flushJobLogs();
-    return { success: false, emailId, error: error.message, newsExtracted: 0, eventsExtracted: 0 };
-  }
-}
-
-/**
- * Process a newsletter email by its database ID (called by pg-boss worker).
- * Reads raw email from newsletter_emails, runs processNewsletter().
+ * Process a newsletter email by its database ID (called by the pg-boss worker).
+ * Maps the sender to a POI, picks an entry page (view-in-browser link, or the
+ * stored email body pre-seeded into the render cache), then runs the standard
+ * collection pipeline twice (news, then events). Unmapped senders are
+ * quarantined for admin assignment.
  * @param {Pool} pool - Database pool
  * @param {number} emailId - ID of the newsletter_emails row
  */
 export async function processNewsletterById(pool, emailId) {
   const emailRow = await pool.query(
-    'SELECT from_address, subject, body_html, body_text, received_at FROM newsletter_emails WHERE id = $1',
+    'SELECT from_address, subject, body_html FROM newsletter_emails WHERE id = $1',
     [emailId]
   );
 
@@ -402,13 +119,84 @@ export async function processNewsletterById(pool, emailId) {
   }
 
   const email = emailRow.rows[0];
-  await processNewsletter(pool, {
-    from: email.from_address,
-    subject: email.subject,
-    html: email.body_html,
-    text: email.body_text,
-    receivedAt: email.received_at
-  });
+  const from = email.from_address || '';
+  const subject = email.subject || '(no subject)';
+
+  const poiResult = await pool.query(
+    `SELECT p.* FROM poi_newsletter_sources s
+       JOIN pois p ON p.id = s.poi_id
+      WHERE POSITION(LOWER(s.from_pattern) IN LOWER($1)) > 0
+      ORDER BY LENGTH(s.from_pattern) DESC
+      LIMIT 1`,
+    [from]
+  );
+
+  if (poiResult.rows.length === 0) {
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = FALSE, error_message = $1, processed_at = CURRENT_TIMESTAMP
+       WHERE id = $2`,
+      [`unassigned: no POI mapped for sender ${from}`, emailId]
+    );
+    console.log(`[Newsletter] Quarantined #${emailId} — no POI mapping for "${from}"`);
+    return;
+  }
+
+  const poi = poiResult.rows[0];
+  const { markdown, links, viewInBrowserUrl } = extractEmailParts(email.body_html || '');
+
+  let entryUrl = viewInBrowserUrl;
+  if (!entryUrl) {
+    if (!markdown || markdown.length < 50) {
+      await pool.query(
+        `UPDATE newsletter_emails
+           SET processed = TRUE, error_message = 'Insufficient content',
+               news_extracted = 0, events_extracted = 0, processed_at = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [emailId]
+      );
+      return;
+    }
+    entryUrl = `https://newsletter.local/email/${emailId}`;
+    await pool.query(
+      `INSERT INTO rendered_page_cache (url, markdown, raw_text, og_dates, og_image, title, links, page_type, rendered_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NOW())
+       ON CONFLICT (url) DO UPDATE SET
+         markdown = EXCLUDED.markdown, raw_text = EXCLUDED.raw_text,
+         links = EXCLUDED.links, page_type = NULL, rendered_at = NOW()`,
+      [entryUrl, markdown, markdown, JSON.stringify({}), null, subject, JSON.stringify(links)]
+    );
+  }
+
+  const transientPoi = { ...poi, news_url: entryUrl, events_url: entryUrl };
+  const opts = { skipPhaseTwo: true };
+
+  try {
+    const newsRun = await collectPoi(pool, transientPoi, null, 'America/New_York', 'news', null, opts);
+    const eventRun = await collectPoi(pool, transientPoi, null, 'America/New_York', 'events', null, opts);
+
+    const newsSaved = await saveNewsItems(pool, poi.id, newsRun.news || [], { contentSource: 'newsletter' });
+    const eventsSaved = await saveEventItems(pool, poi.id, eventRun.events || [], { contentSource: 'newsletter' });
+
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = TRUE, news_extracted = $1, events_extracted = $2,
+             error_message = NULL, processed_at = CURRENT_TIMESTAMP
+       WHERE id = $3`,
+      [newsSaved, eventsSaved, emailId]
+    );
+    logInfo(emailId, 'newsletter', poi.id, poi.name,
+      `${newsSaved} news, ${eventsSaved} events from "${subject}"`, { from, poiId: poi.id });
+    await flushJobLogs();
+  } catch (err) {
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = TRUE, error_message = $1, processed_at = CURRENT_TIMESTAMP
+       WHERE id = $2`,
+      [err.message, emailId]
+    );
+    console.error(`[Newsletter] Processing failed for #${emailId}:`, err.message);
+  }
 }
 
 /**

--- a/frontend/src/components/NewsletterSettings.jsx
+++ b/frontend/src/components/NewsletterSettings.jsx
@@ -13,12 +13,19 @@ function NewsletterSettings({ user }) {
   const [testing, setTesting] = useState(false);
   const [testMessage, setTestMessage] = useState(null);
 
+  const [inbound, setInbound] = useState([]);
+  const [pois, setPois] = useState([]);
+  const [assignSel, setAssignSel] = useState({});
+  const [inboundMsg, setInboundMsg] = useState(null);
+
   useEffect(() => {
     if (user?.email) {
       setEmail(user.email);
     }
     loadAdminSettings();
     loadStats();
+    loadInbound();
+    loadPois();
   }, [user]);
 
   const loadAdminSettings = async () => {
@@ -53,6 +60,61 @@ function NewsletterSettings({ user }) {
       }
     } catch (err) {
       console.error('Failed to load newsletter stats:', err);
+    }
+  };
+
+  const loadInbound = async () => {
+    try {
+      const res = await fetch('/api/newsletter/inbound', { credentials: 'include' });
+      if (res.ok) setInbound(await res.json());
+    } catch (err) {
+      console.error('Failed to load inbound newsletters:', err);
+    }
+  };
+
+  const loadPois = async () => {
+    try {
+      const res = await fetch('/api/pois', { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        setPois((data || []).slice().sort((a, b) => (a.name || '').localeCompare(b.name || '')));
+      }
+    } catch (err) {
+      console.error('Failed to load POIs:', err);
+    }
+  };
+
+  const handleReprocess = async (id) => {
+    setInboundMsg(null);
+    try {
+      const res = await fetch(`/api/newsletter/inbound/${id}/reprocess`, { method: 'POST', credentials: 'include' });
+      const data = await res.json();
+      setInboundMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
+      setTimeout(loadInbound, 1500);
+    } catch (err) {
+      setInboundMsg({ type: 'error', text: 'Reprocess failed' });
+    }
+  };
+
+  const handleAssign = async (id) => {
+    const sel = assignSel[id] || {};
+    if (!sel.poiId) {
+      setInboundMsg({ type: 'error', text: 'Pick a POI first' });
+      return;
+    }
+    setInboundMsg(null);
+    try {
+      const res = await fetch(`/api/newsletter/inbound/${id}/assign-poi`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ poi_id: parseInt(sel.poiId, 10), from_pattern: sel.pattern || undefined }),
+        credentials: 'include'
+      });
+      const data = await res.json();
+      setInboundMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
+      setTimeout(loadInbound, 1500);
+    } catch (err) {
+      setInboundMsg({ type: 'error', text: 'Assign failed' });
     }
   };
 
@@ -324,6 +386,72 @@ function NewsletterSettings({ user }) {
             </div>
           )}
         </div>
+      </div>
+
+      <div className="settings-divider"></div>
+
+      {/* Admin Section - Inbound Newsletters */}
+      <div className="settings-section">
+        <h3>📥 Inbound Newsletters</h3>
+        <p className="settings-description">
+          Newsletters forwarded to news@rootsofthevalley.org are crawled through the standard
+          collection pipeline and scoped to one POI by sender. Unassigned senders are quarantined
+          here until you map them to a POI.
+        </p>
+
+        {inboundMsg && (
+          <div className={`save-message ${inboundMsg.type}`} style={{ marginBottom: '12px' }}>
+            {inboundMsg.type === 'success' ? '✓' : '✗'} {inboundMsg.text}
+          </div>
+        )}
+
+        {inbound.length === 0 ? (
+          <p style={{ color: '#666' }}>No inbound newsletters yet.</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+            {inbound.map((item) => {
+              const unassigned = !item.poi_id;
+              const sel = assignSel[item.id] || {};
+              return (
+                <div key={item.id} style={{
+                  border: '1px solid #ddd',
+                  borderRadius: '6px',
+                  padding: '12px',
+                  backgroundColor: unassigned ? '#fff8e1' : '#fff'
+                }}>
+                  <div style={{ fontWeight: 'bold' }}>{item.subject || '(no subject)'}</div>
+                  <div style={{ fontSize: '0.85rem', color: '#666' }}>{item.from_address}</div>
+                  <div style={{ fontSize: '0.85rem', marginTop: '4px' }}>
+                    {unassigned ? (
+                      <span style={{ color: '#b8860b' }}>⚠ Unassigned — map a POI to ingest</span>
+                    ) : (
+                      <span>POI: <strong>{item.poi_name}</strong> · {item.news_extracted ?? 0} news, {item.events_extracted ?? 0} events</span>
+                    )}
+                    {item.error_message && <span style={{ color: '#721c24' }}> · {item.error_message}</span>}
+                  </div>
+                  <div style={{ display: 'flex', gap: '8px', marginTop: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                    <select
+                      value={sel.poiId ?? (item.poi_id || '')}
+                      onChange={(ev) => setAssignSel({ ...assignSel, [item.id]: { ...sel, poiId: ev.target.value } })}
+                    >
+                      <option value="">Select POI…</option>
+                      {pois.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                    </select>
+                    <input
+                      type="text"
+                      placeholder="match pattern (optional)"
+                      value={sel.pattern ?? ''}
+                      onChange={(ev) => setAssignSel({ ...assignSel, [item.id]: { ...sel, pattern: ev.target.value } })}
+                      style={{ flex: '1', minWidth: '160px' }}
+                    />
+                    <button className="save-settings-btn" onClick={() => handleAssign(item.id)}>Assign &amp; Reprocess</button>
+                    <button className="save-settings-btn" onClick={() => handleReprocess(item.id)}>Reprocess</button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div className="settings-divider"></div>


### PR DESCRIPTION
## Summary
- Routes inbound newsletters through the same crawl/extract/score/save pipeline as Phase I/II collection instead of a separate one-shot Gemini extraction that picked URLs/dates (which hallucinated homepage links and skipped date scoring).
- One newsletter = one POI via a new `poi_newsletter_sources` sender→POI mapping (migration 060); unmapped senders quarantine for admin assignment.
- Entry page = the email's "view in browser" link (or the email body pre-seeded into the render cache), crawled twice — once for news, once for events.
- Deterministic link handling extended: trusted content paths now apply to news as well as events; cross-origin links are followed when path-matched **or** on the POI's own website domain; Constant Contact `*.rs6.net` trackers are resolved before filtering. (Also fixes off-site links for POIs like Cleveland Metroparks.)
- Admin: `newsletter_assign_poi` MCP tool + `/api/newsletter/inbound` REST endpoints + an Inbound Newsletters section in the Newsletter Admin tab.

## Test plan
- [x] `./run.sh build` (frontend + backend compile)
- [x] Gourmand 0 violations
- [x] `./run.sh test` — 348 passed (3 failures are pre-existing UI/OG flakes in code this branch doesn't touch)
- [x] End-to-end: real Akron Zoo newsletter run through the pipeline locally → 5 events + 5 news, all deep links (`/renaissance-faire`, `/zoothing-hour`, …), real dates, `content_source='newsletter'`
- [ ] Production: forward newsletter, assign sender→POI, verify in moderation queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)