### PR TITLE
fix: have rotv-base listen for parent-image-updated

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, master]
     paths:
       - Containerfile.base
+  repository_dispatch:
+    types: [parent-image-updated]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
rotv-base is FROM `quay.io/crunchtools/ubi10-core` but build-base.yml didn't listen for `repository_dispatch`. So when ubi10-core rebuilt, rotv-base was never refreshed — only the app was. Add the listener so the cascade actually reaches rotv-base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)