### PR TITLE
fix: replace long-press tooltip with tap-to-show on mobile (#411)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2812,6 +2812,7 @@ body {
   align-items: center;
   gap: 0.35rem;
   padding: 0.25rem 0.5rem;
+  user-select: none;
   border-radius: 12px;
   font-size: 0.75rem;
   cursor: pointer;
@@ -3672,6 +3673,7 @@ body {
   align-items: center;
   gap: 0.35rem;
   font-size: 0.75rem;
+  user-select: none;
   padding: 0.2rem 0.3rem;
   border-radius: 4px;
   cursor: pointer;

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents, CircleMarker } from 'react-leaflet';
 import L from 'leaflet';
 import VirtualPoiCreator from './VirtualPoiCreator';
@@ -205,27 +206,19 @@ function Legend({
   const [touchTooltip, setTouchTooltip] = useState(null);
   const touchTimerRef = useRef(null);
 
-  const handleTouchStart = useCallback((e, text) => {
-    touchTimerRef.current = setTimeout(() => {
-      const touch = e.touches[0];
-      setTouchTooltip({ text, x: touch.clientX, y: touch.clientY });
-    }, 500);
-  }, []);
-
-  const handleTouchEnd = useCallback(() => {
-    if (touchTimerRef.current) { clearTimeout(touchTimerRef.current); touchTimerRef.current = null; }
-    setTouchTooltip(null);
+  const showTapTooltip = useCallback((e, text) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (touchTimerRef.current) clearTimeout(touchTimerRef.current);
+    setTouchTooltip({ text, x: rect.left + rect.width / 2, y: rect.top });
+    touchTimerRef.current = setTimeout(() => setTouchTooltip(null), 2500);
   }, []);
 
   const renderBoundaryChip = (boundary) => (
     <button
       key={boundary.id}
       className={`boundary-chip ${visibleBoundaries.has(boundary.id) ? 'active' : 'inactive'}`}
-      onClick={() => onToggleBoundary(boundary.id)}
+      onClick={(e) => { onToggleBoundary(boundary.id); showTapTooltip(e, boundary.name); }}
       title={boundary.name}
-      onTouchStart={(e) => handleTouchStart(e, boundary.name)}
-      onTouchEnd={handleTouchEnd}
-      onTouchMove={handleTouchEnd}
     >
       <span
         className="boundary-chip-color"
@@ -268,12 +261,9 @@ function Legend({
                   <button
                     key={type.id}
                     className={`legend-icon-item ${type.isActive ? 'active' : 'inactive'}`}
-                    onClick={type.onToggle}
+                    onClick={(e) => { type.onToggle(); showTapTooltip(e, type.label); }}
                     aria-pressed={type.isActive}
                     title={type.label}
-                    onTouchStart={(e) => handleTouchStart(e, type.label)}
-                    onTouchEnd={handleTouchEnd}
-                    onTouchMove={handleTouchEnd}
                     type="button"
                   >
                     <img src={`/icons/layers/${type.id}.svg`} alt="" aria-hidden="true" />
@@ -286,12 +276,9 @@ function Legend({
                   <button
                     key={type.id}
                     className={`legend-icon-item ${isActive ? 'active' : 'inactive'}`}
-                    onClick={() => onToggleType(type.id)}
+                    onClick={(e) => { onToggleType(type.id); showTapTooltip(e, type.label); }}
                     aria-pressed={isActive}
                     title={type.label}
-                    onTouchStart={(e) => handleTouchStart(e, type.label)}
-                    onTouchEnd={handleTouchEnd}
-                    onTouchMove={handleTouchEnd}
                     type="button"
                   >
                     {type.svg_content ? (
@@ -338,10 +325,11 @@ function Legend({
         </LegendSection>
 
       </div>
-      {touchTooltip && (
+      {touchTooltip && createPortal(
         <div className="touch-tooltip" style={{ top: touchTooltip.y - 40, left: touchTooltip.x }}>
           {touchTooltip.text}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace 500ms long-press tooltip with instant tap-to-show — tooltip appears on normal tap and auto-dismisses after 2.5s
- Render tooltip via React portal (`document.body`) to escape legend panel's `overflow: hidden` clipping
- Add `user-select: none` to boundary chips and legend buttons to prevent Android text selection on touch
- Remove `onTouchStart`/`onTouchEnd`/`onTouchMove` handlers (no longer needed)

## Test plan
- [x] Tap a truncated chip on mobile — full name tooltip appears above it for ~2.5s
- [x] Tooltip auto-dismisses
- [x] No text selection highlighting on Android long-press
- [x] Desktop hover tooltip (`title` attr) still works
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)