### PR TITLE
feat: three-gate auto-moderation (date/relevance/POI) + retroactive domain block

### DIFF
--- a/.specify/specs/030-moderation-gates/plan.md
+++ b/.specify/specs/030-moderation-gates/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: Three-Gate Auto-Moderation
+
+> **Spec ID:** 030-moderation-gates
+> **Status:** Planning
+> **Last Updated:** 2026-05-29
+> **Estimated Effort:** M
+
+## Summary
+
+Refactor the news/event branch of `processItem()` in `moderationService.js` into three
+explicit gates — **Date**, **Relevance**, **POI** — each returning a `{verdict, reason}`,
+combine them into the publish/reject/pending decision, persist the verdicts in a new
+`moderation_gates` JSONB column, and surface them in the moderation card. Fold the POI
+Tier-1 check into the existing relevance votes; add geo-driven Tier-2 auto-reassign. Make
+the sweep batch size configurable so a monthly dump clears quickly.
+
+---
+
+## Architecture
+
+### Decision flow (news/event)
+
+```
+processItem(news|event)
+  ├─ hard rejects (unchanged): duplicate · no source URL · deny list
+  │
+  ├─ Gate: DATE        evaluateDateGate(row, { threshold, floorYear, trustedDomains })
+  │        pass  = date present, not future, year ≥ floor, AND (consensus ≥ threshold OR trusted domain)
+  │        review = missing / implausible / low-consensus-untrusted
+  │
+  ├─ Gate: RELEVANCE   from runContentRelevanceVotes() (3 votes, each {relevant, about_poi})
+  │        pass  = unanimous YES
+  │        fail  = unanimous NO     → REJECT (hard)
+  │        review= split
+  │
+  ├─ Gate: POI         evaluatePoiGate(pool, row, votes)
+  │        Tier 1 pass  = majority about_poi=YES (free, from votes)
+  │        Tier 2       = on Tier-1 miss, getReassignmentCandidates() → 1 LLM call picks
+  │                       owner/boundary/none; match ⇒ reassign poi_id + pass
+  │        Tier 3 review= none confirmed
+  │
+  └─ COMBINE
+       all three pass            → auto_approved (moderated_by = AUTO_PUBLISHER_USER_ID)
+       relevance fail            → rejected
+       otherwise                 → pending
+     persist: moderation_status, moderation_gates JSONB, ai_reasoning (summary),
+              relevance_signals (votes), confidence_score, moderation_processed=true
+```
+
+### Data flow for Tier-2 reassignment
+
+1. Tier 1 misses (content relevant but not about the assigned POI).
+2. `getReassignmentCandidates(pool, poiId)` returns `{ owner: {id,name}|null, boundary: {id,name}|null }`
+   — owner from `pois.owner_id`, boundary = smallest containing boundary POI.
+3. One structured LLM call: given title/summary + candidate names, return `assigned|owner|boundary|none`.
+4. `owner`/`boundary` ⇒ `UPDATE … SET poi_id = <newId>`, gate `pass`, record `reassigned_from/to`.
+5. `none`/no candidates/geo error ⇒ Tier 3 `review`.
+
+---
+
+## Implementation Steps
+
+### Phase 1: Schema + settings
+- [ ] `backend/migrations/070_moderation_gates.sql` — `ADD COLUMN IF NOT EXISTS moderation_gates JSONB` on `poi_news` and `poi_events`; insert `moderation_date_floor_year` (2010) and `moderation_sweep_batch_size` (50) into `admin_settings` (ON CONFLICT DO NOTHING).
+- [ ] `backend/routes/admin.js` — add both keys to the allowed-settings write list (~line 515–532).
+
+### Phase 2: Gate logic (backend)
+- [ ] `geoService.js` — add `getReassignmentCandidates(pool, poiId)` (owner via `owner_id`; smallest containing boundary POI id+name). Graceful `{owner:null,boundary:null}` on error.
+- [ ] `geminiService.js` — extend the relevance-vote response contract to include `about_poi` (boolean); add `assignBestPoi(pool, item, candidates)` returning `assigned|owner|boundary|none`.
+- [ ] `moderationService.js`:
+  - [ ] `evaluateDateGate(row, cfg)` → `{verdict, reason, trusted_source}`.
+  - [ ] `evaluatePoiGate(pool, row, votes)` → `{verdict, tier, reason, reassigned_from, reassigned_to}` (does the reassign UPDATE on Tier 2).
+  - [ ] derive relevance gate from votes (`unanimousYes`/`unanimousNo`/split).
+  - [ ] replace the inline decision block (lines ~374–427) with the three-gate combine; write `moderation_gates`.
+  - [ ] `processPendingItems()` — read `moderation_sweep_batch_size` and use it for the three `LIMIT` queries (default 50).
+  - [ ] `getQueue()` — add `n.moderation_gates` / `e.moderation_gates` to the SELECT lists (NULL for photos).
+
+### Phase 3: Admin UI
+- [ ] `ModerationExtras.jsx` — render three gate badges (Date / Relevance / POI) colored by verdict (green/orange/red) with reason tooltips; show reassignment ("→ Liberty Park") on Tier-2; expand to list relevance votes. Render only when `moderation_gates` present.
+
+### Phase 4: Tests
+- [ ] `backend/tests/services/moderationService.test.js` — unit-test `evaluateDateGate` (trusted vs untrusted, floor-year, future, missing) and the combine logic; keep existing `applyQualityFilters`/`getDomainReputation` tests or migrate them.
+- [ ] Add a focused test for `evaluatePoiGate` Tier-1/2/3 with mocked candidates + LLM.
+
+---
+
+## File Changes
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `backend/migrations/070_moderation_gates.sql` | `moderation_gates` column + 2 settings |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `backend/services/moderationService.js` | three-gate refactor of `processItem`, configurable sweep batch, `getQueue` SELECT |
+| `backend/services/geoService.js` | `getReassignmentCandidates()` |
+| `backend/services/geminiService.js` | `about_poi` in vote contract; `assignBestPoi()` |
+| `backend/routes/admin.js` | allow new settings keys |
+| `frontend/src/components/ModerationExtras.jsx` | gate badges + votes |
+| `backend/tests/services/moderationService.test.js` | gate unit tests |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 070_moderation_gates
+ALTER TABLE poi_news   ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+
+INSERT INTO admin_settings (key, value, updated_at) VALUES
+  ('moderation_date_floor_year', '2010', CURRENT_TIMESTAMP),
+  ('moderation_sweep_batch_size', '50', CURRENT_TIMESTAMP)
+ON CONFLICT (key) DO NOTHING;
+```
+
+---
+
+## Testing Strategy
+
+### Manual Testing (port 8083, container `rotv-modgates`)
+1. `./run.sh start`, log in to admin, open Moderation Queue.
+2. Trigger a sweep (or wait for the scheduler); confirm pending items gain confidence % + three gate badges.
+3. Verify a trusted-source recent-date news item with unanimous-yes relevance auto-publishes.
+4. Verify an item about a park (assigned to a sub-POI) gets reassigned to the parent boundary and shows "→ <Park>".
+5. Verify a split-relevance or no-date item stays pending with the failing gate flagged.
+
+---
+
+## Risks and Mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Tier-2 reassign moves an item to the wrong POI | Med | Only on confident LLM pick among a tiny candidate set; records reassignment for audit; never rejects |
+| Extra LLM call raises cost | Low | Tier-2 call fires only on Tier-1 misses, not every item |
+| Relaxing/auto-publishing too aggressively | Med | Publish requires ALL three pass + unanimous relevance; defaults conservative |
+| Migration re-run on every deploy | Low | Additive + `IF NOT EXISTS` / `ON CONFLICT DO NOTHING` |
+
+---
+
+## Changelog
+| Date | Changes |
+|------|---------|
+| 2026-05-29 | Initial plan |

--- a/.specify/specs/030-moderation-gates/spec.md
+++ b/.specify/specs/030-moderation-gates/spec.md
@@ -1,0 +1,159 @@
+# Specification: Three-Gate Auto-Moderation
+
+> **Spec ID:** 030-moderation-gates
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-05-29
+
+## Overview
+
+The monthly collection run dumps hundreds of unscored items into the moderation
+queue (610 pending news items as of this writing, all with `confidence_score = null`).
+The existing auto-moderation logic collapses several distinct judgments into one
+opaque decision, never auto-rejects borderline content, and surfaces almost nothing
+to the admin about *why* an item is pending.
+
+This feature restructures auto-moderation around the **three independent judgments
+Scott actually makes by hand** when reviewing an item — **Date**, **Relevance**, and
+**POI correctness** — and auto-publishes only when all three pass. Each gate's verdict
+and reasoning is stored and shown in the admin UI, so a pending item tells you exactly
+which gate needs a human. The sweep that scores the backlog is made fast enough to
+clear a monthly dump.
+
+---
+
+## User Stories
+
+### Auto-moderation
+
+**US-001: Three-gate auto-publish**
+> As the site admin, I want items auto-published only when the date, relevance, AND
+> POI assignment all pass, so that I only hand-review the items where one of those
+> three judgments is uncertain.
+
+Acceptance Criteria:
+- [ ] An item is `auto_approved` only when all three gates return `pass`.
+- [ ] An item is `rejected` only on a hard-fail (existing: duplicate, no source URL, deny list) or a unanimous-NO relevance vote.
+- [ ] Every other item is `pending` with each gate's verdict recorded.
+- [ ] No item is ever rejected for being *old* — age is never a negative signal (historical content is valuable).
+
+**US-002: Date gate**
+> As the admin, I want a date to count as trustworthy when it is plausible and comes
+> from a source I trust, so that good dates from sources like cleveland.com / akron.com /
+> the trusted-domain list auto-pass without me checking each one.
+
+Acceptance Criteria:
+- [ ] Date gate `pass` requires: a publication date present, not in the future, with a plausible year (≥ floor, default 2010), AND (date-consensus score ≥ threshold **OR** the source domain is on `moderation_trusted_domains`).
+- [ ] A hallucinated date (year below the floor, e.g. an 1800s value) yields `review`, not `pass`.
+- [ ] A missing date, or a low-consensus date from an untrusted domain, yields `review`.
+- [ ] Old-but-trusted dates still pass (no recency ceiling).
+
+**US-003: Relevance gate (with visibility)**
+> As the admin, I want to see how the LLM relevance vote actually went, so that I trust
+> (or correct) the relevance judgment instead of guessing.
+
+Acceptance Criteria:
+- [ ] Relevance gate `pass` = unanimous YES across the votes; `fail` (reject) = unanimous NO; anything split = `review`.
+- [ ] The individual votes and their one-line reasons are visible in the moderation card.
+
+**US-004: POI gate (three-tier, with auto-reassign)**
+> As the admin, I want the AI to confirm the item belongs to its assigned POI — or, if
+> it really belongs to that POI's owner or its containing park boundary, to move it
+> there automatically — and only drop it on me when neither can be confirmed.
+
+The gate resolves in three tiers:
+
+1. **Relevant to the assigned POI?** → `pass`, keep the POI as-is.
+2. **Otherwise, more relevant to the POI's _owner_ (its `owner_id` organization) or its
+   _immediate geofence_ (the smallest boundary POI that contains it — e.g. Liberty Park
+   Nature Center → its parent *Liberty Park* boundary)?** → **reassign** `poi_id` to that
+   owner/boundary POI and `pass`.
+3. **Neither can be confirmed** → `review` (drop into the pending queue).
+
+Acceptance Criteria:
+- [ ] The relevance vote also returns whether the content is about the assigned POI (folded into the existing call — Tier 1 costs no extra round-trips).
+- [ ] Tier 2 candidate POIs come from existing relationships: `pois.owner_id` (owner org) and the smallest containing boundary POI (via the `getContainingBoundaries` machinery in `geoService.js`). A single follow-up LLM call — made **only** for items that fail Tier 1 — picks the best-fitting candidate or "none".
+- [ ] On a Tier 2 match, `poi_id` is updated to the owner/boundary POI; the gate verdict records the reassignment (old → new POI) for visibility.
+- [ ] POI gate never auto-rejects. Tier 3 routes to `pending` with a "Check POI" signal.
+- [ ] If PostGIS / geo lookups are unavailable, Tier 2 degrades gracefully to Tier 3 (review) rather than erroring — mirroring `getRollupPoiIds`.
+
+### Backlog throughput
+
+**US-005: Sweep keeps up with a monthly dump**
+> As the admin, I want the scoring sweep to clear a monthly backlog in a reasonable
+> number of cycles, so the queue isn't stuck showing hundreds of unscored items.
+
+Acceptance Criteria:
+- [ ] The per-cycle sweep batch size is a configurable setting (default raised from 20).
+- [ ] After the sweep runs, pending items carry gate verdicts and a confidence score (no more `null` scores sitting in the queue).
+
+---
+
+## Data Model
+
+### Schema Changes
+
+```sql
+-- Per-item structured gate verdicts (idempotent, additive)
+ALTER TABLE poi_news   ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+```
+
+`moderation_gates` shape:
+```json
+{
+  "date":      { "verdict": "pass|review|fail", "reason": "...", "trusted_source": true },
+  "relevance": { "verdict": "pass|review|fail", "reason": "...", "yes": 3, "total": 3 },
+  "poi":       { "verdict": "pass|review", "tier": 1, "reason": "...", "reassigned_from": null, "reassigned_to": null }
+}
+```
+
+### New `admin_settings`
+
+| key | default | purpose |
+|-----|---------|---------|
+| `moderation_date_floor_year` | `2010` | dates below this year are implausible → date gate `review` |
+| `moderation_sweep_batch_size` | `50` | items processed per type per sweep cycle |
+
+Reuses existing `moderation_trusted_domains` and `moderation_news_date_threshold`.
+
+---
+
+## API Endpoints
+
+No new endpoints. `GET /api/admin/moderation/queue` gains a `moderation_gates` field per item; the two new keys are added to the allowed `admin_settings` write list.
+
+---
+
+## UI/UX Requirements
+
+### Modified Components
+
+- `ModerationExtras` — add three gate badges (Date / Relevance / POI), colored
+  green (`pass`) / orange (`review`) / red (`fail`), each with its reason as a tooltip;
+  expand to show the relevance votes. Existing confidence % and triage chips stay.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: No added LLM cost**
+- The POI judgment folds into the existing relevance-vote call. No new per-item model round-trips.
+
+**NFR-002: Idempotent + backward compatible**
+- Migration is additive and re-runnable. Items without `moderation_gates` render exactly as today.
+
+---
+
+## Open Questions
+
+_None blocking — defaults chosen per Scott's review and the "old news is valuable" rule._
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-05-29 | Initial draft |

--- a/backend/migrations/070_moderation_gates.sql
+++ b/backend/migrations/070_moderation_gates.sql
@@ -1,0 +1,24 @@
+-- Migration 070: Three-gate auto-moderation
+-- Spec 030-moderation-gates
+--
+-- Stores the per-item verdicts of the three independent moderation gates
+-- (date / relevance / POI) so the admin queue can show exactly which gate
+-- needs a human. Additive and idempotent — re-runs on every container start.
+
+ALTER TABLE poi_news   ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS moderation_gates JSONB;
+
+-- Date gate: dates below this year are implausible (e.g. hallucinated 1800s
+-- values) and fail the gate to review instead of passing.
+-- Sweep batch: items scored per content type per scheduled sweep cycle
+-- (raised from the old hardcoded 20 so a monthly dump clears in a few cycles).
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'admin_settings') THEN
+    INSERT INTO admin_settings (key, value, updated_at)
+    VALUES
+      ('moderation_date_floor_year', '2010', CURRENT_TIMESTAMP),
+      ('moderation_sweep_batch_size', '50', CURRENT_TIMESTAMP)
+    ON CONFLICT (key) DO NOTHING;
+  END IF;
+END$$;

--- a/backend/migrations/071_pois_boundary_geom_gist.sql
+++ b/backend/migrations/071_pois_boundary_geom_gist.sql
@@ -1,0 +1,9 @@
+-- Migration 071: GiST index on pois.boundary_geom
+-- Spec 030-moderation-gates (PR #447 review)
+--
+-- The POI gate's Tier-2 reassignment (getReassignmentCandidates) runs ST_Contains
+-- against boundary polygons, as do getContainingBoundaries and getRollupPoiIds. Only
+-- the point `geom` column was indexed (idx_pois_geom); index boundary_geom too so the
+-- spatial containment lookups stay index-backed as boundary data grows.
+
+CREATE INDEX IF NOT EXISTS idx_pois_boundary_geom ON pois USING GIST (boundary_geom);

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -515,6 +515,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'moderation_enabled',
       'moderation_auto_approve_threshold',
       'moderation_auto_approve_enabled',
+      'moderation_date_floor_year',
+      'moderation_sweep_batch_size',
       'photo_submissions_enabled',
       'apify_api_token',
       'news_collection_prompt',

--- a/backend/routes/userSettings.js
+++ b/backend/routes/userSettings.js
@@ -115,10 +115,10 @@ export function createUserSettingsRouter(pool) {
 
   router.get('/mcp-token', isAuthenticated, async (req, res) => {
     try {
-      const result = await pool.query(
+      const tokenRow = await pool.query(
         'SELECT mcp_token FROM users WHERE id = $1', [req.user.id]
       );
-      let token = result.rows[0]?.mcp_token;
+      let token = tokenRow.rows[0]?.mcp_token;
       if (!token) {
         token = crypto.randomBytes(32).toString('base64url');
         await pool.query(

--- a/backend/services/dateExtractor.js
+++ b/backend/services/dateExtractor.js
@@ -184,7 +184,10 @@ export function scoreDeterministicSources(sources = {}) {
   for (const d of (sources.meta || [])) add(d, 1, 'meta');
   for (const d of (sources.timeTags || [])) add(d, 1, 'time-tag');
   add(sources.url, 1, 'url');
-  add(sources.searchDate, 3, 'search-date');
+  // Search-engine dates have proven reliable in moderation (often dead-on, even for
+  // Facebook/blog sources with no on-page date), so weight them on par with JSON-LD —
+  // an SE date alone then clears the date gate. (spec 030)
+  add(sources.searchDate, 4, 'search-date');
 
   return { scores, sourceMap };
 }

--- a/backend/services/filterLists.js
+++ b/backend/services/filterLists.js
@@ -19,18 +19,10 @@ export async function loadListSetting(pool, key) {
   }
 }
 
-// Normalize a stored URL and a blocklist prefix the same way getDomainReputation does
-// (drop scheme + leading www + trailing slash), so a blocklist entry that is a bare
-// domain or a domain+path matches via startsWith. Kept local to avoid a circular import
-// with moderationService.
-function normalizeUrlForPrefix(url) {
-  try {
-    const u = new URL(url);
-    return (u.hostname.toLowerCase().replace(/^www\./, '') + u.pathname).toLowerCase().replace(/\/+$/, '');
-  } catch {
-    return null;
-  }
-}
+// Normalize a blocklist prefix (drop scheme + leading www + trailing slash) so a bare
+// domain or a domain+path entry matches a stored URL via startsWith, the same way
+// getDomainReputation treats the blocklist. Kept local to avoid a circular import with
+// moderationService.
 function normalizeBlocklistPrefix(prefix) {
   return String(prefix).toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/+$/, '');
 }
@@ -72,8 +64,13 @@ export const DENY_LISTS = [
     reason: 'Rejected: source domain is on the URL blocklist',
     contentTypes: ['news', 'event'],
     matches: (row, prefixes) => {
-      const norm = normalizeUrlForPrefix(row.source_url);
-      if (!norm) return false;
+      let norm;
+      try {
+        const u = new URL(row.source_url);
+        norm = (u.hostname.toLowerCase().replace(/^www\./, '') + u.pathname).toLowerCase().replace(/\/+$/, '');
+      } catch {
+        return false;
+      }
       return prefixes.some(p => typeof p === 'string' && p.trim() && norm.startsWith(normalizeBlocklistPrefix(p)));
     },
     sweepFragment: (prefixes) => {

--- a/backend/services/filterLists.js
+++ b/backend/services/filterLists.js
@@ -19,6 +19,22 @@ export async function loadListSetting(pool, key) {
   }
 }
 
+// Normalize a stored URL and a blocklist prefix the same way getDomainReputation does
+// (drop scheme + leading www + trailing slash), so a blocklist entry that is a bare
+// domain or a domain+path matches via startsWith. Kept local to avoid a circular import
+// with moderationService.
+function normalizeUrlForPrefix(url) {
+  try {
+    const u = new URL(url);
+    return (u.hostname.toLowerCase().replace(/^www\./, '') + u.pathname).toLowerCase().replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
+function normalizeBlocklistPrefix(prefix) {
+  return String(prefix).toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/+$/, '');
+}
+
 // Registry of hard-reject deny lists, applied during moderation.
 // - matches(row, values): per-item test.
 // - sweepFragment(values, textCols): SQL WHERE fragment for the retroactive
@@ -46,6 +62,25 @@ export const DENY_LISTS = [
       if (!valid.length) return null;
       const conds = valid.flatMap((_, i) => textCols.map(c => `${c} ILIKE $${i + 1}`)).join(' OR ');
       return { sql: `(${conds})`, params: valid.map(p => `%${p.trim()}%`) };
+    }
+  },
+  {
+    // Domain/URL blocklist. Previously enforced only at collection time (URLs skipped
+    // before fetching); now also a retroactive hard reject so blocking a domain cleans
+    // up items already collected from it.
+    key: 'blocklist_urls',
+    reason: 'Rejected: source domain is on the URL blocklist',
+    contentTypes: ['news', 'event'],
+    matches: (row, prefixes) => {
+      const norm = normalizeUrlForPrefix(row.source_url);
+      if (!norm) return false;
+      return prefixes.some(p => typeof p === 'string' && p.trim() && norm.startsWith(normalizeBlocklistPrefix(p)));
+    },
+    sweepFragment: (prefixes) => {
+      const valid = prefixes.filter(p => typeof p === 'string' && p.trim());
+      if (!valid.length) return null;
+      const conds = valid.map((_, i) => `regexp_replace(lower(source_url), '^https?://(www\\.)?', '') LIKE $${i + 1}`).join(' OR ');
+      return { sql: `source_url IS NOT NULL AND (${conds})`, params: valid.map(p => normalizeBlocklistPrefix(p) + '%') };
     }
   }
 ];

--- a/backend/services/filterLists.js
+++ b/backend/services/filterLists.js
@@ -79,7 +79,7 @@ export const DENY_LISTS = [
     sweepFragment: (prefixes) => {
       const valid = prefixes.filter(p => typeof p === 'string' && p.trim());
       if (!valid.length) return null;
-      const conds = valid.map((_, i) => `regexp_replace(lower(source_url), '^https?://(www\\.)?', '') LIKE $${i + 1}`).join(' OR ');
+      const conds = valid.map((_, i) => `regexp_replace(lower(source_url), '^https?://(www\\.)?|/+$', '', 'g') LIKE $${i + 1}`).join(' OR ');
       return { sql: `source_url IS NOT NULL AND (${conds})`, params: valid.map(p => normalizeBlocklistPrefix(p) + '%') };
     }
   }

--- a/backend/services/geoService.js
+++ b/backend/services/geoService.js
@@ -48,6 +48,72 @@ export async function getContainingBoundaries(pool, poiId) {
 }
 
 /**
+ * Find the candidate POIs an item could be reassigned to when it is relevant but
+ * not about its assigned POI (POI gate, Tier 2).
+ *
+ * - owner: the organization that owns the assigned POI (pois.owner_id), if any.
+ * - boundary: the smallest boundary POI that geographically contains the assigned
+ *   POI (e.g. Liberty Park Nature Center -> Liberty Park). Excludes the POI itself.
+ *
+ * Spatial lookup is wrapped so a PostGIS failure degrades to a null boundary rather
+ * than erroring — mirroring getContainingBoundaries.
+ *
+ * @param {Pool} pool - Database connection pool
+ * @param {number} poiId - assigned POI id
+ * @returns {Promise<{owner: {id:number,name:string}|null, boundary: {id:number,name:string}|null}>}
+ */
+export async function getReassignmentCandidates(pool, poiId) {
+  const id = parseInt(poiId, 10);
+  const candidates = { owner: null, boundary: null };
+  if (!Number.isInteger(id) || id <= 0) return candidates;
+
+  try {
+    const ownerQuery = await pool.query(
+      `SELECT o.id, o.name
+         FROM pois x
+         JOIN pois o ON o.id = x.owner_id
+        WHERE x.id = $1 AND (o.deleted IS NULL OR o.deleted = FALSE)`,
+      [id]
+    );
+    if (ownerQuery.rows.length) candidates.owner = ownerQuery.rows[0];
+  } catch (err) {
+    console.warn(`[Geo] Owner lookup failed for POI ${id}: ${err.message}`);
+  }
+
+  try {
+    const boundaryQuery = await pool.query(`
+      WITH poi_point AS (
+        SELECT
+          CASE
+            WHEN 'point' = ANY(poi_roles) AND geom IS NOT NULL THEN geom
+            WHEN poi_roles && ARRAY['trail','boundary','river']::text[] AND geometry IS NOT NULL THEN
+              ST_StartPoint(ST_GeometryN(ST_GeomFromGeoJSON(geometry::text), 1))
+            ELSE NULL
+          END as point_geom
+        FROM pois
+        WHERE id = $1
+      )
+      SELECT boundary.id, boundary.name
+      FROM poi_point
+      JOIN pois AS boundary
+        ON 'boundary' = ANY(boundary.poi_roles)
+        AND boundary.boundary_geom IS NOT NULL
+        AND boundary.id != $1
+        AND (boundary.deleted IS NULL OR boundary.deleted = FALSE)
+        AND ST_Contains(boundary.boundary_geom, poi_point.point_geom)
+      WHERE poi_point.point_geom IS NOT NULL
+      ORDER BY ST_Area(boundary.boundary_geom) ASC
+      LIMIT 1
+    `, [id]);
+    if (boundaryQuery.rows.length) candidates.boundary = boundaryQuery.rows[0];
+  } catch (err) {
+    console.warn(`[Geo] Boundary candidate lookup unavailable for POI ${id}: ${err.message}`);
+  }
+
+  return candidates;
+}
+
+/**
  * Expand a POI id into the set of POI ids whose news/events should roll up to it.
  *
  * - A normal point POI returns just [id] (no spatial cost, no behavior change).

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -5,7 +5,8 @@ import { logInfo, logError, flush as flushJobLogs } from './jobLogger.js';
 import { parseDate, parseDateTime, localToUTC, scoreDateConsensus, extractUrlDate } from './dateExtractor.js';
 import { AUTO_PUBLISHER_USER_ID } from '../utils/systemUsers.js';
 import { scoreDate, normalizeRenderUrl, normalizeTitle } from './newsService.js';
-import { denyReason, sweepDenyLists } from './filterLists.js';
+import { denyReason, sweepDenyLists, loadListSetting } from './filterLists.js';
+import { getReassignmentCandidates } from './geoService.js';
 
 function sameOrigin(urlA, urlB) {
   try { return new URL(urlA).origin === new URL(urlB).origin; }
@@ -146,7 +147,6 @@ async function attemptDeepCrawl(pool, contentType, contentId, row, scoring) {
 }
 
 async function runContentRelevanceVotes(pool, { title, description, poiName, contentType }, numVotes = 3) {
-  const typeLabel = contentType === 'event' ? 'event' : 'news article or announcement';
   const prompt = `You are evaluating content for "Roots of The Valley," a guide to Cuyahoga Valley National Park and the surrounding region including Cleveland Metroparks, Summit Metro Parks, and other nearby parks, trails, and outdoor recreation areas.
 
 Title: "${title}"
