### PR TITLE
fix: apply EXIF orientation so tall images aren't displayed sideways (#393)

### DIFF
--- a/frontend/src/components/Mosaic.css
+++ b/frontend/src/components/Mosaic.css
@@ -63,6 +63,17 @@
   display: block;
 }
 
+/* Single primary image: show the whole image and pad tall/skinny ones with
+   brand green instead of cropping or rotating them (issue #393). Multi-image
+   grids keep object-fit: cover so their tiles stay filled. */
+.mosaic-1 .mosaic-item {
+  background-color: #2d5016;
+}
+
+.mosaic-1 .mosaic-image {
+  object-fit: contain;
+}
+
 /* Video/YouTube Indicators */
 .mosaic-video-indicator,
 .mosaic-youtube-indicator {

--- a/image-server/src/image_server/thumbnails.py
+++ b/image-server/src/image_server/thumbnails.py
@@ -6,7 +6,7 @@ import io
 import logging
 from pathlib import Path
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 from .config import THUMBNAIL_SIZES, get_config
 
@@ -14,6 +14,17 @@ logger = logging.getLogger(__name__)
 
 JPEG_QUALITY = 85
 RGBA_MODES = ("RGBA", "P")
+
+
+def _normalize_orientation(img: Image.Image) -> Image.Image:
+    """Bake EXIF orientation into the pixels.
+
+    Phones store portrait photos as landscape pixels plus an EXIF orientation
+    tag. Pillow's thumbnail/save drops that tag, so without this the resized
+    JPEG renders sideways (issue #393). exif_transpose rotates the pixels and
+    strips the now-redundant tag.
+    """
+    return ImageOps.exif_transpose(img)
 
 
 def generate_thumbnail(source_path: Path, dest_path: Path) -> tuple[int, int]:
@@ -25,6 +36,7 @@ def generate_thumbnail(source_path: Path, dest_path: Path) -> tuple[int, int]:
     max_dim = cfg.thumbnail_size
 
     with Image.open(source_path) as img:
+        img = _normalize_orientation(img)
         if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
@@ -46,6 +58,7 @@ def generate_thumbnail_from_bytes(
     max_dim = cfg.thumbnail_size
 
     with Image.open(io.BytesIO(image_bytes)) as img:
+        img = _normalize_orientation(img)
         if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
@@ -61,6 +74,7 @@ def generate_all_thumbnails_from_bytes(image_bytes: bytes, file_uuid: str) -> No
     base = Path(cfg.media_path) / "thumbnails"
 
     with Image.open(io.BytesIO(image_bytes)) as img:
+        img = _normalize_orientation(img)
         if img.mode in RGBA_MODES:
             img = img.convert("RGB")
 
@@ -88,6 +102,7 @@ def generate_all_thumbnails_from_path(source_path: Path, file_uuid: str) -> None
 
 
 def get_image_dimensions(image_bytes: bytes) -> tuple[int, int]:
-    """Get width and height from image bytes without fully decoding."""
+    """Get display width and height from image bytes, honoring EXIF orientation."""
     with Image.open(io.BytesIO(image_bytes)) as img:
+        img = _normalize_orientation(img)
         return img.width, img.height

--- a/image-server/tests/test_thumbnails.py
+++ b/image-server/tests/test_thumbnails.py
@@ -1,5 +1,6 @@
 """Tests for thumbnail generation."""
 
+import io
 from pathlib import Path
 
 from PIL import Image
@@ -9,6 +10,20 @@ from image_server.thumbnails import (
     generate_thumbnail_from_bytes,
     get_image_dimensions,
 )
+
+# EXIF Orientation tag id; value 6 = stored landscape, displays rotated 90deg
+# (i.e. a portrait photo). exif_transpose must swap the dimensions.
+_ORIENTATION_TAG = 0x0112
+
+
+def _landscape_jpeg_tagged_portrait() -> bytes:
+    """A 100x50 JPEG carrying EXIF Orientation=6 (should display as 50x100)."""
+    img = Image.new("RGB", (100, 50), color=(0, 0, 255))
+    exif = img.getexif()
+    exif[_ORIENTATION_TAG] = 6
+    buf = io.BytesIO()
+    img.save(buf, "JPEG", exif=exif)
+    return buf.getvalue()
 
 
 def test_generate_thumbnail(sample_jpeg, tmp_path, monkeypatch):
@@ -55,3 +70,23 @@ def test_get_image_dimensions(sample_jpeg_bytes):
     w, h = get_image_dimensions(sample_jpeg_bytes)
     assert w == 100
     assert h == 80
+
+
+def test_get_image_dimensions_honors_exif_orientation():
+    """A landscape buffer tagged Orientation=6 reports portrait dimensions (#393)."""
+    w, h = get_image_dimensions(_landscape_jpeg_tagged_portrait())
+    # Without exif_transpose this would be (100, 50).
+    assert (w, h) == (50, 100)
+
+
+def test_thumbnail_applies_exif_orientation(tmp_path, monkeypatch):
+    """Thumbnail of an Orientation=6 image comes out portrait, not sideways (#393)."""
+    monkeypatch.setenv("THUMBNAIL_SIZE", "100")
+
+    dest = tmp_path / "thumb.jpg"
+    w, h = generate_thumbnail_from_bytes(_landscape_jpeg_tagged_portrait(), dest)
+
+    # The 100x50 landscape buffer must be rotated to portrait (taller than wide).
+    assert h > w
+    with Image.open(dest) as img:
+        assert img.height > img.width


### PR DESCRIPTION
## Summary
Fixes #393 — tall/skinny POI images (e.g. https://rootsofthevalley.org/bo-463-bridge) render sideways.

**Root cause:** the Python image-server resized images with Pillow but never applied EXIF orientation. Portrait phone photos are stored as landscape pixels + an orientation tag; `thumbnail()` + `save()` resized the landscape buffer as-is and dropped the tag, leaving the browser nothing to rotate by. Originals keep their EXIF (fine); the POI page shows the **medium thumbnail**, which didn't.

## Changes
- **image-server:** apply `ImageOps.exif_transpose` on every decode path (`generate_thumbnail`, `generate_thumbnail_from_bytes`, `generate_all_thumbnails_from_bytes`, `get_image_dimensions`) — rotation is baked into the pixels; stored dimensions now match display orientation.
- **frontend:** pad the single primary image (`.mosaic-1`) with brand green (`#2d5016`) via `object-fit: contain`, so tall/skinny images show fully instead of cropping. Multi-image grids keep `cover`.
- **tests:** assert an `Orientation=6` image is transposed to portrait (dimensions + thumbnail).

## Deploy notes (two containers)
- `image-server/**` → builds `quay.io/crunchtools/images-rotv` → service `images.rootsofthevalley.org`
- `frontend/**` → builds `quay.io/crunchtools/rotv` → service `rootsofthevalley.org`
- **Data:** after the image-server deploys, run `image-server/scripts/regenerate-thumbnails.py` in the `images.rootsofthevalley.org` container to re-orient already-uploaded images.

## Test plan
- [x] `pytest tests/test_thumbnails.py` — 6 passed (incl. 2 new orientation tests)
- [x] `./run.sh build` — container builds clean
- [ ] Post-deploy: `bo-463-bridge` primary image renders upright with green padding

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)