### PR TITLE
feat: widen news collection breadth + tidy Data Collection settings

### DIFF
--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -265,7 +265,7 @@ function shortestUrlDedup(urls) {
   return [...byUrl.keys()];
 }
 
-async function classifyPage(pool, markdown, links, url, contentType, sheets, trustedEventPaths = []) {
+async function classifyPage(pool, markdown, links, url, contentType, sheets, trustedEventPaths = [], poiName = '') {
   let sourceOrigin;
   try { sourceOrigin = new URL(url).pathname; } catch { sourceOrigin = ''; }
   const contentLinks = (links || []).filter(l => {
@@ -309,13 +309,16 @@ async function classifyPage(pool, markdown, links, url, contentType, sheets, tru
   const otherLinks = dedup(links.filter(l => !seen.has(l.url)).filter(notSelfRef));
   const rankedLinks = [...filteredContentLinks, ...otherLinks].slice(0, 30);
 
-  const prompt = `Classify this web page. Based on the content, is it:
+  const detailDesc = contentType === 'news'
+    ? `a single news item — an article, announcement, or press release about ${poiName || 'this place'} or the surrounding area`
+    : `a single ${contentType} with dates/descriptions/details`;
+  const prompt = `Classify this web page${poiName ? ` about "${poiName}"` : ''}. Based on the content, is it:
 A) LISTING — lists multiple ${contentType}s with links to individual pages
-B) DETAIL — describes a single ${contentType} with dates/descriptions/details
+B) DETAIL — ${detailDesc}
 C) NEITHER — not a ${contentType} page at all (e.g., about page, contact form, login, navigation, store/shop, generic info)
 
 PAGE URL: ${url}
-CONTENT (first 3000 chars):
+CONTENT (first 5000 chars):
 ${markdown.substring(0, 5000)}
 
 Return ONLY valid JSON:
@@ -705,7 +708,7 @@ async function crawlPage(pool, startUrl, contentType, poi, sheets, checkCancella
         }
       } else {
         updateProgress(poi.id, { phase: 'classify', message: url });
-        classification = await classifyPage(pool, extracted.markdown, extracted.links || [], url, contentType, sheets, trustedEventPaths);
+        classification = await classifyPage(pool, extracted.markdown, extracted.links || [], url, contentType, sheets, trustedEventPaths, poi?.name || '');
         logInfo(jobId, jobType, poi.id, poi.name, `${phase}: [Classify] ${url} → ${classification.pageType} (${classification.reasoning})`);
         await setCachePageType(pool, url, classification.pageType);
       }
@@ -961,13 +964,14 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
             } catch { return false; }
           });
 
-          const urlsToProcessRaw = externalUrls.slice(0, MAX_SEARCH_URLS);
-          if (externalUrls.length > MAX_SEARCH_URLS) {
-            logInfo(jobId, jobType, poi.id, poi.name, `Phase II: Capped at ${MAX_SEARCH_URLS} URLs (${externalUrls.length} external of ${serperResult.urls.length} total)`);
-          }
-
-          const urlsToProcess = await filterKnownPages(pool, urlsToProcessRaw, 'news',
+          /* Filter already-collected URLs BEFORE the cap so the crawl budget is
+             spent on fresh URLs, not consumed by ones we have already processed. */
+          const freshUrls = await filterKnownPages(pool, externalUrls, 'news',
             { jobId, jobType, poiId: poi.id, poiName: poi.name, phase: 'Phase II' });
+          const urlsToProcess = freshUrls.slice(0, MAX_SEARCH_URLS);
+          if (freshUrls.length > MAX_SEARCH_URLS) {
+            logInfo(jobId, jobType, poi.id, poi.name, `Phase II: Capped at ${MAX_SEARCH_URLS} URLs (${freshUrls.length} fresh of ${serperResult.urls.length} total)`);
+          }
 
           let renderedCount = 0;
           let phase2PagesCollected = 0;
@@ -996,6 +1000,34 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
               const items = await processPage(pool, page, poi, 'news', { phase: 'Phase II', jobId, jobType: 'collectionPhaseTwo', timezone });
               pageItems.push(...(items.news || []));
               phase2PagesCollected++;
+            }
+
+            /* Recovery: if a dated search result yielded no item (e.g. the page blocked
+               rendering or returned no content), keep the article using the search
+               snippet so it still reaches moderation instead of being lost. */
+            if (pageItems.length === 0 && urlData.date && urlData.title && urlData.snippet) {
+              const snippetText = `${urlData.title}\n${urlData.snippet}`;
+              const llmVotes = await runLlmDateVotes(pool, snippetText.substring(0, 2000));
+              const consensus = await scoreDate(pool, {
+                title: urlData.title, description: urlData.snippet, pageContent: snippetText,
+                sources: { jsonLd: [], meta: [urlData.date], timeTags: [], url: extractUrlDate(urlData.url) },
+                timezone, llmVotes
+              });
+              let sourceName;
+              try { sourceName = new URL(urlData.url).hostname.replace(/^www\./, ''); } catch { sourceName = 'External source'; }
+              pageItems.push({
+                title: urlData.title,
+                summary: urlData.snippet,
+                source_name: sourceName,
+                news_type: 'general',
+                published_date: consensus.date,
+                date_consensus_score: consensus.score,
+                date_signals: consensus.rawSignals,
+                source_url: urlData.url,
+                rendered_content: urlData.snippet,
+                image_url: null
+              });
+              logInfo(jobId, jobType, poi.id, poi.name, `Phase II: [Snippet] Recovered dated search result (render produced no item): ${urlData.url}`);
             }
             return pageItems;
           }), pageConcurrency, pageDelayMs);

