### PR TITLE
fix: crop primary POI image instead of padding (#393 follow-up)

### DIFF
--- a/frontend/src/components/Mosaic.css
+++ b/frontend/src/components/Mosaic.css
@@ -63,17 +63,6 @@
   display: block;
 }
 
-/* Single primary image: show the whole image and pad tall/skinny ones with
-   brand green instead of cropping or rotating them (issue #393). Multi-image
-   grids keep object-fit: cover so their tiles stay filled. */
-.mosaic-1 .mosaic-item {
-  background-color: #2d5016;
-}
-
-.mosaic-1 .mosaic-image {
-  object-fit: contain;
-}
-
 /* Video/YouTube Indicators */
 .mosaic-video-indicator,
 .mosaic-youtube-indicator {


### PR DESCRIPTION
## Summary
Follow-up to #397. The letterbox/padding on the single primary image looked worse than the cropped tooltip. This reverts the `.mosaic-1` override so the primary image uses `object-fit: cover` like all other images — consistent cropping for tall/skinny and wide/short photos alike.

The EXIF orientation fix from #397 is unaffected (images are still correctly oriented; they're now just cropped to fill rather than padded).

## Test plan
- [x] `./run.sh build` — clean
- [ ] Post-deploy: bo-463-bridge primary image is cropped (no green bars), upright

🤖 Generated with [Claude Code](https://claude.com/claude-code)