### PR TITLE
fix: scrollable 2-column legend sections + auto-zoom on enable (#396)

### DIFF
--- a/.specify/specs/021-park-panel-overflow/plan.md
+++ b/.specify/specs/021-park-panel-overflow/plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Scrollable Legend Sections (Park/Municipal Panel Overflow Fix)
+
+> **Spec ID:** 021-park-panel-overflow
+> **Status:** Planning
+> **Last Updated:** 2026-05-22
+> **Estimated Effort:** S
+
+## Summary
+
+Make the open accordion section's body scroll within the fixed-height legend panel by
+turning `.legend-content` into a flex column, pinning the search box and section
+headers, and letting the open section grow and scroll. One small JSX change tags the
+open section; the rest is CSS.
+
+---
+
+## Architecture
+
+### Current layout (desktop, docked)
+
+```
+.legend            height: min(480px, 70vh); display:flex; flex-direction:column
+└─ .legend-content flex:1; min-height:0; overflow:hidden   ← clips overflow, no scroll
+   ├─ .legend-search
+   ├─ .legend-section (poi)        accordion; one open at a time
+   ├─ .legend-section (parks)      └─ .legend-section-body (hidden when closed)
+   └─ .legend-section (municipal)
+```
+
+Root cause: `.legend-content { overflow: hidden }` (App.css ~2626) clips the open
+section's `.boundary-chips` once they exceed the panel height; nothing scrolls.
+
+### Target layout
+
+```
+.legend-content    flex column (unchanged: flex:1; min-height:0; overflow:hidden)
+   ├─ .legend-search          flex: 0 0 auto   (pinned)
+   ├─ .legend-section         flex column; closed = content height (pinned header)
+   └─ .legend-section.open    flex: 1 1 auto; min-height:0
+        └─ .legend-section-body  flex:1 1 auto; min-height:0; overflow-y:auto  ← scrolls
+```
+
+Because the sections are already an accordion (single `openSection` state), only one
+body ever needs to scroll, and it gets all remaining panel height.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Layout | CSS flexbox (existing) | `.legend` is already a flex column; extend it rather than add JS measurement |
+| Open-section marker | React class toggle | Minimal: add `open` class in `LegendSection` from existing `isOpen` prop |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Mark the open section
+
+- [ ] In `frontend/src/components/Map.jsx`, `LegendSection`: change the wrapper to
+      `className={`legend-section ${isOpen ? 'open' : ''}`}`.
+
+### Phase 2: CSS scroll behavior (desktop docked)
+
+- [ ] `.legend-content`: add `display: flex; flex-direction: column;` (keep `flex:1; min-height:0; overflow:hidden`).
+- [ ] `.legend-search`: `flex: 0 0 auto;` so it stays pinned.
+- [ ] `.legend-section`: `display: flex; flex-direction: column;`.
+- [ ] `.legend-section.open`: `flex: 1 1 auto; min-height: 0;`.
+- [ ] `.legend-section.open .legend-section-body`: `flex: 1 1 auto; min-height: 0; overflow-y: auto;`.
+- [ ] Hide the scrollbar (per user request — overlay/transparent scrolling) using the
+      existing pattern from `.poi-news-list-content` (App.css ~1561): `scrollbar-width: none;`
+      (Firefox), `-ms-overflow-style: none;` (IE/Edge), and `::-webkit-scrollbar { display: none; }`
+      (Chrome/Safari). Scrolling via wheel/trackpad/touch/drag still works.
+
+### Phase 3: Verify no mobile/expanded regression
+
+- [ ] Confirm `@media (max-width: 768px)` still makes `.legend` scroll as a whole
+      (`.legend-content { display: block }` neutralizes the flex sizing; the open body
+      has no height constraint so the panel scrolls — existing behavior).
+- [ ] Confirm `.legend.legend-expanded` (desktop popup, `height:auto; max-height:80vh; overflow-y:auto`)
+      still scrolls the whole popup.
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/components/Map.jsx` | Add `open` class to `LegendSection` wrapper (1 line) |
+| `frontend/src/App.css` | Flex/scroll rules on `.legend-content`, `.legend-search`, `.legend-section`, `.legend-section.open`, `.legend-section.open .legend-section-body` |
+
+### New Files
+
+None.
+
+---
+
+## Database Migrations
+
+None.
+
+---
+
+## Testing Strategy
+
+### Manual Testing (primary)
+
+1. Desktop: open the **Parks** section — confirm a scrollbar appears and all ~36 chips
+   are reachable; the panel does not run off the map.
+2. Desktop: open **Municipal** — same behavior; search box and headers stay visible.
+3. Switch between sections — accordion still closes the others; open section gets the height.
+4. Open a short section (e.g. POI with few items) — no scrollbar, no awkward empty space.
+5. Mobile (≤768px, devtools): whole panel still scrolls; no clipping.
+6. Desktop expanded popup: still scrolls as before.
+
+### Automated
+
+- No existing Playwright/unit tests target the legend list. Tests run post-merge via
+  `/deploy` (`./run.sh test`); a smoke check that the map + legend render is sufficient.
+
+---
+
+## Rollback Plan
+
+If issues appear:
+1. Revert the App.css rules and the one-line `Map.jsx` class change.
+2. The panel returns to the prior (clipping) behavior; no data or API impact.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Flex sizing differs across browsers | Low | Standard `flex:1 1 auto; min-height:0; overflow-y:auto` pattern; verify in Chrome (issue browser) |
+| Mobile regression | Low | Mobile rules are `!important` and override desktop flex; verify in devtools |
+| Short sections look odd when grown | Low | Only the open section grows; closed headers stay compact — verified manually |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-22 | Initial plan |

--- a/.specify/specs/021-park-panel-overflow/spec.md
+++ b/.specify/specs/021-park-panel-overflow/spec.md
@@ -1,0 +1,121 @@
+# Specification: Scrollable Legend Sections (Park/Municipal Panel Overflow Fix)
+
+> **Spec ID:** 021-park-panel-overflow
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-22
+
+## Overview
+
+The map legend panel groups POIs, Parks, and Municipal boundaries into collapsible
+accordion sections (see `015-grouped-legend-sections`). Since then the catalog has
+grown to ~36 park boundaries plus a long and growing list of municipal/county/city
+boundaries (issue #198). On desktop the legend has a fixed height and its content area
+is clipped (`overflow: hidden`), so when a user opens the **Parks** or **Municipal**
+section the list runs off the bottom of the panel with no way to reach the hidden
+entries. This fixes the overflow by making the open section scroll within the panel.
+
+Reported in [#396](https://github.com/crunchtools/rotv/issues/396).
+
+---
+
+## User Stories
+
+### Browsing Parks on the Map
+
+**US-001: See every park in an overflowing section**
+> As a map user, I want to scroll through the full list of parks (or municipal
+> boundaries) when I open that section, so that I can find and toggle any boundary
+> even when there are more than fit on screen.
+
+Acceptance Criteria:
+- [ ] Opening the **Parks** section with more entries than fit lets the user scroll (wheel/trackpad/touch/drag) to reach every park chip.
+- [ ] No visible scrollbar is rendered — scrolling is "overlay"/hidden, matching the existing pattern used by `.poi-news-list-content` (App.css ~1561).
+- [ ] Opening the **Municipal** section behaves identically.
+- [ ] The legend panel itself does not grow beyond its existing bounds or run off the map.
+- [ ] The section header (and the "All"/"None" actions) and the search box remain visible while the section body scrolls.
+
+**US-002: Accordion behavior is preserved**
+> As a map user, I want only one section open at a time so the panel stays compact and
+> the open section gets the available height for scrolling.
+
+Acceptance Criteria:
+- [ ] Opening one section still collapses the others (existing accordion behavior unchanged).
+- [ ] The open section expands to use the remaining panel height; closed section headers stay visible above/below it.
+
+**US-003: Mobile remains usable**
+> As a mobile user, I want the panel to keep working as it does today.
+
+Acceptance Criteria:
+- [ ] On viewports ≤768px the panel continues to scroll as a whole (no regression).
+
+---
+
+## Data Model
+
+No changes.
+
+---
+
+## API Endpoints
+
+No changes.
+
+---
+
+## UI/UX Requirements
+
+### Changed Components
+
+- `LegendSection` (in `frontend/src/components/Map.jsx`) — mark the open section so CSS can let it grow and scroll.
+
+### Behavior
+
+```
+┌─ legend (fixed height: min(480px, 70vh)) ─┐
+│ [ Search destinations…            ]       │  ← stays pinned
+│ ▸ Points of Interest (14)                 │  ← closed header, pinned
+│ ▾ Parks (36)                              │  ← open header + actions, pinned
+│   ┌─────────────────────────────────┐ ▲  │
+│   │ [chip][chip][chip][chip]        │ │  │  ← body scrolls (overflow-y: auto)
+│   │ [chip][chip][chip][chip]        │ █  │
+│   │ … remaining chips reachable …   │ ▼  │
+│   └─────────────────────────────────┘    │
+│ ▸ Municipal (40)                          │  ← closed header, pinned
+└───────────────────────────────────────────┘
+```
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: CSS-only behavior change where possible**
+- No new dependencies. Reuse existing flexbox layout of `.legend` / `.legend-content`.
+- No change to map rendering, boundary fetching, or the show/hide-all actions.
+
+**NFR-002: No regression on mobile**
+- The existing `@media (max-width: 768px)` rules that make the whole `.legend` scroll must continue to govern mobile.
+
+---
+
+## Dependencies
+
+- Depends on: `015-grouped-legend-sections` (introduced the accordion sections this fix scrolls).
+- Related data growth: issue #198 (added ~36 park + many municipal boundaries).
+
+---
+
+## Open Questions
+
+1. None blocking. A tree/hierarchical grouping (county → city → park) was floated in the
+   issue as an alternative, but is deferred as a future enhancement (MINOR) — scrolling
+   resolves the reported bug.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-22 | Initial draft |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2624,6 +2624,14 @@ body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  /* Fix: flex column so the open section can scroll within the panel (PR for #396) */
+  display: flex;
+  flex-direction: column;
+}
+
+/* Fix: pin the search box so only the open section scrolls (#396) */
+.legend-search {
+  flex: 0 0 auto;
 }
 
 .legend h4 {
@@ -2665,11 +2673,35 @@ body {
 .legend-section {
   border-top: 1px solid #e0e0e0;
   padding: 0.5rem 0;
+  /* Fix: flex column so the open section's body can grow + scroll (#396) */
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .legend-section:first-of-type {
   border-top: none;
   padding-top: 0;
+}
+
+/* Fix: the open section claims remaining panel height; its body scrolls (#396) */
+.legend-section.open {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.legend-section.open .legend-section-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* Overlay/transparent scrolling: scroll without a visible scrollbar,
+     matching .poi-news-list-content above. (#396) */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.legend-section.open .legend-section-body::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
 }
 
 .legend-section-header {
@@ -2775,13 +2807,14 @@ body {
 }
 
 .boundary-chips {
-  display: flex;
-  flex-wrap: wrap;
+  /* Two-column grid to match the Points of Interest layout (#396 follow-up) */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 0.35rem;
 }
 
 .boundary-chip {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.35rem;
   padding: 0.25rem 0.5rem;
@@ -2791,6 +2824,8 @@ body {
   border: 1px solid #ddd;
   background: white;
   transition: all 0.15s ease;
+  /* Allow the name to truncate within its grid column */
+  min-width: 0;
 }
 
 .boundary-chip.active {
@@ -2824,7 +2859,9 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 100px;
+  /* Fill the grid column and truncate to fit instead of a fixed cap (#396 follow-up) */
+  flex: 1;
+  min-width: 0;
 }
 
 .legend-toggle {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -215,7 +215,9 @@ function AppContent() {
   // Pre-compute each boundary's bounds once per data load so toggles don't re-walk
   // geometry on every click. (PR #401 review)
   const boundaryBoundsById = useMemo(() => {
-    const byId = new Map();
+    // globalThis.Map: the bare name `Map` resolves to our imported <Map> component
+    // in this module, so `new Map()` would construct the component. (PR #401 review)
+    const byId = new globalThis.Map();
     for (const f of linearFeatures) {
       if (!f.geometry) continue;
       const b = geometryBounds([f.geometry]);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,6 +53,29 @@ const DEFAULT_PARK_BOUNDS = [
   [41.45, -81.50]   // Northeast corner (expanded to fit all trailheads)
 ];
 
+// Feature: auto-zoom legend toggles to what was just enabled (#396 follow-up).
+// Walk arbitrarily-nested GeoJSON coordinate arrays ([lng, lat] order) and return
+// Leaflet bounds [[swLat, swLng], [neLat, neLng]], or null if no coordinates found.
+function geometryBounds(geometries) {
+  let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+  const visit = (coords) => {
+    if (typeof coords[0] === 'number') {
+      const [lng, lat] = coords;
+      if (lat < minLat) minLat = lat;
+      if (lat > maxLat) maxLat = lat;
+      if (lng < minLng) minLng = lng;
+      if (lng > maxLng) maxLng = lng;
+    } else {
+      for (const c of coords) visit(c);
+    }
+  };
+  for (const g of geometries) {
+    if (g && Array.isArray(g.coordinates)) visit(g.coordinates);
+  }
+  if (minLat === Infinity) return null;
+  return [[minLat, minLng], [maxLat, maxLng]];
+}
+
 function AppContent() {
   const { isAuthenticated, isAdmin, role, loginWithGoogle, loginWithFacebook, logout, user } = useAuth();
   const { activeTheme, isNightMode, videoUrls } = useSeasonalTheme();
@@ -163,6 +186,26 @@ function AppContent() {
   const [activeTab, setActiveTab] = useState('view');
 
   const [boundsToFit, setBoundsToFit] = useState(null);
+  // Bumped on every explicit user-driven fit so BoundsFitter re-zooms even when the
+  // target bounds are identical to the previous fit (e.g. re-enabling the same
+  // boundary). (#396 follow-up)
+  const [fitNonce, setFitNonce] = useState(0);
+
+  // Request a guaranteed map fit to the given bounds (always re-zooms).
+  const requestFit = useCallback((bounds) => {
+    if (!bounds) return;
+    setBoundsToFit(bounds);
+    setFitNonce(n => n + 1);
+  }, []);
+
+  // Fit the map to the union of the given boundary ids' geometry; falls back to the
+  // default park view when none have geometry.
+  const fitToBoundaries = useCallback((ids) => {
+    const geoms = linearFeatures
+      .filter(f => ids.includes(f.id) && f.geometry)
+      .map(f => f.geometry);
+    requestFit(geometryBounds(geoms) || DEFAULT_PARK_BOUNDS);
+  }, [linearFeatures, requestFit]);
 
   const cachedMtbBoundsRef = useRef(null);
 
@@ -2237,30 +2280,47 @@ function AppContent() {
           showRivers={showRivers}
           onToggleRivers={setShowRivers}
           visibleBoundaries={visibleBoundaries}
-          onToggleBoundary={(id) => setVisibleBoundaries(prev => {
-            const next = new Set(prev);
-            if (next.has(id)) {
-              next.delete(id);
-            } else {
-              next.add(id);
+          onToggleBoundary={(id) => {
+            const willEnable = !visibleBoundaries.has(id);
+            setVisibleBoundaries(prev => {
+              const next = new Set(prev);
+              if (next.has(id)) next.delete(id); else next.add(id);
+              return next;
+            });
+            // Enabling: zoom to the boundary just enabled. Disabling the last visible
+            // boundary: zoom back to the default view. (#396 follow-up)
+            if (willEnable) {
+              fitToBoundaries([id]);
+            } else if (visibleBoundaries.size === 1 && visibleBoundaries.has(id)) {
+              requestFit(DEFAULT_PARK_BOUNDS);
             }
-            return next;
-          })}
-          onShowBoundaries={(ids) => setVisibleBoundaries(prev => {
-            const next = new Set(prev);
-            ids.forEach(id => next.add(id));
-            return next;
-          })}
-          onHideBoundaries={(ids) => setVisibleBoundaries(prev => {
-            const next = new Set(prev);
-            ids.forEach(id => next.delete(id));
-            return next;
-          })}
+          }}
+          onShowBoundaries={(ids) => {
+            setVisibleBoundaries(prev => {
+              const next = new Set(prev);
+              ids.forEach(id => next.add(id));
+              return next;
+            });
+            fitToBoundaries(ids); // fit to the whole set just shown
+          }}
+          onHideBoundaries={(ids) => {
+            setVisibleBoundaries(prev => {
+              const next = new Set(prev);
+              ids.forEach(id => next.delete(id));
+              return next;
+            });
+            const remaining = new Set(visibleBoundaries);
+            ids.forEach(id => remaining.delete(id));
+            if (remaining.size === 0) requestFit(DEFAULT_PARK_BOUNDS);
+          }}
           searchQuery={activeFilters.search}
           onSearchChange={(value) => handleFilterChange('search', value)}
           onNewsRefresh={() => setNewsRefreshTrigger(prev => prev + 1)}
           skipFlyRef={skipNextFlyRef}
           boundsToFit={boundsToFit}
+          fitNonce={fitNonce}
+          onFitBounds={requestFit}
+          defaultBounds={DEFAULT_PARK_BOUNDS}
           visiblePoiCount={visiblePoiCount}
           iconConfig={iconConfig}
           isDrawingAssociations={isDrawingAssociations}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,6 +76,20 @@ function geometryBounds(geometries) {
   return [[minLat, minLng], [maxLat, maxLng]];
 }
 
+// Combine a list of Leaflet bounds into one enclosing bounds, or null if empty.
+function unionBounds(boundsList) {
+  let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+  for (const b of boundsList) {
+    if (!b) continue;
+    if (b[0][0] < minLat) minLat = b[0][0];
+    if (b[0][1] < minLng) minLng = b[0][1];
+    if (b[1][0] > maxLat) maxLat = b[1][0];
+    if (b[1][1] > maxLng) maxLng = b[1][1];
+  }
+  if (minLat === Infinity) return null;
+  return [[minLat, minLng], [maxLat, maxLng]];
+}
+
 function AppContent() {
   const { isAuthenticated, isAdmin, role, loginWithGoogle, loginWithFacebook, logout, user } = useAuth();
   const { activeTheme, isNightMode, videoUrls } = useSeasonalTheme();
@@ -198,14 +212,24 @@ function AppContent() {
     setFitNonce(n => n + 1);
   }, []);
 
-  // Fit the map to the union of the given boundary ids' geometry; falls back to the
-  // default park view when none have geometry.
+  // Pre-compute each boundary's bounds once per data load so toggles don't re-walk
+  // geometry on every click. (PR #401 review)
+  const boundaryBoundsById = useMemo(() => {
+    const byId = new Map();
+    for (const f of linearFeatures) {
+      if (!f.geometry) continue;
+      const b = geometryBounds([f.geometry]);
+      if (b) byId.set(f.id, b);
+    }
+    return byId;
+  }, [linearFeatures]);
+
+  // Fit the map to the union of the given boundary ids (from cached bounds); falls
+  // back to the default park view when none have geometry.
   const fitToBoundaries = useCallback((ids) => {
-    const geoms = linearFeatures
-      .filter(f => ids.includes(f.id) && f.geometry)
-      .map(f => f.geometry);
-    requestFit(geometryBounds(geoms) || DEFAULT_PARK_BOUNDS);
-  }, [linearFeatures, requestFit]);
+    const bounds = ids.map(id => boundaryBoundsById.get(id)).filter(Boolean);
+    requestFit(unionBounds(bounds) || DEFAULT_PARK_BOUNDS);
+  }, [boundaryBoundsById, requestFit]);
 
   const cachedMtbBoundsRef = useRef(null);
 

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1033,7 +1033,9 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   // doesn't re-scan every POI on each click. Stored as [minLat,minLng,maxLat,maxLng].
   // (PR #401 review)
   const typeBoundsById = useMemo(() => {
-    const byType = new Map();
+    // globalThis.Map: the bare name `Map` is this file's <Map> component, so
+    // `new Map()` would construct the component. (PR #401 review)
+    const byType = new globalThis.Map();
     for (const dest of destinations) {
       if (!dest.latitude || !dest.longitude) continue;
       const t = getDestinationIconType(dest);

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -66,10 +66,16 @@ const DEFAULT_ZOOM = 11;
 
 const TOOLTIP_HOVER_DELAY = 250; // ms
 
+// All park boundaries render in CVNP's forest green for a consistent "park" look;
+// municipal/county/state keep their own per-row boundary_color. (#396 follow-up)
+const PARK_BOUNDARY_COLOR = '#228B22';
+const boundaryDisplayColor = (b) =>
+  b.boundary_type === 'park' ? PARK_BOUNDARY_COLOR : (b.boundary_color || PARK_BOUNDARY_COLOR);
+
 function LegendSection({ id, title, count, isOpen, onToggle, showActions, onShowAll, onHideAll, children }) {
   const bodyId = `legend-section-${id}`;
   return (
-    <div className="legend-section">
+    <div className={`legend-section ${isOpen ? 'open' : ''}`}>
       <div className="legend-section-header">
         <button
           type="button"
@@ -163,7 +169,7 @@ function Legend({
     >
       <span
         className="boundary-chip-color"
-        style={{ backgroundColor: boundary.boundary_color || '#228B22' }}
+        style={{ backgroundColor: boundaryDisplayColor(boundary) }}
       />
       <span className="boundary-chip-name">{boundary.name}</span>
     </button>
@@ -345,25 +351,36 @@ function MapVisibilityHandler({ activeTab }) {
   return null;
 }
 
-function BoundsFitter({ boundsToFit }) {
+function BoundsFitter({ boundsToFit, fitNonce }) {
   const map = useMap();
   const prevBounds = useRef(null);
+  const prevNonce = useRef(fitNonce);
 
   useEffect(() => {
-    if (boundsToFit && JSON.stringify(boundsToFit) !== JSON.stringify(prevBounds.current)) {
+    if (!boundsToFit) return;
 
+    // Re-fit when an explicit user action bumped the nonce (even if the target
+    // bounds are unchanged, e.g. re-enabling the same boundary), or when the
+    // bounds themselves changed. (#396 follow-up)
+    const nonceChanged = fitNonce !== undefined && fitNonce !== prevNonce.current;
+    const boundsChanged = JSON.stringify(boundsToFit) !== JSON.stringify(prevBounds.current);
+    if (nonceChanged || boundsChanged) {
       const latRange = boundsToFit[1][0] - boundsToFit[0][0];
       const lngRange = boundsToFit[1][1] - boundsToFit[0][1];
       const geoSize = Math.max(latRange, lngRange);
 
+      // Clamp how far we zoom in for a tight cluster / single point so a one-POI
+      // type (or a tiny boundary) doesn't slam to max zoom.
       const padding = geoSize >= 0.3 ? [20, 20] : [50, 50];
-      const maxZoom = geoSize >= 0.3 ? 12 : undefined; // Limit zoom for large areas
-
+      let maxZoom;
+      if (geoSize >= 0.3) maxZoom = 12;       // large areas
+      else if (geoSize < 0.02) maxZoom = 15;  // very small / single point
 
       map.fitBounds(boundsToFit, { padding, maxZoom });
       prevBounds.current = boundsToFit;
+      prevNonce.current = fitNonce;
     }
-  }, [boundsToFit, map]);
+  }, [boundsToFit, fitNonce, map]);
 
   return null;
 }
@@ -958,7 +975,7 @@ function CoordinateConfirmDialog({ destination, newLat, newLng, onConfirm, onCan
 
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default']);
 
-function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, visiblePoiCount, iconConfig }) {
+function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, fitNonce, onFitBounds, defaultBounds, visiblePoiCount, iconConfig }) {
   // Unified selection: one selectedPoi in, one onSelectPoi out (spec 019).
   // `selectedIsLinear` reflects the selection KIND (path), not geometry — a
   // dual-role organization+boundary may be selected as a destination yet still
@@ -1012,17 +1029,42 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   const [saving, setSaving] = useState(false);
 
 
+  // Fit the map to all visible POIs of the given icon type(s). (#396 follow-up)
+  const fitToTypes = useCallback((typeIds) => {
+    if (!onFitBounds) return;
+    const typeSet = typeIds instanceof Set ? typeIds : new Set(typeIds);
+    let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+    for (const dest of destinations) {
+      if (!dest.latitude || !dest.longitude) continue;
+      if (!typeSet.has(getDestinationIconType(dest))) continue;
+      const lat = parseFloat(dest.latitude);
+      const lng = parseFloat(dest.longitude);
+      if (lat < minLat) minLat = lat;
+      if (lat > maxLat) maxLat = lat;
+      if (lng < minLng) minLng = lng;
+      if (lng > maxLng) maxLng = lng;
+    }
+    if (minLat === Infinity) {
+      if (defaultBounds) onFitBounds(defaultBounds);
+      return;
+    }
+    onFitBounds([[minLat, minLng], [maxLat, maxLng]]);
+  }, [destinations, getDestinationIconType, onFitBounds, defaultBounds]);
+
   const handleToggleType = (typeId) => {
-    if (onVisibleTypesChange) {
-      onVisibleTypesChange(prev => {
-        const newSet = new Set(prev);
-        if (newSet.has(typeId)) {
-          newSet.delete(typeId);
-        } else {
-          newSet.add(typeId);
-        }
-        return newSet;
-      });
+    if (!onVisibleTypesChange) return;
+    const willEnable = !visibleTypes.has(typeId);
+    onVisibleTypesChange(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(typeId)) newSet.delete(typeId); else newSet.add(typeId);
+      return newSet;
+    });
+    // Enabling a type: zoom to fit all POIs of that type. Disabling the last visible
+    // type: zoom back to the default view. (#396 follow-up)
+    if (willEnable) {
+      fitToTypes([typeId]);
+    } else if (visibleTypes.size === 1 && visibleTypes.has(typeId) && onFitBounds && defaultBounds) {
+      onFitBounds(defaultBounds);
     }
   };
 
@@ -1030,12 +1072,14 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     if (onVisibleTypesChange) onVisibleTypesChange(new Set(allIconTypes));
     onToggleTrails(true);
     onToggleRivers(true);
+    fitToTypes(allIconTypes); // fit to every POI now shown
   };
 
   const handleHideAll = () => {
     if (onVisibleTypesChange) onVisibleTypesChange(new Set());
     onToggleTrails(false);
     onToggleRivers(false);
+    if (onFitBounds && defaultBounds) onFitBounds(defaultBounds);
   };
 
   const handleFileSelect = (e) => {
@@ -1163,7 +1207,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#1E90FF'
       };
     } else if (feature.poi_roles?.includes('boundary')) {
-      const boundaryColor = feature.boundary_color || '#228B22';
+      const boundaryColor = boundaryDisplayColor(feature);
       const selectedStrokeColor = editMode ? editSelectedColor : viewSelectedColor;
 
       return {
@@ -1409,7 +1453,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
 
         <MapUpdater selectedDestination={selectedDestination} selectedLinearFeature={selectedLinearFeature} skipFlyRef={skipFlyRef} />
         <MapVisibilityHandler activeTab={activeTab} />
-        <BoundsFitter boundsToFit={boundsToFit} />
+        <BoundsFitter boundsToFit={boundsToFit} fitNonce={fitNonce} />
         <MapBoundsTracker
           destinations={destinations}
           visibleTypes={visibleTypes}

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1029,27 +1029,48 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   const [saving, setSaving] = useState(false);
 
 
-  // Fit the map to all visible POIs of the given icon type(s). (#396 follow-up)
+  // Pre-compute each icon type's POI bounds once per data load, so toggling a type
+  // doesn't re-scan every POI on each click. Stored as [minLat,minLng,maxLat,maxLng].
+  // (PR #401 review)
+  const typeBoundsById = useMemo(() => {
+    const byType = new Map();
+    for (const dest of destinations) {
+      if (!dest.latitude || !dest.longitude) continue;
+      const t = getDestinationIconType(dest);
+      const lat = parseFloat(dest.latitude);
+      const lng = parseFloat(dest.longitude);
+      const cur = byType.get(t);
+      if (!cur) {
+        byType.set(t, [lat, lng, lat, lng]);
+      } else {
+        if (lat < cur[0]) cur[0] = lat;
+        if (lng < cur[1]) cur[1] = lng;
+        if (lat > cur[2]) cur[2] = lat;
+        if (lng > cur[3]) cur[3] = lng;
+      }
+    }
+    return byType;
+  }, [destinations, getDestinationIconType]);
+
+  // Fit the map to all POIs of the given icon type(s), from cached per-type bounds.
   const fitToTypes = useCallback((typeIds) => {
     if (!onFitBounds) return;
     const typeSet = typeIds instanceof Set ? typeIds : new Set(typeIds);
     let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
-    for (const dest of destinations) {
-      if (!dest.latitude || !dest.longitude) continue;
-      if (!typeSet.has(getDestinationIconType(dest))) continue;
-      const lat = parseFloat(dest.latitude);
-      const lng = parseFloat(dest.longitude);
-      if (lat < minLat) minLat = lat;
-      if (lat > maxLat) maxLat = lat;
-      if (lng < minLng) minLng = lng;
-      if (lng > maxLng) maxLng = lng;
+    for (const t of typeSet) {
+      const b = typeBoundsById.get(t);
+      if (!b) continue;
+      if (b[0] < minLat) minLat = b[0];
+      if (b[1] < minLng) minLng = b[1];
+      if (b[2] > maxLat) maxLat = b[2];
+      if (b[3] > maxLng) maxLng = b[3];
     }
     if (minLat === Infinity) {
       if (defaultBounds) onFitBounds(defaultBounds);
       return;
     }
     onFitBounds([[minLat, minLng], [maxLat, maxLng]]);
-  }, [destinations, getDestinationIconType, onFitBounds, defaultBounds]);
+  }, [typeBoundsById, onFitBounds, defaultBounds]);
 
   const handleToggleType = (typeId) => {
     if (!onVisibleTypesChange) return;


### PR DESCRIPTION
## Summary
Fixes the Parks/Municipal legend panel overflow reported in #396, plus follow-up UX requested during review.

- **Scroll fix:** the open accordion section now grows and scrolls within the fixed-height panel (overlay/hidden scrollbar), so all 42 parks / 18 municipal boundaries are reachable. Search box + section headers stay pinned. Mobile and expanded-popup modes unchanged.
- **2-column layout:** boundary chips render in a `1fr 1fr` grid matching Points of Interest; long names truncate with an ellipsis.
- **Auto-zoom on enable:** enabling a single boundary fits the map to that boundary; "All" fits the whole set; enabling a POI type fits all POIs of that type; "None"/last-off returns to the default view. A fit *nonce* makes re-enabling the same target re-zoom (CVNP is always on, so a union fit would never zoom in).
- **Uniform park color:** all park boundaries render in CVNP's forest green `#228B22` (polygon + chip); municipal/county/state keep their distinct colors. Done at the render layer so re-imports can't reintroduce drift.

Spec: `.specify/specs/021-park-panel-overflow/`.

## Test plan
- [x] `./run.sh build` passes on rebased code
- [x] Human-verified on port 8082 with production data (42 parks, 18 municipal): scroll, 2-column grid, auto-zoom, uniform green
- [ ] CI container build + smoke test

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)