--- a/backend/services/serperService.js
+++ b/backend/services/serperService.js
@@ -52,11 +52,11 @@ export async function searchNewsUrls(pool, poi, { contentType = 'news' } = {}) {
   const prefix = contentType === 'events' ? 'Upcoming events' : 'Latest news';
 
   const maxResultsRow = await pool.query(
-    "SELECT value FROM admin_settings WHERE key = 'serper_max_results'"
+    "SELECT value FROM admin_settings WHERE key = 'max_search_urls'"
   );
   const maxResults = maxResultsRow.rows.length
-    ? Math.min(10, Math.max(1, parseInt(maxResultsRow.rows[0].value, 10) || 3))
-    : 3;
+    ? Math.min(20, Math.max(1, parseInt(maxResultsRow.rows[0].value, 10) || 10))
+    : 10;
 
   const boundaries = await getContainingBoundaries(pool, poi.id);
 
@@ -68,32 +68,48 @@ export async function searchNewsUrls(pool, poi, { contentType = 'news' } = {}) {
       ? `${prefix} for ${poi.name} in ${context}`
       : `${prefix} for ${poi.name}`;
 
-  console.log(`[Serper] Query: "${query}" (grounded: ${!!context})`);
+  /* News pulls from both Google web search and Google News and merges the two;
+     events use web search only. */
+  const endpoints = contentType === 'events' ? ['search'] : ['search', 'news'];
+  console.log(`[Serper] Query: "${query}" (grounded: ${!!context}, endpoints: ${endpoints.join('+')})`);
 
-  const response = await fetch('https://google.serper.dev/search', {
-    method: 'POST',
-    headers: {
-      'X-API-KEY': apiKey,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ q: query, num: maxResults })
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Serper API error: ${response.status} - ${errorText}`);
-  }
-
-  const searchResults = await response.json();
-
-  const urls = (searchResults.organic || []).map(r => ({
-    url: r.link,
-    title: r.title,
-    snippet: r.snippet,
-    date: r.date || null
+  const perEndpoint = await Promise.all(endpoints.map(async endpoint => {
+    const response = await fetch(`https://google.serper.dev/${endpoint}`, {
+      method: 'POST',
+      headers: {
+        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ q: query, num: maxResults })
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Serper API error (${endpoint}): ${response.status} - ${errorText}`);
+    }
+    const searchResults = await response.json();
+    const rawResults = endpoint === 'news' ? (searchResults.news || []) : (searchResults.organic || []);
+    return {
+      items: rawResults.map(r => ({ url: r.link, title: r.title, snippet: r.snippet, date: r.date || null })),
+      credits: searchResults.credits || 1
+    };
   }));
 
-  console.log(`[Serper] Found ${urls.length} external ${contentType} URLs (${urls.filter(u => u.date).length} with dates)`);
+  const seen = new Set();
+  const urls = [];
+  let credits = 0;
+  for (const { items, credits: endpointCredits } of perEndpoint) {
+    credits += endpointCredits;
+    for (const item of items) {
+      let key;
+      try { const u = new URL(item.url); key = (u.origin + u.pathname).toLowerCase().replace(/\/+$/, ''); }
+      catch { key = (item.url || '').toLowerCase().replace(/\/+$/, ''); }
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      urls.push(item);
+    }
+  }
+
+  console.log(`[Serper] Found ${urls.length} external ${contentType} URLs (${urls.filter(u => u.date).length} with dates) from ${endpoints.join('+')}`);
 
   return {
     query,
@@ -101,7 +117,7 @@ export async function searchNewsUrls(pool, poi, { contentType = 'news' } = {}) {
     groundingContext: context,
     boundaries,
     urls,
-    credits: searchResults.credits || 1
+    credits: credits || 1
   };
 }
 

--- a/backend/tests/serperService.unit.test.js
+++ b/backend/tests/serperService.unit.test.js
@@ -8,6 +8,10 @@ import { searchNewsUrls, testSerperApiKey } from '../services/serperService.js';
 import fetch from 'node-fetch';
 
 describe('Serper Service', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+  });
+
   describe('searchNewsUrls', () => {
     const mockPoi = {
       id: 123,
@@ -17,7 +21,7 @@ describe('Serper Service', () => {
       poi_roles: ['trail']
     };
 
-    it('should construct grounded query with single boundary', async () => {
+    it('should merge web search and news results for a grounded news query', async () => {
       const mockPool = {
         query: vi.fn()
           .mockResolvedValueOnce({
@@ -29,16 +33,21 @@ describe('Serper Service', () => {
           })
       };
 
-      fetch.mockResolvedValue({
+      fetch.mockImplementation((url) => Promise.resolve({
         ok: true,
-        json: async () => ({
-          organic: [
-            { link: 'https://example.com/news1', title: 'News 1', snippet: 'Snippet 1', date: '2026-04-01' },
-            { link: 'https://example.com/news2', title: 'News 2', snippet: 'Snippet 2' }
-          ],
-          credits: 1
-        })
-      });
+        json: async () => url.endsWith('/news')
+          ? {
+              news: [{ link: 'https://example.com/news3', title: 'News 3', snippet: 'Snippet 3', date: '2026-04-02' }],
+              credits: 1
+            }
+          : {
+              organic: [
+                { link: 'https://example.com/news1', title: 'News 1', snippet: 'Snippet 1', date: '2026-04-01' },
+                { link: 'https://example.com/news2', title: 'News 2', snippet: 'Snippet 2' }
+              ],
+              credits: 1
+            }
+      }));
 
       const result = await searchNewsUrls(mockPool, mockPoi);
 
@@ -46,12 +55,18 @@ describe('Serper Service', () => {
       expect(result.grounded).toBe(true);
       expect(result.groundingContext).toBe('Cuyahoga Valley National Park');
       expect(result.boundaries).toEqual(['Cuyahoga Valley National Park']);
-      expect(result.urls).toHaveLength(2);
-      expect(result.urls[0].url).toBe('https://example.com/news1');
+      expect(result.urls).toHaveLength(3);
+      expect(result.urls.map(u => u.url)).toEqual([
+        'https://example.com/news1',
+        'https://example.com/news2',
+        'https://example.com/news3'
+      ]);
       expect(result.urls[0].date).toBe('2026-04-01');
       expect(result.urls[1].date).toBeNull();
-      expect(result.credits).toBe(1);
+      expect(result.urls[2].date).toBe('2026-04-02');
+      expect(result.credits).toBe(2);
 
+      expect(fetch).toHaveBeenCalledTimes(2);
       expect(fetch).toHaveBeenCalledWith(
         'https://google.serper.dev/search',
         expect.objectContaining({
@@ -60,9 +75,34 @@ describe('Serper Service', () => {
             'X-API-KEY': 'test-api-key-123',
             'Content-Type': 'application/json'
           }),
-          body: JSON.stringify({ q: 'Latest news for Ledges Trail in Cuyahoga Valley National Park', num: 3 })
+          body: JSON.stringify({ q: 'Latest news for Ledges Trail in Cuyahoga Valley National Park', num: 10 })
         })
       );
+      expect(fetch).toHaveBeenCalledWith(
+        'https://google.serper.dev/news',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should dedupe a URL returned by both endpoints', async () => {
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({ rows: [{ value: 'test-api-key-123' }] })
+          .mockResolvedValueOnce({ rows: [] })
+          .mockResolvedValueOnce({ rows: [{ name: 'Cuyahoga Valley National Park' }] })
+      };
+
+      fetch.mockImplementation((url) => Promise.resolve({
+        ok: true,
+        json: async () => url.endsWith('/news')
+          ? { news: [{ link: 'https://example.com/shared/?utm=x', title: 'Shared', snippet: 'S', date: '2026-04-02' }], credits: 1 }
+          : { organic: [{ link: 'https://example.com/shared', title: 'Shared', snippet: 'S' }], credits: 1 }
+      }));
+
+      const result = await searchNewsUrls(mockPool, mockPoi);
+
+      expect(result.urls).toHaveLength(1);
+      expect(result.urls[0].url).toBe('https://example.com/shared');
     });
 
     it('should construct multi-boundary grounded query (smallest area first)', async () => {
@@ -122,7 +162,7 @@ describe('Serper Service', () => {
       expect(result.query).toBe('Upcoming events at Ledges Trail (Cuyahoga Valley National Park)');
     });
 
-    it('should include num: 3 in Serper API call body', async () => {
+    it('should use max_search_urls (default 10) for the Serper num', async () => {
       const mockPool = {
         query: vi.fn()
           .mockResolvedValueOnce({ rows: [{ value: 'test-api-key-123' }] })
@@ -137,7 +177,25 @@ describe('Serper Service', () => {
       await searchNewsUrls(mockPool, mockPoi);
 
       const callBody = JSON.parse(fetch.mock.calls[0][1].body);
-      expect(callBody.num).toBe(3);
+      expect(callBody.num).toBe(10);
+    });
+
+    it('should honor a configured max_search_urls value for the Serper num', async () => {
+      const mockPool = {
+        query: vi.fn()
+          .mockResolvedValueOnce({ rows: [{ value: 'test-api-key-123' }] })
+          .mockResolvedValueOnce({ rows: [{ value: '5' }] })
+      };
+
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ organic: [], credits: 1 })
+      });
+
+      await searchNewsUrls(mockPool, mockPoi);
+
+      const callBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(callBody.num).toBe(5);
     });
 
     it('should construct ungrounded query when POI is outside boundaries', async () => {
@@ -214,7 +272,7 @@ describe('Serper Service', () => {
       });
 
       await expect(searchNewsUrls(mockPool, mockPoi)).rejects.toThrow(
-        'Serper API error: 401'
+        'Serper API error (search): 401'
       );
     });
 
@@ -236,7 +294,7 @@ describe('Serper Service', () => {
       const result = await searchNewsUrls(mockPool, mockPoi);
 
       expect(result.urls).toHaveLength(0);
-      expect(result.credits).toBe(1);
+      expect(result.credits).toBe(2);
     });
   });
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5588,7 +5588,6 @@ body {
 
 /* AI Provider Configuration Section */
 .ai-config-section {
-  margin-bottom: 24px;
   padding: 16px;
   background: #f8f9fa;
   border-radius: 8px;

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -67,19 +67,11 @@ function DataCollectionSettings() {
   const [selectedPoiId, setSelectedPoiId] = useState('');
 
   const [maxConcurrency, setMaxConcurrency] = useState(10);
-  const [maxConcurrencyLoading, setMaxConcurrencyLoading] = useState(true);
-  const [maxConcurrencySaving, setMaxConcurrencySaving] = useState(false);
-
   const [maxSearchUrls, setMaxSearchUrls] = useState(10);
-  const [maxSearchUrlsLoading, setMaxSearchUrlsLoading] = useState(true);
-  const [maxSearchUrlsSaving, setMaxSearchUrlsSaving] = useState(false);
-
   const [pageConcurrency, setPageConcurrency] = useState(3);
-  const [pageConcurrencyLoading, setPageConcurrencyLoading] = useState(true);
-  const [pageConcurrencySaving, setPageConcurrencySaving] = useState(false);
   const [pageDelayMs, setPageDelayMs] = useState(2000);
-  const [pageDelayMsLoading, setPageDelayMsLoading] = useState(true);
-  const [pageDelayMsSaving, setPageDelayMsSaving] = useState(false);
+  const [contentCollectionLoading, setContentCollectionLoading] = useState(true);
+  const [contentCollectionSaving, setContentCollectionSaving] = useState(false);
 
   const [subtabs, setSubtabs] = useState([]);
   const [subtabsLoading, setSubtabsLoading] = useState(true);
@@ -126,10 +118,7 @@ function DataCollectionSettings() {
     fetchModerationConfig();
     fetchDomainLists();
     fetchExcludedPois();
-    fetchMaxConcurrency();
-    fetchMaxSearchUrls();
-    fetchPageConcurrency();
-    fetchPageDelayMs();
+    fetchContentCollection();
     fetchSubtabs();
   }, []);
 
@@ -565,104 +554,43 @@ function DataCollectionSettings() {
     setExcludedPois(excludedPois.filter(p => p.id !== id));
   };
 
-  const fetchMaxConcurrency = async () => {
+  const fetchContentCollection = async () => {
     try {
       const response = await fetch('/api/admin/settings', { credentials: 'include' });
       if (response.ok) {
         const settings = await response.json();
-        const val = parseInt(settings.max_concurrency?.value, 10);
-        setMaxConcurrency(Number.isFinite(val) && val >= 1 ? val : 10);
+        const concurrency = parseInt(settings.max_concurrency?.value, 10);
+        const searchUrls = parseInt(settings.max_search_urls?.value, 10);
+        const pageConc = parseInt(settings.page_concurrency?.value, 10);
+        const delay = parseInt(settings.page_delay_ms?.value, 10);
+        setMaxConcurrency(Number.isFinite(concurrency) && concurrency >= 1 ? concurrency : 10);
+        setMaxSearchUrls(Number.isFinite(searchUrls) && searchUrls >= 1 ? searchUrls : 10);
+        setPageConcurrency(Number.isFinite(pageConc) && pageConc >= 1 ? pageConc : 3);
+        setPageDelayMs(Number.isFinite(delay) && delay >= 0 ? delay : 2000);
       }
-    } catch (err) { console.error('Error fetching max concurrency:', err); }
-    finally { setMaxConcurrencyLoading(false); }
+    } catch (err) { console.error('Error fetching content collection settings:', err); }
+    finally { setContentCollectionLoading(false); }
   };
 
-  const handleSaveMaxConcurrency = async () => {
-    setMaxConcurrencySaving(true); setResult(null);
+  const handleSaveContentCollection = async () => {
+    setContentCollectionSaving(true); setResult(null);
     try {
-      const response = await fetch('/api/admin/settings/max_concurrency', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: String(maxConcurrency) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Max concurrency saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save max concurrency: ${err.message}` }); }
-    finally { setMaxConcurrencySaving(false); }
-  };
-
-  const fetchMaxSearchUrls = async () => {
-    try {
-      const response = await fetch('/api/admin/settings', { credentials: 'include' });
-      if (response.ok) {
-        const settings = await response.json();
-        const val = parseInt(settings.max_search_urls?.value, 10);
-        setMaxSearchUrls(Number.isFinite(val) && val >= 1 ? val : 10);
+      const updates = [
+        ['max_concurrency', maxConcurrency],
+        ['max_search_urls', maxSearchUrls],
+        ['page_concurrency', pageConcurrency],
+        ['page_delay_ms', pageDelayMs]
+      ];
+      for (const [key, value] of updates) {
+        const response = await fetch(`/api/admin/settings/${key}`, {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+          body: JSON.stringify({ value: String(value) })
+        });
+        if (!response.ok) { const err = await response.json(); throw new Error(err.error || `Failed to save ${key}`); }
       }
-    } catch (err) { console.error('Error fetching max Serper URLs:', err); }
-    finally { setMaxSearchUrlsLoading(false); }
-  };
-
-  const handleSaveMaxSearchUrls = async () => {
-    setMaxSearchUrlsSaving(true); setResult(null);
-    try {
-      const response = await fetch('/api/admin/settings/max_search_urls', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: String(maxSearchUrls) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Max Serper URLs saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save max Serper URLs: ${err.message}` }); }
-    finally { setMaxSearchUrlsSaving(false); }
-  };
-
-  const fetchPageConcurrency = async () => {
-    try {
-      const response = await fetch('/api/admin/settings', { credentials: 'include' });
-      if (response.ok) {
-        const settings = await response.json();
-        const val = parseInt(settings.page_concurrency?.value, 10);
-        setPageConcurrency(Number.isFinite(val) && val >= 1 ? val : 3);
-      }
-    } catch (err) { console.error('Error fetching page concurrency:', err); }
-    finally { setPageConcurrencyLoading(false); }
-  };
-
-  const handleSavePageConcurrency = async () => {
-    setPageConcurrencySaving(true); setResult(null);
-    try {
-      const response = await fetch('/api/admin/settings/page_concurrency', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: String(pageConcurrency) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Page concurrency saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save page concurrency: ${err.message}` }); }
-    finally { setPageConcurrencySaving(false); }
-  };
-
-  const fetchPageDelayMs = async () => {
-    try {
-      const response = await fetch('/api/admin/settings', { credentials: 'include' });
-      if (response.ok) {
-        const settings = await response.json();
-        const val = parseInt(settings.page_delay_ms?.value, 10);
-        setPageDelayMs(Number.isFinite(val) && val >= 0 ? val : 2000);
-      }
-    } catch (err) { console.error('Error fetching page delay:', err); }
-    finally { setPageDelayMsLoading(false); }
-  };
-
-  const handleSavePageDelayMs = async () => {
-    setPageDelayMsSaving(true); setResult(null);
-    try {
-      const response = await fetch('/api/admin/settings/page_delay_ms', {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-        body: JSON.stringify({ value: String(pageDelayMs) })
-      });
-      if (!response.ok) { const err = await response.json(); throw new Error(err.error || 'Failed to save'); }
-      setResult({ type: 'success', message: 'Page delay saved' });
-    } catch (err) { setResult({ type: 'error', message: `Failed to save page delay: ${err.message}` }); }
-    finally { setPageDelayMsSaving(false); }
+      setResult({ type: 'success', message: 'Content collection settings saved' });
+    } catch (err) { setResult({ type: 'error', message: `Failed to save content collection settings: ${err.message}` }); }
+    finally { setContentCollectionSaving(false); }
   };
 
   const handleTestPlaywright = async () => {
@@ -925,66 +853,79 @@ function DataCollectionSettings() {
       </div>
 
 
-      <div className="ai-config-section">
-        <h4>Twitter/X Credentials</h4>
-        <p className="settings-description">Login credentials for scraping Twitter content (used for Trail Status).</p>
-        {twitterLoading ? <p>Loading credentials...</p> : (
-          <>
-            <div style={{ marginTop: '0.5rem' }}>
-              <h5 style={{ marginBottom: '0.5rem' }}>Authentication Status</h5>
-              <p className="settings-description" style={{ fontSize: '0.85rem', marginBottom: '1rem' }}>
-                Twitter authentication uses browser cookies. Log in to Twitter in your browser, then export cookies below. Cookies last 30-90 days.
-              </p>
-              {twitterAuthStatus && (
-                <div className="config-row" style={{ marginBottom: '1rem' }}>
-                  <label>Status:</label>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                    {twitterAuthStatus.authenticated ? (
-                      <>
-                        <span style={{ color: '#4caf50', fontWeight: 'bold' }}>Authenticated</span>
-                        <span style={{ fontSize: '0.85rem', color: '#666' }}>Expires: {new Date(twitterAuthStatus.expires).toLocaleDateString()}</span>
-                      </>
-                    ) : (
-                      <span style={{ color: '#f44336', fontWeight: 'bold' }}>Not Authenticated</span>
-                    )}
+      <div className="playwright-status-section" style={{ padding: '1rem', backgroundColor: '#f8f9fa', borderRadius: '8px', border: '1px solid #e9ecef' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+          <h4 style={{ margin: 0, fontSize: '1rem' }}>Browser Rendering (Playwright)</h4>
+          <button className="action-btn secondary" onClick={handleTestPlaywright} disabled={playwrightLoading || playwrightTesting}
+            style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}>
+            {playwrightTesting ? 'Testing...' : 'Test'}
+          </button>
+        </div>
+        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.75rem' }}>Required for Twitter/X status pages and JavaScript-heavy websites.</p>
+        {playwrightLoading ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span className="pulse" style={{ display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%', backgroundColor: '#ffc107' }}></span>
+            <span style={{ fontSize: '0.9rem' }}>Checking Playwright status...</span>
+          </div>
+        ) : playwrightStatus ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+            {playwrightStatus.status === 'working' ? (
+              <>
+                <span style={{ color: '#28a745', fontWeight: 'bold', fontSize: '0.95rem' }}>Working</span>
+                <span style={{ fontSize: '0.85rem', color: '#666' }}>Chromium {playwrightStatus.browser_version} - Launch: {playwrightStatus.launch_time_ms}ms</span>
+              </>
+            ) : (
+              <>
+                <span style={{ color: '#dc3545', fontWeight: 'bold', fontSize: '0.95rem' }}>Not Working</span>
+                <span style={{ fontSize: '0.85rem', color: '#666' }}>{playwrightStatus.message}</span>
+                {playwrightStatus.suggestion && (
+                  <div style={{ width: '100%', marginTop: '0.5rem', padding: '0.5rem', backgroundColor: '#fff3cd', borderRadius: '4px', fontSize: '0.85rem' }}>
+                    <strong>Fix:</strong> {playwrightStatus.suggestion}
                   </div>
-                </div>
-              )}
-              {twitterAuthStatus && twitterAuthStatus.cookies_possibly_stale && (
-                <div style={{ padding: '0.75rem', backgroundColor: '#fff3cd', border: '1px solid #ffc107', borderRadius: '4px', marginBottom: '1rem', fontSize: '0.85rem' }}>
-                  <strong>Cookies may be stale.</strong> Trail status collection has failed {twitterAuthStatus.consecutive_failures} times in a row.
-                </div>
-              )}
-            </div>
-            <div style={{ display: 'flex', gap: '10px', marginTop: '0.5rem' }}>
-              <button className="action-btn primary" onClick={handleTwitterLogin} disabled={twitterAuthLoading}>Login to Twitter</button>
-              {twitterAuthStatus && twitterAuthStatus.authenticated && (
-                <button className="action-btn secondary" onClick={handleTestTwitterAuth} disabled={twitterAuthTesting}>
-                  {twitterAuthTesting ? 'Testing...' : 'Test Authentication'}
-                </button>
-              )}
-            </div>
-            {showCookieInput && (
-              <div style={{ marginTop: '1.5rem', padding: '1rem', backgroundColor: '#f9f9f9', borderRadius: '4px' }}>
-                <h5 style={{ marginBottom: '0.5rem', fontSize: '0.95rem' }}>Export Cookies from Browser</h5>
-                <ol style={{ fontSize: '0.85rem', marginBottom: '1rem', paddingLeft: '1.5rem' }}>
-                  <li>Install browser extension: <a href="https://chrome.google.com/webstore/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm" target="_blank" rel="noopener noreferrer">Cookie-Editor for Chrome</a> or <a href="https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/" target="_blank" rel="noopener noreferrer">Firefox</a></li>
-                  <li>Log in to Twitter in the opened tab</li>
-                  <li>Click the Cookie-Editor extension icon</li>
-                  <li>Click &quot;Export&quot; &gt; &quot;JSON&quot; format</li>
-                  <li>Paste the JSON below</li>
-                </ol>
-                <textarea value={twitterCookiesJson} onChange={e => setTwitterCookiesJson(e.target.value)}
-                  placeholder='Paste cookies JSON here...' rows="6"
-                  style={{ width: '100%', fontFamily: 'monospace', fontSize: '0.8rem', padding: '0.75rem', border: '1px solid #ccc', borderRadius: '4px', marginBottom: '1rem' }} />
-                <div style={{ display: 'flex', gap: '10px' }}>
-                  <button className="action-btn primary" onClick={handleSaveCookies} disabled={twitterAuthLoading || !twitterCookiesJson.trim()}>
-                    {twitterAuthLoading ? 'Saving...' : 'Save Cookies'}
-                  </button>
-                  <button className="action-btn secondary" onClick={() => { setShowCookieInput(false); setTwitterCookiesJson(''); }}>Cancel</button>
-                </div>
-              </div>
+                )}
+              </>
             )}
+          </div>
+        ) : <span style={{ color: '#6c757d', fontSize: '0.9rem' }}>Status unknown</span>}
+      </div>
+
+
+      <div className="ai-config-section">
+        <h4>Content Collection</h4>
+        <p className="settings-description">Tune how aggressively collection jobs crawl. These apply to every news and events run.</p>
+        {contentCollectionLoading ? <p>Loading...</p> : (
+          <>
+            <div className="config-row">
+              <label>Places collected at once</label>
+              <input type="number" min="1" max="50" value={maxConcurrency}
+                onChange={e => setMaxConcurrency(Math.max(1, Math.min(50, parseInt(e.target.value, 10) || 1)))}
+                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }} disabled={contentCollectionSaving} />
+              <span className="config-hint">How many places are collected in parallel. Higher finishes faster but uses more memory. (1–50, default 10)</span>
+            </div>
+            <div className="config-row">
+              <label>Search results per place</label>
+              <input type="number" min="1" max="20" value={maxSearchUrls}
+                onChange={e => setMaxSearchUrls(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
+                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }} disabled={contentCollectionSaving} />
+              <span className="config-hint">How many web and news search results to gather and crawl per place when looking beyond its own pages. (1–20, default 10)</span>
+            </div>
+            <div className="config-row">
+              <label>Pages processed at once</label>
+              <input type="number" min="1" max="20" value={pageConcurrency}
+                onChange={e => setPageConcurrency(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
+                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }} disabled={contentCollectionSaving} />
+              <span className="config-hint">How many pages are processed in parallel within a single place. Lower eases memory pressure. (1–20, default 3)</span>
+            </div>
+            <div className="config-row">
+              <label>Delay between pages (ms)</label>
+              <input type="number" min="0" max="10000" step="100" value={pageDelayMs}
+                onChange={e => setPageDelayMs(Math.max(0, Math.min(10000, parseInt(e.target.value, 10) || 0)))}
+                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }} disabled={contentCollectionSaving} />
+              <span className="config-hint">Pause between dispatching each page, to avoid rate-limiting and browser contention. (0–10000, default 2000)</span>
+            </div>
+            <button className="action-btn primary" onClick={handleSaveContentCollection} disabled={contentCollectionSaving}>
+              {contentCollectionSaving ? 'Saving...' : 'Save'}
+            </button>
           </>
         )}
       </div>
@@ -1124,147 +1065,6 @@ function DataCollectionSettings() {
 
 
       <div className="ai-config-section">
-        <h4>MAX_CONCURRENCY — Collection Concurrency</h4>
-        <p className="settings-description">How many POIs run concurrently during a collection job (news, events, or both). Each slot opens a browser context — higher values finish faster but use more memory. Range: 1–50, default: 10.</p>
-        {maxConcurrencyLoading ? <p>Loading...</p> : (
-          <>
-            <div className="config-row">
-              <label>MAX_CONCURRENCY</label>
-              <input
-                type="number"
-                min="1"
-                max="50"
-                value={maxConcurrency}
-                onChange={e => setMaxConcurrency(Math.max(1, Math.min(50, parseInt(e.target.value, 10) || 1)))}
-                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
-                disabled={maxConcurrencySaving}
-              />
-              <span className="config-hint">Range: 1–50 (default: 10)</span>
-            </div>
-            <button className="action-btn primary" onClick={handleSaveMaxConcurrency} disabled={maxConcurrencySaving}>
-              {maxConcurrencySaving ? 'Saving...' : 'Save'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="ai-config-section">
-        <h4>MAX_SEARCH_URLS — Phase II URL Crawl Limit</h4>
-        <p className="settings-description">How many Serper search result URLs are crawled per POI during Phase II (runs for all collection types). Serper returns up to 10 results; raise this only if you have a paid Serper plan. Range: 1–20, default: 10.</p>
-        {maxSearchUrlsLoading ? <p>Loading...</p> : (
-          <>
-            <div className="config-row">
-              <label>MAX_SEARCH_URLS</label>
-              <input
-                type="number"
-                min="1"
-                max="20"
-                value={maxSearchUrls}
-                onChange={e => setMaxSearchUrls(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
-                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
-                disabled={maxSearchUrlsSaving}
-              />
-              <span className="config-hint">Range: 1–20 (default: 10)</span>
-            </div>
-            <button className="action-btn primary" onClick={handleSaveMaxSearchUrls} disabled={maxSearchUrlsSaving}>
-              {maxSearchUrlsSaving ? 'Saving...' : 'Save'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="ai-config-section">
-        <h4>PAGE_CONCURRENCY — Per-POI Page Processing</h4>
-        <p className="settings-description">How many detail pages are processed concurrently within a single POI crawl (dates + summarize). Lower values reduce browser memory pressure. Range: 1–20, default: 3.</p>
-        {pageConcurrencyLoading ? <p>Loading...</p> : (
-          <>
-            <div className="config-row">
-              <label>PAGE_CONCURRENCY</label>
-              <input
-                type="number"
-                min="1"
-                max="20"
-                value={pageConcurrency}
-                onChange={e => setPageConcurrency(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1)))}
-                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
-                disabled={pageConcurrencySaving}
-              />
-              <span className="config-hint">Range: 1–20 (default: 3)</span>
-            </div>
-            <button className="action-btn primary" onClick={handleSavePageConcurrency} disabled={pageConcurrencySaving}>
-              {pageConcurrencySaving ? 'Saving...' : 'Save'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="ai-config-section">
-        <h4>PAGE_DELAY_MS — Stagger Between Pages</h4>
-        <p className="settings-description">Milliseconds to wait between dispatching each page for processing. Prevents rate-limiting from external sites and reduces browser contention. Range: 0–10000, default: 2000.</p>
-        {pageDelayMsLoading ? <p>Loading...</p> : (
-          <>
-            <div className="config-row">
-              <label>PAGE_DELAY_MS</label>
-              <input
-                type="number"
-                min="0"
-                max="10000"
-                step="100"
-                value={pageDelayMs}
-                onChange={e => setPageDelayMs(Math.max(0, Math.min(10000, parseInt(e.target.value, 10) || 0)))}
-                style={{ width: '80px', padding: '0.4rem', fontSize: '0.95rem' }}
-                disabled={pageDelayMsSaving}
-              />
-              <span className="config-hint">Range: 0–10000ms (default: 2000)</span>
-            </div>
-            <button className="action-btn primary" onClick={handleSavePageDelayMs} disabled={pageDelayMsSaving}>
-              {pageDelayMsSaving ? 'Saving...' : 'Save'}
-            </button>
-          </>
-        )}
-      </div>
-
-
-      <div className="playwright-status-section" style={{ marginTop: '2rem', padding: '1rem', backgroundColor: '#f8f9fa', borderRadius: '8px', border: '1px solid #e9ecef' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
-          <h4 style={{ margin: 0, fontSize: '1rem' }}>Browser Rendering (Playwright)</h4>
-          <button className="action-btn secondary" onClick={handleTestPlaywright} disabled={playwrightLoading || playwrightTesting}
-            style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}>
-            {playwrightTesting ? 'Testing...' : 'Test'}
-          </button>
-        </div>
-        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.75rem' }}>Required for Twitter/X status pages and JavaScript-heavy websites.</p>
-        {playwrightLoading ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <span className="pulse" style={{ display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%', backgroundColor: '#ffc107' }}></span>
-            <span style={{ fontSize: '0.9rem' }}>Checking Playwright status...</span>
-          </div>
-        ) : playwrightStatus ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-            {playwrightStatus.status === 'working' ? (
-              <>
-                <span style={{ color: '#28a745', fontWeight: 'bold', fontSize: '0.95rem' }}>Working</span>
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>Chromium {playwrightStatus.browser_version} - Launch: {playwrightStatus.launch_time_ms}ms</span>
-              </>
-            ) : (
-              <>
-                <span style={{ color: '#dc3545', fontWeight: 'bold', fontSize: '0.95rem' }}>Not Working</span>
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>{playwrightStatus.message}</span>
-                {playwrightStatus.suggestion && (
-                  <div style={{ width: '100%', marginTop: '0.5rem', padding: '0.5rem', backgroundColor: '#fff3cd', borderRadius: '4px', fontSize: '0.85rem' }}>
-                    <strong>Fix:</strong> {playwrightStatus.suggestion}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        ) : <span style={{ color: '#6c757d', fontSize: '0.9rem' }}>Status unknown</span>}
-      </div>
-
-      <div className="ai-config-section">
         <h4>Results Sub-tabs</h4>
         <p className="settings-description">Configure which sub-tabs appear in the public Results tab.</p>
         {subtabsLoading ? <p>Loading sub-tabs...</p> : (
@@ -1350,6 +1150,71 @@ function DataCollectionSettings() {
                 {subtabsSaving ? 'Saving...' : 'Save Sub-tab Configuration'}
               </button>
             </div>
+          </>
+        )}
+      </div>
+
+
+      <div className="ai-config-section">
+        <h4>Twitter/X Credentials</h4>
+        <p className="settings-description">Login credentials for scraping Twitter content (used for Trail Status).</p>
+        {twitterLoading ? <p>Loading credentials...</p> : (
+          <>
+            <div style={{ marginTop: '0.5rem' }}>
+              <h5 style={{ marginBottom: '0.5rem' }}>Authentication Status</h5>
+              <p className="settings-description" style={{ fontSize: '0.85rem', marginBottom: '1rem' }}>
+                Twitter authentication uses browser cookies. Log in to Twitter in your browser, then export cookies below. Cookies last 30-90 days.
+              </p>
+              {twitterAuthStatus && (
+                <div className="config-row" style={{ marginBottom: '1rem' }}>
+                  <label>Status:</label>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                    {twitterAuthStatus.authenticated ? (
+                      <>
+                        <span style={{ color: '#4caf50', fontWeight: 'bold' }}>Authenticated</span>
+                        <span style={{ fontSize: '0.85rem', color: '#666' }}>Expires: {new Date(twitterAuthStatus.expires).toLocaleDateString()}</span>
+                      </>
+                    ) : (
+                      <span style={{ color: '#f44336', fontWeight: 'bold' }}>Not Authenticated</span>
+                    )}
+                  </div>
+                </div>
+              )}
+              {twitterAuthStatus && twitterAuthStatus.cookies_possibly_stale && (
+                <div style={{ padding: '0.75rem', backgroundColor: '#fff3cd', border: '1px solid #ffc107', borderRadius: '4px', marginBottom: '1rem', fontSize: '0.85rem' }}>
+                  <strong>Cookies may be stale.</strong> Trail status collection has failed {twitterAuthStatus.consecutive_failures} times in a row.
+                </div>
+              )}
+            </div>
+            <div style={{ display: 'flex', gap: '10px', marginTop: '0.5rem' }}>
+              <button className="action-btn primary" onClick={handleTwitterLogin} disabled={twitterAuthLoading}>Login to Twitter</button>
+              {twitterAuthStatus && twitterAuthStatus.authenticated && (
+                <button className="action-btn secondary" onClick={handleTestTwitterAuth} disabled={twitterAuthTesting}>
+                  {twitterAuthTesting ? 'Testing...' : 'Test Authentication'}
+                </button>
+              )}
+            </div>
+            {showCookieInput && (
+              <div style={{ marginTop: '1.5rem', padding: '1rem', backgroundColor: '#f9f9f9', borderRadius: '4px' }}>
+                <h5 style={{ marginBottom: '0.5rem', fontSize: '0.95rem' }}>Export Cookies from Browser</h5>
+                <ol style={{ fontSize: '0.85rem', marginBottom: '1rem', paddingLeft: '1.5rem' }}>
+                  <li>Install browser extension: <a href="https://chrome.google.com/webstore/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm" target="_blank" rel="noopener noreferrer">Cookie-Editor for Chrome</a> or <a href="https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/" target="_blank" rel="noopener noreferrer">Firefox</a></li>
+                  <li>Log in to Twitter in the opened tab</li>
+                  <li>Click the Cookie-Editor extension icon</li>
+                  <li>Click &quot;Export&quot; &gt; &quot;JSON&quot; format</li>
+                  <li>Paste the JSON below</li>
+                </ol>
+                <textarea value={twitterCookiesJson} onChange={e => setTwitterCookiesJson(e.target.value)}
+                  placeholder='Paste cookies JSON here...' rows="6"
+                  style={{ width: '100%', fontFamily: 'monospace', fontSize: '0.8rem', padding: '0.75rem', border: '1px solid #ccc', borderRadius: '4px', marginBottom: '1rem' }} />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <button className="action-btn primary" onClick={handleSaveCookies} disabled={twitterAuthLoading || !twitterCookiesJson.trim()}>
+                    {twitterAuthLoading ? 'Saving...' : 'Save Cookies'}
+                  </button>
+                  <button className="action-btn secondary" onClick={() => { setShowCookieInput(false); setTwitterCookiesJson(''); }}>Cancel</button>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
News collection was finding far less than expected — the **collection phase** gathered too little. Root causes (verified in prod 2026-05-22): Serper returned only 3 web results, render failures silently discarded Serper hits, and 98% of POIs have no `news_url` (no Phase I).

### Backend — collection breadth
- **Dual-endpoint Serper for news**: query both Google web (`/search`) and Google News (`/news`), merge + dedupe by normalized URL. Recovers the dated local-news articles a manual Google search surfaces. Events unchanged (`/search` only).
- **One knob**: Serper `num` now reads the existing `max_search_urls` setting (default 10) instead of a hidden `serper_max_results` (default 3) — removed.
- **Snippet fallback**: when a *dated* search result fails to render, keep the article from the Serper title/snippet/date so it reaches moderation instead of being dropped (the cleveland.com Parma Heights case). Gated on a date to avoid undated organic noise.
- **filterKnownPages before the cap**: crawl budget is spent on fresh URLs, not already-collected ones.
- **classifyPage**: POI context added; a news article now counts as a valid DETAIL (less over-rejection to "neither"); fixed 3000/5000 char label.

### Frontend — Data Collection sub-tab
- New **Content Collection** section consolidating the four crawl knobs with plain-English labels and a single Save button (mirrors News & Events Filters).
- Sections **alphabetized**: API Keys → Browser Rendering → Content Collection → Content Moderation → News & Events Filters → Results Sub-tabs → Twitter/X.
- **Uniform spacing**: removed the redundant per-section margin and the Browser Rendering inline `marginTop` so every gap is the container's 3rem.

## Test plan
- [x] `./run.sh build` passes
- [x] Gourmand: 0 violations
- [x] Serper unit tests updated (merge/dedupe/num); events case still passes
- [x] UI human-verified on :8081 (alphabetical, Content Collection one-Save, uniform spacing)
- [ ] Post-deploy: trigger news collection on Parma Heights (5769) + CVSR (5660); confirm ~10-20 merged Serper URLs and cleveland.com snippet recovery; compare poi_news count before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)