@@ -154,37 +154,40 @@ Summary: "${description || '(none)'}"
 Location: ${poiName || '(unknown)'}
 Type: ${contentType}
 
-Is this a real ${typeLabel}, NOT a static reference page?
+Is this content a good fit for this guide?
 
-APPROVE if the content:
-- Reports on something that happened or will happen (article, announcement, press release)
-- Describes a specific event with dates
-- Scheduled recreational excursions, tours, or rides with specific dates (e.g., scenic train rides, guided hikes, boat tours) — even if they run regularly
-- The TOPIC is directly related to: nature, trails, hiking, biking, paddling, outdoor recreation,
-  conservation, ecology, wildlife, park operations, land management, environmental education,
-  local history of the Cuyahoga Valley, or outdoor arts/music events hosted by a park or nature organization
-- Old news IS valid — a 2021 trail opening article is still news
+APPROVE if the SUBJECT relates to the Cuyahoga Valley / Northeast Ohio outdoors —
+nature, trails, hiking, biking, paddling, outdoor recreation, conservation, ecology,
+wildlife, park operations, land management, environmental education, local/regional
+history, scenic destinations and waterfalls, or outdoor arts/music events at a park or
+nature organization. This INCLUDES, equally:
+- News, announcements, and press releases
+- Events and scheduled excursions/tours/rides (even recurring ones)
+- Evergreen and descriptive content — trail write-ups, destination and "things to do"
+  guides, historical features and local legends, scenic-spot descriptions, hike recaps
+- Old content — a 2021 trail-opening article or a decades-old history piece is valid
 
