### PR TITLE
feat: multi-image upload (#390)

### DIFF
--- a/.specify/specs/021-multi-image-upload/plan.md
+++ b/.specify/specs/021-multi-image-upload/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Multi-Image Upload
+
+> **Spec ID:** 021-multi-image-upload
+> **Status:** Planning
+> **Last Updated:** 2026-05-22
+> **Estimated Effort:** S
+
+## Summary
+
+Convert the Image tab of `MediaUploadModal` from single-file to multi-file
+selection, capped at 3 for regular users and unlimited for admins, and upload
+the staged images sequentially through the existing
+`POST /api/pois/:id/media` endpoint. No backend or database changes.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. User opens the modal, selects N images on the Image tab (picker `multiple`).
+2. Files are validated (type/size, same rules as today) and the cap is enforced
+   client-side using `isAdmin` from `useAuth()`.
+3. Staged images render as a thumbnail list with per-item remove.
+4. On Upload, the modal POSTs each image to `/api/pois/:id/media` in sequence,
+   updating "Uploading i of N…".
+5. Successes are tallied; failures stay staged with an aggregated error message.
+6. If all succeed: `onSuccess()` + `onClose()` (unchanged); the gallery/mosaic
+   refreshes via the existing cache invalidation per upload.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Role gate | `useAuth().isAdmin` | Already the app-wide source of admin state |
+| Upload | Sequential `fetch` to existing endpoint | Reuses proven moderation + rollback path; no new backend surface |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Modal state refactor (Image tab only)
+
+- [ ] Replace single `selectedFile`/`preview` with a `selectedImages` array of
+      `{ file, preview, id, caption }` (Video/YouTube keep their single-file state).
+- [ ] Import and use `useAuth()` to read `isAdmin`; define `MAX_REGULAR = 3`.
+- [ ] `handleFileSelect` accepts a `FileList`, validates each, enforces the cap
+      (reject overflow with a message), and appends valid images.
+- [ ] Per-image remove; show count (e.g. "2 / 3 selected" for regular users).
+
+### Phase 2: Batch upload
+
+- [ ] `handleUpload` for the Image tab loops over `selectedImages`, awaiting each
+      POST; track `succeeded`/`failed` and current index for progress text.
+- [ ] Each image's own `caption` is sent with its POST.
+- [ ] On partial failure, keep failed images staged, surface
+      "X uploaded, Y failed" and the first error.
+
+### Phase 3: Markup + styles
+
+- [ ] Replace the single preview block with the staged-image list/grid.
+- [ ] Add minimal CSS to `MediaUploadModal.css` for the multi-image list.
+- [ ] Keep the `multiple` attribute on the image file input only.
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/components/MediaUploadModal.jsx` | Multi-select state, cap, staged list, sequential batch upload, conditional caption |
+| `frontend/src/components/MediaUploadModal.css` | Styles for the staged-image list/grid |
+
+### Unchanged
+
+- `backend/server.js` `POST /api/pois/:id/media` — no signature or logic change.
+- `poi_media` schema — no migration.
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. As a regular user: select 4 images → only 3 stage, message shown; remove one,
+   add another; upload → all land in moderation queue; gallery refreshes.
+2. As admin: select 6 images → all stage; upload → all succeed.
+3. Single image → caption field appears and is saved.
+4. Video tab: one file ≤10MB still works; >10MB rejected. YouTube tab unchanged.
+5. Force a mid-batch failure (e.g. oversized file slipping through) → modal
+   reports partial success and keeps the failed item staged.
+
+### Automated
+
+- Existing `backend/tests/poiMedia.integration.test.js` continues to cover the
+  endpoint (unchanged). No backend test changes expected; add a frontend
+  component test only if the existing suite already exercises this modal.
+
+---
+
+## Rollback Plan
+
+Frontend-only change. Revert the two files / the PR commit; no data or schema to
+unwind.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Partial-batch failure leaves user confused | Med | Explicit "X of N uploaded" message; failed items remain staged for retry |
+| Client-only cap is bypassable | Low | Accepted — single uploads are already unlimited by repetition; cap is UX, not security (see spec) |
+| Caption semantics for batches | Low | Caption hidden unless exactly one image staged |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-22 | Initial plan |

--- a/.specify/specs/021-multi-image-upload/spec.md
+++ b/.specify/specs/021-multi-image-upload/spec.md
@@ -1,0 +1,144 @@
+# Specification: Multi-Image Upload
+
+> **Spec ID:** 021-multi-image-upload
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-22
+> **Issue:** [#390](https://github.com/crunchtools/rotv/issues/390)
+
+## Overview
+
+Today the media upload modal accepts only one file per submission, forcing
+users to repeat the entire pick → preview → upload flow for every photo. This
+feature lets a contributor select several images at once: regular users may
+batch up to **3 images**, and admins (`admin` / `media_admin`) may select an
+**unlimited** number. Video and YouTube remain single-item flows.
+
+---
+
+## User Stories
+
+### Contributor Uploads
+
+**US-001: Batch image selection (regular user)**
+> As a signed-in contributor, I want to select up to three images in one go so
+> that I can share a small set of photos without repeating the upload flow.
+
+Acceptance Criteria:
+- [ ] On the Image tab, the file picker allows selecting multiple files.
+- [ ] A regular user may stage at most 3 images; attempting more shows a clear
+      message and the extra files are not added.
+- [ ] Each staged image shows a thumbnail preview and a per-image remove control.
+- [ ] Uploading submits all staged images; each lands in the moderation queue
+      exactly as a single upload does today.
+
+**US-002: Unlimited batch (admin)**
+> As an admin or media_admin, I want to select as many images as I need at once
+> so that I can populate a POI gallery quickly.
+
+Acceptance Criteria:
+- [ ] An admin/media_admin user is not capped at 3 images.
+- [ ] The cap message does not appear for admins.
+
+**US-003: Per-image upload feedback**
+> As a user uploading a batch, I want to see progress and know which images
+> succeeded so that I can retry only what failed.
+
+Acceptance Criteria:
+- [ ] During upload, progress is shown (e.g. "Uploading 2 of 3…").
+- [ ] If some images fail, the modal reports how many succeeded and which failed,
+      and leaves the failed ones staged for retry.
+- [ ] If all succeed, the modal closes and the gallery refreshes (current behavior).
+
+### Unchanged Flows
+
+**US-004: Video and YouTube stay single**
+> As a user, I expect the Video and YouTube tabs to behave exactly as before.
+
+Acceptance Criteria:
+- [ ] Video tab accepts one file (≤10MB) as today.
+- [ ] YouTube tab accepts one URL as today.
+
+---
+
+## Data Model
+
+No schema changes. Each image is one `poi_media` row, inserted by the existing
+`POST /api/pois/:id/media` endpoint.
+
+---
+
+## API Endpoints
+
+No new endpoints. The frontend calls the existing single-file endpoint once per
+image:
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/pois/:id/media` | Upload one image/video or add a YouTube link (unchanged) | Authenticated |
+
+**Decision — client-side sequential upload, not `upload.array`:** The role cap
+is a UX guardrail, not a security boundary. A user can already upload unlimited
+images today by repeating single submissions, so a server-enforced per-batch
+cap would add a duplicated multi-file code path (moderation status, asset
+rollback, mosaic cache invalidation) without preventing anything. Looping over
+the proven single-file endpoint keeps the change small and the backend
+untouched.
+
+---
+
+## UI/UX Requirements
+
+### Modified Components
+
+- `MediaUploadModal` — Image tab becomes multi-select: staged-file list with
+  per-image thumbnail + remove, role-based cap, batch upload with progress and
+  partial-failure reporting. Video/YouTube tabs unchanged.
+
+### Role Source
+
+`useAuth()` already exposes `isAdmin` and `user`. The modal reads `isAdmin` to
+decide the cap (3 vs unlimited).
+
+### Caption Behavior
+
+**Decision (per #390 review):** each staged image carries its own optional
+caption input in the staged-file list. The per-image caption is sent with that
+image's POST, preserving the existing single-image caption behavior for every
+item in a batch.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: No regression**
+- Single-image, video, and YouTube uploads behave identically to today.
+- Existing moderation queue, asset rollback, and mosaic-cache invalidation are
+  reused unchanged (one invocation per image).
+
+**NFR-002: Bounded client work**
+- Regular users are capped at 3; admin batches are sequential, so memory and
+  network stay bounded to one in-flight upload at a time.
+
+---
+
+## Dependencies
+
+- Builds on spec 005-era multi-image POI support (Issue #181 / PR #182):
+  `poi_media` table, `MediaUploadModal`, role-based moderation.
+
+---
+
+## Resolved Decisions
+
+1. Captions: **per-image** optional caption input in the staged list (#390 review).
+2. Regular-user cap: **hard-coded constant** `MAX_REGULAR = 3` (#390 review).
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-22 | Initial draft |

--- a/frontend/src/components/MediaUploadModal.css
+++ b/frontend/src/components/MediaUploadModal.css
@@ -191,6 +191,106 @@
   color: #333;
 }
 
+/* Staged image list (multi-image upload) */
+.staged-images-count {
+  font-size: 14px;
+  font-weight: 500;
+  color: #525252;
+  margin: 16px 0 8px;
+}
+
+.staged-images-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.staged-image {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.staged-image-thumb {
+  flex: 0 0 72px;
+  width: 72px;
+  height: 72px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.staged-image-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.staged-image-loading {
+  color: #999;
+  font-size: 20px;
+}
+
+.staged-image-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.staged-image-details .file-info {
+  margin-bottom: 8px;
+}
+
+.staged-image-details .file-info strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 60%;
+}
+
+.staged-image-caption {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  transition: border-color 0.2s;
+}
+
+.staged-image-caption:focus {
+  outline: none;
+  border-color: #007bff;
+}
+
+.staged-image-remove {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #999;
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.staged-image-remove:hover:not(:disabled) {
+  background: #f0f0f0;
+  color: #d00;
+}
+
+.staged-image-remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* Form Group */
 .form-group {
   margin-bottom: 20px;

--- a/frontend/src/components/MediaUploadModal.jsx
+++ b/frontend/src/components/MediaUploadModal.jsx
@@ -1,27 +1,36 @@
 import { useState, useRef } from 'react';
+import { useAuth } from '../hooks/useAuth';
 import './MediaUploadModal.css';
+
+const MAX_REGULAR_IMAGES = 3;
+let nextStagedId = 0;
 
 /**
  * MediaUploadModal Component
- * Modal for uploading images, videos, or adding YouTube links
+ * Modal for uploading images, videos, or adding YouTube links.
+ * The Image tab supports selecting multiple files at once: regular users may
+ * stage up to MAX_REGULAR_IMAGES, admins are unlimited. Each staged image
+ * carries its own optional caption and is uploaded sequentially.
  */
 function MediaUploadModal({ poiId, onClose, onSuccess }) {
+  const { isAdmin } = useAuth();
+  const imageLimit = isAdmin ? Infinity : MAX_REGULAR_IMAGES;
+
   const [activeTab, setActiveTab] = useState('image');
   const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(null);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [dragActive, setDragActive] = useState(false);
 
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const [caption, setCaption] = useState('');
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [preview, setPreview] = useState(null);
+  const [selectedImages, setSelectedImages] = useState([]);
+  const [selectedVideo, setSelectedVideo] = useState(null);
 
   const fileInputRef = useRef(null);
 
-  const handleFileSelect = (file) => {
-    if (!file) return;
-
+  const validateFile = (file) => {
     const isVideo = activeTab === 'video';
     const fileName = file.name.toLowerCase();
 
@@ -38,28 +47,104 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
 
     if (!hasValidType && !hasValidExtension) {
       const expected = isVideo ? 'MP4, WebM, or MOV' : 'JPEG, PNG, or WebP';
-      setError(`Please select a ${expected} file`);
-      return;
+      return `Please select a ${expected} file`;
     }
 
-    if (isVideo && file.size > 10 * 1024 * 1024) {
-      setError('Video must be less than 10MB. Please upload larger videos to YouTube instead.');
-      return;
+    if (file.size > 10 * 1024 * 1024) {
+      return isVideo
+        ? 'Video must be less than 10MB. Please upload larger videos to YouTube instead.'
+        : 'Image must be less than 10MB';
     }
 
-    if (!isVideo && file.size > 10 * 1024 * 1024) {
-      setError('Image must be less than 10MB');
+    return null;
+  };
+
+  const handleImageSelect = (fileList) => {
+    const files = Array.from(fileList || []);
+    if (files.length === 0) return;
+
+    setError(null);
+
+    const remaining = imageLimit - selectedImages.length;
+    const accepted = [];
+    let rejectedForCap = 0;
+
+    for (const file of files) {
+      if (accepted.length >= remaining) {
+        rejectedForCap += 1;
+        continue;
+      }
+      const validationError = validateFile(file);
+      if (validationError) {
+        setError(validationError);
+        continue;
+      }
+      accepted.push(file);
+    }
+
+    if (rejectedForCap > 0 && Number.isFinite(imageLimit)) {
+      setError(`You can upload up to ${imageLimit} images at once.`);
+    }
+
+    if (accepted.length === 0) return;
+
+    const staged = accepted.map((file) => ({
+      id: nextStagedId++,
+      file,
+      preview: null,
+      caption: ''
+    }));
+
+    setSelectedImages((prev) => [...prev, ...staged]);
+
+    staged.forEach(({ id, file }) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        setSelectedImages((prev) =>
+          prev.map((img) => (img.id === id ? { ...img, preview: e.target.result } : img))
+        );
+      };
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const handleVideoSelect = (file) => {
+    if (!file) return;
+
+    const validationError = validateFile(file);
+    if (validationError) {
+      setError(validationError);
       return;
     }
 
     setError(null);
-    setSelectedFile(file);
+    setSelectedVideo({ file, preview: null });
 
     const reader = new FileReader();
     reader.onload = (e) => {
-      setPreview(e.target.result);
+      setSelectedVideo((prev) => (prev ? { ...prev, preview: e.target.result } : prev));
     };
     reader.readAsDataURL(file);
+  };
+
+  const removeImage = (id) => {
+    setSelectedImages((prev) => prev.filter((img) => img.id !== id));
+  };
+
+  const updateImageCaption = (id, value) => {
+    setSelectedImages((prev) =>
+      prev.map((img) => (img.id === id ? { ...img, caption: value } : img))
+    );
+  };
+
+  const switchTab = (tab) => {
+    setActiveTab(tab);
+    setSelectedImages([]);
+    setSelectedVideo(null);
+    setError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
   };
 
   const handleDragEnter = (e) => {
@@ -84,101 +169,244 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
     e.stopPropagation();
     setDragActive(false);
 
-    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      handleFileSelect(e.dataTransfer.files[0]);
+    if (!e.dataTransfer.files || e.dataTransfer.files.length === 0) return;
+
+    if (activeTab === 'video') {
+      handleVideoSelect(e.dataTransfer.files[0]);
+    } else {
+      handleImageSelect(e.dataTransfer.files);
     }
   };
 
-  const handleUpload = async () => {
-    setError(null);
-    setSuccess(null);
+  const uploadFile = async (file, mediaType, itemCaption) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('media_type', mediaType);
+    if (itemCaption) {
+      formData.append('caption', itemCaption);
+    }
+
+    const response = await fetch(`/api/pois/${poiId}/media`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      const text = await response.text();
+      throw new Error(`Upload failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
+    }
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || `Upload failed (HTTP ${response.status})`);
+    }
+
+    return response.json();
+  };
+
+  const handleYouTubeUpload = async () => {
+    if (!youtubeUrl.trim()) {
+      setError('Please enter a YouTube URL');
+      return;
+    }
+
     setUploading(true);
-
     try {
-      if (activeTab === 'youtube') {
-        if (!youtubeUrl.trim()) {
-          setError('Please enter a YouTube URL');
-          setUploading(false);
-          return;
-        }
+      const response = await fetch(`/api/pois/${poiId}/media`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          media_type: 'youtube',
+          youtube_url: youtubeUrl,
+          caption: caption || null
+        })
+      });
 
-        const response = await fetch(`/api/pois/${poiId}/media`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            media_type: 'youtube',
-            youtube_url: youtubeUrl,
-            caption: caption || null
-          })
-        });
-
-        const contentType = response.headers.get('content-type') || '';
-        if (!contentType.includes('application/json')) {
-          const text = await response.text();
-          throw new Error(`Request failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
-        }
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || `Failed to add YouTube video (HTTP ${response.status})`);
-        }
-
-        const result = await response.json();
-        setSuccess(result.message);
-        setTimeout(() => {
-          onSuccess();
-          onClose();
-        }, 1500);
-      } else {
-        if (!selectedFile) {
-          setError('Please select a file');
-          setUploading(false);
-          return;
-        }
-
-        const formData = new FormData();
-        formData.append('file', selectedFile);
-        formData.append('media_type', activeTab);
-        if (caption) {
-          formData.append('caption', caption);
-        }
-
-        const response = await fetch(`/api/pois/${poiId}/media`, {
-          method: 'POST',
-          credentials: 'include',
-          body: formData
-        });
-
-        const contentType = response.headers.get('content-type') || '';
-        if (!contentType.includes('application/json')) {
-          const text = await response.text();
-          throw new Error(`Upload failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
-        }
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || `Upload failed (HTTP ${response.status})`);
-        }
-
-        const result = await response.json();
-        setSuccess(result.message);
-        setTimeout(() => {
-          onSuccess();
-          onClose();
-        }, 1500);
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        const text = await response.text();
+        throw new Error(`Request failed (HTTP ${response.status}). Server returned ${contentType || 'unknown content-type'}: ${text.slice(0, 120)}`);
       }
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Failed to add YouTube video (HTTP ${response.status})`);
+      }
+
+      const result = await response.json();
+      setSuccess(result.message);
+      setTimeout(() => {
+        onSuccess();
+        onClose();
+      }, 1500);
     } catch (err) {
       setError(err.message);
       setUploading(false);
     }
   };
 
-  const renderFileUpload = () => (
+  const handleVideoUpload = async () => {
+    if (!selectedVideo) {
+      setError('Please select a file');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const result = await uploadFile(selectedVideo.file, 'video', caption);
+      setSuccess(result.message);
+      setTimeout(() => {
+        onSuccess();
+        onClose();
+      }, 1500);
+    } catch (err) {
+      setError(err.message);
+      setUploading(false);
+    }
+  };
+
+  const handleImageUpload = async () => {
+    if (selectedImages.length === 0) {
+      setError('Please select at least one image');
+      return;
+    }
+
+    setUploading(true);
+
+    const failed = [];
+    let succeeded = 0;
+
+    for (let i = 0; i < selectedImages.length; i++) {
+      const img = selectedImages[i];
+      setProgress({ current: i + 1, total: selectedImages.length });
+      try {
+        await uploadFile(img.file, 'image', img.caption);
+        succeeded += 1;
+      } catch (err) {
+        failed.push({ id: img.id, error: err.message });
+      }
+    }
+
+    setProgress(null);
+
+    if (failed.length === 0) {
+      setSuccess(`${succeeded} image${succeeded === 1 ? '' : 's'} submitted for review`);
+      setTimeout(() => {
+        onSuccess();
+        onClose();
+      }, 1500);
+      return;
+    }
+
+    const failedIds = new Set(failed.map((f) => f.id));
+    setSelectedImages((prev) => prev.filter((img) => failedIds.has(img.id)));
+    setUploading(false);
+    setError(`${succeeded} uploaded, ${failed.length} failed. First error: ${failed[0].error}`);
+    if (succeeded > 0) {
+      onSuccess();
+    }
+  };
+
+  const handleUpload = () => {
+    setError(null);
+    setSuccess(null);
+
+    if (activeTab === 'youtube') {
+      return handleYouTubeUpload();
+    }
+    if (activeTab === 'video') {
+      return handleVideoUpload();
+    }
+    return handleImageUpload();
+  };
+
+  const renderImageUpload = () => {
+    const atLimit = selectedImages.length >= imageLimit;
+    return (
+      <div className="media-upload-section">
+        {!atLimit && (
+          <div
+            className={`media-upload-dropzone ${dragActive ? 'drag-active' : ''}`}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <div className="upload-icon">📁</div>
+            <p>Drag and drop images here, or click to browse</p>
+            <p className="upload-hint">
+              JPEG, PNG, or WebP (max 10MB each)
+              {Number.isFinite(imageLimit) ? ` — up to ${imageLimit} at once` : ''}
+            </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+              multiple
+              onChange={(e) => {
+                handleImageSelect(e.target.files);
+                e.target.value = '';
+              }}
+              style={{ display: 'none' }}
+            />
+          </div>
+        )}
+
+        {selectedImages.length > 0 && (
+          <>
+            <div className="staged-images-count">
+              {selectedImages.length}
+              {Number.isFinite(imageLimit) ? ` / ${imageLimit}` : ''} selected
+            </div>
+            <div className="staged-images-list">
+              {selectedImages.map((img) => (
+                <div key={img.id} className="staged-image">
+                  <div className="staged-image-thumb">
+                    {img.preview ? (
+                      <img src={img.preview} alt={img.file.name} />
+                    ) : (
+                      <div className="staged-image-loading">…</div>
+                    )}
+                  </div>
+                  <div className="staged-image-details">
+                    <div className="file-info">
+                      <strong>{img.file.name}</strong>
+                      <span>{(img.file.size / 1024 / 1024).toFixed(2)} MB</span>
+                    </div>
+                    <input
+                      type="text"
+                      className="staged-image-caption"
+                      value={img.caption}
+                      onChange={(e) => updateImageCaption(img.id, e.target.value)}
+                      placeholder="Caption (optional)"
+                      maxLength={200}
+                      disabled={uploading}
+                    />
+                  </div>
+                  <button
+                    className="staged-image-remove"
+                    onClick={() => removeImage(img.id)}
+                    disabled={uploading}
+                    aria-label={`Remove ${img.file.name}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const renderVideoUpload = () => (
     <div className="media-upload-section">
-      {!selectedFile ? (
+      {!selectedVideo ? (
         <div
           className={`media-upload-dropzone ${dragActive ? 'drag-active' : ''}`}
           onDragEnter={handleDragEnter}
@@ -188,38 +416,23 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
           onClick={() => fileInputRef.current?.click()}
         >
           <div className="upload-icon">📁</div>
-          <p>
-            Drag and drop your {activeTab} here, or click to browse
-          </p>
-          <p className="upload-hint">
-            {activeTab === 'video'
-              ? 'MP4, WebM, or MOV (max 10MB)'
-              : 'JPEG, PNG, or WebP (max 10MB)'}
-          </p>
+          <p>Drag and drop your video here, or click to browse</p>
+          <p className="upload-hint">MP4, WebM, or MOV (max 10MB)</p>
           <input
             ref={fileInputRef}
             type="file"
-            accept={
-              activeTab === 'video'
-                ? 'video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov'
-                : 'image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp'
-            }
-            onChange={(e) => handleFileSelect(e.target.files[0])}
+            accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+            onChange={(e) => handleVideoSelect(e.target.files[0])}
             style={{ display: 'none' }}
           />
         </div>
       ) : (
         <div className="media-upload-preview">
-          {activeTab === 'image' ? (
-            <img src={preview} alt="Preview" />
-          ) : (
-            <video src={preview} controls />
-          )}
+          <video src={selectedVideo.preview} controls />
           <button
             className="preview-remove"
             onClick={() => {
-              setSelectedFile(null);
-              setPreview(null);
+              setSelectedVideo(null);
               if (fileInputRef.current) {
                 fileInputRef.current.value = '';
               }
@@ -228,10 +441,8 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
             Remove
           </button>
           <div className="file-info">
-            <strong>{selectedFile.name}</strong>
-            <span>
-              {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
-            </span>
+            <strong>{selectedVideo.file.name}</strong>
+            <span>{(selectedVideo.file.size / 1024 / 1024).toFixed(2)} MB</span>
           </div>
         </div>
       )}
@@ -277,6 +488,31 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
     </div>
   );
 
+  const renderTabBody = () => {
+    if (activeTab === 'youtube') return renderYouTubeForm();
+    if (activeTab === 'video') return renderVideoUpload();
+    return renderImageUpload();
+  };
+
+  const uploadDisabled =
+    uploading ||
+    (activeTab === 'image' && selectedImages.length === 0) ||
+    (activeTab === 'video' && !selectedVideo) ||
+    (activeTab === 'youtube' && !youtubeUrl.trim());
+
+  const uploadLabel = () => {
+    if (uploading) {
+      if (progress) {
+        return `Uploading ${progress.current} of ${progress.total}…`;
+      }
+      return 'Uploading…';
+    }
+    if (activeTab === 'image' && selectedImages.length > 1) {
+      return `Upload ${selectedImages.length} images`;
+    }
+    return 'Upload';
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content media-upload-modal" onClick={(e) => e.stopPropagation()}>
@@ -290,41 +526,26 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
         <div className="modal-tabs">
           <button
             className={activeTab === 'image' ? 'active' : ''}
-            onClick={() => {
-              setActiveTab('image');
-              setSelectedFile(null);
-              setPreview(null);
-              setError(null);
-            }}
+            onClick={() => switchTab('image')}
           >
             📷 Image
           </button>
           <button
             className={activeTab === 'video' ? 'active' : ''}
-            onClick={() => {
-              setActiveTab('video');
-              setSelectedFile(null);
-              setPreview(null);
-              setError(null);
-            }}
+            onClick={() => switchTab('video')}
           >
             🎥 Video
           </button>
           <button
             className={activeTab === 'youtube' ? 'active' : ''}
-            onClick={() => {
-              setActiveTab('youtube');
-              setSelectedFile(null);
-              setPreview(null);
-              setError(null);
-            }}
+            onClick={() => switchTab('youtube')}
           >
             ▶️ YouTube
           </button>
         </div>
 
         <div className="modal-body">
-          {activeTab === 'youtube' ? renderYouTubeForm() : renderFileUpload()}
+          {renderTabBody()}
 
           {error && <div className="upload-error">{error}</div>}
           {success && <div className="upload-success">{success}</div>}
@@ -337,9 +558,9 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
           <button
             className="btn-primary"
             onClick={handleUpload}
-            disabled={uploading || (!selectedFile && activeTab !== 'youtube')}
+            disabled={uploadDisabled}
           >
-            {uploading ? 'Uploading...' : 'Upload'}
+            {uploadLabel()}
           </button>
         </div>
       </div>

--- a/frontend/src/components/MediaUploadModal.jsx
+++ b/frontend/src/components/MediaUploadModal.jsx
@@ -68,6 +68,7 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
     const remaining = imageLimit - selectedImages.length;
     const accepted = [];
     let rejectedForCap = 0;
+    let firstValidationError = null;
 
     for (const file of files) {
       if (accepted.length >= remaining) {
@@ -76,14 +77,23 @@ function MediaUploadModal({ poiId, onClose, onSuccess }) {
       }
       const validationError = validateFile(file);
       if (validationError) {
-        setError(validationError);
+        if (!firstValidationError) {
+          firstValidationError = validationError;
+        }
         continue;
       }
       accepted.push(file);
     }
 
+    const messages = [];
+    if (firstValidationError) {
+      messages.push(firstValidationError);
+    }
     if (rejectedForCap > 0 && Number.isFinite(imageLimit)) {
-      setError(`You can upload up to ${imageLimit} images at once.`);
+      messages.push(`You can upload up to ${imageLimit} images at once.`);
+    }
+    if (messages.length > 0) {
+      setError(messages.join(' '));
     }
 
     if (accepted.length === 0) return;


### PR DESCRIPTION
## Summary
- Image tab of `MediaUploadModal` now supports selecting multiple files at once.
- Regular users may stage up to **3 images**; admins (`admin`/`media_admin` via `useAuth`) are **unlimited**.
- Each staged image has its own thumbnail, optional caption, and remove control.
- Batch uploads run **sequentially** through the existing `POST /api/pois/:id/media` endpoint with per-image progress ("Uploading 2 of 3…") and partial-failure reporting (failed items stay staged for retry).
- Video and YouTube tabs are unchanged (single-item).

## Design notes
- **No backend or schema changes.** Each image reuses the proven moderation-queue + asset-rollback path (one endpoint call per image).
- The role cap is a **UX guardrail, not a security boundary** — single uploads are already unlimited by repetition today, so a server-enforced per-batch cap would duplicate the multi-file path without preventing anything. See `.specify/specs/021-multi-image-upload/spec.md`.

## Spec
- `.specify/specs/021-multi-image-upload/spec.md` + `plan.md`

Closes #390

## Test plan
- [x] Regular user: selecting 4+ images stages only 3 with a cap message
- [x] Batch upload of 2 images verified end-to-end (Boston Ski Lodge → 2 `poi_media` rows, 3s apart, both pending moderation)
- [x] Per-image caption, thumbnail, and remove controls
- [x] Video (≤10MB) and YouTube tabs unchanged
- [x] Gourmand: 0 violations
- [ ] Admin unlimited batch
- [ ] Mid-batch partial-failure reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)