### PR TITLE
fix: My Valley row name overlapping chips on mobile (#459 follow-up)

### DIFF
--- a/frontend/src/components/MyValley.css
+++ b/frontend/src/components/MyValley.css
@@ -128,6 +128,8 @@
 
 .my-valley-row-name {
   font-weight: 600;
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -140,6 +142,7 @@
   padding: 0.2rem 0.5rem;
   font-size: 0.8rem;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 .my-valley-empty {
@@ -211,6 +214,8 @@
 
 /* Clickable favorite name — a green link, like normal links */
 .my-valley-row-open {
+  display: flex;
+  align-items: center;
   flex: 1;
   min-width: 0;
   border: none;


### PR DESCRIPTION
## Summary
On narrow (phone) widths, long favorite/visited names **overlapped** the news/events count chips and the Remove/Unmark button. The name's ellipsis truncation never engaged because `.my-valley-row-name` was an inline `<span>` and its flex parent didn't constrain/clip it.

Fix (CSS only, `MyValley.css`):
- `.my-valley-row-name`: `flex:1` + `min-width:0` → shrinks and truncates with ellipsis in both the favorites `row-open` container and the visited row.
- `.my-valley-row-open`: `display:flex` so the name truncates within it.
- `.my-valley-remove-btn`: `flex-shrink:0` so the button keeps its size.

Follow-up to #459 (favorites list). Found via Chrome at simulated phone width.

## Test plan
- [x] `./run.sh build` passes
- [x] Verified in Chrome at 360px: long names ("Cuyahoga Valley Scenic Railroad – …") truncate, chips + Remove fully visible, no overflow — favorites and visited rows
- [ ] CI smoke suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)