-REJECT if the content is:
-- A permanent informational page (trail description, facility info, visitor guide)
-- An education resource or reference tool (StoryMap, interactive map, FAQ)
-- A general "about us" or organization overview page
-- A product/service page or commercial listing
-- A page that describes what something IS rather than what happened or will happen
-- A religious service, worship gathering, spiritual discussion, or faith-based event
-- A political rally, campaign event, or partisan meeting
-- A private party, wedding, corporate retreat, or commercial rental event
-- A general community event unrelated to nature, parks, or outdoor recreation
-  (e.g., book clubs, support groups, fitness classes, fundraising galas)
+Good, on-topic regional outdoor/park/history content is valuable to this guide whether
+or not it reports a specific "happening." Do NOT reject it merely for being a
+description, a reference page, a list, or evergreen rather than breaking news.
 
-IMPORTANT: Location alone does NOT make content relevant. An event held at a park
-venue is NOT automatically on-topic — the event's SUBJECT must relate to nature,
-trails, parks, conservation, history, or outdoor recreation.
+REJECT only if the content is genuinely a poor fit:
+- Off-topic for an outdoor/park/history guide — a religious service or worship gathering,
+  a political rally or partisan event, a private party/wedding/corporate rental, a purely
+  commercial product/service listing, or a general community event unrelated to nature,
+  parks, or regional history (e.g. book clubs, support groups, fitness classes, galas)
+- About a place OUTSIDE Northeast Ohio (e.g. a trail or park in another state)
+- Spam, navigation chrome, an error page, or content with no discernible subject
 
