### PR TITLE
feat: left-justify legend panel items (#411)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2803,6 +2803,7 @@ body {
   /* Two-column grid to match the Points of Interest layout (#396 follow-up) */
   display: grid;
   grid-template-columns: 1fr 1fr;
+  justify-items: start;
   gap: 0.35rem;
 }
 
@@ -3646,6 +3647,7 @@ body {
 .legend-icons {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  justify-items: start;
   gap: 0.25rem;
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Add `justify-items: start` to `.legend-icons` grid so POI type buttons left-align within their column cells
- Add `justify-items: start` to `.boundary-chips` grid so park and municipal boundary chips left-align similarly
- Keeps 2-column layout, items just no longer stretch to fill each cell

Closes #411

## Test plan
- [x] Verified POI types left-justified in legend panel
- [x] Verified park boundary chips left-justified
- [x] Verified municipal boundary chips left-justified
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)