### PR TITLE
fix: click-outside behavior for moderation edit modal and legend panel

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2588,6 +2588,10 @@ body {
   flex-direction: column;
 }
 
+.legend-close-btn {
+  display: none;
+}
+
 /* Desktop popup mode when expanded */
 .legend.legend-expanded {
   position: fixed;
@@ -2604,20 +2608,6 @@ body {
 }
 
 /* Legend backdrop when shown as popup */
-.legend-backdrop {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 1999;
-}
-
-.legend-backdrop.visible {
-  display: block;
-}
 
 /* Legend content wrapper - always visible on desktop */
 .legend-content {
@@ -3157,6 +3147,25 @@ body {
 
   .legend-content {
     display: block;
+  }
+
+  .legend-close-btn {
+    display: block;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #666;
+    padding: 0.25rem 0.5rem;
+    z-index: 1;
+  }
+
+  .legend-expanded .legend-search {
+    padding-right: 2rem;
   }
 
   /* POI count chip - tighter spacing on mobile */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -285,6 +285,7 @@ function AppContent() {
   const [isInOrganizationsMode, setIsInOrganizationsMode] = useState(false);
 
   const [bypassViewportFilter, setBypassViewportFilter] = useState(false);
+  const [isLegendExpanded, setIsLegendExpanded] = useState(false);
 
   useEffect(() => {
     if (destinations && destinations.length > 0) {
@@ -2349,6 +2350,8 @@ function AppContent() {
           defaultBounds={DEFAULT_PARK_BOUNDS}
           visiblePoiCount={visiblePoiCount}
           iconConfig={iconConfig}
+          isLegendExpanded={isLegendExpanded}
+          setIsLegendExpanded={setIsLegendExpanded}
           isDrawingAssociations={isDrawingAssociations}
           addingAssociationsToOrgId={addingAssociationsToOrgId}
           onAddAssociationsFromDrawing={handleAddAssociationsFromDrawing}

--- a/frontend/src/components/ContentFormModal.jsx
+++ b/frontend/src/components/ContentFormModal.jsx
@@ -122,7 +122,7 @@ function ContentFormModal({
     : `Create ${contentType === 'news' ? 'News Item' : 'Event'}`;
 
   return (
-    <div className="new-content-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+    <div className="new-content-overlay">
       <div className="new-content-modal">
         <div className="new-content-header">
           <h3>{title}</h3>

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -110,7 +110,7 @@ function Legend({
   parkBoundaries = [], municipalBoundaries = [],
   visibleTypes, onToggleType, onShowAll, onHideAll,
   searchQuery, onSearchChange,
-  isExpanded, _onClose,
+  isExpanded, onClose, innerRef,
   editMode,
   _activeTab, iconConfig, _onOpenAdmin,
   _onFileSelect, _selectedFileName, _importType, _onImportTypeChange,
@@ -176,7 +176,10 @@ function Legend({
   );
 
   return (
-    <div className={`legend ${isExpanded ? 'legend-expanded' : ''} ${editMode ? 'legend-edit-mode' : ''}`}>
+    <div ref={innerRef} className={`legend ${isExpanded ? 'legend-expanded' : ''} ${editMode ? 'legend-edit-mode' : ''}`}>
+      {isExpanded && onClose && (
+        <button className="legend-close-btn" onClick={onClose} aria-label="Close legend">&times;</button>
+      )}
       <div className="legend-content">
         <div className="legend-search">
           <input
@@ -975,7 +978,7 @@ function CoordinateConfirmDialog({ destination, newLat, newLng, onConfirm, onCan
 
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default']);
 
-function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, fitNonce, onFitBounds, defaultBounds, visiblePoiCount, iconConfig }) {
+function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, fitNonce, onFitBounds, defaultBounds, visiblePoiCount, iconConfig, isLegendExpanded, setIsLegendExpanded }) {
   // Unified selection: one selectedPoi in, one onSelectPoi out (spec 019).
   // `selectedIsLinear` reflects the selection KIND (path), not geometry — a
   // dual-role organization+boundary may be selected as a destination yet still
@@ -984,7 +987,21 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   const selectedLinearFeature = selectedPoi && selectedIsLinear ? selectedPoi : null;
   const onSelectDestination = onSelectPoi;
   const onSelectLinearFeature = onSelectPoi;
-  const [isLegendExpanded, setIsLegendExpanded] = useState(false);
+  // isLegendExpanded + setIsLegendExpanded come from props (lifted to App)
+  const legendRef = useRef(null);
+  const legendChipRef = useRef(null);
+
+  useEffect(() => {
+    if (!isLegendExpanded) return;
+    function handlePointerDown(e) {
+      if (legendRef.current?.contains(e.target)) return;
+      if (legendChipRef.current?.contains(e.target)) return;
+      setIsLegendExpanded(false);
+    }
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
+  }, [isLegendExpanded, setIsLegendExpanded]);
+
   const [useSatellite, setUseSatellite] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState(null); // Just for UI display
   const [importType, setImportType] = useState('trail');
@@ -1594,6 +1611,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
       </MapContainer>
 
       <button
+        ref={legendChipRef}
         className={`map-poi-count ${(selectedDestination || selectedLinearFeature || newPOI || newOrganization) ? 'sidebar-open' : ''}`}
         onClick={() => setIsLegendExpanded(!isLegendExpanded)}
       >
@@ -1607,11 +1625,6 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           <button className="dismiss-btn" onClick={() => setRefreshResult(null)}>×</button>
         </div>
       )}
-
-      <div
-        className={`legend-backdrop ${isLegendExpanded ? 'visible' : ''}`}
-        onClick={() => setIsLegendExpanded(false)}
-      />
 
       <Legend
         showTrails={showTrails}
@@ -1632,6 +1645,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         onSearchChange={onSearchChange}
         isExpanded={isLegendExpanded}
         onClose={() => setIsLegendExpanded(false)}
+        innerRef={legendRef}
         editMode={editMode}
         activeTab={activeTab}
         iconConfig={iconConfig}


### PR DESCRIPTION
## Summary
Two opposite click-outside bugs, both user-reported:

1. **Moderation queue edit modal** — clicking outside the edit form dismissed it, causing accidental data loss. Removed the overlay `onClick` handler so the only exit paths are Save, Cancel, or ×.

2. **Legend panel on mobile** — no way to dismiss the POI/Parks/Municipal panel by tapping outside it. Added a document-level `pointerdown` listener that closes the panel when tapping anywhere outside (header, map, or bottom area). Also added a visible × close button and padded the search box so it doesn't overlap the button.

### Technical note
The legend panel lives inside `main-content` which has `position: relative` + `z-index: 1` (inline style), creating a stacking context. A `position: fixed` backdrop inside it can never escape to cover the header (`z-index: 10000`). Replaced the backdrop div with a document-level `pointerdown` listener in capture phase, which works regardless of stacking contexts.

## Test plan
- [x] `./run.sh build` passes
- [x] Human-verified: moderation edit modal stays open on outside click
- [x] Human-verified: legend panel dismisses on tap outside (header, map, margins)
- [x] Human-verified: legend panel interactions (toggle POIs, parks, municipal) still work
- [x] Human-verified: × close button visible, search box not overlapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)