-The key test: does this page report on a HAPPENING (past, present, or future)
-whose TOPIC relates to nature, parks, or outdoor recreation in the Cuyahoga Valley?
+IMPORTANT: judge by SUBJECT, not venue. An off-topic event (a wedding, a political
+rally) held at a park is still a reject. But on-topic content about the parks, trails,
+nature, or history of the region is relevant even when it is purely descriptive.
 
-Return ONLY valid JSON: {"relevant": true, "reasoning": "one sentence why"}`;
+Also judge "about_poi": is this content specifically about "${poiName || '(unknown)'}"
+— either named directly or located there? Set about_poi false when the content is
+relevant to the region but is really about a different, broader, or neighboring place.
+
+Return ONLY valid JSON: {"relevant": true, "about_poi": true, "reasoning": "one sentence why"}`;
 
   const results = await Promise.all(
     Array.from({ length: numVotes }, () =>
@@ -193,7 +196,7 @@ Return ONLY valid JSON: {"relevant": true, "reasoning": "one sentence why"}`;
           const raw = (r || '').trim().replace(/^```json\s*/, '').replace(/\s*```$/, '');
           try {
             const parsed = JSON.parse(raw);
-            return { relevant: !!parsed.relevant, reasoning: parsed.reasoning || '' };
+            return { relevant: !!parsed.relevant, about_poi: !!parsed.about_poi, reasoning: parsed.reasoning || '' };
           } catch {
             return null;
           }
@@ -204,18 +207,127 @@ Return ONLY valid JSON: {"relevant": true, "reasoning": "one sentence why"}`;
   return results.filter(Boolean);
 }
 
+// Tier-2 POI gate: when content is relevant but not about its assigned POI, ask which
+// candidate it actually belongs to — the assigned POI, its owner org, or its containing
+// boundary — or none. Single call, fired only on a Tier-1 miss.
+async function assignBestPoi(pool, { title, description, poiName }, candidates) {
+  const options = ['assigned'];
+  let optionText = `- "assigned": the content is about "${poiName || '(unknown)'}"`;
+  if (candidates.owner) {
+    options.push('owner');
+    optionText += `\n- "owner": the content is about "${candidates.owner.name}" (the organization that owns it)`;
+  }
+  if (candidates.boundary) {
+    options.push('boundary');
+    optionText += `\n- "boundary": the content is about "${candidates.boundary.name}" (the park/area it sits within)`;
+  }
+  optionText += `\n- "none": none of the above`;
+
+  const prompt = `You are routing a news/event item to the correct place for "Roots of The Valley."
+
+Title: "${title}"
+Summary: "${description || '(none)'}"
+
+Which one is this content most about? Choose exactly one:
+${optionText}
+
+Return ONLY valid JSON: {"choice": "assigned|owner|boundary|none"}`;
+
+  try {
+    const r = await generateTextWithCustomPrompt(pool, prompt, { maxOutputTokens: 64, thinkingBudget: 0 });
+    const raw = (r || '').trim().replace(/^```json\s*/, '').replace(/\s*```$/, '');
+    const choice = JSON.parse(raw).choice;
+    return options.includes(choice) ? choice : 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+// Date gate: a date passes when it is present, not in the future, plausible (year at or
+// above the floor — catches hallucinated 1800s values), AND trustworthy (consensus score
+// at/above threshold OR from a trusted-domain source). Age is never penalized.
+export function evaluateDateGate(effectiveDate, dateScore, sourceUrl, { threshold, floorYear, trustedSet, allowFuture = false }) {
+  if (!effectiveDate) {
+    return { verdict: 'review', reason: 'No publication date', trusted_source: false };
+  }
+  const parsed = new Date(effectiveDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return { verdict: 'review', reason: 'Unparseable publication date', trusted_source: false };
+  }
+  if (!allowFuture && parsed > new Date()) {
+    return { verdict: 'review', reason: `Future publication date ${effectiveDate}`, trusted_source: false };
+  }
+  const year = parsed.getUTCFullYear();
+  if (year < floorYear) {
+    return { verdict: 'review', reason: `Implausible year ${year} (below ${floorYear})`, trusted_source: false };
+  }
+  const trusted = getDomainReputation(sourceUrl, trustedSet) === 'trusted';
+  if (dateScore >= threshold) {
+    return { verdict: 'pass', reason: `Date consensus ${dateScore}/${threshold}`, trusted_source: trusted };
+  }
+  if (trusted) {
+    return { verdict: 'pass', reason: `Trusted source date (consensus ${dateScore}/${threshold})`, trusted_source: true };
+  }
+  return { verdict: 'review', reason: `Low date confidence ${dateScore}/${threshold} from untrusted source`, trusted_source: false };
+}
+
+// POI gate (three tiers). Returns the verdict plus newPoiId when a Tier-2 reassignment
+// should be applied by the caller's write. Never rejects.
+//
+// deniedPoiIds (the POI deny list) is filtered out of the candidates so a reassignment
+// can never route an item onto a deny-listed POI — that would silently defeat the
+// hard-reject deny check, which runs once against the original poi_id earlier in the
+// pipeline. A would-be denied target drops the item to Tier 3 (manual review) instead.
+export async function evaluatePoiGate(pool, row, votes, deniedPoiIds = new Set()) {
+  const total = votes.length;
+  const aboutCount = votes.filter(v => v.about_poi).length;
+  if (total > 0 && aboutCount * 2 >= total) {
+    return { verdict: 'pass', tier: 1, reason: `About assigned POI (${aboutCount}/${total} votes)`, reassigned_from: null, reassigned_to: null, newPoiId: null };
+  }
+
+  const candidates = await getReassignmentCandidates(pool, row.poi_id);
+  if (candidates.owner && deniedPoiIds.has(candidates.owner.id)) candidates.owner = null;
+  if (candidates.boundary && deniedPoiIds.has(candidates.boundary.id)) candidates.boundary = null;
+  if (!candidates.owner && !candidates.boundary) {
+    return { verdict: 'review', tier: 3, reason: 'Not about assigned POI; no eligible owner/boundary candidate', reassigned_from: null, reassigned_to: null, newPoiId: null };
+  }
+
+  const choice = await assignBestPoi(pool, { title: row.title, description: row.description, poiName: row.poi_name }, candidates);
+  if (choice === 'assigned') {
+    return { verdict: 'pass', tier: 1, reason: 'Confirmed about assigned POI', reassigned_from: null, reassigned_to: null, newPoiId: null };
+  }
+  const target = choice === 'owner' ? candidates.owner : choice === 'boundary' ? candidates.boundary : null;
+  if (target) {
+    return {
+      verdict: 'pass', tier: 2,
+      reason: `Reassigned to ${target.name} (${choice})`,
+      reassigned_from: row.poi_id, reassigned_to: target.id, newPoiId: target.id
+    };
+  }
+  return { verdict: 'review', tier: 3, reason: 'Not confidently about assigned POI, owner, or boundary', reassigned_from: null, reassigned_to: null, newPoiId: null };
+}
+
 export async function processItem(pool, contentType, contentId, { forceStatus = null, runId = null } = {}) {
   const itemRunId = runId || Math.floor(Date.now() / 1000);
   console.log(`[Moderation] Processing ${contentType} #${contentId}${forceStatus ? ` (forced → ${forceStatus})` : ''}`);
 
   const settingsRows = await pool.query(
-    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_threshold', 'moderation_news_date_threshold')`
+    `SELECT key, value FROM admin_settings WHERE key IN ('moderation_auto_approve_threshold', 'moderation_news_date_threshold', 'moderation_date_floor_year', 'moderation_trusted_domains')`
   );
   const settings = Object.fromEntries(settingsRows.rows.map(r => [r.key, r.value]));
   const parsedNewsThreshold = parseInt(settings.moderation_news_date_threshold);
   const newsDateThreshold = Number.isNaN(parsedNewsThreshold) ? 4 : parsedNewsThreshold;
+  const parsedFloorYear = parseInt(settings.moderation_date_floor_year);
+  const dateFloorYear = Number.isNaN(parsedFloorYear) ? 2010 : parsedFloorYear;
+  let trustedSet = new Set();
+  try {
+    const domains = JSON.parse(settings.moderation_trusted_domains || '[]');
+    if (Array.isArray(domains)) trustedSet = new Set(domains.map(d => String(d).toLowerCase().replace(/^www\./, '')));
+  } catch { /* leave empty on bad JSON */ }
   const parsedPhotoThreshold = parseFloat(settings.moderation_auto_approve_threshold);
   const photoThreshold = Number.isNaN(parsedPhotoThreshold) ? 0.9 : parsedPhotoThreshold;
+  // Deny-listed POIs must never be a reassignment target (POI gate Tier 2).
+  const deniedPoiIds = new Set((await loadListSetting(pool, 'news_collection_excluded_pois')).map(Number).filter(Number.isInteger));
 
   let scoring;
 
@@ -302,7 +414,7 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
         if (row.date_signals) {
           const signals = row.date_signals;
           consensus = scoreDateConsensus(
-            { jsonLd: signals.jsonLd || [], meta: signals.meta || [], timeTags: signals.timeTags || [], url: signals.url || null },
+            { jsonLd: signals.jsonLd || [], meta: signals.meta || [], timeTags: signals.timeTags || [], url: signals.url || null, searchDate: signals.searchDate || null },
             signals.llmVotes || []
           );
         } else {
@@ -377,52 +489,72 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
 
     const effectiveDate = newDate || row.publication_date;
-    const isFutureDate = contentType === 'news' && effectiveDate && new Date(effectiveDate) > new Date();
+
+    // Three independent gates — auto-publish only when all three pass (spec 030).
+    // Events legitimately carry future dates, so the future-date check is news-only.
+    const dateGate = evaluateDateGate(effectiveDate, newScore, row.source_url,
+      { threshold: effectiveThreshold, floorYear: dateFloorYear, trustedSet, allowFuture: contentType === 'event' });
+
+    const relevanceGate = unanimousYes
+      ? { verdict: 'pass', reason: `Relevance ${yesCount}/${relevanceVotes.length} yes` }
+      : unanimousNo
+        ? { verdict: 'fail', reason: `Unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})` }
+        : { verdict: 'review', reason: `Relevance split ${yesCount}/${relevanceVotes.length} yes` };
+
+    // Skip the POI gate's extra lookup/LLM call when relevance already failed (we reject regardless).
+    const poiGate = relevanceGate.verdict === 'fail'
+      ? { verdict: 'review', tier: 0, reason: 'Not evaluated (relevance failed)', reassigned_from: null, reassigned_to: null, newPoiId: null }
+      : await evaluatePoiGate(pool, row, relevanceVotes, deniedPoiIds);
 
     let resolvedStatus;
-    let reasoning;
     if (forceStatus) {
       resolvedStatus = forceStatus;
-      reasoning = `Forced to ${forceStatus}`;
-    } else if (isFutureDate) {
-      resolvedStatus = 'pending';
-      reasoning = `Pending: future publication date ${effectiveDate} — needs review`;
-    } else if (unanimousNo) {
+    } else if (relevanceGate.verdict === 'fail') {
       resolvedStatus = 'rejected';
-      reasoning = `Rejected: relevance vote unanimous NO (${relevanceVotes.map(v => v.reasoning).join('; ')})`;
-    } else if (unanimousYes && newScore >= effectiveThreshold && effectiveDate) {
+    } else if (dateGate.verdict === 'pass' && relevanceGate.verdict === 'pass' && poiGate.verdict === 'pass') {
       resolvedStatus = 'published';
-      reasoning = `Published: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${effectiveThreshold}`;
     } else {
       resolvedStatus = 'pending';
-      reasoning = `Pending: relevance ${yesCount}/${relevanceVotes.length} yes, date score ${newScore}/${effectiveThreshold}`;
     }
+
+    const gates = {
+      date: { verdict: dateGate.verdict, reason: dateGate.reason, trusted_source: dateGate.trusted_source },
+      relevance: { verdict: relevanceGate.verdict, reason: relevanceGate.reason, yes: yesCount, total: relevanceVotes.length },
+      poi: { verdict: poiGate.verdict, tier: poiGate.tier, reason: poiGate.reason, reassigned_from: poiGate.reassigned_from, reassigned_to: poiGate.reassigned_to }
+    };
+    const reasoning = forceStatus
+      ? `Forced to ${forceStatus}`
+      : `${resolvedStatus} — date: ${dateGate.verdict}; relevance: ${relevanceGate.verdict} (${yesCount}/${relevanceVotes.length}); poi: ${poiGate.verdict}${poiGate.reassigned_to ? ` → #${poiGate.reassigned_to}` : ''}`;
 
     scoring = { confidence_score: newScore / 8.0, reasoning };
     const autoModeratedBy = resolvedStatus !== 'pending' ? AUTO_PUBLISHER_USER_ID : null;
+    const newPoiId = poiGate.newPoiId; // Tier-2 reassignment target, or null to keep current poi_id
+    const gatesJson = JSON.stringify(gates);
     // Only write publication_date when rescore produced a new value — writing the existing
     // value back through this path can silently corrupt a previously-good timestamp
     if (rescoredDate) {
       await pool.query(
         `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
                 publication_date = $2, date_consensus_score = $3,
-                ai_reasoning = $4, relevance_signals = $5, moderation_date = CURRENT_TIMESTAMP,
+                ai_reasoning = $4, relevance_signals = $5, moderation_gates = $8::jsonb,
+                poi_id = COALESCE($9, poi_id), moderation_date = CURRENT_TIMESTAMP,
                 moderated_by = COALESCE($7, moderated_by), moderated_at = CASE WHEN $7 IS NOT NULL THEN CURRENT_TIMESTAMP ELSE moderated_at END
          WHERE id = $6`,
         [resolvedStatus, newDate, newScore, reasoning,
          relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
-         contentId, autoModeratedBy]
+         contentId, autoModeratedBy, gatesJson, newPoiId]
       );
     } else {
       await pool.query(
         `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
                 date_consensus_score = $2,
-                ai_reasoning = $3, relevance_signals = $4, moderation_date = CURRENT_TIMESTAMP,
+                ai_reasoning = $3, relevance_signals = $4, moderation_gates = $7::jsonb,
+                poi_id = COALESCE($8, poi_id), moderation_date = CURRENT_TIMESTAMP,
                 moderated_by = COALESCE($6, moderated_by), moderated_at = CASE WHEN $6 IS NOT NULL THEN CURRENT_TIMESTAMP ELSE moderated_at END
          WHERE id = $5`,
         [resolvedStatus, newScore, reasoning,
          relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
-         contentId, autoModeratedBy]
+         contentId, autoModeratedBy, gatesJson, newPoiId]
       );
     }
 
@@ -482,14 +614,25 @@ export async function processPendingItems(pool) {
     console.error('[Moderation] Deny-list sweep failed:', e.message);
   }
 
+  // Per-cycle batch size is configurable so a monthly collection dump clears in a few
+  // sweep cycles instead of grinding through 20 at a time (spec 030).
+  const batchRow = await pool.query(
+    "SELECT value FROM admin_settings WHERE key = 'moderation_sweep_batch_size'"
+  );
+  const parsedBatch = parseInt(batchRow.rows[0]?.value);
+  const batchSize = Number.isNaN(parsedBatch) || parsedBatch <= 0 ? 50 : parsedBatch;
+
   const pendingNews = await pool.query(
-    `SELECT id FROM poi_news WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT 20`
+    `SELECT id FROM poi_news WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT $1`,
+    [batchSize]
   );
   const pendingEvents = await pool.query(
-    `SELECT id FROM poi_events WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT 20`
+    `SELECT id FROM poi_events WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT $1`,
+    [batchSize]
   );
   const pendingPhotos = await pool.query(
-    `SELECT id FROM photo_submissions WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT 20`
+    `SELECT id FROM photo_submissions WHERE moderation_status = 'pending' AND moderation_processed = false LIMIT $1`,
+    [batchSize]
   );
   const totalPending = pendingNews.rows.length + pendingEvents.rows.length + pendingPhotos.rows.length;
 
@@ -747,7 +890,8 @@ export async function fixDate(pool, contentType, contentId) {
       jsonLd: signals.jsonLd || [],
       meta: signals.meta || [],
       timeTags: signals.timeTags || [],
-      url: signals.url || null
+      url: signals.url || null,
+      searchDate: signals.searchDate || null
     };
     consensus = scoreDateConsensus(deterministicSources, signals.llmVotes || []);
   } else {
@@ -808,7 +952,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
 
   const baseQuery = `
     SELECT n.id, 'news' AS content_type, n.poi_id, n.title, n.summary AS description,
-           n.moderation_status, n.confidence_score, n.ai_reasoning, n.ai_issues,
+           n.moderation_status, n.confidence_score, n.ai_reasoning, n.ai_issues, n.moderation_gates,
            n.submitted_by, n.moderated_by, n.moderated_at, n.collection_date AS created_at, n.source_url,
            n.content_source, n.publication_date, n.date_consensus_score,
            NULL::TIMESTAMPTZ AS start_date, NULL::TIMESTAMPTZ AS end_date,
@@ -823,7 +967,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
     GROUP BY n.id, p.name
     UNION ALL
     SELECT e.id, 'event' AS content_type, e.poi_id, e.title, e.description,
-           e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
+           e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues, e.moderation_gates,
            e.submitted_by, e.moderated_by, e.moderated_at, e.collection_date AS created_at, e.source_url,
            e.content_source, e.publication_date, e.date_consensus_score,
            e.start_date, e.end_date,
@@ -843,7 +987,7 @@ export async function getQueue(pool, { page = 1, limit = 20, contentType = null,
              ELSE CONCAT(media_type, ' #', id)
            END AS title,
            caption AS description,
-           moderation_status, confidence_score, ai_reasoning, NULL AS ai_issues,
+           moderation_status, confidence_score, ai_reasoning, NULL AS ai_issues, NULL::jsonb AS moderation_gates,
            submitted_by, moderated_by, moderated_at, created_at, youtube_url AS source_url,
            NULL AS content_source, NULL::DATE AS publication_date, 0 AS date_consensus_score,
            NULL::TIMESTAMPTZ AS start_date, NULL::TIMESTAMPTZ AS end_date,

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -530,33 +530,21 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     const autoModeratedBy = resolvedStatus !== 'pending' ? AUTO_PUBLISHER_USER_ID : null;
     const newPoiId = poiGate.newPoiId; // Tier-2 reassignment target, or null to keep current poi_id
     const gatesJson = JSON.stringify(gates);
-    // Only write publication_date when rescore produced a new value — writing the existing
-    // value back through this path can silently corrupt a previously-good timestamp
-    if (rescoredDate) {
-      await pool.query(
-        `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
-                publication_date = $2, date_consensus_score = $3,
-                ai_reasoning = $4, relevance_signals = $5, moderation_gates = $8::jsonb,
-                poi_id = COALESCE($9, poi_id), moderation_date = CURRENT_TIMESTAMP,
-                moderated_by = COALESCE($7, moderated_by), moderated_at = CASE WHEN $7 IS NOT NULL THEN CURRENT_TIMESTAMP ELSE moderated_at END
-         WHERE id = $6`,
-        [resolvedStatus, newDate, newScore, reasoning,
-         relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
-         contentId, autoModeratedBy, gatesJson, newPoiId]
-      );
-    } else {
-      await pool.query(
-        `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
-                date_consensus_score = $2,
-                ai_reasoning = $3, relevance_signals = $4, moderation_gates = $7::jsonb,
-                poi_id = COALESCE($8, poi_id), moderation_date = CURRENT_TIMESTAMP,
-                moderated_by = COALESCE($6, moderated_by), moderated_at = CASE WHEN $6 IS NOT NULL THEN CURRENT_TIMESTAMP ELSE moderated_at END
-         WHERE id = $5`,
-        [resolvedStatus, newScore, reasoning,
-         relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
-         contentId, autoModeratedBy, gatesJson, newPoiId]
-      );
-    }
+    // publication_date is only overwritten when a rescore produced a new value; otherwise
+    // COALESCE keeps the existing value (writing the old value back can corrupt a good timestamp).
+    const pubDateUpdate = rescoredDate ? newDate : null;
+    await pool.query(
+      `UPDATE ${table} SET moderation_processed = true, moderation_status = $1,
+              publication_date = COALESCE($2, publication_date), date_consensus_score = $3,
+              ai_reasoning = $4, relevance_signals = $5, moderation_gates = $6::jsonb,
+              poi_id = COALESCE($7, poi_id), moderation_date = CURRENT_TIMESTAMP,
+              moderated_by = COALESCE($8, moderated_by),
+              moderated_at = CASE WHEN $8 IS NOT NULL THEN CURRENT_TIMESTAMP ELSE moderated_at END
+       WHERE id = $9`,
+      [resolvedStatus, pubDateUpdate, newScore, reasoning,
+       relevanceVotes.length > 0 ? JSON.stringify(relevanceVotes) : null,
+       gatesJson, newPoiId, autoModeratedBy, contentId]
+    );
 
   } else if (contentType === 'photo') {
     const photoQuery = await pool.query(

--- a/backend/tests/dateExtractor.unit.test.js
+++ b/backend/tests/dateExtractor.unit.test.js
@@ -188,25 +188,28 @@ describe('scoreDateConsensus', () => {
     expect(result.score).toBe(4);
   });
 
-  it('scores searchDate (Serper publisher date) alone at 3 pts', () => {
+  it('scores searchDate (Serper publisher date) alone at 4 pts', () => {
+    // Search-engine dates have proven reliable in moderation, so they are weighted on
+    // par with JSON-LD (4 pts) — an SE date alone clears the date gate (spec 030).
     const result = scoreDateConsensus({ searchDate: '2026-03-09' }, []);
     expect(result.date).toBe('2026-03-09');
-    expect(result.score).toBe(3);
+    expect(result.score).toBe(4);
     expect(result.sourceMap['2026-03-09']).toContain('search-date');
   });
 
   it('searchDate outweighs a disagreeing weak signal (the #1557 fix)', () => {
-    // Before: the Serper date sat in `meta` (1 pt) and lost to noise. Now it is a
-    // first-class deterministic source (3 pts) and wins over a single weak signal.
+    // The Serper date is a first-class deterministic source (4 pts) and wins over a
+    // single weak signal.
     const result = scoreDateConsensus({ searchDate: '2026-03-09', meta: ['2026-05-22'] }, []);
     expect(result.date).toBe('2026-03-09');
-    expect(result.score).toBe(3);
+    expect(result.score).toBe(4);
   });
 
-  it('on-page JSON-LD still outranks searchDate on conflict', () => {
+  it('searchDate ties on-page JSON-LD on conflict (both 4 pts) -> no consensus', () => {
+    // SE dates are now on par with JSON-LD, so a disagreement is a 4-vs-4 tie and
+    // yields score 0 (routed to review rather than auto-trusted).
     const result = scoreDateConsensus({ jsonLd: ['2026-03-09'], searchDate: '2026-05-22' }, []);
-    expect(result.date).toBe('2026-03-09');
-    expect(result.score).toBe(4);
+    expect(result.score).toBe(0);
   });
 });
 

--- a/backend/tests/services/moderationService.test.js
+++ b/backend/tests/services/moderationService.test.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, test, expect } from 'vitest';
-import { applyQualityFilters, getDomainReputation } from '../../services/moderationService.js';
+import { applyQualityFilters, getDomainReputation, evaluateDateGate } from '../../services/moderationService.js';
 
 // Test domain lists (mirrors production config from migration 019)
 const TRUSTED_DOMAINS = [
@@ -122,5 +122,42 @@ describe('Domain reputation detection', () => {
     expect(getDomainReputation('not-a-url', TRUSTED_SET, COMPETITOR_SET)).toBe('unknown');
     expect(getDomainReputation('', TRUSTED_SET, COMPETITOR_SET)).toBe('unknown');
     expect(getDomainReputation(null, TRUSTED_SET, COMPETITOR_SET)).toBe('unknown');
+  });
+});
+
+describe('Date gate (spec 030)', () => {
+  const cfg = { threshold: 4, floorYear: 2010, trustedSet: TRUSTED_SET };
+
+  test('missing date -> review', () => {
+    expect(evaluateDateGate(null, 0, 'https://nps.gov/a', cfg).verdict).toBe('review');
+  });
+
+  test('high consensus passes from any source', () => {
+    const g = evaluateDateGate('2023-06-01', 6, 'https://example.com/a', cfg);
+    expect(g.verdict).toBe('pass');
+  });
+
+  test('trusted source passes a recent date with low consensus', () => {
+    const g = evaluateDateGate('2024-09-10', 1, 'https://cleveland.com/story', cfg);
+    expect(g.verdict).toBe('pass');
+    expect(g.trusted_source).toBe(true);
+  });
+
+  test('untrusted source with low consensus -> review', () => {
+    expect(evaluateDateGate('2024-09-10', 1, 'https://example.com/a', cfg).verdict).toBe('review');
+  });
+
+  test('old date from trusted source still passes (age never penalized)', () => {
+    expect(evaluateDateGate('2015-04-01', 1, 'https://beaconjournal.com/x', cfg).verdict).toBe('pass');
+  });
+
+  test('hallucinated pre-floor year -> review', () => {
+    expect(evaluateDateGate('1899-01-01', 8, 'https://cleveland.com/x', cfg).verdict).toBe('review');
+  });
+
+  test('future news date -> review, but events allow future', () => {
+    const future = new Date(Date.now() + 90 * 86400000).toISOString().slice(0, 10);
+    expect(evaluateDateGate(future, 6, 'https://cleveland.com/x', cfg).verdict).toBe('review');
+    expect(evaluateDateGate(future, 6, 'https://cleveland.com/x', { ...cfg, allowFuture: true }).verdict).toBe('pass');
   });
 });

--- a/frontend/src/components/ModerationExtras.jsx
+++ b/frontend/src/components/ModerationExtras.jsx
@@ -33,6 +33,37 @@ const getConfidenceColor = (score) => {
   return '#4caf50';
 };
 
+const GATE_VERDICT_COLOR = { pass: '#4caf50', review: '#ff9800', fail: '#f44336' };
+
+// Compact pass/review/fail pills for the three auto-moderation gates (spec 030).
+// Hover shows each gate's reason; a Tier-2 POI reassignment is called out inline.
+function GateBadges({ gates }) {
+  if (!gates) return null;
+  const items = [
+    ['Date', gates.date],
+    ['Relevance', gates.relevance],
+    ['POI', gates.poi]
+  ].filter(([, g]) => g && g.verdict);
+  if (items.length === 0) return null;
+  const reassigned = gates.poi && gates.poi.reassigned_to;
+  return (
+    <span style={{ display: 'inline-flex', gap: '4px', alignItems: 'center', flexWrap: 'wrap' }}>
+      {items.map(([label, g]) => (
+        <span key={label} title={g.reason || ''}
+          style={{ ...badgeStyle(GATE_VERDICT_COLOR[g.verdict] || '#757575'), textTransform: 'none' }}>
+          {label} {g.verdict === 'pass' ? '✓' : g.verdict === 'fail' ? '✗' : '?'}
+        </span>
+      ))}
+      {reassigned && (
+        <span style={{ fontSize: '0.72rem', color: '#1565c0', fontWeight: 600 }}
+          title={gates.poi.reason || ''}>
+          reassigned
+        </span>
+      )}
+    </span>
+  );
+}
+
 const getTypeBadgeColor = (type) => {
   switch (type) {
     case 'news': return '#2196f3';
@@ -154,6 +185,8 @@ export default function ModerationExtras({
             {(item.confidence_score * 100).toFixed(0)}%
           </span>
         )}
+
+        {item.content_type !== 'photo' && <GateBadges gates={item.moderation_gates} />}
 
         <span style={{ fontSize: '0.72rem', color: '#aaa' }}>
           {formatPublicationDate(item.collection_date || item.created_at)}


### PR DESCRIPTION
## Summary
Restructures news/event auto-moderation around **three independent gates** — Date, Relevance, POI — auto-publishing only when all three pass, and showing each gate's verdict in the admin queue so a pending item reveals exactly which gate needs a human. Spec: `.specify/specs/030-moderation-gates/`.

- **Migration 070**: `moderation_gates` JSONB on `poi_news`/`poi_events`; settings `moderation_date_floor_year` (2010), `moderation_sweep_batch_size` (50, was hardcoded 20/type).
- **Date gate**: passes when a date is present, not future, plausible (≥ floor), and trustworthy (consensus ≥ threshold OR trusted domain). Search-engine date weight raised 3→4 (proven reliable); rescore path no longer drops `searchDate`.
- **Relevance gate**: 3-vote consensus, prompt loosened to keep on-topic evergreen content (trail/history/destination) and reject only off-topic / out-of-region. Unanimous-NO auto-rejects.
- **POI gate (three-tier)**: about-assigned-POI → reassign to owner (`owner_id`) or smallest containing boundary → review. Deny-listed POIs are filtered out of reassignment candidates so a reassignment can never land on a blocked POI.
- **Retroactive domain block**: `blocklist_urls` is now a hard-reject deny list (was collection-time skip only) — blocking a domain cleans up already-collected items on the next sweep.
- **Admin UI**: three gate badges (pass/review/fail) with reasons in `ModerationExtras`.

Verified live against production data: ~80% of a 50-item sample auto-cleared (78% published, 2% rejected), with the remainder held for review on POI/missing-date — and date trust validated against real article bylines.

## Test plan
- [ ] GHA build green
- [ ] Migration 070 applies on prod
- [ ] Moderation sweep populates gate badges; auto-publish requires all three gates
- [ ] Blocking a domain retroactively rejects stored items from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)