### PR TITLE
fix: smaller My Valley titles on mobile (#459 follow-up)

### DIFF
--- a/frontend/src/components/MyValley.css
+++ b/frontend/src/components/MyValley.css
@@ -99,6 +99,16 @@
     flex-wrap: wrap;
     overflow: visible;
   }
+
+  /* Smaller titles on mobile so more of the name shows before truncating */
+  .my-valley-row-name,
+  .my-valley-detail-name {
+    font-size: 0.9rem;
+  }
+
+  .my-valley-row {
+    padding: 0.5rem 0.6rem;
+  }
 }
 
 .my-valley-body {


### PR DESCRIPTION
## Summary
On mobile (`max-width: 768px`), reduce `.my-valley-row-name` and `.my-valley-detail-name` to `0.9rem` and trim the favorites/visited row's side padding, so longer titles fit more characters before the ellipsis truncates them.

CSS only (`MyValley.css`), additive to the existing mobile media block. Follow-up to #459 / #460.

## Test plan
- [x] `./run.sh build` passes
- [x] Verified at 360px: row + detail titles compute to 14.4px (was ~16px); desktop unchanged
- [ ] CI smoke suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)