### PR TITLE
fix: river gauge carousel UX — swipe isolation, layout, and prefetch

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15153,29 +15153,35 @@ button.feedback-link-inline {
   animation: pulse-ring 1.5s ease-out infinite;
 }
 
-.river-levels-tab { padding: 0.5rem 0; }
+.river-levels-tab { padding: 0.25rem 0; }
+
+/* Carousel wrapper — positions the nav arrows over the gauge card */
+.river-gauge-carousel-wrapper {
+  position: relative;
+}
 .river-gauge-card {
   border: 1px solid var(--border-color, #ddd);
   border-radius: 8px;
-  padding: 0.75rem;
-  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
 }
-.river-gauge-name { margin: 0 0 0.35rem; font-size: 1rem; }
+.river-gauge-name { margin: 0 0 0.25rem; font-size: 0.95rem; }
 .river-gauge-current {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.4rem;
-  margin-bottom: 0.5rem;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
 }
 .river-gauge-value { font-weight: 700; color: #1e6fb8; }
 .river-gauge-sep { color: #999; }
-.river-gauge-time { color: #666; font-size: 0.85rem; }
-.river-gauge-metric-toggle { display: flex; gap: 0; margin-bottom: 0.5rem; }
+.river-gauge-time { color: #666; font-size: 0.8rem; }
+.river-gauge-metric-toggle { display: flex; gap: 0; margin-bottom: 0.35rem; }
 .river-gauge-metric-toggle button {
   flex: 1;
-  padding: 0.3rem 0.5rem;
-  font-size: 0.8rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.78rem;
   border: 1px solid var(--border-color, #ccc);
   background: #f6f6f6;
   cursor: pointer;
@@ -15184,36 +15190,54 @@ button.feedback-link-inline {
 .river-gauge-metric-toggle button:last-child { border-radius: 0 6px 6px 0; border-left: none; }
 .river-gauge-metric-toggle button.active { background: #1e6fb8; color: #fff; border-color: #1e6fb8; }
 .river-gauge-metric-toggle button:disabled { opacity: 0.4; cursor: not-allowed; }
-.river-gauge-link { display: inline-block; margin-top: 0.4rem; font-size: 0.85rem; }
+.river-gauge-link { display: inline-block; margin-top: 0.25rem; font-size: 0.8rem; }
 .river-levels-empty { color: #777; font-style: italic; padding: 0.5rem 0; }
 
-/* River Levels carousel nav */
-.river-gauge-nav {
+/* Nav arrows — flanking the gauge card like the photo nav arrows */
+.river-gauge-nav-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(128, 128, 128, 0.3);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-.river-gauge-arrow {
-  flex: 0 0 auto;
-  width: 2rem;
-  height: 2rem;
-  font-size: 1.4rem;
-  line-height: 1;
-  border: 1px solid var(--border-color, #ccc);
-  border-radius: 50%;
-  background: #fff;
-  color: #1e6fb8;
+  justify-content: center;
+  font-size: 1.6rem;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.9);
   cursor: pointer;
+  transition: background 0.2s;
+  z-index: 5;
+  line-height: 1;
 }
-.river-gauge-arrow:hover { background: #1e6fb8; color: #fff; border-color: #1e6fb8; }
-.river-gauge-pager { font-size: 0.85rem; color: #666; }
+.river-gauge-nav-arrow:hover { background: rgba(128, 128, 128, 0.5); }
+.river-gauge-nav-prev { left: 0; border-radius: 0 4px 4px 0; }
+.river-gauge-nav-next { right: 0; border-radius: 4px 0 0 4px; }
+
+/* Subtitle + pager below the card */
+.river-gauge-subtitle {
+  text-align: center;
+  font-size: 0.78rem;
+  color: #777;
+  font-style: italic;
+  margin: 0.4rem 0 0.15rem;
+}
+.river-gauge-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.1rem;
+}
+.river-gauge-pager { font-size: 0.8rem; color: #666; }
 .river-gauge-dots {
   display: flex;
   justify-content: center;
   gap: 0.4rem;
-  margin-top: 0.6rem;
 }
 .river-gauge-dot-btn {
   width: 9px;

--- a/frontend/src/components/LevelChart.jsx
+++ b/frontend/src/components/LevelChart.jsx
@@ -33,7 +33,7 @@ function LevelChart({ readings, metric }) {
 
   return (
     <ResponsiveContainer width="100%" height={160}>
-      <LineChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
+      <LineChart data={data} margin={{ top: 8, right: 40, bottom: 4, left: 28 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="t"

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -17,17 +17,6 @@ function createGaugeIcon(label, active) {
   });
 }
 
-// Pans/zooms the map to the gauge currently shown in the River Levels carousel (#92)
-function GaugeFocuser({ activeGauge }) {
-  const map = useMap();
-  React.useEffect(() => {
-    if (!activeGauge || activeGauge.latitude == null || activeGauge.longitude == null) return;
-    const targetZoom = Math.max(map.getZoom(), 13);
-    map.flyTo([activeGauge.latitude, activeGauge.longitude], targetZoom, { animate: true, duration: 0.6 });
-  }, [activeGauge, map]);
-  return null;
-}
-
 function createTripStopIcon(n) {
   return L.divIcon({
     className: 'trip-stop-icon',
@@ -1571,7 +1560,9 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
         })}
 
         <MapUpdater selectedDestination={selectedDestination} selectedLinearFeature={selectedLinearFeature} skipFlyRef={skipFlyRef} />
-        <GaugeFocuser activeGauge={activeGauge} />
+        {/* GaugeFocuser removed — flyTo on gauge change cascades through
+            moveend → updateVisiblePois → poiNavigationList recompute →
+            currentPoiIndex update → ThumbnailCarousel remount */}
         <MapVisibilityHandler activeTab={activeTab} />
         <BoundsFitter boundsToFit={boundsToFit} fitNonce={fitNonce} />
         <MapBoundsTracker

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -125,8 +125,9 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
     const target = e.target;
     const isCarousel = target.closest('.thumbnail-carousel-wrapper, .thumbnail-carousel');
     const isNavButton = target.closest('.image-nav-btn');
+    const isGaugeCarousel = target.closest('.river-levels-tab');
 
-    if (isCarousel || isNavButton) {
+    if (isCarousel || isNavButton || isGaugeCarousel) {
       touchStartX.current = null;
       touchStartY.current = null;
       return;

--- a/frontend/src/components/sidebar/RiverLevels.jsx
+++ b/frontend/src/components/sidebar/RiverLevels.jsx
@@ -27,23 +27,18 @@ function fmt(value, unit) {
   return `${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })} ${unit}`;
 }
 
-function GaugeCard({ gauge }) {
-  const [readings, setReadings] = useState(null);
+function GaugeCard({ gauge, cachedReadings }) {
+  const [readings, setReadings] = useState(cachedReadings ?? null);
   const [error, setError] = useState(false);
   const [metric, setMetric] = useState(
     gauge.latest?.discharge_cfs != null ? 'discharge_cfs' : 'gage_height_ft'
   );
 
   useEffect(() => {
-    let cancelled = false;
+    if (cachedReadings) { setReadings(cachedReadings); return; }
     setReadings(null);
     setError(false);
-    fetch(`/api/river-gauges/${gauge.id}/readings?days=7`)
-      .then(res => (res.ok ? res.json() : Promise.reject(new Error('fetch failed'))))
-      .then(data => { if (!cancelled) setReadings(data.readings || []); })
-      .catch(() => { if (!cancelled) setError(true); });
-    return () => { cancelled = true; };
-  }, [gauge.id]);
+  }, [gauge.id, cachedReadings]);
 
   const dischargeAvailable = readings
     ? readings.some(r => r.discharge_cfs != null)
@@ -52,7 +47,6 @@ function GaugeCard({ gauge }) {
     ? readings.some(r => r.gage_height_ft != null)
     : gauge.latest?.gage_height_ft != null;
 
-  // If the chosen metric has no data for this gauge, switch to the one that does.
   useEffect(() => {
     if (readings === null) return;
     if (metric === 'discharge_cfs' && !dischargeAvailable && heightAvailable) setMetric('gage_height_ft');
@@ -86,7 +80,7 @@ function GaugeCard({ gauge }) {
       </div>
 
       {error ? (
-        <p className="river-levels-empty">Couldn’t load readings.</p>
+        <p className="river-levels-empty">Couldn't load readings.</p>
       ) : readings === null ? (
         <p className="river-levels-empty">Loading…</p>
       ) : (
@@ -104,21 +98,34 @@ function RiverLevels({ poiId, onActiveGaugeChange }) {
   const [gauges, setGauges] = useState(null);
   const [index, setIndex] = useState(0);
   const touchStartX = useRef(null);
+  const readingsCache = useRef(new globalThis.Map());
+  const [cacheVersion, setCacheVersion] = useState(0);
 
   useEffect(() => {
     if (!poiId) return undefined;
     let cancelled = false;
+    readingsCache.current.clear();
+    setCacheVersion(0);
     fetch(`/api/pois/${poiId}/river-gauges`)
       .then(res => (res.ok ? res.json() : []))
       .then(data => {
         if (cancelled) return;
         setGauges(data);
-        // Focus a specific gauge if a map marker linked here with ?gauge=<id>
         const focusId = new URLSearchParams(window.location.search).get('gauge');
         if (focusId) {
           const i = data.findIndex(g => String(g.id) === String(focusId));
           if (i >= 0) setIndex(i);
         }
+        data.forEach(g => {
+          fetch(`/api/river-gauges/${g.id}/readings?days=7`)
+            .then(res => (res.ok ? res.json() : { readings: [] }))
+            .then(d => {
+              if (cancelled) return;
+              readingsCache.current.set(g.id, d.readings || []);
+              setCacheVersion(v => v + 1);
+            })
+            .catch(() => {});
+        });
       })
       .catch(() => { if (!cancelled) setGauges([]); });
     return () => { cancelled = true; };
@@ -160,8 +167,13 @@ function RiverLevels({ poiId, onActiveGaugeChange }) {
     return <div className="river-levels-tab"><p className="river-levels-empty">No gauge data yet for this river.</p></div>;
   }
 
-  const onTouchStart = (e) => { touchStartX.current = e.touches[0]?.clientX ?? null; };
+  const onTouchStart = (e) => {
+    e.stopPropagation();
+    touchStartX.current = e.touches[0]?.clientX ?? null;
+  };
+  const onTouchMove = (e) => { e.stopPropagation(); };
   const onTouchEnd = (e) => {
+    e.stopPropagation();
     if (touchStartX.current == null) return;
     const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartX.current;
     if (Math.abs(dx) > 40) go(dx < 0 ? 1 : -1);
@@ -169,30 +181,45 @@ function RiverLevels({ poiId, onActiveGaugeChange }) {
   };
 
   return (
-    <div className="river-levels-tab" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
-      <p className="tab-subtitle">Official USGS gauge readings for kayakers</p>
+    <div className="river-levels-tab" onTouchStart={onTouchStart} onTouchMove={onTouchMove} onTouchEnd={onTouchEnd}>
+      <div className="river-gauge-carousel-wrapper">
+        {count > 1 && (
+          <button
+            className="river-gauge-nav-arrow river-gauge-nav-prev"
+            onTouchEnd={(e) => { e.preventDefault(); e.stopPropagation(); go(-1); }}
+            onClick={(e) => { e.stopPropagation(); go(-1); }}
+            aria-label="Previous gauge"
+          >‹</button>
+        )}
+
+        <GaugeCard gauge={current} cachedReadings={readingsCache.current.get(current.id) ?? null} />
+
+        {count > 1 && (
+          <button
+            className="river-gauge-nav-arrow river-gauge-nav-next"
+            onTouchEnd={(e) => { e.preventDefault(); e.stopPropagation(); go(1); }}
+            onClick={(e) => { e.stopPropagation(); go(1); }}
+            aria-label="Next gauge"
+          >›</button>
+        )}
+      </div>
+
+      <p className="river-gauge-subtitle">Official USGS gauge readings for kayakers</p>
 
       {count > 1 && (
-        <div className="river-gauge-nav">
-          <button className="river-gauge-arrow" onClick={() => go(-1)} aria-label="Previous gauge">‹</button>
+        <div className="river-gauge-footer">
           <span className="river-gauge-pager">{safeIndex + 1} of {count} gauges</span>
-          <button className="river-gauge-arrow" onClick={() => go(1)} aria-label="Next gauge">›</button>
-        </div>
-      )}
-
-      <GaugeCard key={current.id} gauge={current} />
-
-      {count > 1 && (
-        <div className="river-gauge-dots" role="tablist" aria-label="Select gauge">
-          {gauges.map((g, i) => (
-            <button
-              key={g.id}
-              className={`river-gauge-dot-btn ${i === safeIndex ? 'active' : ''}`}
-              onClick={() => setIndex(i)}
-              aria-label={g.name || g.usgs_site_id}
-              aria-selected={i === safeIndex}
-            />
-          ))}
+          <div className="river-gauge-dots" role="tablist" aria-label="Select gauge">
+            {gauges.map((g, i) => (
+              <button
+                key={g.id}
+                className={`river-gauge-dot-btn ${i === safeIndex ? 'active' : ''}`}
+                onClick={() => setIndex(i)}
+                aria-label={g.name || g.usgs_site_id}
+                aria-selected={i === safeIndex}
+              />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/sidebar/RiverLevels.jsx
+++ b/frontend/src/components/sidebar/RiverLevels.jsx
@@ -116,15 +116,15 @@ function RiverLevels({ poiId, onActiveGaugeChange }) {
           const i = data.findIndex(g => String(g.id) === String(focusId));
           if (i >= 0) setIndex(i);
         }
-        data.forEach(g => {
+        Promise.all(data.map(g =>
           fetch(`/api/river-gauges/${g.id}/readings?days=7`)
             .then(res => (res.ok ? res.json() : { readings: [] }))
-            .then(d => {
-              if (cancelled) return;
-              readingsCache.current.set(g.id, d.readings || []);
-              setCacheVersion(v => v + 1);
-            })
-            .catch(() => {});
+            .then(d => ({ id: g.id, readings: d.readings || [] }))
+            .catch(() => ({ id: g.id, readings: [] }))
+        )).then(results => {
+          if (cancelled) return;
+          results.forEach(r => readingsCache.current.set(r.id, r.readings));
+          setCacheVersion(v => v + 1);
         });
       })
       .catch(() => { if (!cancelled) setGauges([]); });


### PR DESCRIPTION
## Summary
- **Root cause fix**: Removed `GaugeFocuser` from Map.jsx — `flyTo` on gauge change cascaded through `moveend` → `updateVisiblePois` → `poiNavigationList` recompute → `currentPoiIndex` update → ThumbnailCarousel remount, causing the POI carousel to re-appear on every gauge switch
- **Swipe isolation**: Added `.river-levels-tab` to Sidebar touch exclusion + `stopPropagation` on gauge touch handlers so swipes inside the gauge area don't trigger POI navigation
- **Layout restructure**: Arrows flank the chart (like photo nav), subtitle and pager moved below chart
- **Prefetch**: All gauge readings fetched in parallel on tab open — navigating between gauges is instant with no loading flash
- **Mobile fit**: Compact spacing so gauge card fits on screen after photo carousel hides

## Test plan
- [ ] Open a river with multiple gauges (Cuyahoga, Tuscarawas)
- [ ] Tap left/right arrows — gauge switches instantly, POI carousel does NOT re-appear
- [ ] Swipe on chart area — switches gauges, not POIs
- [ ] Verify chart clears both arrows with no overlap
- [ ] Verify subtitle and pager text appear below chart
- [ ] Verify POI swipe still works on other tabs (Info, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)