### PR TITLE
feat: enriched favorites list + Following→Favorite rename + shared BackButton (#437)

### DIFF
--- a/.specify/specs/033-favorites-list/plan.md
+++ b/.specify/specs/033-favorites-list/plan.md
@@ -1,0 +1,155 @@
+# Implementation Plan: Favorites List (enriched) + rename
+
+> **Spec ID:** 033-favorites-list
+> **Status:** Planning
+> **Last Updated:** 2026-06-01
+> **Estimated Effort:** M
+
+## Summary
+
+Enrich `GET /api/favorites` with status + news/events counts via one `LEFT JOIN LATERAL`
+query, then rebuild the My Valley "Favorites" tab to show those on clickable, sortable,
+filterable rows — and rename "Following" → "Favorite" across UI copy and `MyValley.jsx`
+internals. No schema or backend-table renames.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. My Valley opens → signed-in client GETs `/api/favorites?tz=<browser tz>`.
+2. Backend returns favorite rows + `trail_status`, `news_count`, `events_count` (one query).
+3. `MyValley` renders rows with `StatusBadge` + count chips; client-side sort/filter state
+   reorders/filters the loaded array.
+4. Row click → `generateSlug(name)` → `navigate('/' + slug)` + `onClose()`.
+5. Anonymous → localStorage ids → name + navigate + remove only (no status/counts).
+
+---
+
+## Technology Choices
+
+| Concern | Choice | Rationale |
+|---------|--------|-----------|
+| Enrichment query | single `LEFT JOIN LATERAL` for status + two counts | No N+1; mirrors tab-counts rules |
+| tz handling | reuse the whitelisted IANA regex from `/api/pois/:id/tab-counts` | Prevents `AT TIME ZONE` injection (PR #368 fix) |
+| Status display | existing `StatusBadge` | `trail_status.status` values already match its config |
+| Navigation | `generateSlug` + router `navigate` | Same path the map/gauges use (`/<slug>`) |
+| Sort/filter | client-side `useMemo` over loaded list | Lists are small; instant, no round-trips |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend enrichment
+
+- [ ] In `backend/routes/favorites.js` GET `/`, add `tz` whitelist + extend the query with:
+  - `LEFT JOIN LATERAL (SELECT status FROM trail_status WHERE poi_id = p.id ORDER BY created_at DESC LIMIT 1) ts`
+  - `LEFT JOIN LATERAL (SELECT COUNT(*) FROM poi_news … published/auto_approved) nc`
+  - `LEFT JOIN LATERAL (SELECT COUNT(*) FROM poi_events … published/auto_approved AND future) ec`
+  - return `trail_status`, `news_count` (int), `events_count` (int) alongside existing fields.
+
+### Phase 2: Rename Following → Favorite
+
+- [ ] `FavoriteToggle.jsx`: text `Following`/`Follow` → `Favorited`/`Favorite`; titles → `Remove from favorites` / `Add to favorites`.
+- [ ] `MyValley.jsx`: tab label `⭐ Following` → `★ Favorites`; empty-state copy; docstring; internals `followingList`→`favoriteList`, `view==='following'`→`'favorites'`, `handleUnfollow`→`handleRemoveFavorite`.
+- [ ] `NotificationBell.jsx`: "Follow places (★) …" → "Favorite places (★) …".
+- [ ] Sweep `GuidedTour.jsx` for a favorites/follow step and align if present.
+
+### Phase 3: Enriched, interactive list (MyValley)
+
+- [ ] Render each row: clickable name → navigate + close; `StatusBadge` when `trail_status` set; count chips `📰 {news_count} 📅 {events_count}`; Remove button with `stopPropagation`.
+- [ ] Add sort control (Recently added | Name A–Z | Most activity) and type-filter chips derived from `poi_roles` (shown only when >1 type present); apply via `useMemo`.
+- [ ] Wire navigation (`useNavigate` in MyValley, or an `onNavigate` prop from App) and confirm `/<slug>` selects the POI.
+
+### Phase 4: Styling
+
+- [ ] `MyValley.css`: row layout for badge + chips + remove; sort/filter control styles; keep within the existing modal (`height:80vh`, z-index>nav per #429 gotcha).
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/routes/favorites.js` | Enrich GET `/` with status + counts (+ tz whitelist) |
+| `frontend/src/components/MyValley.jsx` | Rename + enriched/sortable/filterable favorites list + navigation |
+| `frontend/src/components/FavoriteToggle.jsx` | Relabel to Favorite/Favorited |
+| `frontend/src/components/NotificationBell.jsx` | "Favorite places" copy |
+| `frontend/src/components/GuidedTour.jsx` | Align favorites step copy if present |
+| `frontend/src/components/MyValley.css` | Row + controls styling |
+
+### New Files
+
+None.
+
+---
+
+## Database Migrations
+
+None.
+
+---
+
+## API Implementation
+
+### `GET /api/favorites?tz=America/New_York`
+
+**Response (additive fields in bold):**
+```json
+[
+  {
+    "id": 42, "name": "Brandywine Falls", "poi_roles": ["trail"],
+    "brief_description": "…", "has_primary_image": true,
+    "favorited_at": "2026-05-30T12:00:00Z",
+    "trail_status": "open", "news_count": 3, "events_count": 1
+  }
+]
+```
+
+---
+
+## Testing Strategy
+
+### Automated
+
+- [ ] Extend `backend/tests` favorites coverage (or UI integration) to assert the enriched
+  fields are present and numeric, and that the rename strings render. Update any test that
+  asserts the old "Following" label or the old favorites response shape.
+
+### Manual
+
+1. Favorite a trail POI with news/events → open My Valley → row shows status badge + counts.
+2. Click a row → navigates to the place, modal closes.
+3. Remove (✕) → row disappears, no navigation.
+4. Sort + filter behave; controls hidden when only one type.
+5. Signed-out: favorites still list, navigate, and remove (no status/counts) — local-first intact.
+6. Toggle/tab/notification copy all say "Favorite".
+
+---
+
+## Rollback Plan
+
+1. Additive API + frontend-only UI — revert the changed files.
+2. No migration to unwind.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `/api/favorites` shape change breaks a consumer | Med | Additive only; existing fields untouched |
+| Rename misses a string → mixed "Follow/Favorite" copy | Low | Grep sweep for `follow`/`Following` in user-facing files during Phase 2 |
+| Row click vs. Remove button event overlap | Low | `stopPropagation` on Remove |
+| Tests assert old label/shape | Med | Update tests in Phase 1/2 (the #452 button-count test was a similar coupling) |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-01 | Initial plan |

--- a/.specify/specs/033-favorites-list/spec.md
+++ b/.specify/specs/033-favorites-list/spec.md
@@ -1,0 +1,147 @@
+# Specification: Favorites List (enriched) + "Following" → "Favorite" rename
+
+> **Spec ID:** 033-favorites-list
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-01
+
+## Overview
+
+The My Valley hub already has a list of the places a user follows, but each row only
+shows a name and an Unfollow button. This feature turns that into the "My List" view
+#437 asked for: each favorited place shows its current trail status, recent-news count,
+and upcoming-events count, is clickable to jump to the place on the map, and the list is
+sortable and filterable. It also renames the feature from **"Following"** to
+**"Favorite"** across the interface and code, so the saved-places concept reads
+consistently with the existing favorites backend and can grow.
+
+Resolves [#437](https://github.com/crunchtools/rotv/issues/437) (child of #141 UX 1.0).
+Builds on the My Valley hub + favorites system from #429/PR #451 and #387.
+
+---
+
+## User Stories
+
+### Enriched list
+
+**US-001: See what's happening at my places**
+> As a signed-in (or anonymous) user, I want each favorite to show its current status and
+> activity so that I can tell at a glance where something is going on.
+
+Acceptance Criteria:
+- [ ] Each favorite row shows a trail StatusBadge when a trail status is known (open/closed/limited/maintenance), and nothing (or "—") when not applicable.
+- [ ] Each row shows a recent-news count and an upcoming-events count (counts use the same published/auto_approved + future-event rules as the POI detail tab counts).
+- [ ] Counts of zero render as a muted "0" (or are omitted), not an error.
+
+**US-002: Jump to a place**
+> As a user, I want to click a favorite so that I'm taken to it on the map.
+
+Acceptance Criteria:
+- [ ] Clicking a row navigates to the POI (`/<slug>`) and closes the My Valley modal.
+- [ ] The Remove (un-favorite) control still works and does not trigger navigation.
+
+**US-003: Sort and filter**
+> As a user with many favorites, I want to sort and filter the list so that I can find what
+> I care about.
+
+Acceptance Criteria:
+- [ ] Sort options: Recently added (default), Name (A–Z), Most activity (news + upcoming events).
+- [ ] Filter by type derived from `poi_roles` (e.g. All / Trails / Parks / Rivers), shown only when there is more than one type present.
+- [ ] Sorting/filtering is client-side over the already-loaded list (no extra round-trips).
+
+### Rename
+
+**US-004: Consistent "Favorite" language**
+> As a user, I want the saved-places feature to be called "Favorite" everywhere so that the
+> star icon, the toggle, the list tab, and the notifications copy all agree.
+
+Acceptance Criteria:
+- [ ] The My Valley tab reads "★ Favorites (N)" (was "⭐ Following").
+- [ ] The POI toggle reads "Favorite" / "Favorited" with "Add to favorites" / "Remove from favorites" titles (was "Follow" / "Following").
+- [ ] Empty-state and NotificationBell copy say "Favorite places" (was "Follow places").
+- [ ] Internal identifiers in `MyValley.jsx` use favorite naming (`view === 'favorites'`, `favoriteList`, `handleRemoveFavorite`). Backend already uses `favorites` / `user_poi_favorites`; no DB rename.
+
+---
+
+## Data Model
+
+No schema changes. Reads existing tables: `user_poi_favorites`, `pois`, `poi_news`,
+`poi_events`, `trail_status`.
+
+---
+
+## API Endpoints
+
+### Modified
+
+| Method | Path | Change | Auth |
+|--------|------|--------|------|
+| GET | `/api/favorites` | **Additive**: each row also returns `trail_status` (latest, or null), `news_count`, `events_count`. Accepts `?tz=` (whitelisted IANA, like `/api/pois/:id/tab-counts`). Existing fields unchanged. | Yes |
+
+Counts are computed against the POI's own id (no boundary/org rollup) in a single query
+via `LEFT JOIN LATERAL` — favorites are overwhelmingly point POIs, and this keeps the
+endpoint to two queries with no N+1.
+
+---
+
+## UI/UX Requirements
+
+### Modified Components
+
+- `MyValley.jsx` — rename Following→Favorites; enrich rows (StatusBadge, count chips,
+  clickable navigate); add sort + type-filter controls over the favorites list.
+- `FavoriteToggle.jsx` — relabel to Favorite/Favorited.
+- `NotificationBell.jsx` — "Favorite places (★) …" copy.
+
+### Anonymous users
+
+Anonymous favorites (localStorage ids) render name + navigate + Remove, but **without**
+status/counts (those require the authenticated server query). The sort/filter controls
+still work on what's shown. This preserves the local-first rule.
+
+### Wireframe
+
+```
+★ Favorites (4)     [ Sort: Recently added ▾ ]  [ All | Trails | Parks ]
+┌──────────────────────────────────────────────┐
+│ Brandywine Falls          ✓ Open   📰 3  📅 1  ✕ │
+│ East Rim MTB Trails       ⚠ Limited 📰 0  📅 2  ✕ │
+│ Boston Mill Visitor Ctr             📰 5  📅 0  ✕ │
+└──────────────────────────────────────────────┘
+  (row click → navigate to /<slug> + close;  ✕ = remove)
+```
+
+---
+
+## Non-Functional Requirements
+
+**NFR-001: Local-first preserved** — anonymous path keeps working from localStorage; no sign-in required to see/remove favorites.
+
+**NFR-002: No N+1** — enrichment is a single SQL query; sort/filter is client-side.
+
+**NFR-003: No regression** — `/api/favorites` change is additive; existing consumers keep working. Backend favorite tables/routes are not renamed.
+
+**NFR-004: Code quality** — passes the Gourmand gate.
+
+---
+
+## Dependencies
+
+- Depends on: favorites system (#387), My Valley hub (#429/PR #451), `StatusBadge`, `generateSlug`, `getRollupPoiIds` pattern.
+- Parent: #141 (UX 1.0).
+
+---
+
+## Open Questions
+
+1. Should boundary/org favorites use rolled-up counts like the detail view? — Deferred; own-id counts for now (favorites are rarely boundaries).
+2. Filter set — start with type chips derived from `poi_roles`; revisit status-based filtering if asked.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-01 | Initial draft |

--- a/.specify/specs/033-favorites-list/spec.md
+++ b/.specify/specs/033-favorites-list/spec.md
@@ -38,7 +38,10 @@ Acceptance Criteria:
 > As a user, I want to click a favorite so that I'm taken to it on the map.
 
 Acceptance Criteria:
-- [ ] Clicking a row navigates to the POI (`/<slug>`) and closes the My Valley modal.
+- [ ] Clicking a favorite's name navigates to the POI (`/<slug>/info`) and closes the My Valley modal (i.e. "show it on the map").
+- [ ] The news / events count chips open that POI's news/events **inside My Valley** as a back-able detail panel (master→detail), so focus stays in the modal and the behavior is identical on mobile and desktop. The panel reuses the existing sidebar `PoiNews`/`PoiEvents` components for the same look/feel, with a News|Events toggle.
+- [ ] Clicking an individual article opens the full article **inside** My Valley (reusing the sidebar `ContentDetail`), with Back returning to the news/events list — focus never leaves the modal. Three levels: favorites list → POI news/events → article.
+- [ ] Clickable name + counts render green, like normal links.
 - [ ] The Remove (un-favorite) control still works and does not trigger navigation.
 
 **US-003: Sort and filter**
@@ -57,7 +60,7 @@ Acceptance Criteria:
 > star icon, the toggle, the list tab, and the notifications copy all agree.
 
 Acceptance Criteria:
-- [ ] The My Valley tab reads "★ Favorites (N)" (was "⭐ Following").
+- [ ] The My Valley tab reads "★ Favorites (N)" (was "⭐ Following"), and is the **first** tab (order: Favorites, Visited, Trips), shown by default when the modal opens.
 - [ ] The POI toggle reads "Favorite" / "Favorited" with "Add to favorites" / "Remove from favorites" titles (was "Follow" / "Following").
 - [ ] Empty-state and NotificationBell copy say "Favorite places" (was "Follow places").
 - [ ] Internal identifiers in `MyValley.jsx` use favorite naming (`view === 'favorites'`, `favoriteList`, `handleRemoveFavorite`). Backend already uses `favorites` / `user_poi_favorites`; no DB rename.
@@ -79,9 +82,15 @@ No schema changes. Reads existing tables: `user_poi_favorites`, `pois`, `poi_new
 |--------|------|--------|------|
 | GET | `/api/favorites` | **Additive**: each row also returns `trail_status` (latest, or null), `news_count`, `events_count`. Accepts `?tz=` (whitelisted IANA, like `/api/pois/:id/tab-counts`). Existing fields unchanged. | Yes |
 
+### New
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/pois/summary?ids=1,2,3&tz=` | Public batch enrichment: returns `[{ id, trail_status, news_count, events_count }]` for the requested ids (non-deleted, capped at 200). Mirrors the notification feed's `?pois=` precedent so **anonymous** (localStorage) favorites get the same status/counts as the signed-in list — closes the local-first gap. Registered before `/api/pois/:id` so `summary` isn't parsed as an id. | No |
+
 Counts are computed against the POI's own id (no boundary/org rollup) in a single query
-via `LEFT JOIN LATERAL` — favorites are overwhelmingly point POIs, and this keeps the
-endpoint to two queries with no N+1.
+via `LEFT JOIN LATERAL` — favorites are overwhelmingly point POIs, and this keeps each
+endpoint to one query with no N+1.
 
 ---
 
@@ -90,15 +99,28 @@ endpoint to two queries with no N+1.
 ### Modified Components
 
 - `MyValley.jsx` — rename Following→Favorites; enrich rows (StatusBadge, count chips,
-  clickable navigate); add sort + type-filter controls over the favorites list.
+  clickable navigate); add sort + type-filter controls; in-modal news/events/article detail.
 - `FavoriteToggle.jsx` — relabel to Favorite/Favorited.
 - `NotificationBell.jsx` — "Favorite places (★) …" copy.
 
+### App-wide back button (US-005)
+
+New shared `BackButton.jsx` standardizes every navigational back control to a single
+look (`.back-button`) and a destination-agnostic label — just **"← Back"**. A back button
+describes the action, not the destination, because a view (e.g. `ContentDetail`) can be
+reached from multiple places; a baked-in name ("Back to <POI>") is misleading in one of
+them. Swapped at all text call sites: `ContentDetail`, `MyValley`, `NewsPermalink`,
+`EventPermalink`, `TripsManager`, `PrivacyPolicy`. (Icon-only/​pagination controls are
+out of scope: the sidebar MTB header `←` and ModerationInbox pagination "Back".)
+
 ### Anonymous users
 
-Anonymous favorites (localStorage ids) render name + navigate + Remove, but **without**
-status/counts (those require the authenticated server query). The sort/filter controls
-still work on what's shown. This preserves the local-first rule.
+Anonymous favorites (localStorage ids) render with the **same** status/counts as the
+signed-in list, fetched from the public `GET /api/pois/summary` batch endpoint and merged
+client-side. Name + navigate + Remove + sort/filter all work without sign-in. If the
+enrichment fetch fails, rows gracefully fall back to names only. This fully honors the
+local-first rule (the user-specific favorites state is localStorage-backed and syncs on
+sign-in; the public POI status/counts are available to everyone).
 
 ### Wireframe
 
@@ -116,7 +138,7 @@ still work on what's shown. This preserves the local-first rule.
 
 ## Non-Functional Requirements
 
-**NFR-001: Local-first preserved** — anonymous path keeps working from localStorage; no sign-in required to see/remove favorites.
+**NFR-001: Local-first parity** — anonymous path works from localStorage and gets the same public status/counts as signed-in (via `/api/pois/summary`); no sign-in required to see/enrich/remove favorites.
 
 **NFR-002: No N+1** — enrichment is a single SQL query; sort/filter is client-side.
 

--- a/backend/routes/favorites.js
+++ b/backend/routes/favorites.js
@@ -21,14 +21,37 @@ export function createFavoritesRouter(pool) {
 
   router.get('/', isAuthenticated, async (req, res) => {
     try {
+      // Whitelist tz to IANA Region/City — Postgres AT TIME ZONE takes arbitrary input (PR #368 review)
+      const rawTz = req.query.tz;
+      const tz = (typeof rawTz === 'string' && /^[A-Za-z_]+\/[A-Za-z_]+(?:\/[A-Za-z_]+)?$/.test(rawTz))
+        ? rawTz
+        : 'America/New_York';
       const favorites = await pool.query(
         `SELECT p.id, p.name, p.poi_roles, p.brief_description, p.has_primary_image,
-                f.created_at AS favorited_at
+                f.created_at AS favorited_at,
+                ts.status AS trail_status,
+                COALESCE(nc.cnt, 0)::int AS news_count,
+                COALESCE(ec.cnt, 0)::int AS events_count
            FROM user_poi_favorites f
            JOIN pois p ON p.id = f.poi_id
+           LEFT JOIN LATERAL (
+             SELECT status FROM trail_status
+              WHERE poi_id = p.id ORDER BY created_at DESC LIMIT 1
+           ) ts ON true
+           LEFT JOIN LATERAL (
+             SELECT COUNT(*) AS cnt FROM poi_news n
+              WHERE n.poi_id = p.id
+                AND n.moderation_status IN ('published', 'auto_approved')
+           ) nc ON true
+           LEFT JOIN LATERAL (
+             SELECT COUNT(*) AS cnt FROM poi_events e
+              WHERE e.poi_id = p.id
+                AND e.moderation_status IN ('published', 'auto_approved')
+                AND (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
+           ) ec ON true
           WHERE f.user_id = $1 AND p.deleted IS NOT TRUE
           ORDER BY f.created_at DESC`,
-        [req.user.id]
+        [req.user.id, tz]
       );
       res.json(favorites.rows);
     } catch (err) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -949,6 +949,56 @@ app.get('/api/pois', async (req, res) => {
   }
 });
 
+// Public batch enrichment for an arbitrary list of POI ids: latest trail status +
+// published news count + upcoming-events count. Lets anonymous (localStorage) favorites
+// show the same status/counts as the signed-in list (#437, local-first parity).
+// Registered before /api/pois/:id so the literal "summary" path is not parsed as an id.
+app.get('/api/pois/summary', async (req, res) => {
+  try {
+    const ids = String(req.query.ids || '')
+      .split(',')
+      .map(s => parseInt(s, 10))
+      .filter(n => Number.isInteger(n) && n > 0)
+      .slice(0, 200);
+    if (ids.length === 0) {
+      return res.json([]);
+    }
+    // Whitelist tz to IANA Region/City — Postgres AT TIME ZONE takes arbitrary input (PR #368 review)
+    const rawTz = req.query.tz;
+    const tz = (typeof rawTz === 'string' && /^[A-Za-z_]+\/[A-Za-z_]+(?:\/[A-Za-z_]+)?$/.test(rawTz))
+      ? rawTz
+      : 'America/New_York';
+    const summary = await pool.query(`
+      SELECT p.id,
+             ts.status AS trail_status,
+             COALESCE(nc.cnt, 0)::int AS news_count,
+             COALESCE(ec.cnt, 0)::int AS events_count
+        FROM pois p
+        LEFT JOIN LATERAL (
+          SELECT status FROM trail_status
+           WHERE poi_id = p.id ORDER BY created_at DESC LIMIT 1
+        ) ts ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt FROM poi_news n
+           WHERE n.poi_id = p.id
+             AND n.moderation_status IN ('published', 'auto_approved')
+        ) nc ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt FROM poi_events e
+           WHERE e.poi_id = p.id
+             AND e.moderation_status IN ('published', 'auto_approved')
+             AND (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
+        ) ec ON true
+       WHERE p.id = ANY($1) AND p.deleted IS NOT TRUE`,
+      [ids, tz]
+    );
+    res.json(summary.rows);
+  } catch (error) {
+    console.error('Error fetching POI summary:', error);
+    res.status(500).json({ error: 'Failed to fetch POI summary' });
+  }
+});
+
 app.get('/api/pois/:id', async (req, res) => {
   try {
     const poiQuery = await pool.query(`

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1724,17 +1724,18 @@ body {
   padding: 0.75rem;
 }
 
-.content-detail-back {
+/* Standard app-wide back control (see BackButton.jsx) */
+.back-button {
   background: none;
   border: none;
   color: #2e7d32;
   cursor: pointer;
   padding: 0;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   margin-bottom: 1rem;
 }
 
-.content-detail-back:hover {
+.back-button:hover {
   text-decoration: underline;
 }
 
@@ -14311,20 +14312,6 @@ svg.leaflet-zoom-animated {
   margin-bottom: 24px;
 }
 
-.permalink-back-btn {
-  background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 6px 14px;
-  cursor: pointer;
-  color: #555;
-  font-size: 14px;
-}
-
-.permalink-back-btn:hover {
-  background: #f0f0f0;
-}
-
 .permalink-header {
   display: flex;
   align-items: flex-start;
@@ -14446,20 +14433,6 @@ svg.leaflet-zoom-animated {
   border-radius: 8px;
   padding: 2.5rem 3rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.privacy-back-btn {
-  background: none;
-  border: none;
-  color: #2d6a4f;
-  font-size: 0.95rem;
-  cursor: pointer;
-  padding: 0;
-  margin-bottom: 1.5rem;
-}
-
-.privacy-back-btn:hover {
-  text-decoration: underline;
 }
 
 .privacy-policy-content h1 {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -870,6 +870,17 @@ function AppContent() {
           setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
           return;
         }
+        // Resolve organization (virtual) POIs for sub-tab paths too, so a favorite (or
+        // permalink) to an org opens its sidebar — not just destinations & linear features (#437)
+        const virtualPoi = virtualPois.find(v => generateSlug(v.name) === poiSlug);
+        if (virtualPoi) {
+          setSelectedDestination(virtualPoi);
+          setSelectedLinearFeature(null);
+          setActiveTab('view');
+          document.title = `${virtualPoi.name} | Roots of The Valley`;
+          setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
+          return;
+        }
         const lf = linearFeatures.find(f => generateSlug(f.name) === poiSlug);
         if (lf) {
           setSelectedLinearFeature(lf);

--- a/frontend/src/components/BackButton.jsx
+++ b/frontend/src/components/BackButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Standard back control used across the app. Describes the action ("Back"),
+ * never the destination — the destination depends on how the user arrived, so a
+ * baked-in name (e.g. "Back to <POI>") is misleading when a view is reachable
+ * from more than one place. Pass an optional className for layout tweaks.
+ */
+export default function BackButton({ onClick, className = '' }) {
+  return (
+    <button type="button" className={`back-button${className ? ` ${className}` : ''}`} onClick={onClick}>
+      ← Back
+    </button>
+  );
+}

--- a/frontend/src/components/EventPermalink.jsx
+++ b/frontend/src/components/EventPermalink.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatDateWithWeekday, EventTypeIcon, DetailImage } from './NewsEventsShared';
 import ShareButton from './ShareButton';
+import BackButton from './BackButton';
 
 function generateSlug(name) {
   if (!name) return '';
@@ -43,9 +44,7 @@ export default function EventPermalink({ poiSlug, titleSlug }) {
         <div className="permalink-error">
           <h2>{error || 'Event not found'}</h2>
           <p>This event may have been removed or the link may be incorrect.</p>
-          <button onClick={() => navigate('/')} className="permalink-back-btn">
-            Back to Map
-          </button>
+          <BackButton onClick={() => navigate('/')} />
         </div>
       </div>
     );
@@ -57,9 +56,7 @@ export default function EventPermalink({ poiSlug, titleSlug }) {
     <div className="permalink-page">
       <div className="permalink-card">
         <div className="permalink-nav">
-          <button onClick={() => navigate('/')} className="permalink-back-btn">
-            &larr; Back to Map
-          </button>
+          <BackButton onClick={() => navigate('/')} />
         </div>
 
         <DetailImage imageUrl={item.image_url} poiId={item.poi_id} alt={item.title} />

--- a/frontend/src/components/FavoriteToggle.jsx
+++ b/frontend/src/components/FavoriteToggle.jsx
@@ -26,7 +26,7 @@ export default function FavoriteToggle({ poi, className = 'share-badge-btn favor
       className={`${className} ${favorited ? 'favorited' : ''}`}
       onClick={handleClick}
       disabled={busy}
-      title={favorited ? 'Unfollow this place' : 'Follow for news & event updates'}
+      title={favorited ? 'Remove from favorites' : 'Add to favorites for news & event updates'}
       aria-pressed={favorited}
     >
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
@@ -36,7 +36,7 @@ export default function FavoriteToggle({ poi, className = 'share-badge-btn favor
           <path fill="currentColor" d="M12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4zM12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61z" />
         )}
       </svg>
-      {favorited ? 'Following' : 'Follow'}
+      {favorited ? 'Favorited' : 'Favorite'}
     </button>
   );
 }

--- a/frontend/src/components/MyValley.css
+++ b/frontend/src/components/MyValley.css
@@ -128,6 +128,9 @@
 
 .my-valley-row-name {
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .my-valley-remove-btn {
@@ -157,4 +160,128 @@
 .my-valley-hint {
   color: rgba(0, 0, 0, 0.55);
   font-style: italic;
+}
+
+/* Favorites list: sort + type-filter controls */
+.my-valley-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.my-valley-sort {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.my-valley-sort select {
+  font-size: 0.82rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  background: white;
+}
+
+.my-valley-type-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.my-valley-chip {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: white;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.my-valley-chip.active {
+  background: #2d5016;
+  color: white;
+  border-color: #2d5016;
+}
+
+/* Clickable favorite name — a green link, like normal links */
+.my-valley-row-open {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  color: #2d5016;
+}
+
+.my-valley-row-open:hover .my-valley-row-name {
+  text-decoration: underline;
+}
+
+.my-valley-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+/* News / events counts: green link buttons that deep-link to that tab */
+.my-valley-count {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 0.8rem;
+  color: #2d5016;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.my-valley-count:hover {
+  text-decoration: underline;
+}
+
+/* In-panel news/events detail (PoiNews/PoiEvents render the same look as the sidebar tabs) */
+
+.my-valley-detail-name {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.my-valley-detail-tabs {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.my-valley-detail-tab {
+  border: none;
+  background: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.55);
+  cursor: pointer;
+}
+
+.my-valley-detail-tab.active {
+  color: #2d5016;
+  border-bottom-color: #2d5016;
+}
+
+/* Embedded article reuses ContentDetail; drop its sidebar padding so the article
+   content lines up with the single shared back button and the list view. */
+.my-valley-detail .content-detail {
+  padding: 0;
 }

--- a/frontend/src/components/MyValley.jsx
+++ b/frontend/src/components/MyValley.jsx
@@ -1,22 +1,45 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { readTrips as readLocalTrips } from '../utils/anonSettings';
+import { generateSlug } from './sidebar/helpers';
+import { StatusBadge } from './StatusBadge';
+import PoiNews from './sidebar/PoiNews';
+import PoiEvents from './sidebar/PoiEvents';
+import ContentDetail from './sidebar/ContentDetail';
+import BackButton from './BackButton';
 import TripsManager from './TripsManager';
 import './MyValley.css';
 
 /**
  * "My Valley" — the personalization hub. Combines the user's exploration
- * progress (Visited), followed places (Following), and saved Trips in one
+ * progress (Visited), favorite places (Favorites), and saved Trips in one
  * place. Local-first: works for anonymous visitors from localStorage-backed
  * AuthContext state (favorites/visited) and a sign-in nudge, and shows the
  * richer server-backed lists once signed in. Foundation for #141's
  * personalized home.
  */
+const FAV_TYPE_LABELS = {
+  trail: 'Trails',
+  river: 'Rivers',
+  water_taxi: 'Water Taxis',
+  boundary: 'Areas',
+  astronomy: 'Astronomy'
+};
+
 export default function MyValley({ open, onClose, destinations = [] }) {
   const { isAuthenticated, visited, favorites, toggleVisited, toggleFavorite } = useAuth();
+  const navigate = useNavigate();
   const [view, setView] = useState('visited');
   const [visitedList, setVisitedList] = useState([]);
-  const [followingList, setFollowingList] = useState([]);
+  const [favoriteList, setFavoriteList] = useState([]);
+  const [favSort, setFavSort] = useState('recent');
+  const [favTypeFilter, setFavTypeFilter] = useState('all');
+  // When set, the Favorites tab shows an in-panel news/events detail for one POI
+  // instead of the list — { id, name, tab: 'news' | 'events' }.
+  const [favDetail, setFavDetail] = useState(null);
+  // When set, a single news/event article is shown in-panel — { type, poiSlug, titleSlug }.
+  const [favArticle, setFavArticle] = useState(null);
   const [tripCount, setTripCount] = useState(0);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -47,20 +70,36 @@ export default function MyValley({ open, onClose, destinations = [] }) {
     if (!isAuthenticated) {
       setStats(null);
       setVisitedList(toRows(visited));
-      setFollowingList(toRows(favorites));
       setTripCount(readLocalTrips().length);
+      const baseRows = toRows(favorites);
+      setFavoriteList(baseRows);
+      // Local-first parity (#437): enrich anonymous (localStorage) favorites with the
+      // same public status/counts the signed-in list gets, via the batch summary endpoint.
+      if (favorites.length > 0) {
+        try {
+          const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York';
+          const res = await fetch(`/api/pois/summary?ids=${favorites.join(',')}&tz=${encodeURIComponent(tz)}`);
+          if (res.ok) {
+            const byId = new Map((await res.json()).map(s => [s.id, s]));
+            setFavoriteList(baseRows.map(r => ({ ...r, ...(byId.get(r.id) || {}) })));
+          }
+        } catch (err) {
+          console.warn('Favorite enrichment failed; showing names only:', err);
+        }
+      }
       return;
     }
     setLoading(true);
     try {
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York';
       const [visRes, favRes, tripsRes, statsRes] = await Promise.all([
         fetch('/api/visited', { credentials: 'include' }),
-        fetch('/api/favorites', { credentials: 'include' }),
+        fetch(`/api/favorites?tz=${encodeURIComponent(tz)}`, { credentials: 'include' }),
         fetch('/api/trips/mine', { credentials: 'include' }),
         fetch('/api/visited/stats', { credentials: 'include' })
       ]);
       if (visRes.ok) setVisitedList(await visRes.json());
-      if (favRes.ok) setFollowingList(await favRes.json());
+      if (favRes.ok) setFavoriteList(await favRes.json());
       if (tripsRes.ok) setTripCount((await tripsRes.json()).length);
       if (statsRes.ok) setStats(await statsRes.json());
     } catch {
@@ -72,9 +111,36 @@ export default function MyValley({ open, onClose, destinations = [] }) {
 
   useEffect(() => {
     if (!open) return;
-    setView('visited');
+    setView('favorites');
+    setFavDetail(null);
+    setFavArticle(null);
     load();
   }, [open, load]);
+
+  // The distinct POI types present in favorites, used to offer type-filter chips.
+  const favTypes = useMemo(() => {
+    const seen = new Set();
+    for (const p of favoriteList) {
+      const role = Array.isArray(p.poi_roles) && p.poi_roles.length ? p.poi_roles[0] : null;
+      if (role) seen.add(role);
+    }
+    return Array.from(seen);
+  }, [favoriteList]);
+
+  // Client-side filter + sort over the loaded favorites (lists are small).
+  const visibleFavorites = useMemo(() => {
+    let rows = favoriteList;
+    if (favTypeFilter !== 'all') {
+      rows = rows.filter(p => Array.isArray(p.poi_roles) && p.poi_roles[0] === favTypeFilter);
+    }
+    if (favSort === 'name') {
+      rows = [...rows].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    } else if (favSort === 'activity') {
+      const score = (p) => (p.news_count || 0) + (p.events_count || 0);
+      rows = [...rows].sort((a, b) => score(b) - score(a));
+    }
+    return rows;
+  }, [favoriteList, favTypeFilter, favSort]);
 
   if (!open) return null;
 
@@ -83,9 +149,24 @@ export default function MyValley({ open, onClose, destinations = [] }) {
     await toggleVisited(poiId);
   };
 
-  const handleUnfollow = async (poiId) => {
-    setFollowingList(prev => prev.filter(p => p.id !== poiId));
+  const handleRemoveFavorite = async (poiId) => {
+    setFavoriteList(prev => prev.filter(p => p.id !== poiId));
     await toggleFavorite(poiId);
+  };
+
+  // Switch My Valley tabs, leaving any favorites detail/article view first.
+  const selectView = (next) => {
+    setFavArticle(null);
+    setFavDetail(null);
+    setView(next);
+  };
+
+  // Open a favorite's POI on the map (resolved by App's location effect for the
+  // 'info' sub-tab). Close the modal first so the map is visible underneath.
+  const handleOpenOnMap = (poi) => {
+    const slug = generateSlug(poi.name);
+    onClose();
+    if (slug) navigate(`/${slug}/info`);
   };
 
   return (
@@ -113,20 +194,20 @@ export default function MyValley({ open, onClose, destinations = [] }) {
 
         <nav className="settings-tabs">
           <button
+            className={`settings-tab-btn ${view === 'favorites' ? 'active' : ''}`}
+            onClick={() => selectView('favorites')}
+          >
+            ★ Favorites ({isAuthenticated ? favoriteList.length : favorites.length})
+          </button>
+          <button
             className={`settings-tab-btn ${view === 'visited' ? 'active' : ''}`}
-            onClick={() => setView('visited')}
+            onClick={() => selectView('visited')}
           >
             🧭 Visited ({isAuthenticated ? visitedList.length : visited.length})
           </button>
           <button
-            className={`settings-tab-btn ${view === 'following' ? 'active' : ''}`}
-            onClick={() => setView('following')}
-          >
-            ⭐ Following ({isAuthenticated ? followingList.length : favorites.length})
-          </button>
-          <button
             className={`settings-tab-btn ${view === 'trips' ? 'active' : ''}`}
-            onClick={() => setView('trips')}
+            onClick={() => selectView('trips')}
           >
             🗺️ Trips ({tripCount})
           </button>
@@ -155,23 +236,115 @@ export default function MyValley({ open, onClose, destinations = [] }) {
             )
           )}
 
-          {view === 'following' && !loading && (
-            followingList.length === 0 ? (
+          {view === 'favorites' && !loading && favDetail && (
+            <div className="my-valley-detail">
+              <BackButton onClick={() => (favArticle ? setFavArticle(null) : setFavDetail(null))} />
+              {favArticle ? (
+                <ContentDetail permalinkInfo={favArticle} onBack={() => setFavArticle(null)} showBack={false} />
+              ) : (
+                <>
+                  <div className="my-valley-detail-name">{favDetail.name}</div>
+                  <div className="my-valley-detail-tabs">
+                    <button
+                      className={`my-valley-detail-tab ${favDetail.tab === 'news' ? 'active' : ''}`}
+                      onClick={() => setFavDetail(d => ({ ...d, tab: 'news' }))}
+                    >
+                      News
+                    </button>
+                    <button
+                      className={`my-valley-detail-tab ${favDetail.tab === 'events' ? 'active' : ''}`}
+                      onClick={() => setFavDetail(d => ({ ...d, tab: 'events' }))}
+                    >
+                      Events
+                    </button>
+                  </div>
+                  {favDetail.tab === 'news' ? (
+                    <PoiNews poiId={favDetail.id} poiName={favDetail.name} isAdmin={false} editMode={false}
+                      navigateOnSelect={false} onSelectNews={setFavArticle} />
+                  ) : (
+                    <PoiEvents poiId={favDetail.id} poiName={favDetail.name} isAdmin={false} editMode={false}
+                      navigateOnSelect={false} onSelectEvent={setFavArticle} />
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {view === 'favorites' && !loading && !favDetail && (
+            favoriteList.length === 0 ? (
               <div className="my-valley-empty">
-                <strong>Not following any places yet</strong>
-                <p>Open a place and tap “Follow” to get news and event updates in your notifications.</p>
+                <strong>No favorite places yet</strong>
+                <p>Open a place and tap “Favorite” to get news and event updates in your notifications.</p>
               </div>
             ) : (
-              <ul className="my-valley-list">
-                {followingList.map(poi => (
-                  <li key={poi.id} className="my-valley-row">
-                    <span className="my-valley-row-name">{poi.name}</span>
-                    <button className="my-valley-remove-btn" onClick={() => handleUnfollow(poi.id)} title={`Unfollow ${poi.name}`}>
-                      Unfollow
-                    </button>
-                  </li>
-                ))}
-              </ul>
+              <>
+                <div className="my-valley-controls">
+                  <label className="my-valley-sort">
+                    Sort
+                    <select value={favSort} onChange={(e) => setFavSort(e.target.value)}>
+                      <option value="recent">Recently added</option>
+                      <option value="name">Name (A–Z)</option>
+                      <option value="activity">Most activity</option>
+                    </select>
+                  </label>
+                  {favTypes.length > 1 && (
+                    <div className="my-valley-type-filter">
+                      <button
+                        className={`my-valley-chip ${favTypeFilter === 'all' ? 'active' : ''}`}
+                        onClick={() => setFavTypeFilter('all')}
+                      >
+                        All
+                      </button>
+                      {favTypes.map(t => (
+                        <button
+                          key={t}
+                          className={`my-valley-chip ${favTypeFilter === t ? 'active' : ''}`}
+                          onClick={() => setFavTypeFilter(t)}
+                        >
+                          {FAV_TYPE_LABELS[t] || t}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <ul className="my-valley-list">
+                  {visibleFavorites.map(poi => (
+                    <li key={poi.id} className="my-valley-row">
+                      <button
+                        className="my-valley-row-open"
+                        onClick={() => handleOpenOnMap(poi)}
+                        title={`Open ${poi.name}`}
+                      >
+                        <span className="my-valley-row-name">{poi.name}</span>
+                      </button>
+                      <span className="my-valley-row-meta">
+                        {poi.trail_status && <StatusBadge status={poi.trail_status} />}
+                        {typeof poi.news_count === 'number' && (
+                          <button
+                            className="my-valley-count"
+                            onClick={() => { setFavArticle(null); setFavDetail({ id: poi.id, name: poi.name, tab: 'news' }); }}
+                            title={`${poi.news_count} news — view`}
+                          >
+                            📰 {poi.news_count}
+                          </button>
+                        )}
+                        {typeof poi.events_count === 'number' && (
+                          <button
+                            className="my-valley-count"
+                            onClick={() => { setFavArticle(null); setFavDetail({ id: poi.id, name: poi.name, tab: 'events' }); }}
+                            title={`${poi.events_count} upcoming events — view`}
+                          >
+                            📅 {poi.events_count}
+                          </button>
+                        )}
+                      </span>
+                      <button className="my-valley-remove-btn" onClick={() => handleRemoveFavorite(poi.id)} title={`Remove ${poi.name}`}>
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </>
             )
           )}
 

--- a/frontend/src/components/NewsPermalink.jsx
+++ b/frontend/src/components/NewsPermalink.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatPublicationDate, NewsTypeIcon, DetailImage } from './NewsEventsShared';
 import ShareButton from './ShareButton';
+import BackButton from './BackButton';
 
 function generateSlug(name) {
   if (!name) return '';
@@ -43,9 +44,7 @@ export default function NewsPermalink({ poiSlug, titleSlug }) {
         <div className="permalink-error">
           <h2>{error || 'Article not found'}</h2>
           <p>This article may have been removed or the link may be incorrect.</p>
-          <button onClick={() => navigate('/')} className="permalink-back-btn">
-            Back to Map
-          </button>
+          <BackButton onClick={() => navigate('/')} />
         </div>
       </div>
     );
@@ -57,9 +56,7 @@ export default function NewsPermalink({ poiSlug, titleSlug }) {
     <div className="permalink-page">
       <div className="permalink-card">
         <div className="permalink-nav">
-          <button onClick={() => navigate('/')} className="permalink-back-btn">
-            &larr; Back to Map
-          </button>
+          <BackButton onClick={() => navigate('/')} />
         </div>
 
         <DetailImage imageUrl={item.image_url} poiId={item.poi_id} alt={item.title} />

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -219,7 +219,7 @@ export default function NotificationBell() {
           <div className="notification-dropdown-header">Notifications</div>
           {items.length === 0 ? (
             <div className="notification-empty">
-              No updates yet. Follow places (★) to get news and events about them here.
+              No updates yet. Favorite places (★) to get news and events about them here.
             </div>
           ) : (
             <ul className="notification-list">

--- a/frontend/src/components/PrivacyPolicy.jsx
+++ b/frontend/src/components/PrivacyPolicy.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import MarkdownRenderer from './MarkdownRenderer';
+import BackButton from './BackButton';
 
 function PrivacyEditor({ content, onSave }) {
   const [draft, setDraft] = useState(content || '');
@@ -105,9 +106,7 @@ function PrivacyPolicy({ inline = false, content, isAdmin, editMode }) {
     <div className={`privacy-policy-page ${inline ? 'privacy-inline' : ''}`}>
       <div className="privacy-policy-content">
         {!inline && (
-          <button className="privacy-back-btn" onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}>
-            &larr; Back
-          </button>
+          <BackButton onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')} />
         )}
 
         {isAdmin && editMode && !editing && (

--- a/frontend/src/components/TripsManager.jsx
+++ b/frontend/src/components/TripsManager.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useTrip } from '../hooks/useTrip';
 import { useAuth } from '../hooks/useAuth';
 import { readTrips as readLocalTrips, removeTrip as removeLocalTrip } from '../utils/anonSettings';
+import BackButton from './BackButton';
 import './TripsManager.css';
 
 function formatDate(iso) {
@@ -299,7 +300,7 @@ export default function TripsManager({ active = true, onClosed }) {
             </ul>
           )}
           <div style={{ marginTop: '0.75rem' }}>
-            <button onClick={() => setView('mine')}>&larr; Back to My Trips</button>
+            <BackButton onClick={() => setView('mine')} />
           </div>
         </>
       )}
@@ -330,7 +331,7 @@ export default function TripsManager({ active = true, onClosed }) {
             </ul>
           )}
           <div style={{ marginTop: '0.75rem' }}>
-            <button onClick={() => setView('mine')}>&larr; Back to My Trips</button>
+            <BackButton onClick={() => setView('mine')} />
           </div>
         </>
       )}

--- a/frontend/src/components/sidebar/ContentDetail.jsx
+++ b/frontend/src/components/sidebar/ContentDetail.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { formatPublicationDate, NewsTypeIcon, EventTypeIcon } from '../NewsEventsShared';
 import ShareButton from '../ShareButton';
+import BackButton from '../BackButton';
 
-function ContentDetail({ permalinkInfo, onBack, onItemLoaded }) {
+function ContentDetail({ permalinkInfo, onBack, onItemLoaded, showBack = true }) {
   const [item, setItem] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -23,7 +24,7 @@ function ContentDetail({ permalinkInfo, onBack, onItemLoaded }) {
   if (loading) return <div className="sidebar-tab-loading">Loading...</div>;
   if (error || !item) return (
     <div className="content-detail">
-      <button className="content-detail-back" onClick={onBack}>&larr; Back</button>
+      {showBack && <BackButton onClick={onBack} />}
       <p className="sidebar-tab-empty">{error || 'Not found'}</p>
     </div>
   );
@@ -36,7 +37,7 @@ function ContentDetail({ permalinkInfo, onBack, onItemLoaded }) {
 
   return (
     <div className="content-detail">
-      <button className="content-detail-back" onClick={onBack}>&larr; Back to {item.poi_name || 'POI'}</button>
+      {showBack && <BackButton onClick={onBack} />}
       <div className="content-detail-header">
         {isEvent ? <EventTypeIcon type={item.event_type} /> : <NewsTypeIcon type={item.news_type} />}
         <h3 className="content-detail-title">{item.title}</h3>

--- a/frontend/src/components/sidebar/PoiEvents.jsx
+++ b/frontend/src/components/sidebar/PoiEvents.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { formatPublicationDate } from '../NewsEventsShared';
 import { generateSlug } from './helpers';
 
-function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectEvent }) {
+function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectEvent, navigateOnSelect = true }) {
   const navigate = useNavigate();
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -124,7 +124,7 @@ function PoiEvents({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectE
                if (!sourceName) return;
                const poiSlug = generateSlug(sourceName);
                const titleSlug = generateSlug(item.title);
-               navigate(`/${poiSlug}/events/${titleSlug}`);
+               if (navigateOnSelect) navigate(`/${poiSlug}/events/${titleSlug}`);
                if (onSelectEvent) onSelectEvent({ type: 'event', poiSlug, titleSlug });
              }}
              style={{ cursor: 'pointer' }}>

--- a/frontend/src/components/sidebar/PoiNews.jsx
+++ b/frontend/src/components/sidebar/PoiNews.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { formatPublicationDate, NewsTypeIcon } from '../NewsEventsShared';
 import { generateSlug } from './helpers';
 
-function PoiNews({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectNews }) {
+function PoiNews({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectNews, navigateOnSelect = true }) {
   const navigate = useNavigate();
   const [news, setNews] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -108,7 +108,7 @@ function PoiNews({ poiId, poiName, isAdmin, editMode, onCountChange, onSelectNew
                if (!sourceName) return;
                const poiSlug = generateSlug(sourceName);
                const titleSlug = generateSlug(item.title);
-               navigate(`/${poiSlug}/news/${titleSlug}`);
+               if (navigateOnSelect) navigate(`/${poiSlug}/news/${titleSlug}`);
                if (onSelectNews) onSelectNews({ type: 'news', poiSlug, titleSlug });
              }}
              style={{ cursor: 'pointer' }}>


### PR DESCRIPTION
## Summary
Turns the My Valley "Following" list into the enriched "My List" view from #437, renames the feature to **Favorite**, and standardizes back buttons app-wide.

**Favorites (#437)**
- `/api/favorites` enriched with `trail_status` + news/upcoming-events counts (one `LATERAL` query, tz-whitelisted). New public `GET /api/pois/summary?ids=&tz=` batch endpoint gives **anonymous** favorites the same status/counts (local-first parity; mirrors the notification `?pois=` precedent).
- Renamed **Following → Favorite** across UI + `MyValley` internals (backend `favorites`/`user_poi_favorites` unchanged). Favorites is now the **first tab** and default view.
- Rows: `StatusBadge`, green clickable **name** (opens POI on map), green **📰/📅 count chips**, **sort** (recent/name/activity) + **type-filter** chips.
- Counts open that POI's news/events **inside My Valley** (reuses sidebar `PoiNews`/`PoiEvents`), and an item opens the article **in-panel** (`ContentDetail`) — focus never leaves the modal; identical on mobile + desktop.
- App router now resolves **organization (virtual) POIs** for `/<slug>/<subtab>` paths, so org favorites open the sidebar.

**Shared BackButton**
- New `BackButton.jsx` → every navigational back control reads **"← Back"** (action, not destination — fixes the misleading "Back to <POI>"). Swapped in `ContentDetail`, `MyValley`, `News`/`EventPermalink`, `TripsManager`, `PrivacyPolicy`; one `.back-button` style. My Valley keeps a single fixed back button across all detail levels.

Frontend + two additive backend endpoints. No DB changes. Spec/plan: `.specify/specs/033-favorites-list/`.

Closes #437

## Test plan
- [x] `./run.sh build` passes
- [x] Human-verified on :8083 — enrichment, rename, sort/filter, in-panel news/events/article, org favorites, fixed back button
- [x] Gourmand clean
- [ ] Playwright smoke suite (CI / on deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)