### PR TITLE
fix: per-item notification read state + publication-date ordering (#412)

### DIFF
--- a/.specify/specs/025-notification-read-state/plan.md
+++ b/.specify/specs/025-notification-read-state/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Per-Item Notification Read State & Publication-Date Ordering
+
+> **Spec ID:** 025-notification-read-state
+> **Status:** Planning
+> **Last Updated:** 2026-05-27
+> **Estimated Effort:** S
+
+## Summary
+
+Client-only change in `NotificationBell.jsx`: replace the single "last seen"
+mark-all-read model with a per-item read set in localStorage, and change the
+`normalize()` sort/age field from collection-date-first to publication/start-date.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. On mount, ensure a baseline `last-seen` timestamp exists in localStorage
+   (write `now` once if absent). Items older than the baseline are implicitly read.
+2. Load the read set (`rotv-notifications-read`) — a JSON array of item keys.
+3. `loadFeed()` fetches `/api/notifications/feed`, normalizes, sorts by
+   publication/start date, prunes the read set to current keys, and computes
+   `unread` = items newer than baseline AND not in the read set.
+4. Clicking an item adds its key to the read set, persists it, and recomputes
+   unread/tint. Opening the dropdown no longer mutates read state.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Read state | `localStorage` JSON array | No backend/schema change; matches existing anon-friendly pattern. |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Ordering
+
+- [ ] In `normalize()`, set news `activityTime = n.publication_date || n.collection_date`.
+- [ ] Set event `activityTime = e.start_date || e.collection_date`.
+- [ ] Keep the existing descending merged sort.
+
+### Phase 2: Per-item read state
+
+- [ ] Add read-set helpers (read/write/prune) for `rotv-notifications-read`.
+- [ ] Ensure baseline `last-seen` is written once on mount.
+- [ ] Compute `unread` from baseline + read set; recompute in `loadFeed()`.
+- [ ] Add per-item click handler that marks read and navigates.
+- [ ] Remove the mark-all-read / `setUnread(0)` logic from `handleToggle`.
+- [ ] Drive `.unread` tint from the read set instead of `lastSeen` alone.
+
+### Phase 3: In-app permalink navigation
+
+- [ ] Import `useNavigate` (bell is inside `<BrowserRouter>`) and `generateSlug`
+      from `sidebar/helpers`.
+- [ ] On item click, `navigate('/{poiSlug}/{news|events}/{titleSlug}')` instead
+      of opening the external `<a>`; close the dropdown.
+- [ ] Replace the external link markup with an accessible `<button>` row; add
+      minimal `.notification-item-btn` CSS.
+- [ ] No `App.jsx` change: the pathname-driven effect (deps include
+      `location.pathname`, App.jsx:1024) sets `permalinkInfo` → `ContentDetail`.
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/components/NotificationBell.jsx` | Read-set model, click-to-read, sort field change, in-app permalink navigation. |
+| `frontend/src/App.css` | Add `.notification-item-btn` styles for the clickable row. |
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Follow ≥2 POIs with recent news/events; confirm the badge shows a count.
+2. Open the bell — badge stays, all items tinted.
+3. Click one item — its tint clears, badge decrements by one, others stay tinted.
+4. Reload — read items stay read, unread stay tinted, badge persists.
+5. Confirm feed order is newest publication/start date at the top.
+
+---
+
+## Rollback Plan
+
+1. Revert the single-file change to `NotificationBell.jsx`.
+2. No data migration to undo (localStorage only; stale keys are harmless).
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Existing users see a large unread count on upgrade | Low | Baseline timestamp treats pre-existing items as read. |
+| `localStorage` unavailable (private mode) | Low | All access wrapped in try/catch; falls back to in-memory. |
+| Read set growth | Low | Pruned to current feed keys each load. |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-27 | Initial plan |

--- a/.specify/specs/025-notification-read-state/plan.md
+++ b/.specify/specs/025-notification-read-state/plan.md
@@ -17,14 +17,14 @@ mark-all-read model with a per-item read set in localStorage, and change the
 
 ### Data Flow
 
-1. On mount, ensure a baseline `last-seen` timestamp exists in localStorage
-   (write `now` once if absent). Items older than the baseline are implicitly read.
-2. Load the read set (`rotv-notifications-read`) — a JSON array of item keys.
-3. `loadFeed()` fetches `/api/notifications/feed`, normalizes, sorts by
-   publication/start date, prunes the read set to current keys, and computes
-   `unread` = items newer than baseline AND not in the read set.
-4. Clicking an item adds its key to the read set, persists it, and recomputes
-   unread/tint. Opening the dropdown no longer mutates read state.
+1. Load the read set (`rotv-notifications-read`) — a JSON array of item keys.
+2. `loadFeed()` fetches `/api/notifications/feed`, normalizes, and sorts by
+   publication/start date. A separate effect prunes the read set to keys still
+   present in the feed.
+3. `unread` = items whose key is not in the read set. Opening the dropdown does
+   not mutate read state.
+4. Clicking an item adds its key to the read set, persists it, navigates to the
+   in-app permalink, and closes the dropdown.
 
 ---
 
@@ -46,12 +46,12 @@ mark-all-read model with a per-item read set in localStorage, and change the
 
 ### Phase 2: Per-item read state
 
-- [ ] Add read-set helpers (read/write/prune) for `rotv-notifications-read`.
-- [ ] Ensure baseline `last-seen` is written once on mount.
-- [ ] Compute `unread` from baseline + read set; recompute in `loadFeed()`.
+- [ ] Add read-set helpers (read/write) for `rotv-notifications-read`.
+- [ ] Compute `unread` purely from the read set (item unread iff not in set).
+- [ ] Prune the read set to live feed keys in an effect.
 - [ ] Add per-item click handler that marks read and navigates.
 - [ ] Remove the mark-all-read / `setUnread(0)` logic from `handleToggle`.
-- [ ] Drive `.unread` tint from the read set instead of `lastSeen` alone.
+- [ ] Drive `.unread` tint from the read set.
 
 ### Phase 3: In-app permalink navigation
 
@@ -100,7 +100,7 @@ mark-all-read model with a per-item read set in localStorage, and change the
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Existing users see a large unread count on upgrade | Low | Baseline timestamp treats pre-existing items as read. |
+| Existing users see all current items tinted on upgrade | Low | Intended Facebook-style behavior; badge caps at "9+"; feed is bounded to recent items. |
 | `localStorage` unavailable (private mode) | Low | All access wrapped in try/catch; falls back to in-memory. |
 | Read set growth | Low | Pruned to current feed keys each load. |
 

--- a/.specify/specs/025-notification-read-state/spec.md
+++ b/.specify/specs/025-notification-read-state/spec.md
@@ -1,0 +1,131 @@
+# Specification: Per-Item Notification Read State & Publication-Date Ordering
+
+> **Spec ID:** 025-notification-read-state
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-27
+
+## Overview
+
+The notification bell currently marks every notification as read the moment the
+dropdown is opened, clearing the unread badge in one shot. It also orders items
+primarily by collection date, so the feed reads in the order ROTV scraped
+content rather than by when the content was published. This change makes read
+state per-item (Facebook-style: items stay tinted until individually clicked)
+and reorders the feed newest-publication-date first.
+
+Fixes #412.
+
+---
+
+## User Stories
+
+### Notifications
+
+**US-025-1: Per-item read state**
+> As a follower of places, I want each notification to stay highlighted until I
+> click it individually, so that opening the bell doesn't erase my place and I
+> can tell which updates I've actually looked at.
+
+Acceptance Criteria:
+- [ ] Opening the bell does NOT mark all items read and does NOT clear the badge.
+- [ ] Each unread item is visually tinted; clicking an item removes its tint.
+- [ ] The unread badge count equals the number of not-yet-clicked items and
+      decrements by one as each item is read.
+- [ ] Read state persists across reloads (localStorage).
+- [ ] Existing users are not flooded: items already present at first use of the
+      new behavior are treated as read (baseline), only genuinely new items count.
+
+**US-025-2: Newest publication date first**
+> As a follower of places, I want notifications ordered by when the content was
+> published (news) or scheduled (events), newest first, so the feed reads like a
+> real news feed instead of scrape order.
+
+Acceptance Criteria:
+- [ ] News items sort by `publication_date` (falling back to `collection_date`).
+- [ ] Event items sort by `start_date` (falling back to `collection_date`).
+- [ ] The merged list is ordered newest-first across both types.
+- [ ] The "time ago" label reflects the same date used for sorting.
+
+**US-025-3: Navigate to the in-app permalink, stay on site**
+> As a follower of places, I want clicking a notification to open that news/event
+> inside ROTV (its permalink detail), so I can read it and move through my unread
+> items without leaving the site — then click out to the external article only if
+> I choose to.
+
+Acceptance Criteria:
+- [ ] Clicking a notification navigates to the in-app permalink
+      (`/{poiSlug}/news/{titleSlug}` or `/{poiSlug}/events/{titleSlug}`) and opens
+      the detail view — it does NOT open the external source URL directly.
+- [ ] The notification dropdown closes on navigation.
+- [ ] The external article remains reachable via the detail view's existing
+      "read more" link.
+- [ ] Clicking marks that one item read (US-025-1) regardless of navigation.
+
+---
+
+## Data Model
+
+No schema changes. Read state lives entirely in browser `localStorage`.
+
+| Key | Description |
+|-----|-------------|
+| `rotv-notifications-last-seen` | Existing key, repurposed as the **baseline** timestamp set once on first load; items older than this are implicitly read. |
+| `rotv-notifications-read` | New key: JSON array of read item keys (e.g. `["news-12","event-5"]`). |
+
+---
+
+## API Endpoints
+
+No API changes. `GET /api/notifications/feed` already returns
+`publication_date`, `collection_date`, `start_date` per item; ordering is a
+client concern in `normalize()`.
+
+---
+
+## UI/UX Requirements
+
+### Modified Components
+
+- `NotificationBell` — track a per-item read set, compute unread from it, mark an
+  item read on click, and stop clearing all-read on open. Re-sort using
+  publication/start dates.
+
+### Behavior
+
+- Tint (`.notification-item.unread`, existing light-green style) shown when an
+  item is in the unread set.
+- Clicking anywhere on an item marks it read (and still opens its link if present).
+
+---
+
+## Non-Functional Requirements
+
+**NFR-025-1: Bounded storage**
+- The read set is pruned to keys still present in the current feed on each load,
+  so `localStorage` does not grow without bound.
+
+**NFR-025-2: Graceful degradation**
+- All `localStorage` access stays wrapped in try/catch (private mode / quota).
+
+---
+
+## Dependencies
+
+- Depends on: 019-poi-subscriptions (introduced the notification bell)
+- Blocks: none
+
+---
+
+## Open Questions
+
+_None — event sort key (start_date) confirmed with stakeholder._
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-27 | Initial draft |

--- a/.specify/specs/025-notification-read-state/spec.md
+++ b/.specify/specs/025-notification-read-state/spec.md
@@ -30,12 +30,13 @@ Fixes #412.
 
 Acceptance Criteria:
 - [ ] Opening the bell does NOT mark all items read and does NOT clear the badge.
-- [ ] Each unread item is visually tinted; clicking an item removes its tint.
+- [ ] Every notification is tinted until the user clicks it; clicking removes its
+      tint (Facebook-style — viewing the list is not "reading").
 - [ ] The unread badge count equals the number of not-yet-clicked items and
       decrements by one as each item is read.
 - [ ] Read state persists across reloads (localStorage).
-- [ ] Existing users are not flooded: items already present at first use of the
-      new behavior are treated as read (baseline), only genuinely new items count.
+- [ ] The read set is pruned to items still present in the feed so storage stays
+      bounded.
 
 **US-025-2: Newest publication date first**
 > As a follower of places, I want notifications ordered by when the content was
@@ -71,8 +72,7 @@ No schema changes. Read state lives entirely in browser `localStorage`.
 
 | Key | Description |
 |-----|-------------|
-| `rotv-notifications-last-seen` | Existing key, repurposed as the **baseline** timestamp set once on first load; items older than this are implicitly read. |
-| `rotv-notifications-read` | New key: JSON array of read item keys (e.g. `["news-12","event-5"]`). |
+| `rotv-notifications-read` | JSON array of read item keys (e.g. `["news-12","event-5"]`). An item is unread iff its key is not in this set. The legacy `rotv-notifications-last-seen` key is no longer used. |
 
 ---
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15068,13 +15068,25 @@ button.feedback-link-inline {
   padding: 0;
 }
 .notification-item {
-  display: flex;
-  gap: 0.6rem;
-  padding: 0.7rem 1rem;
   border-bottom: 1px solid #f0f0f0;
 }
 .notification-item.unread {
   background: #f3f8ee;
+}
+.notification-item-btn {
+  display: flex;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.7rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+.notification-item-btn:hover {
+  background: rgba(0, 0, 0, 0.04);
 }
 .notification-icon {
   flex-shrink: 0;
@@ -15082,13 +15094,7 @@ button.feedback-link-inline {
 .notification-title {
   font-size: 0.9rem;
   font-weight: 600;
-}
-.notification-title a {
   color: #2d5016;
-  text-decoration: none;
-}
-.notification-title a:hover {
-  text-decoration: underline;
 }
 .notification-meta {
   font-size: 0.78rem;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -944,15 +944,27 @@ function AppContent() {
       const currentSlug = selectedDestination ? generateSlug(selectedDestination.name)
         : selectedLinearFeature ? generateSlug(selectedLinearFeature.name) : null;
       if (currentSlug !== poiSlug) {
+        isLoadingFromUrlRef.current = true;
+        // Fix: open the permalink sidebar for organization (virtual) and linear
+        // POIs too, not just destinations — notification/shared links to org
+        // news & events were navigating but rendering nothing (#412)
         const destination = destinations.find(d => generateSlug(d.name) === poiSlug);
-        if (destination) {
-          isLoadingFromUrlRef.current = true;
-          setSelectedDestination(destination);
+        const virtualPoi = !destination && virtualPois.find(v => generateSlug(v.name) === poiSlug);
+        const linearFeature = !destination && !virtualPoi
+          && linearFeatures.find(f => generateSlug(f.name) === poiSlug);
+        const pointPoi = destination || virtualPoi;
+        if (pointPoi) {
+          setSelectedDestination(pointPoi);
           setSelectedLinearFeature(null);
           setActiveTab('view');
-          document.title = `${destination.name} | Roots of The Valley`;
-          setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
+          document.title = `${pointPoi.name} | Roots of The Valley`;
+        } else if (linearFeature) {
+          setSelectedLinearFeature(linearFeature);
+          setSelectedDestination(null);
+          setActiveTab('view');
+          document.title = `${linearFeature.name} | Roots of The Valley`;
         }
+        setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
       }
       return;
     }

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -60,8 +60,10 @@ function normalize(feed) {
     poiName: e.poi_name,
     activityTime: e.start_date || e.collection_date
   }));
-  return [...news, ...events].sort(
-    (a, b) => new Date(b.activityTime) - new Date(a.activityTime)
+  // Sort newest-first. Coerce missing/invalid dates to 0 so they sort to the
+  // bottom rather than producing NaN comparisons (unstable order).
+  return [...news, ...events].sort((a, b) =>
+    (new Date(b.activityTime).getTime() || 0) - (new Date(a.activityTime).getTime() || 0)
   );
 }
 

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -24,7 +24,9 @@ function writeReadSet(set) {
 }
 
 function timeAgo(iso) {
-  const diff = Date.now() - new Date(iso).getTime();
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return '';
+  const diff = Date.now() - ms;
   // Future-dated items (upcoming events) read forward: "in 3d".
   if (diff < 0) {
     const mins = Math.floor(-diff / 60000);

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -1,21 +1,23 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
-import { safeHttpUrl } from '../utils/url';
+import { generateSlug } from './sidebar/helpers';
 
 const POLL_MS = 60000;
-const LAST_SEEN_KEY = 'rotv-notifications-last-seen';
+const READ_KEY = 'rotv-notifications-read';
 
-function readLastSeen() {
+function readReadSet() {
   try {
-    return localStorage.getItem(LAST_SEEN_KEY) || new Date().toISOString();
+    const arr = JSON.parse(localStorage.getItem(READ_KEY) || '[]');
+    return new Set(Array.isArray(arr) ? arr : []);
   } catch {
-    return new Date().toISOString();
+    return new Set();
   }
 }
 
-function writeLastSeen(iso) {
+function writeReadSet(set) {
   try {
-    localStorage.setItem(LAST_SEEN_KEY, iso);
+    localStorage.setItem(READ_KEY, JSON.stringify([...set]));
   } catch {
     /* ignore */
   }
@@ -23,6 +25,14 @@ function writeLastSeen(iso) {
 
 function timeAgo(iso) {
   const diff = Date.now() - new Date(iso).getTime();
+  // Future-dated items (upcoming events) read forward: "in 3d".
+  if (diff < 0) {
+    const mins = Math.floor(-diff / 60000);
+    if (mins < 60) return 'soon';
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `in ${hrs}h`;
+    return `in ${Math.floor(hrs / 24)}d`;
+  }
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return 'just now';
   if (mins < 60) return `${mins}m ago`;
@@ -32,21 +42,23 @@ function timeAgo(iso) {
 }
 
 function normalize(feed) {
+  // activityTime drives both ordering and the "time ago" label. Prefer the
+  // content's own date (publication for news, start for events) over the
+  // collection date, so the feed reads newest-published-first rather than in
+  // scrape order.
   const news = (feed.news || []).map(n => ({
     key: `news-${n.id}`,
     type: 'news',
     title: n.title,
     poiName: n.poi_name,
-    url: n.source_url,
-    activityTime: n.collection_date || n.publication_date
+    activityTime: n.publication_date || n.collection_date
   }));
   const events = (feed.events || []).map(e => ({
     key: `event-${e.id}`,
     type: 'event',
     title: e.title,
     poiName: e.poi_name,
-    url: e.source_url,
-    activityTime: e.collection_date || e.start_date
+    activityTime: e.start_date || e.collection_date
   }));
   return [...news, ...events].sort(
     (a, b) => new Date(b.activityTime) - new Date(a.activityTime)
@@ -55,18 +67,23 @@ function normalize(feed) {
 
 export default function NotificationBell() {
   const { isAuthenticated, favorites } = useAuth();
+  const navigate = useNavigate();
   const [items, setItems] = useState([]);
-  const [unread, setUnread] = useState(0);
+  const [readSet, setReadSet] = useState(readReadSet);
   const [open, setOpen] = useState(false);
-  const [lastSeen, setLastSeen] = useState(readLastSeen);
   const [anchorBottom, setAnchorBottom] = useState(null);
   const [anchorRight, setAnchorRight] = useState(null);
   const containerRef = useRef(null);
 
+  // Facebook-style: an item stays unread (tinted, counted) until the user clicks
+  // it. Opening the dropdown does not mark anything read.
+  const isUnread = useCallback((item) => !readSet.has(item.key), [readSet]);
+
+  const unread = items.filter(isUnread).length;
+
   const loadFeed = useCallback(async () => {
     if (!isAuthenticated && favorites.length === 0) {
       setItems([]);
-      setUnread(0);
       return;
     }
     try {
@@ -75,10 +92,7 @@ export default function NotificationBell() {
         : `/api/notifications/feed?pois=${favorites.join(',')}`;
       const res = await fetch(url, { credentials: 'include' });
       if (!res.ok) return;
-      const normalized = normalize(await res.json());
-      setItems(normalized);
-      const seen = readLastSeen();
-      setUnread(normalized.filter(i => new Date(i.activityTime) > new Date(seen)).length);
+      setItems(normalize(await res.json()));
     } catch (err) {
       /* keep last known state on transient failure */
     }
@@ -89,6 +103,19 @@ export default function NotificationBell() {
     const id = setInterval(loadFeed, POLL_MS);
     return () => clearInterval(id);
   }, [loadFeed]);
+
+  // Keep the read set bounded: drop keys no longer present in the feed.
+  useEffect(() => {
+    if (items.length === 0) return;
+    const liveKeys = new Set(items.map(i => i.key));
+    setReadSet(prev => {
+      const pruned = [...prev].filter(k => liveKeys.has(k));
+      if (pruned.length === prev.size) return prev;
+      const next = new Set(pruned);
+      writeReadSet(next);
+      return next;
+    });
+  }, [items]);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -112,11 +139,23 @@ export default function NotificationBell() {
         setAnchorBottom(barRect.bottom);
         setAnchorRight(container.getBoundingClientRect().right - barRect.right);
       }
-      const now = new Date().toISOString();
-      writeLastSeen(now);
-      setLastSeen(now);
-      setUnread(0);
     }
+  };
+
+  const handleItemClick = (item) => {
+    setReadSet(prev => {
+      if (prev.has(item.key)) return prev;
+      const next = new Set(prev);
+      next.add(item.key);
+      writeReadSet(next);
+      return next;
+    });
+    const poiSlug = generateSlug(item.poiName);
+    const titleSlug = generateSlug(item.title);
+    if (poiSlug && titleSlug) {
+      navigate(`/${poiSlug}/${item.type === 'event' ? 'events' : 'news'}/${titleSlug}`);
+    }
+    setOpen(false);
   };
 
   return (
@@ -153,19 +192,21 @@ export default function NotificationBell() {
               {items.map(item => (
                 <li
                   key={item.key}
-                  className={`notification-item ${new Date(item.activityTime) > new Date(lastSeen) ? 'unread' : ''}`}
+                  className={`notification-item ${isUnread(item) ? 'unread' : ''}`}
                 >
-                  <span className="notification-icon">{item.type === 'event' ? '📅' : '📰'}</span>
-                  <div className="notification-body">
-                    <div className="notification-title">
-                      {safeHttpUrl(item.url) ? (
-                        <a href={safeHttpUrl(item.url)} target="_blank" rel="noopener noreferrer">{item.title}</a>
-                      ) : item.title}
+                  <button
+                    type="button"
+                    className="notification-item-btn"
+                    onClick={() => handleItemClick(item)}
+                  >
+                    <span className="notification-icon">{item.type === 'event' ? '📅' : '📰'}</span>
+                    <div className="notification-body">
+                      <div className="notification-title">{item.title}</div>
+                      <div className="notification-meta">
+                        {item.poiName} · {timeAgo(item.activityTime)}
+                      </div>
                     </div>
-                    <div className="notification-meta">
-                      {item.poiName} · {timeAgo(item.activityTime)}
-                    </div>
-                  </div>
+                  </button>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

Fixes two issues reported on the notification bell ([#412](https://github.com/crunchtools/rotv/issues/412)):

1. **Read state is now per-item (Facebook-style).** Opening the bell no longer marks everything read or clears the badge. Each notification stays tinted until *individually* clicked; the badge counts unclicked items and decrements one at a time. Read state persists in `localStorage` (`rotv-notifications-read`) and is pruned to the live feed so it stays bounded.

2. **Feed is ordered newest-publication-date first.** Sort/age now use `publication_date` (news) and `start_date` (events) instead of `collection_date`, so the feed reads like a news feed rather than scrape order.

Additional, from review feedback during development:
- **Clicking a notification opens the in-app ROTV permalink detail** (where the external "read more" link lives) instead of jumping straight to the source URL — users move through their unread items without leaving the site.
- **`App.jsx` permalink fix:** the browser-nav effect only opened the sidebar for map *destinations*. Extended it to resolve organization (virtual) and linear POIs too, so notification/shared permalinks to org news & events actually render the detail view (previously navigated but showed nothing).
- **`timeAgo`** renders upcoming events forward ("in 3d") instead of "just now".

Spec: `.specify/specs/025-notification-read-state/`

## Test plan

Verified in-browser (followed POIs = two organization POIs):
- [x] Opening the bell keeps the badge and leaves all items tinted
- [x] Clicking one item opens its in-app permalink detail; external "read more" link works
- [x] Clicked item un-tints, badge decrements by one, others stay tinted
- [x] Read state persists across reload
- [x] Feed ordered newest-first (events by start date, news by publication date)
- [x] `./run.sh build` passes; gourmand 0 violations

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)