### PR TITLE
fix: legend chip overflow and mobile touch tooltips (#411)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2820,6 +2820,7 @@ body {
   transition: all 0.15s ease;
   /* Allow the name to truncate within its grid column */
   min-width: 0;
+  max-width: 100%;
 }
 
 .boundary-chip.active {
@@ -2856,6 +2857,20 @@ body {
   /* Fill the grid column and truncate to fit instead of a fixed cap (#396 follow-up) */
   flex: 1;
   min-width: 0;
+}
+
+.touch-tooltip {
+  position: fixed;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .legend-toggle {
@@ -3666,6 +3681,14 @@ body {
   font-family: inherit;
   color: inherit;
   text-align: left;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.legend-icon-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .legend-icon-item:hover {

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -202,12 +202,30 @@ function Legend({
   const [openSection, setOpenSection] = useState('poi');
   const toggleSection = (key) => setOpenSection(prev => (prev === key ? null : key));
 
+  const [touchTooltip, setTouchTooltip] = useState(null);
+  const touchTimerRef = useRef(null);
+
+  const handleTouchStart = useCallback((e, text) => {
+    touchTimerRef.current = setTimeout(() => {
+      const touch = e.touches[0];
+      setTouchTooltip({ text, x: touch.clientX, y: touch.clientY });
+    }, 500);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (touchTimerRef.current) { clearTimeout(touchTimerRef.current); touchTimerRef.current = null; }
+    setTouchTooltip(null);
+  }, []);
+
   const renderBoundaryChip = (boundary) => (
     <button
       key={boundary.id}
       className={`boundary-chip ${visibleBoundaries.has(boundary.id) ? 'active' : 'inactive'}`}
       onClick={() => onToggleBoundary(boundary.id)}
       title={boundary.name}
+      onTouchStart={(e) => handleTouchStart(e, boundary.name)}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchEnd}
     >
       <span
         className="boundary-chip-color"
@@ -252,6 +270,10 @@ function Legend({
                     className={`legend-icon-item ${type.isActive ? 'active' : 'inactive'}`}
                     onClick={type.onToggle}
                     aria-pressed={type.isActive}
+                    title={type.label}
+                    onTouchStart={(e) => handleTouchStart(e, type.label)}
+                    onTouchEnd={handleTouchEnd}
+                    onTouchMove={handleTouchEnd}
                     type="button"
                   >
                     <img src={`/icons/layers/${type.id}.svg`} alt="" aria-hidden="true" />
@@ -266,6 +288,10 @@ function Legend({
                     className={`legend-icon-item ${isActive ? 'active' : 'inactive'}`}
                     onClick={() => onToggleType(type.id)}
                     aria-pressed={isActive}
+                    title={type.label}
+                    onTouchStart={(e) => handleTouchStart(e, type.label)}
+                    onTouchEnd={handleTouchEnd}
+                    onTouchMove={handleTouchEnd}
                     type="button"
                   >
                     {type.svg_content ? (
@@ -312,6 +338,11 @@ function Legend({
         </LegendSection>
 
       </div>
+      {touchTooltip && (
+        <div className="touch-tooltip" style={{ top: touchTooltip.y - 40, left: touchTooltip.x }}>
+          {touchTooltip.text}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `max-width: 100%` to `.boundary-chip` and `.legend-icon-item` so names truncate with ellipsis instead of overflowing into the adjacent grid column
- Add `title` attributes to POI type legend buttons for desktop hover tooltips (boundary chips already had them)
- Add touch-hold tooltip (500ms delay) for mobile — shows full name in a dark tooltip above the finger, dismisses on release or move
- Add text truncation (`overflow: hidden; text-overflow: ellipsis`) to `.legend-icon-item span` for defensive consistency

## Test plan
- [x] Park/Municipal chips truncate with ellipsis, no overflow into column 2
- [x] Desktop hover shows full name tooltip
- [x] Mobile long-press shows custom tooltip
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)