### PR TITLE
Add Cleveland water taxis to the map (#28)

### DIFF
--- a/.specify/specs/023-water-taxis/plan.md
+++ b/.specify/specs/023-water-taxis/plan.md
@@ -15,11 +15,14 @@ Add a `water_taxi` POI role and four generic POI columns (seasonal, ADA, bike-fr
 
 ### Data Flow
 
-1. Migration `062_add_water_taxis.sql` adds the four columns and seeds the two POIs (idempotent).
-2. A companion `load-water-taxi-geometry.js` loads route `geometry` (LineString/MultiLineString) into the seeded POIs, mirroring `load-river-geometry.js`.
-3. The POI serializer returns the new columns; the map fetches POIs as today.
-4. `Map.jsx` styles `water_taxi`-role geometry as a dashed transit line and adds a "Water Taxis" legend toggle.
-5. The sidebar reads the new columns to render seasonal/accessibility badges and the Live Tracker button.
+1. Migration `062_add_water_taxis.sql` adds the four columns, seeds the two POIs, **and loads their route `geometry` inline** (idempotent).
+2. The `/api/linear-features` serializer returns the new columns and includes the `water_taxi` role; the map fetches it as today.
+3. `Map.jsx` styles `water_taxi`-role geometry as a dashed transit line and adds a "Water Taxis" legend toggle.
+4. The sidebar reads the new columns to render seasonal/accessibility badges and the Live Tracker button.
+
+### Geometry loading decision
+
+The river feature uses a separate `load-river-geometry.js` script (its OSM geometries are large KB-scale MultiLineStrings) run manually at deploy. We instead embed the two small water taxi LineStrings directly in the SQL migration because: (a) the geometry is tiny (7 and 12 points), and (b) the dev (`entrypoint.sh`, unix-socket) and prod (`rotv-init.sh`, systemd) startup paths run only the numbered `*.sql` migrations and connect differently — a JS loader would need wiring into both and would not run on a plain `run.sh start`. Embedding in SQL gives one source of truth that loads automatically everywhere, with no manual deploy step. Coordinates are sampled from the Cuyahoga River centerline already in the DB so the lines sit on the water.
 
 ---
 
@@ -36,14 +39,13 @@ Add a `water_taxi` POI role and four generic POI columns (seasonal, ADA, bike-fr
 ## Implementation Steps
 
 ### Phase 1: Backend / data
-- [ ] `backend/migrations/062_add_water_taxis.sql` — add 4 columns; seed eLCee2 + Harbor Hopper POIs with `water_taxi` role, descriptions, root notes, seasonal/accessibility flags, live_tracker_url.
-- [ ] `backend/migrations/load-water-taxi-geometry.js` — load dashed route GeoJSON into the seeded POIs (mirror `load-river-geometry.js`); GeoJSON files in `backend/data/water-taxis/`.
-- [ ] Add the 4 new columns to the POI serializer / queries so they reach the frontend.
+- [x] `backend/migrations/062_add_water_taxis.sql` — add 4 columns; seed eLCee2 + Harbor Hopper POIs with `water_taxi` role, descriptions, root notes, seasonal/accessibility flags, live_tracker_url; load route geometry inline (see Geometry loading decision).
+- [x] Add the 4 new columns to `/api/linear-features` and include `water_taxi` in its role filter.
 
 ### Phase 2: Frontend rendering
-- [ ] Add `water_taxi` styling branch in `Map.jsx` `getStyleForFeature` (dashed line, transit color).
-- [ ] Add a "Water Taxis" layer toggle to the legend (`showWaterTaxis` state + handler), and include `water_taxi` in the visibility predicate.
-- [ ] Icon/layer entry in `iconUtils.js` if a layer icon is shown.
+- [x] Add `water_taxi` styling branch in `Map.jsx` `getLinearFeatureStyle` (dashed line, transit color `#0E9E9E`).
+- [x] Add a "Water Taxis" layer toggle to the legend (`showWaterTaxis` state + handler), and include `water_taxi` in the visibility predicate.
+- [x] Add the `water-taxis` layer icon asset (`frontend/public/icons/layers/water-taxis.svg`). Layer icons render from `/icons/layers/<id>.svg`, so no `iconUtils.js` change is needed.
 
 ### Phase 3: Sidebar
 - [ ] Seasonal indicator + ADA / bike-friendly badges in the read-only sidebar view.
@@ -57,19 +59,18 @@ Add a `water_taxi` POI role and four generic POI columns (seasonal, ADA, bike-fr
 
 | File | Purpose |
 |------|---------|
-| `backend/migrations/062_add_water_taxis.sql` | Columns + POI seed |
-| `backend/migrations/load-water-taxi-geometry.js` | Load route geometry |
-| `backend/data/water-taxis/elcee2.geojson` | eLCee2 route line |
-| `backend/data/water-taxis/harbor-hopper.geojson` | Harbor Hopper route line(s) |
+| `backend/migrations/062_add_water_taxis.sql` | Columns + POI seed + inline route geometry |
+| `frontend/public/icons/layers/water-taxis.svg` | "Water Taxis" legend layer icon |
 
 ### Modified Files
 
 | File | Changes |
 |------|---------|
-| `backend/server.js` / POI route serializer | Return new columns |
-| `frontend/src/components/Map.jsx` | `water_taxi` style branch + "Water Taxis" legend toggle |
-| `frontend/src/utils/iconUtils.js` | Layer icon entry (if used) |
-| `frontend/src/components/sidebar/ReadOnlyView.jsx` | Seasonal/ADA/bike badges + Live Tracker button |
+| `backend/server.js` | `/api/linear-features` includes `water_taxi` role + new columns (also added to `/api/pois`) |
+| `frontend/src/components/Map.jsx` | `water_taxi` style branch + "Water Taxis" legend toggle + visibility wiring |
+| `frontend/src/App.jsx` | `showWaterTaxis` state/props; deep-link layer enable |
+| `frontend/src/App.css` | `water-taxi` badge + `service-badge` (seasonal/ADA/bike) styles |
+| `frontend/src/components/sidebar/ReadOnlyView.jsx` | Water Taxi/Seasonal/ADA/bike badges + scheme-validated Live Tracker button |
 
 ---
 

--- a/.specify/specs/023-water-taxis/plan.md
+++ b/.specify/specs/023-water-taxis/plan.md
@@ -22,7 +22,9 @@ Add a `water_taxi` POI role and four generic POI columns (seasonal, ADA, bike-fr
 
 ### Geometry loading decision
 
-The river feature uses a separate `load-river-geometry.js` script (its OSM geometries are large KB-scale MultiLineStrings) run manually at deploy. We instead embed the two small water taxi LineStrings directly in the SQL migration because: (a) the geometry is tiny (7 and 12 points), and (b) the dev (`entrypoint.sh`, unix-socket) and prod (`rotv-init.sh`, systemd) startup paths run only the numbered `*.sql` migrations and connect differently — a JS loader would need wiring into both and would not run on a plain `run.sh start`. Embedding in SQL gives one source of truth that loads automatically everywhere, with no manual deploy step. Coordinates are sampled from the Cuyahoga River centerline already in the DB so the lines sit on the water.
+The river feature uses a separate `load-river-geometry.js` script (its OSM geometries are large KB-scale MultiLineStrings) run manually at deploy. We instead embed the water taxi geometry directly in the SQL migration because: (a) the geometry is small (eLCee2 4 points, Harbor Hopper 69 points), and (b) the dev (`entrypoint.sh`, unix-socket) and prod (`rotv-init.sh`, systemd) startup paths run only the numbered `*.sql` migrations and connect differently — a JS loader would need wiring into both and would not run on a plain `run.sh start`. Embedding in SQL gives one source of truth that loads automatically everywhere, with no manual deploy step.
+
+Geometry and stops are sourced from OpenStreetMap: `route=ferry` ways (eLCee2 way 978606820; Harbor Hopper ways 1417965570/71/72 chained end-to-end) and `amenity=ferry_terminal` nodes for the named stops. Stops live in a `pois.stops` JSONB column and render as labeled circle markers along the route; selecting a water_taxi feature flies the map to fit its route bounds (`MapUpdater`).
 
 ---
 

--- a/.specify/specs/023-water-taxis/plan.md
+++ b/.specify/specs/023-water-taxis/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Cleveland Water Taxis
+
+> **Spec ID:** 023-water-taxis
+> **Status:** Planning
+> **Last Updated:** 2026-05-23
+> **Estimated Effort:** M
+
+## Summary
+
+Add a `water_taxi` POI role and four generic POI columns (seasonal, ADA, bike-friendly, live-tracker URL), seed the two Flats water taxi services as POIs with dashed route geometry, and extend the map legend + linear-feature styling + sidebar to render them. No new tables or endpoints — reuses the river-role linear-feature pattern.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. Migration `062_add_water_taxis.sql` adds the four columns and seeds the two POIs (idempotent).
+2. A companion `load-water-taxi-geometry.js` loads route `geometry` (LineString/MultiLineString) into the seeded POIs, mirroring `load-river-geometry.js`.
+3. The POI serializer returns the new columns; the map fetches POIs as today.
+4. `Map.jsx` styles `water_taxi`-role geometry as a dashed transit line and adds a "Water Taxis" legend toggle.
+5. The sidebar reads the new columns to render seasonal/accessibility badges and the Live Tracker button.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Route geometry | `pois.geometry` JSONB (GeoJSON LineString) | Same column/path the map already renders for river POIs |
+| Role/layer model | `poi_roles[]` + legend layer toggle | Matches Trails/Rivers layers exactly |
+| Accessibility/seasonal | Boolean POI columns | Generic, reusable beyond water taxis |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend / data
+- [ ] `backend/migrations/062_add_water_taxis.sql` — add 4 columns; seed eLCee2 + Harbor Hopper POIs with `water_taxi` role, descriptions, root notes, seasonal/accessibility flags, live_tracker_url.
+- [ ] `backend/migrations/load-water-taxi-geometry.js` — load dashed route GeoJSON into the seeded POIs (mirror `load-river-geometry.js`); GeoJSON files in `backend/data/water-taxis/`.
+- [ ] Add the 4 new columns to the POI serializer / queries so they reach the frontend.
+
+### Phase 2: Frontend rendering
+- [ ] Add `water_taxi` styling branch in `Map.jsx` `getStyleForFeature` (dashed line, transit color).
+- [ ] Add a "Water Taxis" layer toggle to the legend (`showWaterTaxis` state + handler), and include `water_taxi` in the visibility predicate.
+- [ ] Icon/layer entry in `iconUtils.js` if a layer icon is shown.
+
+### Phase 3: Sidebar
+- [ ] Seasonal indicator + ADA / bike-friendly badges in the read-only sidebar view.
+- [ ] "Live Tracker" button (external link, new tab) when `live_tracker_url` is set.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/062_add_water_taxis.sql` | Columns + POI seed |
+| `backend/migrations/load-water-taxi-geometry.js` | Load route geometry |
+| `backend/data/water-taxis/elcee2.geojson` | eLCee2 route line |
+| `backend/data/water-taxis/harbor-hopper.geojson` | Harbor Hopper route line(s) |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/server.js` / POI route serializer | Return new columns |
+| `frontend/src/components/Map.jsx` | `water_taxi` style branch + "Water Taxis" legend toggle |
+| `frontend/src/utils/iconUtils.js` | Layer icon entry (if used) |
+| `frontend/src/components/sidebar/ReadOnlyView.jsx` | Seasonal/ADA/bike badges + Live Tracker button |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 062_add_water_taxis
+-- Description: Water taxi columns + seed eLCee2 and Harbor Hopper POIs. Idempotent.
+
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+
+-- Seed services guarded by NOT EXISTS on (name, 'water_taxi' = ANY(poi_roles)).
+```
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+1. Start the container; confirm migration runs and the two POIs exist with `water_taxi` role.
+2. On the map, toggle "Water Taxis" — dashed routes appear/disappear across the river in the Flats.
+3. Click a route — sidebar shows description, root note, seasonal indicator, accessibility badges (eLCee2: ADA + bike), and Live Tracker button (Harbor Hopper).
+4. Confirm Rivers/Trails layers are unaffected.
+
+### Automated
+- [ ] Extend existing Playwright/map smoke coverage to assert the Water Taxis toggle renders, if a low-cost assertion fits the existing suite.
+
+---
+
+## Rollback Plan
+
+1. New columns are additive and default-safe; leaving them in place is harmless.
+2. To remove the feature: soft-delete the two seeded POIs (`deleted = true`) — routes vanish from the map without schema changes.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Route coordinates are approximate / wrong | Med | Snap coordinates to the Cuyahoga River LineString already in the DB so points sit on the water; verify visually before launch; easy to re-run geometry loader |
+| Real photos not yet available | Low | Imagery is a non-blocking follow-up via existing gallery upload |
+| Live tracker URL unknown/changes | Low | Button only renders when URL set; safe to leave null |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-23 | Initial plan |

--- a/.specify/specs/023-water-taxis/plan.md
+++ b/.specify/specs/023-water-taxis/plan.md
@@ -86,8 +86,10 @@ ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALS
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS stops             JSONB;
 
--- Seed services guarded by NOT EXISTS on (name, 'water_taxi' = ANY(poi_roles)).
+-- Seed services guarded by NOT EXISTS on (name, 'water_taxi' = ANY(poi_roles)),
+-- then load OSM ferry geometry + stops via guarded UPDATEs.
 ```
 
 ---

--- a/.specify/specs/023-water-taxis/spec.md
+++ b/.specify/specs/023-water-taxis/spec.md
@@ -121,7 +121,7 @@ Photos called for by the issue (East Bank dock signage; eLCee2 vs. Harbor Hopper
 
 1. ~~**Geometry source/accuracy**~~ **RESOLVED:** Coordinates are snapped to the Cuyahoga River `geometry` LineString already loaded in the ROTV database (river-role POI), so dock markers and route lines sit on the water exactly as OSM renders it. Approximate dock anchors from the issue (East Bank under Main Ave Bridge; West Bank near the Old River Bed; Harbor Hopper stops at Collision Bend, BrewDog, Main Ave) are matched to the nearest point on that river line.
 2. ~~**One POI vs. one-per-stop**~~ **RESOLVED:** One POI per service carrying the full route geometry.
-3. **Live tracker URL** — `live_tracker_url` is nullable; the "Live Tracker" button renders only when a URL is set. The real Harbor Hopper GPS-app URL could not be confirmed during spec research (web search tooling was degraded) and will be entered via admin edit once verified. eLCee2 likely has none.
+3. ~~**Live tracker URL**~~ **RESOLVED:** Harbor Hopper's live tracker is `https://trackmyshuttle.com/a/5799` (TrackMyShuttle, linked as "Taxi Tracker" from the official clevelandwatertaxi.com) — seeded in migration 062. eLCee2 is the free Cleveland Metroparks boat and has no commercial tracker, so its `live_tracker_url` stays NULL. The button is scheme-validated (http/https only) before rendering.
 
 ---
 

--- a/.specify/specs/023-water-taxis/spec.md
+++ b/.specify/specs/023-water-taxis/spec.md
@@ -1,0 +1,132 @@
+# Specification: Cleveland Water Taxis
+
+> **Spec ID:** 023-water-taxis
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-23
+
+## Overview
+
+Add the two water taxi services operating in the Cleveland Flats — the eLCee2 Metroparks Shuttle and the Harbor Hopper commercial taxi — to the map as a new transit layer. These services connect the East and West banks of the Cuyahoga and tell the "modern roots" story of river transit: the eLCee2 links the Towpath Trail across the water without using road bridges, and the Harbor Hopper mirrors the 1800s bumboat and ferry traffic that shuttled sailors and workers across the river. Routes render as dashed lines across the river, distinct from the solid river line and dashed trail lines already on the map.
+
+---
+
+## User Stories
+
+### Map Exploration
+
+**US-023-1: See water taxi routes on the map**
+> As a map visitor, I want to see the water taxi routes drawn across the Cuyahoga so that I can understand how the East and West banks connect by water.
+
+Acceptance Criteria:
+- [ ] eLCee2 and Harbor Hopper appear as distinct dashed transit lines crossing the river in the Flats.
+- [ ] A "Water Taxis" toggle in the legend shows/hides the transit layer independently of the Rivers and Trails layers.
+- [ ] Clicking a route opens the POI sidebar with its name, description, and root note (historical connection).
+
+**US-023-2: Understand seasonality**
+> As a visitor planning a trip, I want to know the water taxis are seasonal so that I don't expect them to run in winter.
+
+Acceptance Criteria:
+- [ ] Each water taxi POI is flagged `is_seasonal = true`.
+- [ ] The sidebar/popup clearly indicates the service is seasonal (does not run in winter).
+
+**US-023-3: Check accessibility**
+> As a visitor with mobility needs or a bike, I want to know which service is accessible so that I can choose the right one.
+
+Acceptance Criteria:
+- [ ] The eLCee2 is flagged as ADA-accessible and bike-friendly.
+- [ ] Accessibility is surfaced in the sidebar/popup (e.g. ADA + bike-friendly badges).
+
+### Live Tracking
+
+**US-023-4: Track the boat live**
+> As a visitor waiting for a ride, I want a link to the live GPS tracker so that I can see when the boat arrives.
+
+Acceptance Criteria:
+- [ ] A "Live Tracker" button appears in the sidebar/popup for services that have a tracker URL.
+- [ ] The button opens the external GPS tracking app/site in a new tab (`rel="noopener noreferrer"`).
+- [ ] Services without a tracker URL do not show the button.
+
+---
+
+## Data Model
+
+### New Tables
+
+None. Water taxis reuse the existing `pois` table (point marker + linear `geometry`, same pattern as `river`-role POIs).
+
+### Schema Changes
+
+```sql
+-- Migration 062: water taxi support
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+```
+
+- New `poi_roles` value: `water_taxi` (rendered as a dashed transit line; toggled by the "Water Taxis" legend layer).
+- Each service is one POI: a point marker at its primary East Bank dock plus a dashed `geometry` LineString (or MultiLineString for multi-stop Harbor Hopper) describing the transit path across the river.
+- `live_tracker_url` holds the Harbor Hopper GPS app link; `more_info_link` continues to hold the general website.
+
+---
+
+## API Endpoints
+
+No new endpoints. Water taxi POIs are served by the existing POI/linear-feature endpoints; the four new columns are added to the existing POI serializer so they reach the frontend.
+
+---
+
+## UI/UX Requirements
+
+### Map / Legend
+
+- New legend layer toggle **"Water Taxis"** alongside Trails and Rivers.
+- `water_taxi`-role geometry styled as a dashed line (`dashArray`) in a transit color distinct from river blue (`#1E90FF`) and trail brown (`#8B4513`).
+
+### Sidebar / Popup
+
+- Seasonal indicator ("Seasonal — does not run in winter").
+- ADA and bike-friendly badges when the respective flags are set.
+- "Live Tracker" button when `live_tracker_url` is present.
+
+### Imagery (follow-up)
+
+Photos called for by the issue (East Bank dock signage; eLCee2 vs. Harbor Hopper vessel comparison) are uploaded through the existing `poi_media` gallery flow once captured. Not blocking on initial launch.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-023-1: Idempotent migration**
+- Migration re-runs cleanly on every container start (`ADD COLUMN IF NOT EXISTS`).
+
+**NFR-023-2: Graceful rendering**
+- New columns default safely (false / null); existing POIs and the existing map are unaffected when the columns are empty.
+
+**NFR-023-3: External link safety**
+- Live Tracker links open in a new tab with `rel="noopener noreferrer"`.
+
+---
+
+## Dependencies
+
+- Depends on: existing linear-feature rendering (river-role POIs, spec 022) and grouped legend layers (spec 015).
+- Blocks: none.
+
+---
+
+## Open Questions
+
+1. ~~**Geometry source/accuracy**~~ **RESOLVED:** Coordinates are snapped to the Cuyahoga River `geometry` LineString already loaded in the ROTV database (river-role POI), so dock markers and route lines sit on the water exactly as OSM renders it. Approximate dock anchors from the issue (East Bank under Main Ave Bridge; West Bank near the Old River Bed; Harbor Hopper stops at Collision Bend, BrewDog, Main Ave) are matched to the nearest point on that river line.
+2. ~~**One POI vs. one-per-stop**~~ **RESOLVED:** One POI per service carrying the full route geometry.
+3. **Live tracker URL** — `live_tracker_url` is nullable; the "Live Tracker" button renders only when a URL is set. The real Harbor Hopper GPS-app URL could not be confirmed during spec research (web search tooling was degraded) and will be entered via admin edit once verified. eLCee2 likely has none.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-23 | Initial draft |

--- a/.specify/specs/023-water-taxis/spec.md
+++ b/.specify/specs/023-water-taxis/spec.md
@@ -64,6 +64,7 @@ ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALS
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS stops             JSONB;  -- [{name,lat,lng}] ordered transit stops
 ```
 
 - New `poi_roles` value: `water_taxi` (rendered as a dashed transit line; toggled by the "Water Taxis" legend layer).
@@ -119,7 +120,7 @@ Photos called for by the issue (East Bank dock signage; eLCee2 vs. Harbor Hopper
 
 ## Open Questions
 
-1. ~~**Geometry source/accuracy**~~ **RESOLVED:** Coordinates are snapped to the Cuyahoga River `geometry` LineString already loaded in the ROTV database (river-role POI), so dock markers and route lines sit on the water exactly as OSM renders it. Approximate dock anchors from the issue (East Bank under Main Ave Bridge; West Bank near the Old River Bed; Harbor Hopper stops at Collision Bend, BrewDog, Main Ave) are matched to the nearest point on that river line.
+1. ~~**Geometry source/accuracy**~~ **RESOLVED:** Route geometry and stop locations come from OpenStreetMap `route=ferry` ways and `amenity=ferry_terminal` nodes (eLCee2: way 978606820 + East/West Bank docks; Harbor Hopper: ways 1417965570/71/72 chained, with stops Cleveland Water Taxi Main Hub, Flats East Bank, Collision Bend Brewing, BrewDog Outpost). Stops are stored in a new `pois.stops` JSONB column and rendered as labeled markers along the route.
 2. ~~**One POI vs. one-per-stop**~~ **RESOLVED:** One POI per service carrying the full route geometry.
 3. ~~**Live tracker URL**~~ **RESOLVED:** Harbor Hopper's live tracker is `https://trackmyshuttle.com/a/5799` (TrackMyShuttle, linked as "Taxi Tracker" from the official clevelandwatertaxi.com) — seeded in migration 062. eLCee2 is the free Cleveland Metroparks boat and has no commercial tracker, so its `live_tracker_url` stays NULL. The button is scheme-validated (http/https only) before rendering.
 

--- a/backend/migrations/062_add_water_taxis.sql
+++ b/backend/migrations/062_add_water_taxis.sql
@@ -1,0 +1,59 @@
+-- Migration: Add Cleveland Water Taxis (#28)
+-- Created: 2026-05-23
+-- Description: Adds seasonal/accessibility/live-tracker columns to pois and seeds
+--   the two Flats water taxi services (eLCee2 Metroparks Shuttle, Harbor Hopper)
+--   as water_taxi-role linear features, including their dashed route geometry.
+--   Route coordinates are sampled from the Cuyahoga River centerline already in
+--   the DB (the Collision Bend oxbow through the Flats), so every point sits on
+--   the water as OSM renders it.
+-- Idempotent: re-runs cleanly on every container start.
+
+-- 1. Generic POI service attributes (reusable beyond water taxis).
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+
+-- 2. Seed the two water taxi services. Each is one POI carrying the full route
+--    as a dashed linear feature (geometry loaded by the companion JS script).
+--    Guarded by NOT EXISTS on (name, water_taxi role) so re-runs are no-ops.
+INSERT INTO pois (name, poi_roles, brief_description, historical_description,
+                  is_seasonal, is_ada_accessible, is_bike_friendly, live_tracker_url)
+SELECT v.name, ARRAY['water_taxi']::text[], v.brief, v.hist,
+       v.seasonal, v.ada, v.bike, v.tracker
+FROM (VALUES
+  (
+    'eLCee2 (Metroparks Shuttle)',
+    'Cleveland Metroparks'' seasonal water shuttle connecting the East and West banks of the Cuyahoga in the Flats, linking the Towpath Trail across the river without using the road bridges.',
+    'Connects the Towpath Trail directly across the river without using the road bridges — reviving the Cuyahoga as a transit corridor for walkers and cyclists.',
+    TRUE, TRUE, TRUE, NULL::varchar
+  ),
+  (
+    'Harbor Hopper',
+    'Seasonal commercial water taxi making stops around the Flats (Collision Bend, BrewDog, Main Avenue), shuttling visitors across and along the Cuyahoga.',
+    'Mirrors the old "bumboat" and ferry traffic that shuttled sailors and workers across the Cuyahoga in the 1800s.',
+    TRUE, FALSE, FALSE, NULL::varchar
+  )
+) AS v(name, brief, hist, seasonal, ada, bike, tracker)
+WHERE NOT EXISTS (
+  SELECT 1 FROM pois p WHERE p.name = v.name AND 'water_taxi' = ANY(p.poi_roles)
+);
+
+-- 3. Load dashed route geometry (GeoJSON LineStrings) for each service. Only sets
+--    geometry when still NULL, so hand-edits/re-runs are preserved.
+--    eLCee2: Main Avenue Bridge crossing out to the Old River Bed near the mouth.
+UPDATE pois
+SET geometry = '{"type":"LineString","coordinates":[[-81.70568,41.49872],[-81.70707,41.49901],[-81.70813,41.49918],[-81.70877,41.49962],[-81.71067,41.50204],[-81.71080,41.50220],[-81.71186,41.50360]]}'::jsonb,
+    updated_at = NOW()
+WHERE name = 'eLCee2 (Metroparks Shuttle)' AND 'water_taxi' = ANY(poi_roles) AND geometry IS NULL;
+
+--    Harbor Hopper: Collision Bend oxbow through the Flats (Collision Bend -> BrewDog -> Main Ave).
+UPDATE pois
+SET geometry = '{"type":"LineString","coordinates":[[-81.69876,41.49043],[-81.69897,41.48926],[-81.70010,41.48835],[-81.70078,41.48832],[-81.70238,41.48863],[-81.70404,41.48966],[-81.70463,41.49075],[-81.70416,41.49265],[-81.70277,41.49490],[-81.70202,41.49643],[-81.70326,41.49761],[-81.70568,41.49872]]}'::jsonb,
+    updated_at = NOW()
+WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles) AND geometry IS NULL;
+
+COMMENT ON COLUMN pois.is_seasonal      IS 'Service does not operate year-round (e.g. water taxis, closed in winter) (#28)';
+COMMENT ON COLUMN pois.is_ada_accessible IS 'POI/service is ADA-accessible (#28)';
+COMMENT ON COLUMN pois.is_bike_friendly  IS 'POI/service accommodates bicycles (#28)';
+COMMENT ON COLUMN pois.live_tracker_url  IS 'External live GPS tracker URL surfaced as a sidebar button (#28)';

--- a/backend/migrations/062_add_water_taxis.sql
+++ b/backend/migrations/062_add_water_taxis.sql
@@ -15,7 +15,7 @@ ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALS
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
 
 -- 2. Seed the two water taxi services. Each is one POI carrying the full route
---    as a dashed linear feature (geometry loaded by the companion JS script).
+--    as a dashed linear feature (route geometry is loaded in step 3 below).
 --    Guarded by NOT EXISTS on (name, water_taxi role) so re-runs are no-ops.
 INSERT INTO pois (name, poi_roles, brief_description, historical_description,
                   is_seasonal, is_ada_accessible, is_bike_friendly, live_tracker_url)

--- a/backend/migrations/062_add_water_taxis.sql
+++ b/backend/migrations/062_add_water_taxis.sql
@@ -32,7 +32,7 @@ FROM (VALUES
     'Harbor Hopper',
     'Seasonal commercial water taxi making stops around the Flats (Collision Bend, BrewDog, Main Avenue), shuttling visitors across and along the Cuyahoga.',
     'Mirrors the old "bumboat" and ferry traffic that shuttled sailors and workers across the Cuyahoga in the 1800s.',
-    TRUE, FALSE, FALSE, NULL::varchar
+    TRUE, FALSE, FALSE, 'https://trackmyshuttle.com/a/5799'::varchar
   )
 ) AS v(name, brief, hist, seasonal, ada, bike, tracker)
 WHERE NOT EXISTS (
@@ -52,6 +52,12 @@ UPDATE pois
 SET geometry = '{"type":"LineString","coordinates":[[-81.69876,41.49043],[-81.69897,41.48926],[-81.70010,41.48835],[-81.70078,41.48832],[-81.70238,41.48863],[-81.70404,41.48966],[-81.70463,41.49075],[-81.70416,41.49265],[-81.70277,41.49490],[-81.70202,41.49643],[-81.70326,41.49761],[-81.70568,41.49872]]}'::jsonb,
     updated_at = NOW()
 WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles) AND geometry IS NULL;
+
+-- 4. Backfill the Harbor Hopper live GPS tracker (TrackMyShuttle, linked from
+--    clevelandwatertaxi.com) for any DB seeded before the URL was known.
+UPDATE pois
+SET live_tracker_url = 'https://trackmyshuttle.com/a/5799', updated_at = NOW()
+WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles) AND live_tracker_url IS NULL;
 
 COMMENT ON COLUMN pois.is_seasonal      IS 'Service does not operate year-round (e.g. water taxis, closed in winter) (#28)';
 COMMENT ON COLUMN pois.is_ada_accessible IS 'POI/service is ADA-accessible (#28)';

--- a/backend/migrations/062_add_water_taxis.sql
+++ b/backend/migrations/062_add_water_taxis.sql
@@ -2,10 +2,10 @@
 -- Created: 2026-05-23
 -- Description: Adds seasonal/accessibility/live-tracker columns to pois and seeds
 --   the two Flats water taxi services (eLCee2 Metroparks Shuttle, Harbor Hopper)
---   as water_taxi-role linear features, including their dashed route geometry.
---   Route coordinates are sampled from the Cuyahoga River centerline already in
---   the DB (the Collision Bend oxbow through the Flats), so every point sits on
---   the water as OSM renders it.
+--   as water_taxi-role linear features, including their route geometry and stops.
+--   Route geometry and stop locations come from OpenStreetMap route=ferry ways and
+--   amenity=ferry_terminal nodes (eLCee2: way 978606820; Harbor Hopper: ways
+--   1417965570/71/72 chained Main Hub -> Flats East Bank -> Collision Bend -> BrewDog).
 -- Idempotent: re-runs cleanly on every container start.
 
 -- 1. Generic POI service attributes (reusable beyond water taxis).
@@ -13,6 +13,7 @@ ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_seasonal       BOOLEAN DEFAULT FALS
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_ada_accessible BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS is_bike_friendly  BOOLEAN DEFAULT FALSE;
 ALTER TABLE pois ADD COLUMN IF NOT EXISTS live_tracker_url  VARCHAR(500);
+ALTER TABLE pois ADD COLUMN IF NOT EXISTS stops             JSONB;
 
 -- 2. Seed the two water taxi services. Each is one POI carrying the full route
 --    as a dashed linear feature (route geometry is loaded in step 3 below).
@@ -39,19 +40,30 @@ WHERE NOT EXISTS (
   SELECT 1 FROM pois p WHERE p.name = v.name AND 'water_taxi' = ANY(p.poi_roles)
 );
 
--- 3. Load dashed route geometry (GeoJSON LineStrings) for each service. Only sets
+-- 3. Load route geometry (GeoJSON LineStrings from OSM route=ferry ways). Only sets
 --    geometry when still NULL, so hand-edits/re-runs are preserved.
---    eLCee2: Main Avenue Bridge crossing out to the Old River Bed near the mouth.
+--    eLCee2: East Bank Dock -> West Bank Dock crossing (OSM way 978606820).
 UPDATE pois
-SET geometry = '{"type":"LineString","coordinates":[[-81.70568,41.49872],[-81.70707,41.49901],[-81.70813,41.49918],[-81.70877,41.49962],[-81.71067,41.50204],[-81.71080,41.50220],[-81.71186,41.50360]]}'::jsonb,
+SET geometry = '{"type":"LineString","coordinates":[[-81.704992,41.499007],[-81.705279,41.49883],[-81.705566,41.498598],[-81.705941,41.498245]]}'::jsonb,
     updated_at = NOW()
 WHERE name = 'eLCee2 (Metroparks Shuttle)' AND 'water_taxi' = ANY(poi_roles) AND geometry IS NULL;
 
---    Harbor Hopper: Collision Bend oxbow through the Flats (Collision Bend -> BrewDog -> Main Ave).
+--    Harbor Hopper: OSM ways 1417965570/71/72 chained (Main Hub -> Flats East Bank -> Collision Bend -> BrewDog).
 UPDATE pois
-SET geometry = '{"type":"LineString","coordinates":[[-81.69876,41.49043],[-81.69897,41.48926],[-81.70010,41.48835],[-81.70078,41.48832],[-81.70238,41.48863],[-81.70404,41.48966],[-81.70463,41.49075],[-81.70416,41.49265],[-81.70277,41.49490],[-81.70202,41.49643],[-81.70326,41.49761],[-81.70568,41.49872]]}'::jsonb,
+SET geometry = '{"type":"LineString","coordinates":[[-81.707759,41.497377],[-81.707821,41.497338],[-81.707941,41.497307],[-81.70809,41.497307],[-81.708376,41.497354],[-81.708678,41.497425],[-81.708797,41.497495],[-81.708846,41.49759],[-81.708836,41.497727],[-81.708778,41.497827],[-81.707897,41.498698],[-81.707753,41.49877],[-81.707323,41.498839],[-81.706654,41.498896],[-81.7062,41.498947],[-81.705969,41.499026],[-81.705831,41.499108],[-81.705819,41.499035],[-81.705751,41.498916],[-81.70564,41.498829],[-81.705324,41.498698],[-81.705094,41.49861],[-81.704837,41.498533],[-81.7045,41.498458],[-81.704191,41.498415],[-81.703964,41.498449],[-81.703978,41.498356],[-81.703924,41.49823],[-81.703709,41.49803],[-81.702738,41.497537],[-81.702438,41.497366],[-81.702137,41.497105],[-81.701968,41.496859],[-81.701876,41.496638],[-81.701886,41.496304],[-81.701978,41.496025],[-81.702617,41.494919],[-81.70388,41.492931],[-81.704059,41.492605],[-81.704176,41.492239],[-81.704384,41.491484],[-81.704447,41.491017],[-81.704423,41.49056],[-81.704297,41.490121],[-81.704074,41.489841],[-81.70357,41.489461],[-81.702936,41.489054],[-81.702316,41.488757],[-81.701755,41.488547],[-81.701169,41.488456],[-81.700636,41.48842],[-81.700225,41.488434],[-81.699915,41.488529],[-81.699687,41.488645],[-81.699421,41.488891],[-81.699087,41.489268],[-81.698879,41.48962],[-81.698787,41.489867],[-81.698768,41.49015],[-81.69885,41.490436],[-81.699198,41.490984],[-81.699416,41.491379],[-81.699557,41.491934],[-81.699547,41.492405],[-81.699484,41.492696],[-81.699363,41.492942],[-81.699286,41.493019],[-81.699176,41.493056],[-81.699054,41.493053]]}'::jsonb,
     updated_at = NOW()
 WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles) AND geometry IS NULL;
+
+--    Stops (OSM amenity=ferry_terminal nodes), ordered along each route.
+UPDATE pois
+SET stops = '[{"name":"East Bank Dock","lat":41.499007,"lng":-81.704992},{"name":"West Bank Dock","lat":41.498245,"lng":-81.705941}]'::jsonb,
+    updated_at = NOW()
+WHERE name = 'eLCee2 (Metroparks Shuttle)' AND 'water_taxi' = ANY(poi_roles) AND stops IS NULL;
+
+UPDATE pois
+SET stops = '[{"name":"Cleveland Water Taxi Main Hub","lat":41.497377,"lng":-81.707759},{"name":"Flats East Bank","lat":41.499108,"lng":-81.705831},{"name":"Collision Bend Brewing Company","lat":41.498449,"lng":-81.703964},{"name":"BrewDog Cleveland Outpost","lat":41.493053,"lng":-81.699054}]'::jsonb,
+    updated_at = NOW()
+WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles) AND stops IS NULL;
 
 -- 4. Backfill the Harbor Hopper live GPS tracker (TrackMyShuttle, linked from
 --    clevelandwatertaxi.com) for any DB seeded before the URL was known.
@@ -63,3 +75,4 @@ COMMENT ON COLUMN pois.is_seasonal      IS 'Service does not operate year-round 
 COMMENT ON COLUMN pois.is_ada_accessible IS 'POI/service is ADA-accessible (#28)';
 COMMENT ON COLUMN pois.is_bike_friendly  IS 'POI/service accommodates bicycles (#28)';
 COMMENT ON COLUMN pois.live_tracker_url  IS 'External live GPS tracker URL surfaced as a sidebar button (#28)';
+COMMENT ON COLUMN pois.stops             IS 'Ordered JSON array of named stops [{name,lat,lng}] for transit routes, e.g. water taxi ferry terminals (#28)';

--- a/backend/server.js
+++ b/backend/server.js
@@ -902,7 +902,6 @@ app.get('/api/pois', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id
@@ -939,7 +938,6 @@ app.get('/api/pois/:id', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id

--- a/backend/server.js
+++ b/backend/server.js
@@ -902,7 +902,7 @@ app.get('/api/pois', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id
@@ -939,7 +939,7 @@ app.get('/api/pois/:id', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id
@@ -1768,7 +1768,7 @@ app.get('/api/linear-features', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
@@ -1795,7 +1795,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
-             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url, p.stops,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)

--- a/backend/server.js
+++ b/backend/server.js
@@ -902,6 +902,7 @@ app.get('/api/pois', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id
@@ -938,6 +939,7 @@ app.get('/api/pois/:id', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id
@@ -1766,11 +1768,12 @@ app.get('/api/linear-features', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)
       LEFT JOIN eras e ON p.era_id = e.id
-      WHERE p.poi_roles && ARRAY['trail','river','boundary']::text[]
+      WHERE p.poi_roles && ARRAY['trail','river','boundary','water_taxi']::text[]
         AND (p.deleted IS NULL OR p.deleted = FALSE)
       ORDER BY p.poi_roles, p.name
     `);
@@ -1792,6 +1795,7 @@ app.get('/api/linear-features/:id', async (req, res) => {
              p.primary_activities, p.surface, p.pets, p.cell_signal, p.more_info_link,
              p.length_miles, p.difficulty, p.has_primary_image,
              p.boundary_type, p.boundary_color, p.news_url, p.events_url, p.status_url,
+             p.is_seasonal, p.is_ada_accessible, p.is_bike_friendly, p.live_tracker_url,
              p.collection_tier, p.deleted, p.created_at, p.updated_at
       FROM pois p
       LEFT JOIN pois o ON p.owner_id = o.id AND 'organization' = ANY(o.poi_roles)

--- a/frontend/public/icons/layers/water-taxis.svg
+++ b/frontend/public/icons/layers/water-taxis.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="15" fill="#0E9E9E" stroke="white" stroke-width="2"/>
+  <path d="M7 18 H25 L22 22 H10 Z" fill="white"/>
+  <rect x="13" y="10" width="6" height="8" rx="1" fill="white"/>
+  <path d="M7 25 Q10 23 13 25 Q16 27 19 25 Q22 23 25 25" fill="none" stroke="white" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11348,6 +11348,35 @@ body {
   color: #ff9800;
 }
 
+.poi-type-badge.water-taxi {
+  background: #e0f2f1;
+  color: #00695c;
+}
+
+/* Service attribute badges (seasonal / accessibility) — #28 */
+.service-badge {
+  display: inline-block;
+  padding: 0.3rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.service-badge.seasonal {
+  background: #fff8e1;
+  color: #b26a00;
+}
+
+.service-badge.ada {
+  background: #e3f2fd;
+  color: #1565c0;
+}
+
+.service-badge.bike {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
 .poi-type-badge .poi-type-icon {
   width: 18px;
   height: 18px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -106,6 +106,7 @@ function AppContent() {
 
   const [showTrails, setShowTrails] = useState(true);
   const [showRivers, setShowRivers] = useState(true);
+  const [showWaterTaxis, setShowWaterTaxis] = useState(true);
   const [visibleBoundaries, setVisibleBoundaries] = useState(new Set()); // Set of boundary IDs
 
   const [mapState, setMapState] = useState({
@@ -893,6 +894,8 @@ function AppContent() {
           setShowTrails(true);
         } else if (linearFeature.poi_roles?.includes('river')) {
           setShowRivers(true);
+        } else if (linearFeature.poi_roles?.includes('water_taxi')) {
+          setShowWaterTaxis(true);
         }
         setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
         return;
@@ -1005,6 +1008,8 @@ function AppContent() {
           setShowTrails(true);
         } else if (linearFeature.poi_roles?.includes('river')) {
           setShowRivers(true);
+        } else if (linearFeature.poi_roles?.includes('water_taxi')) {
+          setShowWaterTaxis(true);
         }
         setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
         return;
@@ -2307,6 +2312,8 @@ function AppContent() {
           onToggleTrails={setShowTrails}
           showRivers={showRivers}
           onToggleRivers={setShowRivers}
+          showWaterTaxis={showWaterTaxis}
+          onToggleWaterTaxis={setShowWaterTaxis}
           visibleBoundaries={visibleBoundaries}
           onToggleBoundary={(id) => {
             const willEnable = !visibleBoundaries.has(id);

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents, CircleMarker } from 'react-leaflet';
 import L from 'leaflet';
 import VirtualPoiCreator from './VirtualPoiCreator';
 import { getDestinationIconTypeFromConfig } from '../utils/iconUtils';
@@ -356,6 +356,15 @@ function MapUpdater({ selectedDestination, selectedLinearFeature, skipFlyRef }) 
     if (selectedLinearFeature && selectedLinearFeature.geometry) {
       if (skipFlyRef && skipFlyRef.current) {
         skipFlyRef.current = false;
+        return;
+      }
+      // Water taxi routes are small and easy to miss; fit the map to the route on select.
+      if (selectedLinearFeature.poi_roles?.includes('water_taxi')) {
+        const b = getGeometryBounds(selectedLinearFeature.geometry);
+        if (b) {
+          map.invalidateSize();
+          map.flyToBounds([[b.south, b.west], [b.north, b.east]], { padding: [60, 60], maxZoom: 16, duration: 0.6 });
+        }
       }
     }
   }, [selectedLinearFeature, map, skipFlyRef]);
@@ -1581,6 +1590,24 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
               />
             </React.Fragment>
           );
+        })}
+
+        {linearFeatures && linearFeatures.map(feature => {
+          if (!feature.poi_roles?.includes('water_taxi') || !Array.isArray(feature.stops)) return null;
+          const stopsVisible = searchQuery
+            ? feature.name?.toLowerCase().includes(searchQuery.toLowerCase())
+            : showWaterTaxis;
+          if (!stopsVisible) return null;
+          return feature.stops.map((stop, i) => (
+            <CircleMarker
+              key={`wt-stop-${feature.id}-${i}`}
+              center={[stop.lat, stop.lng]}
+              radius={5}
+              pathOptions={{ color: '#ffffff', weight: 2, fillColor: '#0E9E9E', fillOpacity: 1 }}
+            >
+              <Tooltip direction="top" offset={[0, -4]}>{stop.name}</Tooltip>
+            </CircleMarker>
+          ));
         })}
 
         <MapUpdater selectedDestination={selectedDestination} selectedLinearFeature={selectedLinearFeature} skipFlyRef={skipFlyRef} />

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -128,6 +128,7 @@ function LegendSection({ id, title, count, isOpen, onToggle, showActions, onShow
 function Legend({
   showTrails, onToggleTrails,
   showRivers, onToggleRivers,
+  showWaterTaxis, onToggleWaterTaxis,
   visibleBoundaries, onToggleBoundary,
   onShowBoundaries, onHideBoundaries,
   parkBoundaries = [], municipalBoundaries = [],
@@ -174,11 +175,12 @@ function Legend({
 
     const layerIcons = [
       { id: 'trails', label: 'Trails', type: 'layer', isActive: showTrails, onToggle: () => onToggleTrails(!showTrails) },
-      { id: 'rivers', label: 'Rivers', type: 'layer', isActive: showRivers, onToggle: () => onToggleRivers(!showRivers) }
+      { id: 'rivers', label: 'Rivers', type: 'layer', isActive: showRivers, onToggle: () => onToggleRivers(!showRivers) },
+      { id: 'water-taxis', label: 'Water Taxis', type: 'layer', isActive: showWaterTaxis, onToggle: () => onToggleWaterTaxis(!showWaterTaxis) }
     ];
 
     return [...poiTypes, ...layerIcons].sort((a, b) => a.label.localeCompare(b.label));
-  }, [iconConfig, showTrails, showRivers, onToggleTrails, onToggleRivers]);
+  }, [iconConfig, showTrails, showRivers, showWaterTaxis, onToggleTrails, onToggleRivers, onToggleWaterTaxis]);
 
   const [openSection, setOpenSection] = useState('poi');
   const toggleSection = (key) => setOpenSection(prev => (prev === key ? null : key));
@@ -524,7 +526,7 @@ function ZoomTooltipHider() {
   return null;
 }
 
-function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, onVisiblePoisChange, onMapStateChange, linearFeatures, showTrails, showRivers, visibleBoundaries, searchQuery }) {
+function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, onVisiblePoisChange, onMapStateChange, linearFeatures, showTrails, showRivers, showWaterTaxis, visibleBoundaries, searchQuery }) {
   const map = useMap();
   const search = (searchQuery || '').toLowerCase();
 
@@ -558,6 +560,7 @@ function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, 
       const includeLinearFeatures = !!search || !isFilteredMode ||
                                     visibleTypes.has('trail') ||
                                     visibleTypes.has('river') ||
+                                    visibleTypes.has('water_taxi') ||
                                     visibleTypes.has('boundary');
 
       if (includeLinearFeatures && linearFeatures && linearFeatures.length > 0) {
@@ -570,6 +573,8 @@ function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, 
             isLayerVisible = showTrails;
           } else if (feature.poi_roles?.includes('river')) {
             isLayerVisible = showRivers;
+          } else if (feature.poi_roles?.includes('water_taxi')) {
+            isLayerVisible = showWaterTaxis;
           } else if (feature.poi_roles?.includes('boundary')) {
             isLayerVisible = visibleBoundaries.has(feature.id);
           }
@@ -604,7 +609,7 @@ function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, 
       }
     } catch {
     }
-  }, [map, destinations, visibleTypes, getDestinationIconType, onVisiblePoisChange, onMapStateChange, linearFeatures, showTrails, showRivers, visibleBoundaries, search]);
+  }, [map, destinations, visibleTypes, getDestinationIconType, onVisiblePoisChange, onMapStateChange, linearFeatures, showTrails, showRivers, showWaterTaxis, visibleBoundaries, search]);
 
   useMapEvents({
     moveend: updateVisiblePois,
@@ -621,7 +626,7 @@ function MapBoundsTracker({ destinations, visibleTypes, getDestinationIconType, 
 
   useEffect(() => {
     updateVisiblePois();
-  }, [destinations, linearFeatures, showTrails, showRivers, visibleBoundaries, updateVisiblePois]);
+  }, [destinations, linearFeatures, showTrails, showRivers, showWaterTaxis, visibleBoundaries, updateVisiblePois]);
 
   return null;
 }
@@ -1007,7 +1012,7 @@ function CoordinateConfirmDialog({ destination, newLat, newLng, onConfirm, onCan
 
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default']);
 
-function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, fitNonce, onFitBounds, defaultBounds, visiblePoiCount, iconConfig, activeGauge, isLegendExpanded, setIsLegendExpanded }) {
+function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin, onDestinationUpdate, editMode, activeTab, _onDestinationCreate, previewCoords, onPreviewCoordsChange, newPOI, onStartNewPOI, linearFeatures, visibleTypes, onVisibleTypesChange, onVisiblePoisChange, onMapStateChange, showTrails, onToggleTrails, showRivers, onToggleRivers, showWaterTaxis, onToggleWaterTaxis, visibleBoundaries, onToggleBoundary, onShowBoundaries, onHideBoundaries, searchQuery, onSearchChange, _onNewsRefresh, skipFlyRef, newOrganization, onStartNewOrganization, isDrawingAssociations, addingAssociationsToOrgId, onAddAssociationsFromDrawing, onCancelDrawingAssociations, boundsToFit, fitNonce, onFitBounds, defaultBounds, visiblePoiCount, iconConfig, activeGauge, isLegendExpanded, setIsLegendExpanded }) {
   // Unified selection: one selectedPoi in, one onSelectPoi out (spec 019).
   // `selectedIsLinear` reflects the selection KIND (path), not geometry — a
   // dual-role organization+boundary may be selected as a destination yet still
@@ -1286,6 +1291,13 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         opacity: isSelected ? 1 : 0.8,
         color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#1E90FF'
       };
+    } else if (feature.poi_roles?.includes('water_taxi')) {
+      return {
+        weight: isSelected ? 4 : 3,
+        opacity: isSelected ? 1 : 0.85,
+        dashArray: '10, 8',
+        color: isSelected ? (editMode ? editSelectedColor : viewSelectedColor) : '#0E9E9E'
+      };
     } else if (feature.poi_roles?.includes('boundary')) {
       const boundaryColor = boundaryDisplayColor(feature);
       const selectedStrokeColor = editMode ? editSelectedColor : viewSelectedColor;
@@ -1379,6 +1391,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             ? feature.name?.toLowerCase().includes(searchQuery.toLowerCase())
             : ((feature.poi_roles?.includes('trail') && showTrails) ||
                (feature.poi_roles?.includes('river') && showRivers) ||
+               (feature.poi_roles?.includes('water_taxi') && showWaterTaxis) ||
                (feature.poi_roles?.includes('boundary') && visibleBoundaries.has(feature.id)));
           if (!isVisible) return null;
 
@@ -1583,6 +1596,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           linearFeatures={linearFeatures}
           showTrails={showTrails}
           showRivers={showRivers}
+          showWaterTaxis={showWaterTaxis}
           visibleBoundaries={visibleBoundaries}
           searchQuery={searchQuery}
         />
@@ -1714,6 +1728,8 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         onToggleTrails={onToggleTrails}
         showRivers={showRivers}
         onToggleRivers={onToggleRivers}
+        showWaterTaxis={showWaterTaxis}
+        onToggleWaterTaxis={onToggleWaterTaxis}
         visibleBoundaries={visibleBoundaries}
         onToggleBoundary={onToggleBoundary}
         onShowBoundaries={onShowBoundaries}

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1162,10 +1162,37 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     }
   };
 
+  // Fit the map to all water taxi routes (their geometry sits in the Flats).
+  const fitToWaterTaxis = useCallback(() => {
+    if (!onFitBounds || !linearFeatures) return;
+    let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+    for (const f of linearFeatures) {
+      if (!f.poi_roles?.includes('water_taxi') || !f.geometry) continue;
+      const b = getGeometryBounds(f.geometry);
+      if (!b) continue;
+      if (b.south < minLat) minLat = b.south;
+      if (b.west < minLng) minLng = b.west;
+      if (b.north > maxLat) maxLat = b.north;
+      if (b.east > maxLng) maxLng = b.east;
+    }
+    if (minLat === Infinity) {
+      if (defaultBounds) onFitBounds(defaultBounds);
+      return;
+    }
+    onFitBounds([[minLat, minLng], [maxLat, maxLng]]);
+  }, [linearFeatures, onFitBounds, defaultBounds]);
+
+  // Toggling the Water Taxis layer on zooms to its routes, matching POI-type behavior.
+  const handleToggleWaterTaxis = (next) => {
+    onToggleWaterTaxis(next);
+    if (next) fitToWaterTaxis();
+  };
+
   const handleShowAll = () => {
     if (onVisibleTypesChange) onVisibleTypesChange(new Set(allIconTypes));
     onToggleTrails(true);
     onToggleRivers(true);
+    onToggleWaterTaxis(true);
     fitToTypes(allIconTypes); // fit to every POI now shown
   };
 
@@ -1173,6 +1200,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     if (onVisibleTypesChange) onVisibleTypesChange(new Set());
     onToggleTrails(false);
     onToggleRivers(false);
+    onToggleWaterTaxis(false);
     if (onFitBounds && defaultBounds) onFitBounds(defaultBounds);
   };
 
@@ -1756,7 +1784,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         showRivers={showRivers}
         onToggleRivers={onToggleRivers}
         showWaterTaxis={showWaterTaxis}
-        onToggleWaterTaxis={onToggleWaterTaxis}
+        onToggleWaterTaxis={handleToggleWaterTaxis}
         visibleBoundaries={visibleBoundaries}
         onToggleBoundary={onToggleBoundary}
         onShowBoundaries={onShowBoundaries}

--- a/frontend/src/components/sidebar/ReadOnlyView.jsx
+++ b/frontend/src/components/sidebar/ReadOnlyView.jsx
@@ -6,6 +6,10 @@ import CellSignal from './CellSignal';
 import { getNavigationStops, getOwnerClass, formatCoordinate } from './helpers';
 
 function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, onCollectStatus }) {
+  // Fix: only honor http(s) tracker URLs so a stored javascript: URL can't run on click (PR #405 review)
+  const liveTrackerUrl = /^https?:\/\//i.test(destination.live_tracker_url || '')
+    ? destination.live_tracker_url
+    : null;
   return (
     <div className="view-container">
       <div className="view-scroll">
@@ -158,10 +162,10 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
         )}
         </div>
 
-        {destination.live_tracker_url && (
+        {liveTrackerUrl && (
           <div className="more-info-section">
             <a
-              href={destination.live_tracker_url}
+              href={liveTrackerUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="more-info-link live-tracker-link"

--- a/frontend/src/components/sidebar/ReadOnlyView.jsx
+++ b/frontend/src/components/sidebar/ReadOnlyView.jsx
@@ -13,8 +13,9 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
         <div className="sidebar-content">
         <div className="badges-row">
           {isLinearFeature ? (
-            <span className={`poi-type-badge ${destination.poi_roles?.includes('river') ? 'river' : destination.poi_roles?.includes('boundary') ? 'boundary' : 'trail'}`}>
+            <span className={`poi-type-badge ${destination.poi_roles?.includes('river') ? 'river' : destination.poi_roles?.includes('water_taxi') ? 'water-taxi' : destination.poi_roles?.includes('boundary') ? 'boundary' : 'trail'}`}>
               {destination.poi_roles?.includes('river') ? 'River' :
+               destination.poi_roles?.includes('water_taxi') ? 'Water Taxi' :
                destination.poi_roles?.includes('boundary') ? 'Boundary' : 'Trail'}
             </span>
           ) : destination.poi_roles?.includes('organization') ? (
@@ -33,6 +34,21 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
           {isLinearFeature && destination.difficulty && (
             <span className={`difficulty-badge ${destination.difficulty.toLowerCase()}`}>
               {destination.difficulty}
+            </span>
+          )}
+          {destination.is_seasonal && (
+            <span className="service-badge seasonal" title="Seasonal service — does not run in winter">
+              Seasonal
+            </span>
+          )}
+          {destination.is_ada_accessible && (
+            <span className="service-badge ada" title="ADA accessible">
+              ADA
+            </span>
+          )}
+          {destination.is_bike_friendly && (
+            <span className="service-badge bike" title="Bike-friendly">
+              Bike-friendly
             </span>
           )}
           {destination.era_name && !destination.poi_roles?.includes('organization') && (
@@ -141,6 +157,22 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
           </div>
         )}
         </div>
+
+        {destination.live_tracker_url && (
+          <div className="more-info-section">
+            <a
+              href={destination.live_tracker_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="more-info-link live-tracker-link"
+            >
+              Live Tracker
+              <svg viewBox="0 0 24 24" width="16" height="16" style={{ marginLeft: '8px' }}>
+                <path fill="currentColor" d="M12,8A4,4 0 0,0 8,12A4,4 0 0,0 12,16A4,4 0 0,0 16,12A4,4 0 0,0 12,8M12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z" />
+              </svg>
+            </a>
+          </div>
+        )}
 
         {moreInfoLink && (
           <div className="more-info-section">


### PR DESCRIPTION
## Summary
Adds the two Flats water taxi services — **eLCee2 (Metroparks Shuttle)** and **Harbor Hopper** — to the map as a new `water_taxi` POI role, rendered as dashed transit routes (mirroring the existing river/trail linear-feature pattern). This shows the "modern roots" of river transit connecting the East and West banks.

- **Migration 062** (idempotent, runs via the existing SQL migration loop):
  - Adds generic POI columns `is_seasonal`, `is_ada_accessible`, `is_bike_friendly`, `live_tracker_url`.
  - Seeds both services with `water_taxi` role, descriptions, root notes (historical connection), and accessibility/seasonal flags (eLCee2: ADA + bike-friendly).
  - Loads dashed route geometry **sampled from the Cuyahoga River centerline** already in the DB (the Collision Bend oxbow), so every point sits on the water as OSM renders it.
- **API:** `/api/linear-features` now includes the `water_taxi` role and the four new columns.
- **Map:** teal dashed line style for `water_taxi` + a **"Water Taxis"** legend layer toggle (`showWaterTaxis`, default on).
- **Sidebar:** Water Taxi type badge, **Seasonal / ADA / Bike-friendly** badges, and a **Live Tracker** external-link button (rendered only when `live_tracker_url` is set).

Spec/plan: `.specify/specs/023-water-taxis/`.

## Notes / follow-ups
- **Live tracker URL** seeds `NULL` (button hidden until set). The real Harbor Hopper GPS-app URL could not be confirmed during development (web search tooling was degraded) — it can be entered via admin edit once verified. eLCee2 likely has none.
- **Imagery** (East Bank dock signage; eLCee2 vs. Harbor Hopper vessel comparison) is a non-blocking follow-up via the existing gallery upload, since we don't have the photos yet.

Closes #28

## Test plan
- [x] `./run.sh build` passes (frontend compiles)
- [x] Migration 062 runs automatically on fresh container start; both POIs seeded with geometry
- [x] `/api/linear-features` returns both water taxis with geometry + flags
- [x] Both routes render on the map with the dashed transit style (verified via DOM: 2 `dashArray 10,8` paths, teal + selected-blue, permanent tooltip)
- [x] Sidebar shows Water Taxi + Seasonal badges; eLCee2 shows ADA + Bike-friendly
- [x] Gourmand: 0 violations
- [ ] Reviewer: confirm routes look right in the Flats and Live Tracker button appears once a URL is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)