### PR TITLE
chore: strip schedule: trigger from workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,9 +9,6 @@ on:
   repository_dispatch:
     types: [parent-image-updated]
   workflow_dispatch:
-  schedule:
-    - cron: '30 4 * * 1'
-
 env:
   REGISTRY: quay.io
   IMAGE_NAME: crunchtools/images-rotv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ on:
   repository_dispatch:
     types: [parent-image-updated]
   workflow_dispatch:
-  schedule:
-    - cron: '15 4 * * 1'
-
 env:
   REGISTRY: quay.io
   IMAGE_NAME: crunchtools/rotv


### PR DESCRIPTION
Removes the `schedule:` cron trigger from this repo's workflows.

GitHub auto-disables scheduled workflows after 60 days of no repo commits — that's what froze the base-image cascade. Weekly rebuild cadence moves to Hermes on lotor (fires `workflow_dispatch`/`repository_dispatch` at roots; existing cascade fans out from there). Removing `schedule:` makes this workflow structurally immune to `disabled_inactivity`.

Retains: `push`, `pull_request`, `repository_dispatch`, `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)