### PR TITLE
fix: trust Serper publisher date + queue future-dated news instead of rejecting

### DIFF
--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -158,10 +158,11 @@ export function normalizeDateSources(rawSources = {}, timezone = 'America/New_Yo
   const normList = (arr) => (arr || []).map(norm).filter(Boolean);
 
   return {
-    jsonLd:   normList(rawSources.jsonLd),
-    meta:     normList(rawSources.meta),
-    timeTags: normList(rawSources.timeTags),
-    url:      norm(rawSources.url)
+    jsonLd:    normList(rawSources.jsonLd),
+    meta:      normList(rawSources.meta),
+    timeTags:  normList(rawSources.timeTags),
+    url:       norm(rawSources.url),
+    searchDate: norm(rawSources.searchDate)
   };
 }
 
@@ -181,6 +182,7 @@ export function scoreDeterministicSources(sources = {}) {
   for (const d of (sources.meta || [])) add(d, 1, 'meta');
   for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');
   add(sources.url, 1, 'url');
+  add(sources.searchDate, 3, 'search-date');
 
   return { scores, sourceMap };
 }

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -375,8 +375,8 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     const unanimousYes = relevanceVotes.length >= 3 && yesCount === relevanceVotes.length;
     const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
 
-    const isFutureDate = contentType === 'news' && rescoredDate && newDate && new Date(newDate) > new Date();
     const effectiveDate = newDate || row.publication_date;
+    const isFutureDate = contentType === 'news' && effectiveDate && new Date(effectiveDate) > new Date();
 
     let resolvedStatus;
     let reasoning;
@@ -384,8 +384,8 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       resolvedStatus = forceStatus;
       reasoning = `Forced to ${forceStatus}`;
     } else if (isFutureDate) {
-      resolvedStatus = 'rejected';
-      reasoning = `Rejected: future publication date ${newDate}`;
+      resolvedStatus = 'pending';
+      reasoning = `Pending: future publication date ${effectiveDate} — needs review`;
     } else if (unanimousNo) {
       resolvedStatus = 'rejected';
       reasoning = `Rejected: relevance vote unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})`;

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -78,6 +78,7 @@ export async function scoreDate(pool, { title, description, pageContent, sources
       meta: normalizedSources.meta || [],
       timeTags: normalizedSources.timeTags || [],
       url: normalizedSources.url || null,
+      searchDate: normalizedSources.searchDate || null,
       llmVotes: normalizedVotes
     }
   };
@@ -1007,11 +1008,13 @@ export async function collectPoi(pool, poi, sheets = null, timezone = 'America/N
                snippet so it still reaches moderation instead of being lost. */
             if (pageItems.length === 0 && urlData.date && urlData.title && urlData.snippet) {
               const snippetText = `${urlData.title}\n${urlData.snippet}`;
-              const llmVotes = await runLlmDateVotes(pool, snippetText.substring(0, 2000));
+              /* The Serper publisher date is the authoritative deterministic date here;
+                 a 1-2 line snippet has no date content, so LLM date-voting on it only
+                 hallucinates "today" — skip it (llmVotes: []) and trust searchDate. */
               const consensus = await scoreDate(pool, {
                 title: urlData.title, description: urlData.snippet, pageContent: snippetText,
-                sources: { jsonLd: [], meta: [urlData.date], timeTags: [], url: extractUrlDate(urlData.url) },
-                timezone, llmVotes
+                sources: { url: extractUrlDate(urlData.url), searchDate: urlData.date },
+                timezone, llmVotes: []
               });
               let sourceName;
               try { sourceName = new URL(urlData.url).hostname.replace(/^www\./, ''); } catch { sourceName = 'External source'; }

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -89,6 +89,11 @@ describe('normalizeDateSources', () => {
     const result = normalizeDateSources({});
     expect(result).not.toHaveProperty('llm');
   });
+
+  it('keeps and parses the searchDate source (Serper publisher date)', () => {
+    const result = normalizeDateSources({ searchDate: 'March 9, 2026' });
+    expect(result.searchDate).toBe('2026-03-09');
+  });
 });
 
 describe('scoreDateConsensus', () => {
@@ -180,6 +185,27 @@ describe('scoreDateConsensus', () => {
       [null, null, null]
     );
     expect(result.date).toBe('2024-05-20');
+    expect(result.score).toBe(4);
+  });
+
+  it('scores searchDate (Serper publisher date) alone at 3 pts', () => {
+    const result = scoreDateConsensus({ searchDate: '2026-03-09' }, []);
+    expect(result.date).toBe('2026-03-09');
+    expect(result.score).toBe(3);
+    expect(result.sourceMap['2026-03-09']).toContain('search-date');
+  });
+
+  it('searchDate outweighs a disagreeing weak signal (the #1557 fix)', () => {
+    // Before: the Serper date sat in `meta` (1 pt) and lost to noise. Now it is a
+    // first-class deterministic source (3 pts) and wins over a single weak signal.
+    const result = scoreDateConsensus({ searchDate: '2026-03-09', meta: ['2026-05-22'] }, []);
+    expect(result.date).toBe('2026-03-09');
+    expect(result.score).toBe(3);
+  });
+
+  it('on-page JSON-LD still outranks searchDate on conflict', () => {
+    const result = scoreDateConsensus({ jsonLd: ['2026-03-09'], searchDate: '2026-05-22' }, []);
+    expect(result.date).toBe('2026-03-09');
     expect(result.score).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary
A legitimate March-2026 cleveland.com article (news #1557) was auto-**rejected** as "future publication date 2026-05-22". Two compounding bugs, fixed cleanly via the existing date model — no special-casing:

1. **Wrong date.** Snippet-recovered item (PR #399 fallback). Serper gave the correct publisher date `2026-03-09`, but the fallback *also* LLM-date-voted on the 1–2 line snippet → guessed "today" 3×, and 3 LLM votes (1 pt each) beat the date stuffed into `meta` (1 pt).
2. **Auto-reject too harsh.** Future-dated news should be reviewed, not discarded.

### Changes
- **`searchDate` is now a first-class deterministic date source** (`dateExtractor.js`) at **weight 3** — below on-page JSON-LD (4), above single `meta`/`url`/`time-tag`/LLM signals (1). Recorded in `date_signals` via `scoreDate`.
- **Snippet fallback** passes the Serper date as `searchDate` and **skips LLM date-voting** (`llmVotes: []`) — a thin snippet has no date to vote on. #1557 now resolves to `2026-03-09`.
- **Future-dated news → `pending`** (queue), not `rejected`; the future check uses the effective date so non-rescored future items also stay out of auto-publish.

## Test plan
- [x] `./run.sh build` + Gourmand (0 violations)
- [x] New `dateExtractor.unit.test.js` cases: searchDate kept/parsed; scores 3 alone; outweighs a disagreeing weak signal (the #1557 fix); JSON-LD still outranks it on conflict — all pass
- [x] Full suite: only the 3 known unrelated flakes (OG share image, 2× mobile More-Info)
- [ ] Post-deploy: re-collect CVSR (5660) → cleveland.com 2026 lineup article saves with date ≈ 2026-03-09 and lands `pending`, not `rejected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)