### PR TITLE
This Weekend view + recurring events & venues (#436)

### DIFF
--- a/.specify/specs/034-this-weekend-recurring-events/plan.md
+++ b/.specify/specs/034-this-weekend-recurring-events/plan.md
@@ -7,31 +7,36 @@
 
 ## Summary
 
-Add a `poi_event_series` table with a small read-time expander, extend `getRollupPoiIds` with a
-`hosts_at`-gated reverse expansion, project series occurrences into the upcoming/weekend feeds, and
-ship a first-class "This Weekend" surface (#436). Seed CVFM as an overlay org at Howe Meadow with two
-recurring series.
+Add a `poi_event_series` table (the recurrence rule / source of truth) and a generator that
+**materializes** each series' occurrences as real `poi_events` rows, give events/series a
+`venue_poi_id` (organizer vs venue) so venue pages surface events held there, and ship a first-class
+"This Weekend" surface (#436). Seed CVFM as the organizer of two recurring markets at Howe Meadow and
+Old Trail School.
 
 ---
 
 ## Architecture
 
-### Data Flow (weekend view)
+### Generate (write) → query (read)
 
-1. Client requests `GET /api/events/window?range=weekend&tz=America/New_York` (or `range=today`).
-2. Backend computes the window in `tz` — weekend = [Fri 17:00 → Sun 23:59], today = [00:00 → 23:59].
-3. Query one-off `poi_events` (published/auto_approved) with `start_date` in window.
-4. Load active `poi_event_series`; the expander projects each into concrete occurrences in the
-   intersection of the request window and `[season_start, season_end]` (respecting `byday` and
-   `interval`, biweekly anchored on the first `byday` on/after `season_start`).
-5. Merge + sort one-offs and projected occurrences; attach venue + operating-org labels via the
-   POI/association data; return list + count.
+1. **Generate:** `materializeSeries(series)` expands the rule over `[season_start, season_end]`
+   (respecting `byday`/`interval`/`exdates`, biweekly anchored on the first `byday` on/after
+   `season_start`) and upserts the occurrences into `poi_events` (linked by `series_id`, with a
+   denormalized `recurrence_label`). FUTURE rows are regenerated on each run; PAST rows are kept.
+   Runs on series create/update/delete and on backend boot (`materializeAllSeries`). Idempotent via
+   the `(series_id, start_date)` unique index.
+2. **Read:** every events surface just queries `poi_events` — Today/This Weekend window, Future, Past,
+   newsletter, notifications, search, permalinks — no read-time expansion. Card-facing endpoints also
+   select `series_id`, `recurrence_label` (as `cadence_label`), and `venue_name`.
+3. **Timezone:** timed occurrences stored via `($local::timestamp AT TIME ZONE $tz)`; date-only as UTC
+   midnight, so they render correctly in local time.
 
-### Reverse rollup
+### Organizer vs venue
 
-`getRollupPoiIds(poiId)` gains one query: for a physical POI, `SELECT virtual_poi_id FROM
-poi_associations WHERE physical_poi_id = $1 AND association_type = 'hosts_at'`. Those org ids (and
-their own events) join the rolled-up set. Forward behavior for `manages`/`owner_id` is untouched.
+Events and series carry `poi_id` (organizer) and `venue_poi_id` (where). Event/series queries match
+`poi_id = ANY(ids) OR venue_poi_id = ANY(ids)`, so a venue's page surfaces events held there with no
+org-level bleed. `getRollupPoiIds` is unchanged — venue is a per-event link, not a POI association.
+(An earlier draft used a `hosts_at` reverse rollup; the venue column supersedes it and is precise.)
 
 ---
 
@@ -39,41 +44,42 @@ their own events) join the rolled-up set. Forward behavior for `manages`/`owner_
 
 | Component | Technology | Rationale |
 |-----------|------------|-----------|
-| Recurrence expansion | Hand-rolled expander in `backend/services/eventSeriesService.js` | Rule set is narrow (weekly/biweekly/monthly by weekday + seasonal windows); avoids an rrule.js dependency. Revisit if rules get exotic. |
-| Date math / tz | Existing project tz approach (chrono-node already present; native Date in `tz`) | Stay consistent with current `tz`-aware endpoints; don't regress migration 043 tz fixes. |
-| Series storage | New `poi_event_series` table | Rule-based, one row per series; clean edits, no row explosion. |
+| Recurrence + generation | Hand-rolled expander + `materializeSeries` in `backend/services/eventSeriesService.js` | Narrow rule set (weekly/biweekly by weekday + season + exdates); no rrule.js dependency. |
+| Surfacing | Materialize occurrences into `poi_events` | Makes recurring events appear everywhere regular events do (newsletter/notifications/past/search) with zero per-consumer code; bounded by season so finite. |
+| tz storage | `($local::timestamp AT TIME ZONE $tz)` on insert | Stores the correct instant; renders in local time without regressing migration 043. |
 
 ---
 
 ## Implementation Steps
 
 ### Phase 1: Backend foundation
-- [ ] Migration `081_poi_event_series.sql` — create table + indexes (idempotent).
-- [ ] `backend/services/eventSeriesService.js` — `expandSeries(series, fromDate, toDate, tz)` →
-      occurrences; `getActiveSeriesForPois(pool, poiIds)`.
-- [ ] Extend `getRollupPoiIds` with `hosts_at` reverse expansion (+ inline `// Fix:`-style note and
-      a guard so ownership orgs are unaffected).
+- [ ] Migration `081_poi_event_series.sql` — series table + `venue_poi_id`; `ALTER poi_events ADD
+      venue_poi_id, series_id, recurrence_label` + unique `(series_id, start_date)`; widen
+      `chk_events_content_source` to allow `recurring`. Idempotent.
+- [ ] `backend/services/eventSeriesService.js` — `expandSeries`, `cadenceLabel`, `materializeSeries`
+      (tz-correct upsert; future regenerated, past kept), `materializeAllSeries`.
 
 ### Phase 2: API
-- [ ] `GET /api/events/window?range=today|weekend` (one-offs + projected occurrences + count,
-      tz-aware; single endpoint backs both Today and This Weekend subtabs).
-- [ ] `GET /api/events/recurring` (active series + next occurrence).
-- [ ] Project series into existing `GET /api/pois/:id/events`, `/api/events/upcoming`, and tab-counts
-      for the rolled-up POI set.
-- [ ] Admin CRUD: `GET/POST/PUT/DELETE /api/admin/event-series`.
+- [ ] `GET /api/events/window?range=today|weekend` — events in the window (materialized recurring
+      included), tz-aware, with count.
+- [ ] `GET /api/events/recurring` — active series + next occurrence (series management/browse).
+- [ ] Event endpoints (`/api/pois/:id/events`, `/api/events/upcoming|past`, tab-counts) select
+      `series_id` / `recurrence_label` / `venue_name`; venue matching `poi_id OR venue_poi_id`.
+- [ ] Admin CRUD `GET/POST/PUT/DELETE /api/admin/event-series`; create/update call `materializeSeries`,
+      delete removes future occurrences (keeps past). Boot calls `materializeAllSeries`.
 
 ### Phase 3: Frontend
-- [ ] Add "This Weekend" as the **default subtab** in `ParkEvents.jsx` (This Weekend | Future | Past),
-      wired to `/api/events/this-weekend`; reuse existing filters/pagination.
-- [ ] Count badge on the Events nav item in `App.jsx` (sourced from the this-weekend count).
-- [ ] Recurring occurrence rendering in `ParkEvents.jsx` / `NewsEventsShared.jsx` (a `↻` cadence
-      badge; reuse `EventCardBody`) + optional "recurring only" filter chip.
-- [ ] Admin `EventSeriesForm` + relationship-type selector on org association
-      (Owns/manages vs Operates at venue).
+- [ ] `ParkEvents.jsx` — Today/This Weekend subtabs (default Today, else This Weekend), no counts.
+- [ ] `NewsEventsShared.jsx` `EventCardBody` — cadence line ("Weekly: Saturdays") + green venue link
+      on the Location line.
+- [ ] `ContentFormModal.jsx` — "Repeats" dropdown that swaps one-off date fields for recurrence +
+      season + times + venue + skip-dates; create (POST) and edit (PUT) a series.
+- [ ] `ParkEvents.jsx` — Edit/Delete controls on recurring (series-linked) occurrence cards.
 
 ### Phase 4: Data
-- [ ] Migration `082_cvfm_overlay_org.sql` — CVFM org POI, `hosts_at` association to Howe Meadow,
-      two series (Summer weekly Sun, Winter biweekly Sat), seasons/times from cvfm.org.
+- [ ] Migration `082_cvfm_overlay_org.sql` — CVFM org POI + Old Trail School POI; two series
+      (`poi_id`=CVFM, `venue_poi_id`=Howe Meadow / Old Trail School), weekly Saturdays, seasons/times/
+      exdates from cvfm.org.
 
 ---
 
@@ -83,21 +89,21 @@ their own events) join the rolled-up set. Forward behavior for `manages`/`owner_
 
 | File | Purpose |
 |------|---------|
-| `backend/migrations/081_poi_event_series.sql` | Series table + indexes |
-| `backend/migrations/082_cvfm_overlay_org.sql` | CVFM org + association + seed series |
-| `backend/services/eventSeriesService.js` | Series expander + queries |
-| `frontend/src/components/admin/EventSeriesForm.jsx` | Admin series CRUD form |
+| `backend/migrations/081_poi_event_series.sql` | Series table + poi_events `venue_poi_id`/`series_id`/`recurrence_label` + unique index + CHECK widening |
+| `backend/migrations/082_cvfm_overlay_org.sql` | CVFM org + Old Trail School POI + two series (with venue) |
+| `backend/services/eventSeriesService.js` | Expander, cadence label, `materializeSeries`/`materializeAllSeries` |
+| `backend/tests/eventSeries.unit.test.js` | Expander unit tests (cadence, biweekly, season bounds, exdates, venue) |
 
 ### Modified Files
 
 | File | Changes |
 |------|---------|
-| `backend/services/geoService.js` | `hosts_at` reverse rollup in `getRollupPoiIds` |
-| `backend/server.js` | this-weekend + recurring endpoints; series projection into events/tab-counts |
-| `backend/routes/admin.js` | event-series CRUD |
-| `frontend/src/App.jsx` | Events nav count badge |
-| `frontend/src/components/ParkEvents.jsx` / `NewsEventsShared.jsx` | This Weekend default subtab + render recurring occurrences + cadence badge |
-| `frontend/src/components/admin/*` (association editor) | relationship-type selector |
+| `backend/server.js` | window/recurring endpoints; venue matching + venue join + series fields on event queries; boot `materializeAllSeries` |
+| `backend/routes/admin.js` | event-series CRUD + materialize hooks; `venue_poi_id` on series and one-off events |
+| `frontend/src/components/ParkEvents.jsx` | Today/This Weekend subtabs; series Edit/Delete controls; reload after CRUD |
+| `frontend/src/components/NewsEventsShared.jsx` | cadence line + green venue link on event card |
+| `frontend/src/components/ContentFormModal.jsx` | "Repeats" dropdown → series create/edit form |
+| `frontend/src/App.css` | recurrence/venue/series-control styles |
 
 ---
 
@@ -118,15 +124,14 @@ manually on deploy** (`reference_prod_migrations_manual`).
       Saturday on/after `season_start`, then every 2 weeks); year-wrap winter range (Nov→Apr);
       no occurrences outside the season bounds; window/season intersection.
 
-### Integration
-- [ ] Reverse rollup: Howe Meadow events include CVFM events; an ownership org (Metroparks) child POI
-      does **not** inherit parent events (guardrail).
-- [ ] `/api/events/this-weekend`: count + merged one-offs and occurrences for a fixed tz/date.
-
-### Manual
-1. Open This Weekend → count + Sunday market visible.
-2. Open Howe Meadow POI → Farmers Market shows (reverse rollup), labeled CVFM.
-3. Edit Summer Market series day Sun→Sat → future occurrences shift.
+### Integration / manual (verified)
+- [x] Boot materialization: 52 occurrences across 2 series on a clean container (27 summer, 25 winter
+      after 3 exdates).
+- [x] Venue precision: Howe Meadow → summer only; Old Trail School → winter only; CVFM organizer →
+      both (no cross-bleed).
+- [x] Surfaces everywhere: past market Saturdays appear in `/api/events/past`; weekend window shows
+      the Saturday market; tz correct (9am ET stored as 13:00Z).
+- [ ] Edit a series (day/season) → future occurrences regenerate, past kept (browser check).
 
 ---
 
@@ -134,7 +139,7 @@ manually on deploy** (`reference_prod_migrations_manual`).
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Reverse rollup leaks parent feeds onto child pages | High | Gate strictly to `association_type='hosts_at'`; integration test asserts ownership orgs unchanged. |
+| Venue link surfaces wrong events on a POI page | Med | Venue is an explicit per-event `venue_poi_id`; verified no cross-bleed (Howe Meadow=summer only, Old Trail School=winter only). |
 | Timezone drift in weekend window / occurrence dates | Med | Compute in venue tz consistent with existing endpoints; unit-test boundaries; don't regress migration 043. |
 | `reload-app` skips `backend/services|migrations` | Med | Use full `./run.sh build` before verification (known gotcha). |
 | Multi-source CVFM pages (summer/winter/special) | Low | Series are authored manually; only special-event *collection* is single-URL — out of scope for v1, flag as follow-up. |
@@ -143,11 +148,11 @@ manually on deploy** (`reference_prod_migrations_manual`).
 
 ## Rollback Plan
 
-1. Frontend tab is additive — hide the nav entry to disable the surface.
-2. `poi_event_series` is independent; series projection is read-time — stop projecting and one-offs
-   remain.
-3. Reverse rollup is gated to `hosts_at`; removing CVFM's association (or the gate) fully reverts
-   venue behavior.
+1. Frontend subtabs are additive — they reuse the Events tab; no nav change to revert.
+2. To remove recurring events, deactivate the series (`active=false`) and delete their materialized
+   rows: `DELETE FROM poi_events WHERE series_id IS NOT NULL`. One-off events are untouched.
+3. `venue_poi_id` / `series_id` / `recurrence_label` are nullable, additive columns; ordinary events
+   have them NULL, so dropping the feature has no effect on existing data.
 
 ---
 

--- a/.specify/specs/034-this-weekend-recurring-events/plan.md
+++ b/.specify/specs/034-this-weekend-recurring-events/plan.md
@@ -1,0 +1,158 @@
+# Implementation Plan: "This Weekend" + Recurring Events & Overlay Orgs
+
+> **Spec ID:** 034-this-weekend-recurring-events
+> **Status:** Planning
+> **Last Updated:** 2026-06-07
+> **Estimated Effort:** L
+
+## Summary
+
+Add a `poi_event_series` table with a small read-time expander, extend `getRollupPoiIds` with a
+`hosts_at`-gated reverse expansion, project series occurrences into the upcoming/weekend feeds, and
+ship a first-class "This Weekend" surface (#436). Seed CVFM as an overlay org at Howe Meadow with two
+recurring series.
+
+---
+
+## Architecture
+
+### Data Flow (weekend view)
+
+1. Client requests `GET /api/events/window?range=weekend&tz=America/New_York` (or `range=today`).
+2. Backend computes the window in `tz` — weekend = [Fri 17:00 → Sun 23:59], today = [00:00 → 23:59].
+3. Query one-off `poi_events` (published/auto_approved) with `start_date` in window.
+4. Load active `poi_event_series`; the expander projects each into concrete occurrences in the
+   intersection of the request window and `[season_start, season_end]` (respecting `byday` and
+   `interval`, biweekly anchored on the first `byday` on/after `season_start`).
+5. Merge + sort one-offs and projected occurrences; attach venue + operating-org labels via the
+   POI/association data; return list + count.
+
+### Reverse rollup
+
+`getRollupPoiIds(poiId)` gains one query: for a physical POI, `SELECT virtual_poi_id FROM
+poi_associations WHERE physical_poi_id = $1 AND association_type = 'hosts_at'`. Those org ids (and
+their own events) join the rolled-up set. Forward behavior for `manages`/`owner_id` is untouched.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Recurrence expansion | Hand-rolled expander in `backend/services/eventSeriesService.js` | Rule set is narrow (weekly/biweekly/monthly by weekday + seasonal windows); avoids an rrule.js dependency. Revisit if rules get exotic. |
+| Date math / tz | Existing project tz approach (chrono-node already present; native Date in `tz`) | Stay consistent with current `tz`-aware endpoints; don't regress migration 043 tz fixes. |
+| Series storage | New `poi_event_series` table | Rule-based, one row per series; clean edits, no row explosion. |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend foundation
+- [ ] Migration `081_poi_event_series.sql` — create table + indexes (idempotent).
+- [ ] `backend/services/eventSeriesService.js` — `expandSeries(series, fromDate, toDate, tz)` →
+      occurrences; `getActiveSeriesForPois(pool, poiIds)`.
+- [ ] Extend `getRollupPoiIds` with `hosts_at` reverse expansion (+ inline `// Fix:`-style note and
+      a guard so ownership orgs are unaffected).
+
+### Phase 2: API
+- [ ] `GET /api/events/window?range=today|weekend` (one-offs + projected occurrences + count,
+      tz-aware; single endpoint backs both Today and This Weekend subtabs).
+- [ ] `GET /api/events/recurring` (active series + next occurrence).
+- [ ] Project series into existing `GET /api/pois/:id/events`, `/api/events/upcoming`, and tab-counts
+      for the rolled-up POI set.
+- [ ] Admin CRUD: `GET/POST/PUT/DELETE /api/admin/event-series`.
+
+### Phase 3: Frontend
+- [ ] Add "This Weekend" as the **default subtab** in `ParkEvents.jsx` (This Weekend | Future | Past),
+      wired to `/api/events/this-weekend`; reuse existing filters/pagination.
+- [ ] Count badge on the Events nav item in `App.jsx` (sourced from the this-weekend count).
+- [ ] Recurring occurrence rendering in `ParkEvents.jsx` / `NewsEventsShared.jsx` (a `↻` cadence
+      badge; reuse `EventCardBody`) + optional "recurring only" filter chip.
+- [ ] Admin `EventSeriesForm` + relationship-type selector on org association
+      (Owns/manages vs Operates at venue).
+
+### Phase 4: Data
+- [ ] Migration `082_cvfm_overlay_org.sql` — CVFM org POI, `hosts_at` association to Howe Meadow,
+      two series (Summer weekly Sun, Winter biweekly Sat), seasons/times from cvfm.org.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/081_poi_event_series.sql` | Series table + indexes |
+| `backend/migrations/082_cvfm_overlay_org.sql` | CVFM org + association + seed series |
+| `backend/services/eventSeriesService.js` | Series expander + queries |
+| `frontend/src/components/admin/EventSeriesForm.jsx` | Admin series CRUD form |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/services/geoService.js` | `hosts_at` reverse rollup in `getRollupPoiIds` |
+| `backend/server.js` | this-weekend + recurring endpoints; series projection into events/tab-counts |
+| `backend/routes/admin.js` | event-series CRUD |
+| `frontend/src/App.jsx` | Events nav count badge |
+| `frontend/src/components/ParkEvents.jsx` / `NewsEventsShared.jsx` | This Weekend default subtab + render recurring occurrences + cadence badge |
+| `frontend/src/components/admin/*` (association editor) | relationship-type selector |
+
+---
+
+## Database Migrations
+
+See spec Data Model for `081_poi_event_series.sql`. `082` is data-only and idempotent
+(`INSERT ... WHERE NOT EXISTS` / `ON CONFLICT DO NOTHING`), looking CVFM and Howe Meadow up by name.
+
+Per project convention: migrations are idempotent and re-run every deploy; **prod migrations are run
+manually on deploy** (`reference_prod_migrations_manual`).
+
+---
+
+## Testing Strategy
+
+### Unit
+- [ ] `expandSeries`: weekly Sundays within `[season_start, season_end]`; biweekly anchor (first
+      Saturday on/after `season_start`, then every 2 weeks); year-wrap winter range (Nov→Apr);
+      no occurrences outside the season bounds; window/season intersection.
+
+### Integration
+- [ ] Reverse rollup: Howe Meadow events include CVFM events; an ownership org (Metroparks) child POI
+      does **not** inherit parent events (guardrail).
+- [ ] `/api/events/this-weekend`: count + merged one-offs and occurrences for a fixed tz/date.
+
+### Manual
+1. Open This Weekend → count + Sunday market visible.
+2. Open Howe Meadow POI → Farmers Market shows (reverse rollup), labeled CVFM.
+3. Edit Summer Market series day Sun→Sat → future occurrences shift.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Reverse rollup leaks parent feeds onto child pages | High | Gate strictly to `association_type='hosts_at'`; integration test asserts ownership orgs unchanged. |
+| Timezone drift in weekend window / occurrence dates | Med | Compute in venue tz consistent with existing endpoints; unit-test boundaries; don't regress migration 043. |
+| `reload-app` skips `backend/services|migrations` | Med | Use full `./run.sh build` before verification (known gotcha). |
+| Multi-source CVFM pages (summer/winter/special) | Low | Series are authored manually; only special-event *collection* is single-URL — out of scope for v1, flag as follow-up. |
+
+---
+
+## Rollback Plan
+
+1. Frontend tab is additive — hide the nav entry to disable the surface.
+2. `poi_event_series` is independent; series projection is read-time — stop projecting and one-offs
+   remain.
+3. Reverse rollup is gated to `hosts_at`; removing CVFM's association (or the gate) fully reverts
+   venue behavior.
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-07 | Initial plan |

--- a/.specify/specs/034-this-weekend-recurring-events/spec.md
+++ b/.specify/specs/034-this-weekend-recurring-events/spec.md
@@ -1,0 +1,246 @@
+# Specification: "This Weekend" View + Recurring Events & Overlay Organizations
+
+> **Spec ID:** 034-this-weekend-recurring-events
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-07
+
+## Overview
+
+Adds a prominent **"This Weekend / Happening Now"** surface (GitHub #436, child of UX 1.0 #141)
+that answers "what's going on right now?" without tab-diving. Underneath it adds the missing data
+foundation: **recurring events** (rule-based series, not 50 materialized rows) and **overlay
+organizations** — operators like the Cuyahoga Valley Farmers Market (CVFM) that run events *at* a
+venue (Howe Meadow) without owning it. The weekend view is powered by projecting recurring series
+plus one-off events into a near-term window with visible counts.
+
+Concrete driving case: CVFM runs a **Summer Market** (weekly, Sundays, ~May–Oct) and a **Winter
+Market** (biweekly, Saturdays, ~Nov–Apr) at Howe Meadow, plus occasional **special events**.
+
+---
+
+## User Stories
+
+### Weekend Discovery (#436)
+
+**US-034-1: See what's happening this weekend**
+> As a Saturday-morning visitor, I want a prominent view of everything happening today/this weekend
+> with a count, so that I can decide where to go without navigating tabs.
+
+Acceptance Criteria:
+- [ ] Events tab gains temporal subtabs: **Today | This Weekend | Future | Past**. Today and This
+      Weekend each show one-off events + projected recurring occurrences in their window.
+- [ ] **Default subtab** = Today when today has any events, else This Weekend (so weekend visitors
+      land on "happening today" and quiet weekdays show the richer weekend view).
+- [ ] A **count badge on the Events nav item** ("Events ·14") shows the "happening now" count
+      (today's; weekend count when today is empty) without opening the tab — satisfying #436's
+      "see the count without navigating."
+- [ ] Rows show one-off events + recurring occurrences in the window (Today = the day; This Weekend =
+      Fri evening → Sun).
+- [ ] Each row shows title, time, venue, and the operating organization when applicable
+      ("Farmers Market @ Howe Meadow · CVFM").
+- [ ] Anonymous visitors get the full experience (no sign-in required).
+
+### Recurring Events
+
+**US-034-2: Model a recurring event once**
+> As an admin, I want to define "Farmers Market, every Sunday, May–Oct, 9am–noon" as a single
+> series, so that I don't hand-enter 50 rows and can edit the schedule in one place.
+
+Acceptance Criteria:
+- [ ] A series stores a recurrence rule (frequency, interval, weekday), an explicit **season begin
+      and end date** entered by the admin, and start/end time of day.
+- [ ] Occurrences are generated only within `[season_start, season_end]`; biweekly cadence anchors on
+      the first matching weekday on/after `season_start`.
+- [ ] The system projects a series into concrete upcoming occurrences for any requested date window.
+- [ ] Editing the series (e.g., "now Saturdays") changes all future occurrences with one update.
+- [ ] Recurring occurrences appear in the normal upcoming-events feed and the weekend view, not just
+      a separate list.
+
+**US-034-3: Browse recurring schedules**
+> As a regular, I want to see what recurs and when ("Sundays — Farmers Market at Howe Meadow"),
+> so that I can plan around weekly things.
+
+Acceptance Criteria:
+- [ ] Series are browsable with their cadence, venue, time, and next occurrence date.
+
+### Overlay Organizations
+
+**US-034-4: Run events at a venue without owning it**
+> As an admin, I want to create CVFM as an organization that *operates at* Howe Meadow, so that the
+> market's events surface on the Howe Meadow page while CVFM keeps its own identity and content.
+
+Acceptance Criteria:
+- [ ] An org can be linked to a venue with a relationship type of **"operates at" (`hosts_at`)**,
+      distinct from **"owns / manages"**.
+- [ ] On the **venue** page, events belonging to its overlay operators appear (reverse rollup).
+- [ ] Reverse rollup fires **only** for `hosts_at` links — ownership/`manages` orgs are unaffected,
+      so a child POI never inherits a parent system's entire event feed.
+- [ ] CVFM's own page continues to show CVFM events (and, harmlessly, any venue events via the
+      existing forward rollup).
+
+### Special Events
+
+**US-034-5: One-off market events**
+> As an admin, I want CVFM special events to be ordinary one-off events on the CVFM POI, so that no
+> new modeling is needed and they flow through existing display/collection.
+
+Acceptance Criteria:
+- [ ] Special events are normal `poi_events` rows on the CVFM POI and surface at Howe Meadow via
+      reverse rollup like any CVFM event.
+
+---
+
+## Data Model
+
+### New Tables
+
+| Table | Description |
+|-------|-------------|
+| `poi_event_series` | Rule-based recurring event definitions (one row per recurring market/program). |
+
+### Schema Changes
+
+```sql
+-- New: recurring event series (rule stored, occurrences expanded at read time)
+CREATE TABLE IF NOT EXISTS poi_event_series (
+  id              SERIAL PRIMARY KEY,
+  poi_id          INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
+  title           VARCHAR(500) NOT NULL,
+  description     TEXT,
+  event_type      VARCHAR(100),
+  location_details TEXT,
+  source_url      TEXT,
+  image_url       TEXT,
+  -- Recurrence rule (RFC 5545 subset: weekly/biweekly/monthly by weekday)
+  freq            VARCHAR(10) NOT NULL DEFAULT 'WEEKLY',  -- WEEKLY | MONTHLY
+  interval        INTEGER NOT NULL DEFAULT 1,             -- 1 = every, 2 = biweekly
+  byday           TEXT[] NOT NULL DEFAULT '{}',           -- e.g. {SU} or {SA}
+  -- Explicit, admin-entered season bounds. Occurrences only within this range.
+  -- Winter year-wrap is just an ordinary range (e.g. 2025-11-01 .. 2026-04-25).
+  -- Biweekly anchors on the first `byday` match on/after season_start.
+  season_start    DATE NOT NULL,
+  season_end      DATE NOT NULL,
+  -- Time of day
+  time_start      TIME,
+  time_end        TIME,
+  -- Provenance / moderation (mirror poi_events conventions)
+  content_source  VARCHAR(20) DEFAULT 'human',
+  moderation_status VARCHAR(20) DEFAULT 'published',
+  active          BOOLEAN DEFAULT TRUE,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_poi_event_series_poi_id ON poi_event_series(poi_id);
+CREATE INDEX IF NOT EXISTS idx_poi_event_series_active ON poi_event_series(active);
+
+-- No schema change for overlay orgs: poi_associations.association_type already exists.
+-- We introduce a new value 'hosts_at' alongside the default 'manages'.
+```
+
+CVFM data (migration 082, idempotent):
+- Insert CVFM as a POI with `poi_roles = {organization}`, its own `news_url`/`events_url` →
+  `cvfm.org`.
+- Insert `poi_associations(virtual_poi_id=CVFM, physical_poi_id=Howe Meadow, association_type='hosts_at')`.
+- Insert two `poi_event_series` rows (Summer Market, Winter Market) on the CVFM POI.
+
+---
+
+## API Endpoints
+
+### New Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/events/window?range=today\|weekend&tz=` | One-off + projected recurring occurrences in the requested window, with total count. Single endpoint serves both Today and This Weekend subtabs. | No |
+| GET | `/api/events/recurring` | Active series (cadence, venue, next occurrence) — backs the `↻` rendering / "recurring only" filter. | No |
+| GET | `/api/admin/event-series` | List series for admin. | Admin |
+| POST | `/api/admin/event-series` | Create a series. | Admin |
+| PUT | `/api/admin/event-series/:id` | Edit a series. | Admin |
+| DELETE | `/api/admin/event-series/:id` | Delete a series. | Admin |
+
+### Modified Behavior
+
+- `getRollupPoiIds(poiId)` (geoService.js): add a **reverse-association** expansion — a physical POI
+  also rolls up the orgs that `hosts_at` it. Gated strictly to `association_type='hosts_at'`.
+- `GET /api/pois/:id/events`, `/api/events/upcoming`, tab-counts: include projected series
+  occurrences for the rolled-up POI set within the requested window.
+
+---
+
+## UI/UX Requirements
+
+### Components
+
+- **Events tab subtab** — add "This Weekend" as the default subtab in `ParkEvents.jsx` alongside
+  Future/Past. Reuses existing filters/pagination/card rendering. Recurring occurrences render inline
+  with a `↻` cadence badge; an optional "recurring only" filter chip replaces the need for a separate
+  recurring browse view.
+- **Events nav badge** — count badge on the Events nav item ("Events ·14") sourced from the
+  this-weekend count.
+- Admin: `EventSeriesForm` — create/edit a series; org association includes the relationship-type
+  selector (**Owns/manages** vs **Operates at venue**).
+
+### Wireframes
+
+```
+ Nav:  Map   News   Events ·14   About
+                     └─ [ This Weekend ] Future  Past
+── This Weekend ──────────────────────────  [ 14 events ]
+ SUN  9:00a  Farmers Market        Howe Meadow · CVFM   ↻ weekly
+ SAT 10:00a  Guided Ledges Hike    The Ledges
+ SAT  2:00p  Bird Walk             Beaver Marsh
+ ...
+```
+
+---
+
+## Non-Functional Requirements
+
+**NFR-034-1: Local-First (constitution)**
+- The weekend view and series browsing work fully for anonymous visitors. No new user-data storage
+  is introduced here; if "follow this series" is added later it MUST use `createPoiIdListStore` /
+  `syncPoiIdList` per `docs/USER_DATA_FRAMEWORK.md`.
+
+**NFR-034-2: Performance**
+- Series projection happens at read time over a small set (active series for the rolled-up POIs).
+  Expansion is bounded to the requested window; no unbounded loops.
+
+**NFR-034-3: Timezone correctness**
+- Weekend window and occurrence dates computed in the venue/America-New_York timezone, consistent
+  with existing `tz`-aware event endpoints (migration 043 fixed prior tz issues — do not regress).
+
+**NFR-034-4: Safety of reverse rollup**
+- Reverse rollup is restricted to `hosts_at`; ownership orgs (Cleveland Metroparks, Summit Metro
+  Parks, Conservancy) must show no behavioral change.
+
+---
+
+## Dependencies
+
+- Depends on: existing org/`poi_associations` machinery (`005-poi-roles`, `026-geofenced-news`),
+  events schema, `getRollupPoiIds`.
+- Implements: GitHub #436 (child of #141).
+
+---
+
+## Open Questions
+
+1. Recurrence library vs hand-rolled: rrule.js (RFC 5545, robust) vs a small in-repo weekly/biweekly/
+   monthly-by-weekday expander (no dependency, covers all known cases). **Leaning hand-rolled for v1**
+   to avoid a dependency for a narrow rule set — revisit if rules get exotic.
+2. "This Weekend" window definition: Fri 5pm → Sun 11:59pm by default? And does "Happening Today"
+   need to be a distinct quick-filter within the same surface?
+3. Exact CVFM season boundaries, market times, and the winter biweekly anchor date — pull from
+   cvfm.org during data seeding (migration 082).
+4. ~~Dedicated nav tab vs banner~~ **RESOLVED:** This Weekend is the default subtab of Events + a
+   count badge on the Events nav item. Map banner deferred as a fast-follow.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-07 | Initial draft |

--- a/.specify/specs/034-this-weekend-recurring-events/spec.md
+++ b/.specify/specs/034-this-weekend-recurring-events/spec.md
@@ -10,13 +10,18 @@
 
 Adds a prominent **"This Weekend / Happening Now"** surface (GitHub #436, child of UX 1.0 #141)
 that answers "what's going on right now?" without tab-diving. Underneath it adds the missing data
-foundation: **recurring events** (rule-based series, not 50 materialized rows) and **overlay
-organizations** — operators like the Cuyahoga Valley Farmers Market (CVFM) that run events *at* a
-venue (Howe Meadow) without owning it. The weekend view is powered by projecting recurring series
-plus one-off events into a near-term window with visible counts.
+foundation: **recurring events** and **organizer-vs-venue** modeling — operators like the Cuyahoga
+Valley Farmers Market (CVFM) that run events *at* a venue (Howe Meadow / Old Trail School) without
+owning it.
 
-Concrete driving case: CVFM runs a **Summer Market** (weekly, Sundays, ~May–Oct) and a **Winter
-Market** (biweekly, Saturdays, ~Nov–Apr) at Howe Meadow, plus occasional **special events**.
+Recurring events are stored as a **rule** (`poi_event_series`, the editable source of truth) and the
+generator **materializes** each rule's occurrences as real `poi_events` rows. That way recurring
+events appear **everywhere regular events do** — Today/This Weekend, Future, Past, the newsletter,
+notifications, search, and permalinks — with no per-consumer projection code.
+
+Concrete driving case (per cvfm.org): CVFM runs a **Summer Market** (weekly Saturdays, May–Oct, at
+Howe Meadow) and a **Winter Market** (weekly Saturdays, Nov–Apr, at Old Trail School, with holiday
+closures), plus occasional **special events**.
 
 ---
 
@@ -30,14 +35,13 @@ Market** (biweekly, Saturdays, ~Nov–Apr) at Howe Meadow, plus occasional **spe
 
 Acceptance Criteria:
 - [ ] Events tab gains temporal subtabs: **Today | This Weekend | Future | Past**. Today and This
-      Weekend each show one-off events + projected recurring occurrences in their window.
+      Weekend each show one-off events + recurring occurrences in their window.
 - [ ] **Default subtab** = Today when today has any events, else This Weekend (so weekend visitors
-      land on "happening today" and quiet weekdays show the richer weekend view).
-- [ ] A **count badge on the Events nav item** ("Events ·14") shows the "happening now" count
-      (today's; weekend count when today is empty) without opening the tab — satisfying #436's
-      "see the count without navigating."
+      land on "happening today" and quiet weekdays show the richer weekend view). This is what makes
+      the surface reachable for #436 — a Saturday visitor lands directly on today's events.
 - [ ] Rows show one-off events + recurring occurrences in the window (Today = the day; This Weekend =
-      Fri evening → Sun).
+      Fri evening → Sun). No numeric count is shown in subtab titles or as a nav badge (kept clean per
+      product direction).
 - [ ] Each row shows title, time, venue, and the operating organization when applicable
       ("Farmers Market @ Howe Meadow · CVFM").
 - [ ] Anonymous visitors get the full experience (no sign-in required).
@@ -50,13 +54,14 @@ Acceptance Criteria:
 
 Acceptance Criteria:
 - [ ] A series stores a recurrence rule (frequency, interval, weekday), an explicit **season begin
-      and end date** entered by the admin, and start/end time of day.
-- [ ] Occurrences are generated only within `[season_start, season_end]`; biweekly cadence anchors on
-      the first matching weekday on/after `season_start`.
-- [ ] The system projects a series into concrete upcoming occurrences for any requested date window.
-- [ ] Editing the series (e.g., "now Saturdays") changes all future occurrences with one update.
-- [ ] Recurring occurrences appear in the normal upcoming-events feed and the weekend view, not just
-      a separate list.
+      and end date** entered by the admin, start/end time of day, and exception dates.
+- [ ] The generator materializes occurrences into `poi_events` only within `[season_start,
+      season_end]`, skipping exception dates; biweekly cadence anchors on the first matching weekday
+      on/after `season_start`. Runs on series create/edit/delete and on backend boot (idempotent).
+- [ ] Editing the series (e.g., "now Saturdays") regenerates all **future** occurrences with one
+      update; **past** occurrences are kept as historical record.
+- [ ] Because occurrences are real `poi_events`, recurring events appear in **every** events surface —
+      Today/This Weekend, Future, Past, newsletter, notifications, search, permalinks — automatically.
 
 **US-034-3: Browse recurring schedules**
 > As a regular, I want to see what recurs and when ("Sundays — Farmers Market at Howe Meadow"),
@@ -65,20 +70,23 @@ Acceptance Criteria:
 Acceptance Criteria:
 - [ ] Series are browsable with their cadence, venue, time, and next occurrence date.
 
-### Overlay Organizations
+### Organizer vs Venue (overlay organizations)
 
 **US-034-4: Run events at a venue without owning it**
-> As an admin, I want to create CVFM as an organization that *operates at* Howe Meadow, so that the
-> market's events surface on the Howe Meadow page while CVFM keeps its own identity and content.
+> As an admin, I want to set an event's **venue** separately from the **organizer** POI, so that an
+> operator like CVFM can run markets at venues it doesn't own, and each venue surfaces exactly the
+> events held there.
 
 Acceptance Criteria:
-- [ ] An org can be linked to a venue with a relationship type of **"operates at" (`hosts_at`)**,
-      distinct from **"owns / manages"**.
-- [ ] On the **venue** page, events belonging to its overlay operators appear (reverse rollup).
-- [ ] Reverse rollup fires **only** for `hosts_at` links — ownership/`manages` orgs are unaffected,
-      so a child POI never inherits a parent system's entire event feed.
-- [ ] CVFM's own page continues to show CVFM events (and, harmlessly, any venue events via the
-      existing forward rollup).
+- [ ] Events and series carry both `poi_id` (organizer / who runs it) and `venue_poi_id` (where it
+      physically happens). `venue_poi_id` is optional.
+- [ ] A POI's events = those where `poi_id` **or** `venue_poi_id` matches the rolled-up id set, so a
+      **venue** page surfaces events held there and an **organizer** page surfaces what it runs.
+- [ ] No cross-bleed: a venue shows only the events whose `venue_poi_id` is that venue — e.g. Howe
+      Meadow shows the summer market only, Old Trail School the winter market only, while the CVFM
+      organizer page shows both.
+- [ ] Ownership orgs and the generic boundary/org rollup are unchanged (this is a per-event link, not
+      a POI-to-POI association).
 
 ### Special Events
 
@@ -87,8 +95,8 @@ Acceptance Criteria:
 > new modeling is needed and they flow through existing display/collection.
 
 Acceptance Criteria:
-- [ ] Special events are normal `poi_events` rows on the CVFM POI and surface at Howe Meadow via
-      reverse rollup like any CVFM event.
+- [ ] Special events are normal `poi_events` rows organized by CVFM (`poi_id`), optionally with a
+      `venue_poi_id` so they surface at that venue like any venue-tagged event.
 
 ---
 
@@ -103,10 +111,11 @@ Acceptance Criteria:
 ### Schema Changes
 
 ```sql
--- New: recurring event series (rule stored, occurrences expanded at read time)
+-- New: recurring event series (the rule / source of truth; occurrences materialized into poi_events)
 CREATE TABLE IF NOT EXISTS poi_event_series (
   id              SERIAL PRIMARY KEY,
-  poi_id          INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
+  poi_id          INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,  -- organizer
+  venue_poi_id    INTEGER REFERENCES pois(id) ON DELETE SET NULL,          -- where it's held
   title           VARCHAR(500) NOT NULL,
   description     TEXT,
   event_type      VARCHAR(100),
@@ -122,6 +131,8 @@ CREATE TABLE IF NOT EXISTS poi_event_series (
   -- Biweekly anchors on the first `byday` match on/after season_start.
   season_start    DATE NOT NULL,
   season_end      DATE NOT NULL,
+  -- Exception dates (EXDATE): in-season dates the event is skipped (holiday closures).
+  exdates         DATE[] NOT NULL DEFAULT '{}',
   -- Time of day
   time_start      TIME,
   time_end        TIME,
@@ -135,15 +146,28 @@ CREATE TABLE IF NOT EXISTS poi_event_series (
 CREATE INDEX IF NOT EXISTS idx_poi_event_series_poi_id ON poi_event_series(poi_id);
 CREATE INDEX IF NOT EXISTS idx_poi_event_series_active ON poi_event_series(active);
 
--- No schema change for overlay orgs: poi_associations.association_type already exists.
--- We introduce a new value 'hosts_at' alongside the default 'manages'.
+-- One-off events get the same organizer/venue split (nullable; existing events keep their
+-- free-text location_details):
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS venue_poi_id INTEGER REFERENCES pois(id) ON DELETE SET NULL;
+
+-- Materialized recurring occurrences live in poi_events, linked back to their rule. series_id
+-- (ON DELETE SET NULL → past rows survive as standalone history) + recurrence_label (denormalized
+-- cadence, "Weekly: Saturdays"). Unique (series_id, start_date) keeps the generator idempotent.
+-- content_source 'recurring' is added to the chk_events_content_source CHECK.
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS series_id INTEGER REFERENCES poi_event_series(id) ON DELETE SET NULL;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS recurrence_label TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_events_series_start ON poi_events (series_id, start_date);
 ```
 
-CVFM data (migration 082, idempotent):
-- Insert CVFM as a POI with `poi_roles = {organization}`, its own `news_url`/`events_url` →
-  `cvfm.org`.
-- Insert `poi_associations(virtual_poi_id=CVFM, physical_poi_id=Howe Meadow, association_type='hosts_at')`.
-- Insert two `poi_event_series` rows (Summer Market, Winter Market) on the CVFM POI.
+CVFM data (migration 082, idempotent) — actuals confirmed from cvfm.org:
+- Insert CVFM as a POI with `poi_roles = {organization}` (the organizer), `more_info_link → cvfm.org`.
+- Insert **Old Trail School** as a `point` POI (the winter venue; Howe Meadow already exists in prod
+  as POI 6370).
+- Insert two `poi_event_series` with `poi_id = CVFM` and `venue_poi_id` set to the venue, both
+  **weekly Saturdays, 9am–12pm**:
+  - Summer Market — May 2 → Oct 31, 2026, `venue_poi_id = Howe Meadow`.
+  - Winter Market — Nov 7, 2026 → Apr 24, 2027, `venue_poi_id = Old Trail School`, with `exdates`
+    `{2026-11-28, 2026-12-26, 2027-01-02}` (holiday closures).
 
 ---
 
@@ -153,7 +177,7 @@ CVFM data (migration 082, idempotent):
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| GET | `/api/events/window?range=today\|weekend&tz=` | One-off + projected recurring occurrences in the requested window, with total count. Single endpoint serves both Today and This Weekend subtabs. | No |
+| GET | `/api/events/window?range=today\|weekend&tz=` | All events (one-off + materialized recurring) in the requested window, with total count. Single endpoint serves both Today and This Weekend subtabs. | No |
 | GET | `/api/events/recurring` | Active series (cadence, venue, next occurrence) — backs the `↻` rendering / "recurring only" filter. | No |
 | GET | `/api/admin/event-series` | List series for admin. | Admin |
 | POST | `/api/admin/event-series` | Create a series. | Admin |
@@ -162,10 +186,14 @@ CVFM data (migration 082, idempotent):
 
 ### Modified Behavior
 
-- `getRollupPoiIds(poiId)` (geoService.js): add a **reverse-association** expansion — a physical POI
-  also rolls up the orgs that `hosts_at` it. Gated strictly to `association_type='hosts_at'`.
-- `GET /api/pois/:id/events`, `/api/events/upcoming`, tab-counts: include projected series
-  occurrences for the rolled-up POI set within the requested window.
+- Event queries (`GET /api/pois/:id/events`, tab-counts) match `poi_id = ANY(ids) OR venue_poi_id =
+  ANY(ids)` so a venue surfaces events held there. The generic `getRollupPoiIds` is unchanged — venue
+  is a per-event link, not a POI association.
+- No read-time projection: because occurrences are materialized `poi_events`, the event endpoints
+  just query `poi_events` and join the venue. They select `series_id`, `recurrence_label` (as
+  `cadence_label`), and `venue_name` so the card renders the cadence line + venue link.
+- `materializeAllSeries` runs on backend boot (idempotent); `materializeSeries` runs on series
+  create/update/delete via the admin API.
 
 ---
 
@@ -173,24 +201,23 @@ CVFM data (migration 082, idempotent):
 
 ### Components
 
-- **Events tab subtab** — add "This Weekend" as the default subtab in `ParkEvents.jsx` alongside
-  Future/Past. Reuses existing filters/pagination/card rendering. Recurring occurrences render inline
-  with a `↻` cadence badge; an optional "recurring only" filter chip replaces the need for a separate
-  recurring browse view.
-- **Events nav badge** — count badge on the Events nav item ("Events ·14") sourced from the
-  this-weekend count.
-- Admin: `EventSeriesForm` — create/edit a series; org association includes the relationship-type
-  selector (**Owns/manages** vs **Operates at venue**).
+- **Events tab subtabs** — add "Today" and "This Weekend" subtabs in `ParkEvents.jsx` alongside
+  Future/Past, defaulting to Today (or This Weekend when today is empty). Reuses existing
+  filters/pagination/card rendering. Recurring occurrences render inline with a `↻` cadence badge and
+  a `📍` venue line. No numeric counts in titles or nav.
+- Admin: a **"Recurring event" toggle** in the Events "+ New" form (`ContentFormModal`) swaps the
+  one-off date fields for recurrence + season + times + venue + skip-dates, posting to
+  `/api/admin/event-series`.
 
 ### Wireframes
 
 ```
- Nav:  Map   News   Events ·14   About
-                     └─ [ This Weekend ] Future  Past
-── This Weekend ──────────────────────────  [ 14 events ]
- SUN  9:00a  Farmers Market        Howe Meadow · CVFM   ↻ weekly
- SAT 10:00a  Guided Ledges Hike    The Ledges
- SAT  2:00p  Bird Walk             Beaver Marsh
+ Nav:  Map   News   Events   About
+              └─ [ Today ]  This Weekend  Future  Past
+── Events ─────────────────────────────────
+ SAT  9:00a  Farmers Market — Summer    📍 Howe Meadow    ↻ Weekly · Saturdays
+ SAT 10:00a  Guided Ledges Hike         📍 The Ledges
+ SAT  2:00p  Bird Walk                  📍 Beaver Marsh
  ...
 ```
 
@@ -204,16 +231,17 @@ CVFM data (migration 082, idempotent):
   `syncPoiIdList` per `docs/USER_DATA_FRAMEWORK.md`.
 
 **NFR-034-2: Performance**
-- Series projection happens at read time over a small set (active series for the rolled-up POIs).
-  Expansion is bounded to the requested window; no unbounded loops.
+- Generation is bounded by each series' season (≈26 rows/market), so materialized rows are finite and
+  small; read endpoints query `poi_events` with the existing indexes — no read-time expansion.
 
 **NFR-034-3: Timezone correctness**
-- Weekend window and occurrence dates computed in the venue/America-New_York timezone, consistent
-  with existing `tz`-aware event endpoints (migration 043 fixed prior tz issues — do not regress).
+- Occurrence instants are stored tz-correctly (timed occurrences as the venue/America-New_York
+  instant via `AT TIME ZONE`, date-only as UTC midnight) so they render in local time; the weekend
+  window is computed in `tz`. Do not regress the migration 043 tz fixes.
 
-**NFR-034-4: Safety of reverse rollup**
-- Reverse rollup is restricted to `hosts_at`; ownership orgs (Cleveland Metroparks, Summit Metro
-  Parks, Conservancy) must show no behavioral change.
+**NFR-034-4: Venue precision (no cross-bleed)**
+- A venue surfaces only events whose `venue_poi_id` is that venue; the organizer page shows what it
+  runs. Ownership orgs and the generic boundary/org rollup show no behavioral change.
 
 ---
 
@@ -232,8 +260,9 @@ CVFM data (migration 082, idempotent):
    to avoid a dependency for a narrow rule set — revisit if rules get exotic.
 2. "This Weekend" window definition: Fri 5pm → Sun 11:59pm by default? And does "Happening Today"
    need to be a distinct quick-filter within the same surface?
-3. Exact CVFM season boundaries, market times, and the winter biweekly anchor date — pull from
-   cvfm.org during data seeding (migration 082).
+3. ~~Exact CVFM schedule~~ **RESOLVED** from cvfm.org: both markets weekly Saturdays 9am–12pm;
+   summer @ Howe Meadow (May 2–Oct 31 2026), winter @ Old Trail School (Nov 7 2026–Apr 24 2027) with
+   three holiday-closure `exdates`. Added `exdates` (EXDATE) to the model to support the closures.
 4. ~~Dedicated nav tab vs banner~~ **RESOLVED:** This Weekend is the default subtab of Events + a
    count badge on the Events nav item. Map banner deferred as a fast-follow.
 

--- a/backend/migrations/081_poi_event_series.sql
+++ b/backend/migrations/081_poi_event_series.sql
@@ -1,0 +1,71 @@
+-- 081_poi_event_series.sql
+-- Recurring event series (spec 034-this-weekend-recurring-events, issue #436).
+-- A series stores a recurrence RULE plus an explicit, admin-entered season range
+-- (one row per recurring market/program). The rule is the source of truth; the
+-- generator in eventSeriesService.js MATERIALIZES its occurrences as real poi_events
+-- rows (linked by series_id) so recurring events appear everywhere regular events do
+-- — newsletter, notifications, past/future, search, permalinks.
+-- Re-runs on every container start, so all statements are idempotent.
+
+CREATE TABLE IF NOT EXISTS poi_event_series (
+  id               SERIAL PRIMARY KEY,
+  -- poi_id is the ORGANIZER (who runs the event, e.g. the CVFM org).
+  poi_id           INTEGER NOT NULL REFERENCES pois(id) ON DELETE CASCADE,
+  -- venue_poi_id is WHERE it physically happens (e.g. Howe Meadow), separate from the
+  -- organizer. A venue's page surfaces the events whose venue_poi_id points at it.
+  venue_poi_id     INTEGER REFERENCES pois(id) ON DELETE SET NULL,
+  title            VARCHAR(500) NOT NULL,
+  description      TEXT,
+  event_type       VARCHAR(100),
+  location_details TEXT,
+  source_url       TEXT,
+  image_url        TEXT,
+  -- Recurrence rule (RFC 5545 subset). v1 honors WEEKLY (interval 1 = weekly,
+  -- 2 = biweekly); MONTHLY reserved for later.
+  freq             VARCHAR(10) NOT NULL DEFAULT 'WEEKLY',
+  interval         INTEGER NOT NULL DEFAULT 1,
+  byday            TEXT[] NOT NULL DEFAULT '{}',          -- e.g. {SU} or {SA}
+  -- Explicit, admin-entered season bounds. Occurrences only within this range.
+  -- Winter year-wrap is an ordinary range (e.g. 2025-11-01 .. 2026-04-25).
+  -- Biweekly anchors on the first `byday` match on/after season_start.
+  season_start     DATE NOT NULL,
+  season_end       DATE NOT NULL,
+  -- Exception dates (EXDATE): in-season dates the event is skipped (e.g. holiday closures).
+  exdates          DATE[] NOT NULL DEFAULT '{}',
+  -- Time of day (optional)
+  time_start       TIME,
+  time_end         TIME,
+  -- Provenance / moderation (mirror poi_events conventions)
+  content_source   VARCHAR(20) DEFAULT 'human',
+  moderation_status VARCHAR(20) DEFAULT 'published',
+  active           BOOLEAN DEFAULT TRUE,
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_poi_event_series_poi_id ON poi_event_series (poi_id);
+CREATE INDEX IF NOT EXISTS idx_poi_event_series_venue ON poi_event_series (venue_poi_id);
+CREATE INDEX IF NOT EXISTS idx_poi_event_series_active ON poi_event_series (active);
+
+-- One-off events get the same organizer/venue split: poi_id is who runs it, venue_poi_id
+-- is where it happens. Lets a venue POI surface events held there by other organizers
+-- (e.g. concerts at Howe Meadow run by the Conservancy). Nullable; existing events keep
+-- their free-text location_details.
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS venue_poi_id INTEGER REFERENCES pois(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_poi_events_venue ON poi_events (venue_poi_id);
+
+-- Materialized recurring occurrences: a poi_events row generated from a series carries
+-- series_id (its parent rule) and recurrence_label (denormalized cadence for display,
+-- e.g. "Weekly: Saturdays"). ON DELETE SET NULL so removing a series can orphan past
+-- occurrences as standalone history rather than erasing them. The unique index keeps the
+-- generator idempotent (one row per series per start); one-off events keep series_id NULL,
+-- and NULLs are distinct in a unique index so they stay unconstrained.
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS series_id INTEGER REFERENCES poi_event_series(id) ON DELETE SET NULL;
+ALTER TABLE poi_events ADD COLUMN IF NOT EXISTS recurrence_label TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_poi_events_series_start
+  ON poi_events (series_id, start_date);
+
+-- Materialized occurrences use content_source 'recurring'; widen the existing CHECK to allow it.
+ALTER TABLE poi_events DROP CONSTRAINT IF EXISTS chk_events_content_source;
+ALTER TABLE poi_events ADD CONSTRAINT chk_events_content_source
+  CHECK (content_source IN ('human', 'ai', 'newsletter', 'feed', 'api', 'community', 'recurring'));

--- a/backend/migrations/082_cvfm_overlay_org.sql
+++ b/backend/migrations/082_cvfm_overlay_org.sql
@@ -1,0 +1,81 @@
+-- 082_cvfm_overlay_org.sql
+-- Seed the Cuyahoga Valley Farmers Market (CVFM) as an overlay organization
+-- (spec 034, issue #436). CVFM is the ORGANIZER (poi_id) that runs recurring markets
+-- AT two venues it does not own. Each series carries a venue_poi_id pointing at the
+-- venue POI, so a venue's page surfaces exactly the events held there — no org-level
+-- bleed (summer shows only at Howe Meadow, winter only at Old Trail School).
+--
+-- Schedule (per cvfm.org, both markets Saturdays 9am–12pm, weekly):
+--   Summer Market: May 2 – Oct 31, 2026 @ Howe Meadow, Peninsula
+--   Winter Market: Nov 7, 2026 – Apr 24, 2027 @ Old Trail School, Akron
+--                  closed Nov 28 & Dec 26, 2026 and Jan 2, 2027 (exdates)
+-- Idempotent: re-runs cleanly on every container start and deploy.
+
+-- 1. CVFM organization POI (virtual overlay; no coordinates)
+INSERT INTO pois (name, poi_roles, brief_description, more_info_link)
+SELECT 'Cuyahoga Valley Farmers Market', ARRAY['organization'],
+  'A producer-only farmers market bringing local growers, bakers, and makers to the Cuyahoga Valley. Runs a Saturday summer market at Howe Meadow and a winter market at Old Trail School, plus seasonal special events.',
+  'https://cvfm.org'
+WHERE NOT EXISTS (
+  SELECT 1 FROM pois WHERE name = 'Cuyahoga Valley Farmers Market' AND 'organization' = ANY(poi_roles)
+);
+
+-- 2. Old Trail School — winter market venue (2315 Ira Rd., Bath/Akron, OH 44333)
+INSERT INTO pois (name, latitude, longitude, poi_roles, brief_description, has_parking)
+SELECT 'Old Trail School', 41.16640000, -81.63880000, ARRAY['point'],
+  'Independent school in Bath Township whose campus hosts the Cuyahoga Valley Farmers Market''s indoor winter market on Saturday mornings. Located at 2315 Ira Rd., Akron, OH 44333.',
+  TRUE
+WHERE NOT EXISTS (
+  SELECT 1 FROM pois WHERE name = 'Old Trail School' AND 'point' = ANY(poi_roles)
+);
+
+-- 3. PostGIS point geometry for the new venue (mirrors migration 021/073)
+UPDATE pois SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+WHERE latitude IS NOT NULL AND longitude IS NOT NULL AND geom IS NULL;
+
+-- 4. Summer Market series — weekly Saturdays, organized by CVFM, held AT Howe Meadow.
+--    venue_poi_id points at the venue so Howe Meadow's page surfaces exactly this market.
+--    Howe Meadow is an existing prod POI; venue_poi_id is left NULL if absent locally.
+INSERT INTO poi_event_series
+  (poi_id, venue_poi_id, title, description, event_type, location_details, source_url,
+   freq, interval, byday, season_start, season_end, exdates, time_start, time_end,
+   content_source, moderation_status, active)
+SELECT cvfm.id,
+  (SELECT id FROM pois WHERE name = 'Howe Meadow' AND 'point' = ANY(poi_roles) LIMIT 1),
+  'Cuyahoga Valley Farmers Market — Summer Market',
+  'Producer-only outdoor farmers market with seasonal produce, baked goods, prepared foods, and local makers. Cooking demos, live music, and seasonal gatherings throughout the season.',
+  'community', 'Howe Meadow, 4040 Riverview Rd., Peninsula, OH 44264',
+  'https://cvfm.org/summer-market/',
+  'WEEKLY', 1, ARRAY['SA'], DATE '2026-05-02', DATE '2026-10-31',
+  ARRAY[]::date[], TIME '09:00', TIME '12:00',
+  'human', 'published', TRUE
+FROM (SELECT id FROM pois WHERE name = 'Cuyahoga Valley Farmers Market' AND 'organization' = ANY(poi_roles) LIMIT 1) cvfm
+WHERE NOT EXISTS (
+  SELECT 1 FROM poi_event_series WHERE title = 'Cuyahoga Valley Farmers Market — Summer Market'
+);
+
+-- 5. Winter Market series — weekly Saturdays at Old Trail School, with holiday closures.
+INSERT INTO poi_event_series
+  (poi_id, venue_poi_id, title, description, event_type, location_details, source_url,
+   freq, interval, byday, season_start, season_end, exdates, time_start, time_end,
+   content_source, moderation_status, active)
+SELECT cvfm.id,
+  (SELECT id FROM pois WHERE name = 'Old Trail School' AND 'point' = ANY(poi_roles) LIMIT 1),
+  'Cuyahoga Valley Farmers Market — Winter Market',
+  'Indoor winter farmers market with local produce, meats, baked goods, and prepared foods through the cold months. Closed on selected holiday weekends.',
+  'community', 'Old Trail School, 2315 Ira Rd., Akron, OH 44333',
+  'https://cvfm.org/winter-market/',
+  'WEEKLY', 1, ARRAY['SA'], DATE '2026-11-07', DATE '2027-04-24',
+  ARRAY[DATE '2026-11-28', DATE '2026-12-26', DATE '2027-01-02'], TIME '09:00', TIME '12:00',
+  'human', 'published', TRUE
+FROM (SELECT id FROM pois WHERE name = 'Cuyahoga Valley Farmers Market' AND 'organization' = ANY(poi_roles) LIMIT 1) cvfm
+WHERE NOT EXISTS (
+  SELECT 1 FROM poi_event_series WHERE title = 'Cuyahoga Valley Farmers Market — Winter Market'
+);
+
+-- Backfill venue_poi_id for series seeded before Howe Meadow/Old Trail School existed
+-- (e.g. if this migration ran once before the venue POIs were created).
+UPDATE poi_event_series SET venue_poi_id = (SELECT id FROM pois WHERE name = 'Howe Meadow' AND 'point' = ANY(poi_roles) LIMIT 1)
+WHERE title = 'Cuyahoga Valley Farmers Market — Summer Market' AND venue_poi_id IS NULL;
+UPDATE poi_event_series SET venue_poi_id = (SELECT id FROM pois WHERE name = 'Old Trail School' AND 'point' = ANY(poi_roles) LIMIT 1)
+WHERE title = 'Cuyahoga Valley Farmers Market — Winter Market' AND venue_poi_id IS NULL;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -572,15 +572,21 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     if (!Number.isInteger(id) || id <= 0) {
       return res.status(400).json({ error: 'Invalid series id' });
     }
+    const client = await pool.connect();
     try {
-      // Remove future materialized occurrences; past ones are kept as history (their
-      // series_id is set NULL by the FK ON DELETE SET NULL when the series row is dropped).
-      await pool.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [id]);
-      await pool.query('DELETE FROM poi_event_series WHERE id = $1', [id]);
+      // Atomically remove future materialized occurrences and the series; past ones are kept
+      // as history (their series_id is set NULL by the FK ON DELETE SET NULL on series drop).
+      await client.query('BEGIN');
+      await client.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [id]);
+      await client.query('DELETE FROM poi_event_series WHERE id = $1', [id]);
+      await client.query('COMMIT');
       res.json({ success: true });
     } catch (error) {
+      await client.query('ROLLBACK');
       console.error('Error deleting event series:', error);
       res.status(500).json({ error: 'Failed to delete event series' });
+    } finally {
+      client.release();
     }
   });
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -45,6 +45,7 @@ import {
   getDisplaySlots as getNewsDisplaySlots
 } from '../services/newsService.js';
 import { submitBatchNewsJob, getJobScheduler, JOB_NAMES, updateSchedule } from '../services/jobScheduler.js';
+import { materializeSeries } from '../services/eventSeriesService.js';
 import {
   getQueue as getModerationQueue,
   getPendingCount as getModerationPendingCount,
@@ -452,7 +453,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   });
 
   router.post('/events', isAdmin, async (req, res) => {
-    const { poi_id, title, start_date, end_date, description, event_type, location_details, source_url, publication_date } = req.body;
+    const { poi_id, venue_poi_id, title, start_date, end_date, description, event_type, location_details, source_url, publication_date } = req.body;
 
     if (!poi_id || !title || !title.trim() || !start_date) {
       return res.status(400).json({ error: 'poi_id, title, and start_date are required' });
@@ -460,10 +461,10 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
 
     try {
       const eventItem = await pool.query(
-        `INSERT INTO poi_events (poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, content_source, moderation_status, moderated_by, moderated_at, collection_date)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'human', 'published', $10, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        `INSERT INTO poi_events (poi_id, venue_poi_id, title, description, start_date, end_date, event_type, location_details, source_url, publication_date, content_source, moderation_status, moderated_by, moderated_at, collection_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'human', 'published', $11, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
          RETURNING *`,
-        [poi_id, title.trim(), description || null, start_date, end_date || null, event_type || null, location_details || null, source_url || null, publication_date || null, req.user.id]
+        [poi_id, venue_poi_id || null, title.trim(), description || null, start_date, end_date || null, event_type || null, location_details || null, source_url || null, publication_date || null, req.user.id]
       );
 
       console.log(`Admin ${req.user.email} created manual event: ${title}`);
@@ -471,6 +472,115 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     } catch (error) {
       console.error('Error creating event:', error);
       res.status(500).json({ error: 'Failed to create event' });
+    }
+  });
+
+  // Recurring event series CRUD (spec 034, #436). Series store a rule + explicit
+  // season range and are expanded at read time by eventSeriesService.js.
+  router.get('/event-series', isAdmin, async (req, res) => {
+    try {
+      const seriesRows = await pool.query(
+        `SELECT s.*, p.name AS poi_name
+           FROM poi_event_series s
+           JOIN pois p ON p.id = s.poi_id
+          ORDER BY p.name, s.title`
+      );
+      res.json(seriesRows.rows);
+    } catch (error) {
+      console.error('Error listing event series:', error);
+      res.status(500).json({ error: 'Failed to list event series' });
+    }
+  });
+
+  router.post('/event-series', isAdmin, async (req, res) => {
+    const {
+      poi_id, venue_poi_id, title, description, event_type, location_details, source_url, image_url,
+      freq, interval, byday, season_start, season_end, exdates, time_start, time_end, active
+    } = req.body;
+
+    if (!poi_id || !title || !title.trim() || !season_start || !season_end) {
+      return res.status(400).json({ error: 'poi_id, title, season_start, and season_end are required' });
+    }
+    if (!Array.isArray(byday) || byday.length === 0) {
+      return res.status(400).json({ error: 'byday must be a non-empty array of weekday codes (e.g. ["SU"])' });
+    }
+
+    try {
+      const created = await pool.query(
+        `INSERT INTO poi_event_series
+           (poi_id, venue_poi_id, title, description, event_type, location_details, source_url, image_url,
+            freq, interval, byday, season_start, season_end, exdates, time_start, time_end,
+            content_source, moderation_status, active)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+                 'human', 'published', $17)
+         RETURNING *`,
+        [poi_id, venue_poi_id || null, title.trim(), description || null, event_type || null, location_details || null,
+         source_url || null, image_url || null, freq || 'WEEKLY', parseInt(interval, 10) || 1, byday,
+         season_start, season_end, Array.isArray(exdates) ? exdates : [], time_start || null, time_end || null, active !== false]
+      );
+      await materializeSeries(pool, created.rows[0]);
+      console.log(`Admin ${req.user.email} created event series: ${title}`);
+      res.status(201).json(created.rows[0]);
+    } catch (error) {
+      console.error('Error creating event series:', error);
+      res.status(500).json({ error: 'Failed to create event series' });
+    }
+  });
+
+  router.put('/event-series/:id', isAdmin, async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'Invalid series id' });
+    }
+    const {
+      poi_id, venue_poi_id, title, description, event_type, location_details, source_url, image_url,
+      freq, interval, byday, season_start, season_end, exdates, time_start, time_end, active
+    } = req.body;
+    if (!poi_id || !title || !title.trim() || !season_start || !season_end) {
+      return res.status(400).json({ error: 'poi_id, title, season_start, and season_end are required' });
+    }
+    if (!Array.isArray(byday) || byday.length === 0) {
+      return res.status(400).json({ error: 'byday must be a non-empty array of weekday codes (e.g. ["SU"])' });
+    }
+
+    try {
+      const updated = await pool.query(
+        `UPDATE poi_event_series SET
+           poi_id = $1, venue_poi_id = $2, title = $3, description = $4, event_type = $5, location_details = $6,
+           source_url = $7, image_url = $8, freq = $9, interval = $10, byday = $11,
+           season_start = $12, season_end = $13, exdates = $14, time_start = $15, time_end = $16,
+           active = $17, updated_at = NOW()
+         WHERE id = $18
+         RETURNING *`,
+        [poi_id, venue_poi_id || null, title.trim(), description || null, event_type || null, location_details || null,
+         source_url || null, image_url || null, freq || 'WEEKLY', parseInt(interval, 10) || 1, byday,
+         season_start, season_end, Array.isArray(exdates) ? exdates : [], time_start || null, time_end || null, active !== false, id]
+      );
+      if (updated.rows.length === 0) {
+        return res.status(404).json({ error: 'Series not found' });
+      }
+      await materializeSeries(pool, updated.rows[0]);
+      res.json(updated.rows[0]);
+    } catch (error) {
+      console.error('Error updating event series:', error);
+      res.status(500).json({ error: 'Failed to update event series' });
+    }
+  });
+
+  router.delete('/event-series/:id', isAdmin, async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'Invalid series id' });
+    }
+    try {
+      // Remove future materialized occurrences; past ones are kept as history (their
+      // series_id is set NULL by the FK ON DELETE SET NULL when the series row is dropped).
+      await pool.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [id]);
+      await pool.query('DELETE FROM poi_event_series WHERE id = $1', [id]);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting event series:', error);
+      res.status(500).json({ error: 'Failed to delete event series' });
     }
   });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -77,6 +77,12 @@ import { mcpMiddleware } from './services/mcpServer.js';
 import { initJobLogger, stopJobLogger } from './services/jobLogger.js';
 import { startTracker, stopTracker, getBoatPositions } from './services/waterTaxiTrackerService.js';
 import { getRollupPoiIds } from './services/geoService.js';
+import {
+  getAllActiveSeries,
+  nextOccurrence,
+  cadenceLabel,
+  materializeAllSeries
+} from './services/eventSeriesService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1978,7 +1984,7 @@ app.get('/api/pois/:id/tab-counts', async (req, res) => {
          WHERE n.poi_id = ANY($1)
            AND n.moderation_status IN ('published', 'auto_approved')) AS news_count,
         (SELECT COUNT(*) FROM poi_events e
-         WHERE e.poi_id = ANY($1)
+         WHERE (e.poi_id = ANY($1) OR e.venue_poi_id = ANY($1))
            AND e.moderation_status IN ('published', 'auto_approved')
            AND (e.start_date AT TIME ZONE $2)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $2)::date) AS events_count
     `, [poiIds, tz]);
@@ -2033,18 +2039,20 @@ app.get('/api/pois/:id/events', async (req, res) => {
     const poiIds = await getRollupPoiIds(pool, id);
     let query = `
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type, e.location_details, e.source_url, e.collection_date,
-             e.poi_id, src.name AS poi_name,
+             e.poi_id, src.name AS poi_name, e.venue_poi_id, vp.name AS venue_name,
+             e.series_id, e.recurrence_label AS cadence_label, (e.series_id IS NOT NULL) AS is_recurring,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
       LEFT JOIN pois src ON src.id = e.poi_id
-      WHERE e.poi_id = ANY($1)
+      LEFT JOIN pois vp ON vp.id = e.venue_poi_id
+      WHERE (e.poi_id = ANY($1) OR e.venue_poi_id = ANY($1))
         AND e.moderation_status IN ('published', 'auto_approved')
     `;
     if (upcomingOnly) {
       query += ` AND (e.start_date AT TIME ZONE $3)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $3)::date`;
     }
-    query += ` GROUP BY e.id, src.name ORDER BY e.start_date ASC LIMIT $2`;
+    query += ` GROUP BY e.id, src.name, vp.name ORDER BY e.start_date ASC LIMIT $2`;
 
     const eventsQuery = await pool.query(query, upcomingOnly ? [poiIds, limit, tz] : [poiIds, limit]);
     res.json(eventsQuery.rows);
@@ -2286,15 +2294,18 @@ app.get('/api/events/upcoming', async (req, res) => {
       : '';
     const upcomingEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles${adminColumns},
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
+             e.venue_poi_id, vp.name AS venue_name,
+             e.series_id, e.recurrence_label AS cadence_label, (e.series_id IS NOT NULL) AS is_recurring${adminColumns},
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
+      LEFT JOIN pois vp ON vp.id = e.venue_poi_id
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND (e.start_date AT TIME ZONE $1)::date >= (CURRENT_TIMESTAMP AT TIME ZONE $1)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      GROUP BY e.id, p.id, p.name, p.poi_roles
+      GROUP BY e.id, p.id, p.name, p.poi_roles, vp.name
       ORDER BY e.start_date ASC
     `, [tz]);
     res.json(upcomingEventsQuery.rows);
@@ -2315,15 +2326,18 @@ app.get('/api/events/past', async (req, res) => {
       : '';
     const pastEventsQuery = await pool.query(`
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
-             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles${adminColumns},
+             e.location_details, e.source_url, p.id as poi_id, p.name as poi_name, p.poi_roles,
+             e.venue_poi_id, vp.name AS venue_name,
+             e.series_id, e.recurrence_label AS cadence_label, (e.series_id IS NOT NULL) AS is_recurring${adminColumns},
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
+      LEFT JOIN pois vp ON vp.id = e.venue_poi_id
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
       WHERE e.moderation_status IN ('published', 'auto_approved')
         AND (e.start_date AT TIME ZONE $2)::date < (CURRENT_TIMESTAMP AT TIME ZONE $2)::date
         AND (p.deleted IS NULL OR p.deleted = FALSE)
-      GROUP BY e.id, p.id, p.name, p.poi_roles
+      GROUP BY e.id, p.id, p.name, p.poi_roles, vp.name
       ORDER BY e.start_date DESC
       LIMIT $1
     `, [limit, tz]);
@@ -2331,6 +2345,99 @@ app.get('/api/events/past', async (req, res) => {
   } catch (error) {
     console.error('Error fetching past events:', error);
     res.status(500).json({ error: 'Failed to fetch past events' });
+  }
+});
+
+// "Happening Today" / "This Weekend" (#436): one-off events + projected recurring
+// occurrences within a near-term window, with a count for the Events nav badge.
+// range=today → the current day; range=weekend → this/upcoming Fri–Sun.
+app.get('/api/events/window', async (req, res) => {
+  try {
+    const range = req.query.range === 'today' ? 'today' : 'weekend';
+    const rawTz = req.query.tz;
+    // Whitelist tz to IANA Region/City — Postgres AT TIME ZONE accepts arbitrary input (PR #368 review)
+    const tz = (typeof rawTz === 'string' && /^[A-Za-z_]+\/[A-Za-z_]+(?:\/[A-Za-z_]+)?$/.test(rawTz))
+      ? rawTz
+      : 'America/New_York';
+    const isAdmin = req.user && (req.user.role === 'admin' || req.user.isAdmin);
+
+    // "Today" as a calendar date in the venue timezone.
+    const todayRow = await pool.query('SELECT (CURRENT_TIMESTAMP AT TIME ZONE $1)::date::text AS today', [tz]);
+    const today = todayRow.rows[0].today;
+
+    let from = today;
+    let to = today;
+    if (range === 'weekend') {
+      const base = new Date(`${today}T00:00:00Z`);
+      const dow = base.getUTCDay(); // 0=Sun..6=Sat
+      // Days back to the weekend's Friday: Sun -2, Sat -1, Fri 0; Mon–Thu jump forward to the next Friday.
+      const toFriday = dow === 0 ? -2 : 5 - dow;
+      const friday = new Date(base.getTime() + toFriday * 86400000);
+      const sunday = new Date(friday.getTime() + 2 * 86400000);
+      from = friday.toISOString().slice(0, 10);
+      to = sunday.toISOString().slice(0, 10);
+    }
+
+    const adminColumns = isAdmin
+      ? `, e.moderation_status, e.confidence_score, e.ai_reasoning, e.ai_issues,
+           e.content_source, e.moderated_at`
+      : '';
+    const windowEvents = await pool.query(`
+      SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type,
+             e.location_details, e.source_url, e.image_url,
+             p.id as poi_id, p.name as poi_name, p.poi_roles,
+             e.venue_poi_id, vp.name AS venue_name,
+             e.series_id, e.recurrence_label AS cadence_label, (e.series_id IS NOT NULL) AS is_recurring${adminColumns},
+             COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
+      FROM poi_events e
+      JOIN pois p ON e.poi_id = p.id
+      LEFT JOIN pois vp ON vp.id = e.venue_poi_id
+      LEFT JOIN poi_event_urls u ON u.event_id = e.id
+      WHERE e.moderation_status IN ('published', 'auto_approved')
+        AND (e.start_date AT TIME ZONE $3)::date >= $1::date
+        AND (e.start_date AT TIME ZONE $3)::date <= $2::date
+        AND (p.deleted IS NULL OR p.deleted = FALSE)
+      GROUP BY e.id, p.id, p.name, p.poi_roles, vp.name
+      ORDER BY e.start_date ASC
+    `, [from, to, tz]);
+    res.json({ range, from, to, count: windowEvents.rows.length, events: windowEvents.rows });
+  } catch (error) {
+    console.error('Error fetching event window:', error);
+    res.status(500).json({ error: 'Failed to fetch events' });
+  }
+});
+
+// Active recurring series with their next occurrence — backs the recurring filter/badge.
+app.get('/api/events/recurring', async (req, res) => {
+  try {
+    const tz = (typeof req.query.tz === 'string' && /^[A-Za-z_]+\/[A-Za-z_]+(?:\/[A-Za-z_]+)?$/.test(req.query.tz))
+      ? req.query.tz
+      : 'America/New_York';
+    const todayRow = await pool.query('SELECT (CURRENT_TIMESTAMP AT TIME ZONE $1)::date::text AS today', [tz]);
+    const today = todayRow.rows[0].today;
+    const series = await getAllActiveSeries(pool);
+    const recurring = series.map(s => ({
+      id: s.id,
+      poi_id: s.poi_id,
+      poi_name: s.poi_name,
+      poi_roles: s.poi_roles,
+      venue_poi_id: s.venue_poi_id,
+      venue_name: s.venue_name,
+      title: s.title,
+      description: s.description,
+      event_type: s.event_type,
+      location_details: s.location_details,
+      source_url: s.source_url,
+      image_url: s.image_url,
+      season_start: s.season_start,
+      season_end: s.season_end,
+      cadence_label: cadenceLabel(s),
+      next_occurrence: nextOccurrence(s, today)
+    }));
+    res.json(recurring);
+  } catch (error) {
+    console.error('Error fetching recurring series:', error);
+    res.status(500).json({ error: 'Failed to fetch recurring series' });
   }
 });
 
@@ -3013,6 +3120,10 @@ async function start() {
   }
 
   activeSmtpServer = startSmtpServer(pool);
+
+  // Materialize recurring-event series into poi_events so they appear everywhere regular
+  // events do (#436). Idempotent: regenerates future occurrences, keeps past as history.
+  await materializeAllSeries(pool);
 
   const mcpHandler = mcpMiddleware(pool, app.get('boss'));
   app.all('/mcp/:token', mcpHandler);

--- a/backend/services/eventSeriesService.js
+++ b/backend/services/eventSeriesService.js
@@ -1,13 +1,14 @@
 /**
- * Event Series Service - recurring event expansion (spec 034, issue #436).
+ * Event Series Service - recurring events (spec 034, issue #436).
  *
- * Recurring events are stored as a RULE (poi_event_series) and expanded into
- * concrete occurrences at read time here — never materialized as rows. Powers the
- * Today / This Weekend subtabs and the recurring badge on the Events tab.
+ * Recurring events are stored as a RULE (poi_event_series). `expandSeries` turns a rule
+ * into concrete occurrences, and `materializeSeries` writes those occurrences as real
+ * poi_events rows (linked by series_id) so recurring events appear everywhere regular
+ * events do — Today/This Weekend, Future, Past, newsletter, notifications, search.
  *
  * v1 honors weekly cadence (interval 1 = weekly, 2 = biweekly, ...) over an explicit,
- * admin-entered [season_start, season_end] range. Biweekly anchors on the first
- * matching weekday on/after season_start.
+ * admin-entered [season_start, season_end] range with exception dates. Biweekly anchors
+ * on the first matching weekday on/after season_start.
  */
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -162,30 +163,42 @@ export async function materializeSeries(pool, series, tz = 'America/New_York') {
   if (!series || !series.id) return 0;
   const occurrences = expandSeries(series, series.season_start, series.season_end);
   const label = cadenceLabel(series);
-  await pool.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [series.id]);
-  let inserted = 0;
-  for (const o of occurrences) {
-    const hasTime = o.start_date.length > 10;
-    const startLocal = hasTime ? o.start_date : `${o.start_date} 00:00:00`;
-    const startTz = hasTime ? tz : 'UTC';
-    const insertResult = await pool.query(
-      `INSERT INTO poi_events
-         (poi_id, venue_poi_id, series_id, title, description, start_date, end_date,
-          event_type, location_details, source_url, image_url, recurrence_label,
-          content_source, moderation_status, collection_date)
-       VALUES ($1, $2, $3, $4, $5,
-               ($6::text)::timestamp AT TIME ZONE $8,
-               CASE WHEN $7::text IS NULL THEN NULL ELSE ($7::text)::timestamp AT TIME ZONE $9 END,
-               $10, $11, $12, $13, $14, 'recurring', 'published', NOW())
-       ON CONFLICT (series_id, start_date) DO NOTHING`,
-      [series.poi_id, series.venue_poi_id || null, series.id, series.title, series.description || null,
-       startLocal, o.end_date || null, startTz, tz,
-       series.event_type || null, series.location_details || null, series.source_url || null,
-       series.image_url || null, label]
-    );
-    inserted += insertResult.rowCount;
+  // One transaction so an edit never leaves a window with future occurrences deleted
+  // but not yet re-inserted (a concurrent reader would briefly see no upcoming events).
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [series.id]);
+    let inserted = 0;
+    for (const o of occurrences) {
+      const hasTime = o.start_date.length > 10;
+      const startLocal = hasTime ? o.start_date : `${o.start_date} 00:00:00`;
+      const startTz = hasTime ? tz : 'UTC';
+      const insertResult = await client.query(
+        `INSERT INTO poi_events
+           (poi_id, venue_poi_id, series_id, title, description, start_date, end_date,
+            event_type, location_details, source_url, image_url, recurrence_label,
+            content_source, moderation_status, collection_date)
+         VALUES ($1, $2, $3, $4, $5,
+                 ($6::text)::timestamp AT TIME ZONE $8,
+                 CASE WHEN $7::text IS NULL THEN NULL ELSE ($7::text)::timestamp AT TIME ZONE $9 END,
+                 $10, $11, $12, $13, $14, 'recurring', 'published', NOW())
+         ON CONFLICT (series_id, start_date) DO NOTHING`,
+        [series.poi_id, series.venue_poi_id || null, series.id, series.title, series.description || null,
+         startLocal, o.end_date || null, startTz, tz,
+         series.event_type || null, series.location_details || null, series.source_url || null,
+         series.image_url || null, label]
+      );
+      inserted += insertResult.rowCount;
+    }
+    await client.query('COMMIT');
+    return inserted;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
   }
-  return inserted;
 }
 
 /** Materialize every active series — run on backend boot so deploy/seed self-populates. */

--- a/backend/services/eventSeriesService.js
+++ b/backend/services/eventSeriesService.js
@@ -1,0 +1,203 @@
+/**
+ * Event Series Service - recurring event expansion (spec 034, issue #436).
+ *
+ * Recurring events are stored as a RULE (poi_event_series) and expanded into
+ * concrete occurrences at read time here — never materialized as rows. Powers the
+ * Today / This Weekend subtabs and the recurring badge on the Events tab.
+ *
+ * v1 honors weekly cadence (interval 1 = weekly, 2 = biweekly, ...) over an explicit,
+ * admin-entered [season_start, season_end] range. Biweekly anchors on the first
+ * matching weekday on/after season_start.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DOW = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
+const DOW_LABEL = {
+  SU: 'Sundays', MO: 'Mondays', TU: 'Tuesdays', WE: 'Wednesdays',
+  TH: 'Thursdays', FR: 'Fridays', SA: 'Saturdays'
+};
+
+/** Parse a 'YYYY-MM-DD' (or Date) into a UTC-midnight Date, so calendar-date math
+ *  never shifts across the local timezone. */
+function toUtcDate(value) {
+  if (value instanceof Date) {
+    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+  }
+  const [y, m, d] = String(value).slice(0, 10).split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/** First date on/after `from` whose UTC weekday equals `targetDow`. */
+function firstWeekdayOnOrAfter(from, targetDow) {
+  const delta = (targetDow - from.getUTCDay() + 7) % 7;
+  return new Date(from.getTime() + delta * MS_PER_DAY);
+}
+
+/**
+ * Human-readable cadence, e.g. "Weekly: Saturdays" or "Every 2 weeks: Saturdays".
+ * @param {object} series
+ * @returns {string}
+ */
+export function cadenceLabel(series) {
+  const interval = series.interval || 1;
+  const cadence = interval === 1 ? 'Weekly' : `Every ${interval} weeks`;
+  const days = (series.byday || []).map(code => DOW_LABEL[code]).filter(Boolean);
+  return days.length ? `${cadence}: ${days.join(', ')}` : cadence;
+}
+
+/**
+ * Expand one series into concrete occurrences within [fromDate, toDate].
+ *
+ * Occurrences are shaped like event rows (start_date, title, poi_id, ...) plus
+ * is_recurring/series_id/cadence_label, so callers can merge them with one-off
+ * poi_events transparently.
+ *
+ * @param {object} series - a poi_event_series row (+ poi_name if joined)
+ * @param {string|Date} fromDate - window start (inclusive, calendar date)
+ * @param {string|Date} toDate - window end (inclusive, calendar date)
+ * @returns {Array<object>} occurrences sorted ascending by start_date
+ */
+export function expandSeries(series, fromDate, toDate) {
+  if (!series || series.active === false) return [];
+  if ((series.freq || 'WEEKLY') !== 'WEEKLY') return []; // v1: weekly only
+  const interval = Math.max(1, parseInt(series.interval, 10) || 1);
+  const byday = (series.byday || []).filter(code => code in DOW);
+  if (byday.length === 0) return [];
+
+  // Clip the request window to the season.
+  const windowStart = toUtcDate(fromDate);
+  const windowEnd = toUtcDate(toDate);
+  const seasonStart = toUtcDate(series.season_start);
+  const seasonEnd = toUtcDate(series.season_end);
+  const start = windowStart > seasonStart ? windowStart : seasonStart;
+  const end = windowEnd < seasonEnd ? windowEnd : seasonEnd;
+  if (start > end) return [];
+
+  // Exception dates (holiday closures etc.) are skipped. Normalize to 'YYYY-MM-DD'.
+  const exdates = new Set((series.exdates || []).map(iso => String(iso).slice(0, 10)));
+
+  const occurrences = [];
+  for (const code of byday) {
+    const targetDow = DOW[code];
+    // Anchor the interval grid on the first matching weekday of the season.
+    const anchor = firstWeekdayOnOrAfter(seasonStart, targetDow);
+    let candidate = firstWeekdayOnOrAfter(start, targetDow);
+    if (interval > 1) {
+      const weeksFromAnchor = Math.round((candidate - anchor) / (7 * MS_PER_DAY));
+      const remainder = ((weeksFromAnchor % interval) + interval) % interval;
+      if (remainder !== 0) {
+        candidate = new Date(candidate.getTime() + (interval - remainder) * 7 * MS_PER_DAY);
+      }
+    }
+    // TIME columns come back as 'HH:MM:SS' strings; embed them into the date string so
+    // the existing event card renders "Sun, Jun 7, 9:00 AM – 12:00 PM" (date-only when absent).
+    const t1 = series.time_start ? String(series.time_start).slice(0, 8) : null;
+    const t2 = series.time_end ? String(series.time_end).slice(0, 8) : null;
+    for (let d = candidate; d <= end; d = new Date(d.getTime() + interval * 7 * MS_PER_DAY)) {
+      const dateStr = d.toISOString().slice(0, 10);
+      if (exdates.has(dateStr)) continue;
+      occurrences.push({
+        // Synthetic, stable key for React lists — occurrences are not poi_events rows.
+        id: `series-${series.id}-${dateStr}`,
+        series_id: series.id,
+        poi_id: series.poi_id,
+        poi_name: series.poi_name,
+        poi_roles: series.poi_roles,
+        venue_poi_id: series.venue_poi_id,
+        venue_name: series.venue_name,
+        title: series.title,
+        description: series.description,
+        event_type: series.event_type,
+        location_details: series.location_details,
+        source_url: series.source_url,
+        image_url: series.image_url,
+        occurrence_date: dateStr,
+        start_date: t1 ? `${dateStr} ${t1}` : dateStr,
+        end_date: t2 ? `${dateStr} ${t2}` : null,
+        is_recurring: true,
+        cadence_label: cadenceLabel(series)
+      });
+    }
+  }
+  occurrences.sort((a, b) => a.start_date.localeCompare(b.start_date));
+  return occurrences;
+}
+
+/** The first occurrence of a series on/after `fromDate`, or null if the season is over. */
+export function nextOccurrence(series, fromDate) {
+  const list = expandSeries(series, fromDate, series.season_end);
+  return list.length ? list[0] : null;
+}
+
+const ACTIVE_SERIES_SELECT = `
+  SELECT s.*, p.name AS poi_name, p.poi_roles AS poi_roles, vp.name AS venue_name
+    FROM poi_event_series s
+    JOIN pois p ON p.id = s.poi_id
+    LEFT JOIN pois vp ON vp.id = s.venue_poi_id
+   WHERE s.active = TRUE
+     AND s.moderation_status IN ('published', 'auto_approved')
+     AND (p.deleted IS NULL OR p.deleted = FALSE)`;
+
+/** All active, published series across every POI. */
+export async function getAllActiveSeries(pool) {
+  const seriesRows = await pool.query(ACTIVE_SERIES_SELECT);
+  return seriesRows.rows;
+}
+
+/**
+ * Materialize a series' occurrences into real poi_events rows so recurring events
+ * appear everywhere regular events do. The rule is the source of truth: FUTURE rows
+ * are regenerated (so edits to day/season/exdates take effect), PAST rows are left as
+ * historical record. Idempotent via the (series_id, start_date) unique index.
+ *
+ * Occurrence times are local; they are stored tz-correctly — timed occurrences as the
+ * given `tz` instant, date-only occurrences as UTC midnight (so they render date-only).
+ *
+ * @param {Pool} pool
+ * @param {object} series - a poi_event_series row
+ * @param {string} tz - venue timezone for timed occurrences
+ * @returns {Promise<number>} rows inserted
+ */
+export async function materializeSeries(pool, series, tz = 'America/New_York') {
+  if (!series || !series.id) return 0;
+  const occurrences = expandSeries(series, series.season_start, series.season_end);
+  const label = cadenceLabel(series);
+  await pool.query('DELETE FROM poi_events WHERE series_id = $1 AND start_date >= NOW()', [series.id]);
+  let inserted = 0;
+  for (const o of occurrences) {
+    const hasTime = o.start_date.length > 10;
+    const startLocal = hasTime ? o.start_date : `${o.start_date} 00:00:00`;
+    const startTz = hasTime ? tz : 'UTC';
+    const insertResult = await pool.query(
+      `INSERT INTO poi_events
+         (poi_id, venue_poi_id, series_id, title, description, start_date, end_date,
+          event_type, location_details, source_url, image_url, recurrence_label,
+          content_source, moderation_status, collection_date)
+       VALUES ($1, $2, $3, $4, $5,
+               ($6::text)::timestamp AT TIME ZONE $8,
+               CASE WHEN $7::text IS NULL THEN NULL ELSE ($7::text)::timestamp AT TIME ZONE $9 END,
+               $10, $11, $12, $13, $14, 'recurring', 'published', NOW())
+       ON CONFLICT (series_id, start_date) DO NOTHING`,
+      [series.poi_id, series.venue_poi_id || null, series.id, series.title, series.description || null,
+       startLocal, o.end_date || null, startTz, tz,
+       series.event_type || null, series.location_details || null, series.source_url || null,
+       series.image_url || null, label]
+    );
+    inserted += insertResult.rowCount;
+  }
+  return inserted;
+}
+
+/** Materialize every active series — run on backend boot so deploy/seed self-populates. */
+export async function materializeAllSeries(pool) {
+  try {
+    const series = await getAllActiveSeries(pool);
+    let total = 0;
+    for (const s of series) total += await materializeSeries(pool, s);
+    if (total > 0) console.log(`[EventSeries] Materialized ${total} recurring occurrence(s) across ${series.length} series`);
+    return total;
+  } catch (err) {
+    console.warn(`[EventSeries] materializeAllSeries skipped: ${err.message}`);
+    return 0;
+  }
+}

--- a/backend/tests/eventSeries.unit.test.js
+++ b/backend/tests/eventSeries.unit.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { expandSeries, cadenceLabel, nextOccurrence } from '../services/eventSeriesService.js';
+
+// Cuyahoga Valley Farmers Market (spec 034, #436): the two driving series.
+const summer = {
+  id: 1, poi_id: 10, venue_poi_id: 20, venue_name: 'Howe Meadow',
+  freq: 'WEEKLY', interval: 1, byday: ['SU'],
+  season_start: '2026-05-03', season_end: '2026-10-25',
+  time_start: '09:00:00', time_end: '12:00:00', active: true
+};
+// Winter is biweekly Saturdays anchored on 2025-11-01 (itself a Saturday).
+const winter = {
+  id: 2, poi_id: 10, freq: 'WEEKLY', interval: 2, byday: ['SA'],
+  season_start: '2025-11-01', season_end: '2026-04-25',
+  time_start: '09:00:00', time_end: '12:00:00', active: true
+};
+
+const dow = (ymd) => new Date(`${ymd.slice(0, 10)}T00:00:00Z`).getUTCDay();
+
+describe('expandSeries — weekly cadence', () => {
+  it('projects every Sunday within the request window', () => {
+    const dates = expandSeries(summer, '2026-06-01', '2026-06-30').map(o => o.start_date);
+    expect(dates).toEqual([
+      '2026-06-07 09:00:00', '2026-06-14 09:00:00',
+      '2026-06-21 09:00:00', '2026-06-28 09:00:00'
+    ]);
+  });
+
+  it('embeds the time of day so the event card renders a time', () => {
+    const occ = expandSeries(summer, '2026-06-07', '2026-06-07')[0];
+    expect(occ.start_date).toBe('2026-06-07 09:00:00');
+    expect(occ.end_date).toBe('2026-06-07 12:00:00');
+    expect(occ.is_recurring).toBe(true);
+    expect(occ.occurrence_date).toBe('2026-06-07');
+  });
+
+  it('carries the venue (where) distinct from the organizer (poi_id)', () => {
+    const occ = expandSeries(summer, '2026-06-07', '2026-06-07')[0];
+    expect(occ.poi_id).toBe(10);          // organizer
+    expect(occ.venue_poi_id).toBe(20);    // venue
+    expect(occ.venue_name).toBe('Howe Meadow');
+  });
+
+  it('every projected date falls on the requested weekday', () => {
+    const occ = expandSeries(summer, '2026-05-01', '2026-10-31');
+    expect(occ.every(o => dow(o.start_date) === 0)).toBe(true); // Sunday
+  });
+});
+
+describe('expandSeries — biweekly cadence', () => {
+  it('projects every other Saturday on the anchor grid', () => {
+    const dates = expandSeries(winter, '2026-01-01', '2026-02-15').map(o => o.start_date.slice(0, 10));
+    expect(dates).toEqual(['2026-01-10', '2026-01-24', '2026-02-07']);
+  });
+
+  it('keeps every projected date on a Saturday', () => {
+    const occ = expandSeries(winter, '2025-11-01', '2026-04-25');
+    expect(occ.every(o => dow(o.start_date) === 6)).toBe(true);
+  });
+});
+
+describe('expandSeries — season bounds', () => {
+  it('emits nothing before the season starts', () => {
+    expect(expandSeries(summer, '2026-04-01', '2026-04-30')).toHaveLength(0);
+  });
+  it('emits nothing after the season ends', () => {
+    expect(expandSeries(summer, '2026-11-01', '2026-11-30')).toHaveLength(0);
+  });
+  it('clips the request window to the season range', () => {
+    // Window spans April–June but only June Sundays are in season.
+    const dates = expandSeries(summer, '2026-04-15', '2026-06-14').map(o => o.start_date.slice(0, 10));
+    expect(dates).toEqual(['2026-05-03', '2026-05-10', '2026-05-17', '2026-05-24', '2026-05-31', '2026-06-07', '2026-06-14']);
+  });
+});
+
+describe('expandSeries — exception dates', () => {
+  // Real CVFM winter market: weekly Saturdays, closed three holiday Saturdays.
+  const winterWeekly = {
+    id: 3, poi_id: 10, freq: 'WEEKLY', interval: 1, byday: ['SA'],
+    season_start: '2026-11-07', season_end: '2027-04-24',
+    exdates: ['2026-11-28', '2026-12-26', '2027-01-02'],
+    time_start: '09:00:00', time_end: '12:00:00', active: true
+  };
+  it('skips the listed closure dates', () => {
+    const dates = expandSeries(winterWeekly, '2026-11-01', '2027-01-10').map(o => o.occurrence_date);
+    expect(dates).not.toContain('2026-11-28');
+    expect(dates).not.toContain('2026-12-26');
+    expect(dates).not.toContain('2027-01-02');
+    expect(dates).toContain('2026-11-21');
+    expect(dates).toContain('2027-01-09');
+  });
+});
+
+describe('expandSeries — guards', () => {
+  it('returns nothing for inactive series', () => {
+    expect(expandSeries({ ...summer, active: false }, '2026-06-01', '2026-06-30')).toHaveLength(0);
+  });
+  it('returns nothing when byday is empty', () => {
+    expect(expandSeries({ ...summer, byday: [] }, '2026-06-01', '2026-06-30')).toHaveLength(0);
+  });
+  it('ignores non-weekly frequency in v1', () => {
+    expect(expandSeries({ ...summer, freq: 'MONTHLY' }, '2026-06-01', '2026-06-30')).toHaveLength(0);
+  });
+});
+
+describe('nextOccurrence', () => {
+  it('returns the next Sunday on/after a midweek date', () => {
+    expect(nextOccurrence(summer, '2026-06-09').start_date).toBe('2026-06-14 09:00:00');
+  });
+  it('returns null once the season is over', () => {
+    expect(nextOccurrence(summer, '2026-12-01')).toBeNull();
+  });
+});
+
+describe('cadenceLabel', () => {
+  it('labels weekly and biweekly cadences', () => {
+    expect(cadenceLabel(summer)).toBe('Weekly: Sundays');
+    expect(cadenceLabel(winter)).toBe('Every 2 weeks: Saturdays');
+  });
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2296,9 +2296,17 @@ body {
   margin-bottom: 0.5rem;
 }
 
+/* Recurring cadence line on event cards (#436), a bottom section e.g. "Weekly: Saturdays".
+   Bold label + regular value mirrors the "Location:" line. */
+.park-event-recurring {
+  font-size: 0.85rem;
+  color: #1a1a1a;
+  margin-bottom: 0.5rem;
+}
+
 .park-event-location {
   font-size: 0.85rem;
-  color: #525252;
+  color: #1a1a1a;
   margin: 0.5rem 0;
 }
 
@@ -4824,6 +4832,50 @@ body {
 .new-content-form .form-section {
   margin-bottom: 1rem;
 }
+
+/* Recurring-event authoring controls (#436) */
+.recur-weekdays {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.recur-day {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  color: #333;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.recur-day.active {
+  background: #2d5016;
+  border-color: #2d5016;
+  color: #fff;
+}
+.new-content-form .form-row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+/* Manage a recurring event (series) from its occurrence card in edit mode */
+.recur-admin-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.recur-edit-btn,
+.recur-delete-btn {
+  padding: 0.35rem 0.7rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.recur-edit-btn { color: #2d5016; border-color: #2d5016; }
+.recur-delete-btn { color: #c62828; border-color: #c62828; }
 
 .new-content-form .form-section label {
   display: block;

--- a/frontend/src/components/ContentFormModal.jsx
+++ b/frontend/src/components/ContentFormModal.jsx
@@ -8,6 +8,7 @@ function ContentFormModal({
   fields,
   setFields,
   item,
+  seriesEdit,
   pois = [],
   itemUrls = [],
   newUrlInput = '',
@@ -20,13 +21,56 @@ function ContentFormModal({
   onClose
 }) {
   const isEdit = mode === 'edit';
+  const isSeriesEdit = !!seriesEdit;
   const [localFields, setLocalFields] = useState({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [localPois, setLocalPois] = useState(pois);
 
+  // Recurring-event authoring (#436): a "Repeats" dropdown that swaps the one-off date
+  // fields for a recurrence rule + season + venue, posting to the series API. Also reused
+  // to EDIT an existing series (pre-filled, PUT).
+  const [repeatInterval, setRepeatInterval] = useState(0); // 0 = does not repeat (one-time)
+  const [recur, setRecur] = useState({
+    byday: [], season_start: '', season_end: '',
+    time_start: '', time_end: '', venue_poi_id: '', exdates: ''
+  });
+  const showRecurring = isSeriesEdit || (!isEdit && contentType === 'event' && repeatInterval > 0);
+  const WEEKDAYS = [
+    { code: 'SU', label: 'Sun' }, { code: 'MO', label: 'Mon' }, { code: 'TU', label: 'Tue' },
+    { code: 'WE', label: 'Wed' }, { code: 'TH', label: 'Thu' }, { code: 'FR', label: 'Fri' },
+    { code: 'SA', label: 'Sat' }
+  ];
+  const toggleDay = (code) => setRecur(prev => ({
+    ...prev,
+    byday: prev.byday.includes(code) ? prev.byday.filter(d => d !== code) : [...prev.byday, code]
+  }));
+
   const activeFields = isEdit ? fields : localFields;
   const activeSetFields = isEdit ? setFields : setLocalFields;
+
+  // Pre-fill from an existing series when editing one.
+  useEffect(() => {
+    if (!seriesEdit) return;
+    setLocalFields({
+      title: seriesEdit.title || '',
+      description: seriesEdit.description || '',
+      event_type: seriesEdit.event_type || '',
+      location_details: seriesEdit.location_details || '',
+      source_url: seriesEdit.source_url || '',
+      poi_id: seriesEdit.poi_id || ''
+    });
+    setRepeatInterval(seriesEdit.interval || 1);
+    setRecur({
+      byday: seriesEdit.byday || [],
+      season_start: String(seriesEdit.season_start || '').slice(0, 10),
+      season_end: String(seriesEdit.season_end || '').slice(0, 10),
+      time_start: String(seriesEdit.time_start || '').slice(0, 5),
+      time_end: String(seriesEdit.time_end || '').slice(0, 5),
+      venue_poi_id: seriesEdit.venue_poi_id || '',
+      exdates: (seriesEdit.exdates || []).map(d => String(d).slice(0, 10)).join(', ')
+    });
+  }, [seriesEdit]);
 
   useEffect(() => {
     if (pois.length > 0) {
@@ -39,7 +83,53 @@ function ContentFormModal({
       .catch(() => setLocalPois([]));
   }, [pois]);
 
-  const fieldConfigs = FIELD_CONFIGS[contentType] || [];
+  const allFieldConfigs = FIELD_CONFIGS[contentType] || [];
+  // In recurring mode the one-off date fields are replaced by the recurrence/season fields.
+  const fieldConfigs = showRecurring
+    ? allFieldConfigs.filter(fc => !['start_date', 'end_date', 'publication_date'].includes(fc.key))
+    : allFieldConfigs;
+
+  const submitRecurringSeries = async () => {
+    if (!activeFields.poi_id) { setError('Organizer POI is required'); return; }
+    if (recur.byday.length === 0) { setError('Pick at least one day of the week'); return; }
+    if (!recur.season_start || !recur.season_end) { setError('Season start and end dates are required'); return; }
+    setSaving(true);
+    try {
+      const response = await fetch(
+        isSeriesEdit ? `/api/admin/event-series/${seriesEdit.id}` : '/api/admin/event-series', {
+        method: isSeriesEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          poi_id: parseInt(activeFields.poi_id),
+          venue_poi_id: recur.venue_poi_id ? parseInt(recur.venue_poi_id) : null,
+          title: activeFields.title,
+          description: activeFields.description || null,
+          event_type: activeFields.event_type || null,
+          location_details: activeFields.location_details || null,
+          source_url: activeFields.source_url || null,
+          freq: 'WEEKLY',
+          interval: repeatInterval,
+          byday: recur.byday,
+          season_start: recur.season_start,
+          season_end: recur.season_end,
+          time_start: recur.time_start || null,
+          time_end: recur.time_end || null,
+          exdates: recur.exdates.split(',').map(s => s.trim()).filter(Boolean)
+        })
+      });
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error || 'Failed to save recurring event');
+      }
+      if (onCreate) onCreate();
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -52,7 +142,9 @@ function ContentFormModal({
       }
     }
 
-    if (isEdit) {
+    if (showRecurring) {
+      submitRecurringSeries();
+    } else if (isEdit) {
       onSave();
     } else {
       if (!activeFields.poi_id) {
@@ -117,8 +209,12 @@ function ContentFormModal({
       placeholder={fc.label} required={fc.required} lang={lang} />;
   };
 
-  const title = isEdit
+  const title = isSeriesEdit
+    ? 'Edit Recurring Event'
+    : isEdit
     ? `Edit ${contentType === 'news' ? 'News Item' : 'Event'}`
+    : showRecurring
+    ? 'Create Recurring Event'
     : `Create ${contentType === 'news' ? 'News Item' : 'Event'}`;
 
   return (
@@ -131,6 +227,19 @@ function ContentFormModal({
 
         <form onSubmit={handleSubmit} className="new-content-form">
           {error && <div className="form-error">{error}</div>}
+
+          {((!isEdit && contentType === 'event') || isSeriesEdit) && (
+            <div className="form-section">
+              <label>Repeats</label>
+              <select value={repeatInterval} onChange={e => setRepeatInterval(parseInt(e.target.value))}>
+                {!isSeriesEdit && <option value={0}>Does not repeat (one-time)</option>}
+                <option value={1}>Weekly</option>
+                <option value={2}>Every 2 weeks</option>
+                <option value={3}>Every 3 weeks</option>
+                <option value={4}>Every 4 weeks</option>
+              </select>
+            </div>
+          )}
 
           {isEdit && item && (item.ai_reasoning || item.moderation_status) && (
             <div className="form-ai-info">
@@ -150,10 +259,68 @@ function ContentFormModal({
 
           {fieldConfigs.map(fc => (
             <div className="form-section" key={fc.key}>
-              <label>{fc.label}{fc.required ? ' *' : ''}</label>
+              <label>{fc.key === 'poi_id' && showRecurring ? 'Organizer POI' : fc.label}{fc.required ? ' *' : ''}</label>
               {renderFieldInput(fc)}
             </div>
           ))}
+
+          {showRecurring && (
+            <>
+              <div className="form-section">
+                <label>Venue (where it's held)</label>
+                <PoiSearchSelect
+                  pois={localPois}
+                  value={recur.venue_poi_id}
+                  onChange={(id) => setRecur(prev => ({ ...prev, venue_poi_id: id || '' }))}
+                  placeholder="Search venue POIs (optional)..."
+                />
+              </div>
+              <div className="form-section">
+                <label>On days *</label>
+                <div className="recur-weekdays">
+                  {WEEKDAYS.map(d => (
+                    <button
+                      type="button"
+                      key={d.code}
+                      className={`recur-day ${recur.byday.includes(d.code) ? 'active' : ''}`}
+                      onClick={() => toggleDay(d.code)}
+                    >
+                      {d.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="form-section form-row-2">
+                <div>
+                  <label>Season start *</label>
+                  <input type="date" value={recur.season_start} onChange={e => setRecur(prev => ({ ...prev, season_start: e.target.value }))} />
+                </div>
+                <div>
+                  <label>Season end *</label>
+                  <input type="date" value={recur.season_end} onChange={e => setRecur(prev => ({ ...prev, season_end: e.target.value }))} />
+                </div>
+              </div>
+              <div className="form-section form-row-2">
+                <div>
+                  <label>Start time</label>
+                  <input type="time" value={recur.time_start} onChange={e => setRecur(prev => ({ ...prev, time_start: e.target.value }))} />
+                </div>
+                <div>
+                  <label>End time</label>
+                  <input type="time" value={recur.time_end} onChange={e => setRecur(prev => ({ ...prev, time_end: e.target.value }))} />
+                </div>
+              </div>
+              <div className="form-section">
+                <label>Skip dates (optional)</label>
+                <input
+                  type="text"
+                  value={recur.exdates}
+                  onChange={e => setRecur(prev => ({ ...prev, exdates: e.target.value }))}
+                  placeholder="Comma-separated, e.g. 2026-11-28, 2026-12-26"
+                />
+              </div>
+            </>
+          )}
 
           {isEdit && contentType !== 'photo' && (
             <div className="form-section">
@@ -188,7 +355,12 @@ function ContentFormModal({
               Cancel
             </button>
             <button type="submit" className="save-btn" disabled={saving}>
-              {saving ? (isEdit ? 'Saving...' : 'Creating...') : (isEdit ? 'Save' : `Create ${contentType === 'news' ? 'News' : 'Event'}`)}
+              {saving
+                ? ((isEdit || isSeriesEdit) ? 'Saving...' : 'Creating...')
+                : isSeriesEdit ? 'Save Recurring Event'
+                : isEdit ? 'Save'
+                : showRecurring ? 'Create Recurring Event'
+                : `Create ${contentType === 'news' ? 'News' : 'Event'}`}
             </button>
           </div>
         </form>

--- a/frontend/src/components/NewsEventsShared.jsx
+++ b/frontend/src/components/NewsEventsShared.jsx
@@ -358,9 +358,37 @@ export function EventCardBody({ item, onSelectPoi, calendarButtons, children, cl
 
       {item.description && <p className="park-event-description">{item.description}</p>}
 
-      {item.location_details && (
+      {(item.venue_name || item.location_details) && (
         <div className="park-event-location">
-          <strong>Location:</strong> {item.location_details}
+          <strong>Location:</strong>{' '}
+          {item.venue_name ? (
+            onSelectPoi && item.venue_poi_id ? (
+              <button
+                className="park-event-poi-link"
+                onClick={() => onSelectPoi(item.venue_poi_id)}
+                title={`View ${item.venue_name}`}
+              >
+                {item.venue_name}
+              </button>
+            ) : (
+              <span>{item.venue_name}</span>
+            )
+          ) : (
+            item.location_details
+          )}
+        </div>
+      )}
+
+      {item.is_recurring && item.cadence_label && (
+        <div className="park-event-recurring" title="Recurring event">
+          {item.cadence_label.includes(':') ? (
+            <>
+              <strong>{item.cadence_label.slice(0, item.cadence_label.indexOf(':') + 1)}</strong>
+              {' ' + item.cadence_label.slice(item.cadence_label.indexOf(':') + 1).trim()}
+            </>
+          ) : (
+            <strong>{item.cadence_label}</strong>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/ParkEvents.jsx
+++ b/frontend/src/components/ParkEvents.jsx
@@ -25,9 +25,12 @@ function ParkEvents({ isAdmin, editMode, onSelectPoi, onEditEventItem, filteredD
   const [searchText, setSearchText] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const PAGE_SIZE = 20;
-  const [activeSubTab, setActiveSubTab] = useState('future');
+  const [activeSubTab, setActiveSubTab] = useState('today');
   const [pastEvents, setPastEvents] = useState([]);
   const [pastLoading, setPastLoading] = useState(false);
+  // Today / This Weekend windows (#436): { count, events } keyed by range.
+  const [windowData, setWindowData] = useState({ today: null, weekend: null });
+  const [windowLoading, setWindowLoading] = useState(true);
   const [typeFilters, setTypeFilters] = useState({
     'hike': true,
     'race': true,
@@ -40,13 +43,51 @@ function ParkEvents({ isAdmin, editMode, onSelectPoi, onEditEventItem, filteredD
     'alert': true
   });
   const [showNewForm, setShowNewForm] = useState(false);
+  const [seriesEditData, setSeriesEditData] = useState(null);
 
   const mod = useModeration({
     onItemsChanged: () => { fetchEvents(); fetchPastEvents(); }
   });
 
+  const SUBTABS = [
+    { key: 'today', label: 'Today' },
+    { key: 'weekend', label: 'This Weekend' },
+    { key: 'future', label: 'Future' },
+    { key: 'past', label: 'Past' }
+  ];
+
+  const appTz = () => localStorage.getItem('app-timezone')
+    || Intl.DateTimeFormat().resolvedOptions().timeZone
+    || 'America/New_York';
+
   useEffect(() => {
     fetchEvents();
+  }, [refreshTrigger]);
+
+  // Load the Today and This Weekend windows, then land on the most useful default:
+  // Today when it has events, otherwise This Weekend (#436).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setWindowLoading(true);
+      try {
+        const tz = encodeURIComponent(appTz());
+        const [today, weekend] = await Promise.all([
+          fetch(`/api/events/window?range=today&tz=${tz}`).then(r => r.ok ? r.json() : null),
+          fetch(`/api/events/window?range=weekend&tz=${tz}`).then(r => r.ok ? r.json() : null)
+        ]);
+        if (cancelled) return;
+        setWindowData({ today, weekend });
+        if (today && today.count === 0 && weekend && weekend.count > 0) {
+          setActiveSubTab(prev => (prev === 'today' ? 'weekend' : prev));
+        }
+      } catch (err) {
+        console.error('Error fetching event windows:', err);
+      } finally {
+        if (!cancelled) setWindowLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
   }, [refreshTrigger]);
 
   const fetchEvents = async () => {
@@ -92,6 +133,45 @@ function ParkEvents({ isAdmin, editMode, onSelectPoi, onEditEventItem, filteredD
     }
   };
 
+  // Refetch every events surface after a create/edit/delete (one-off or series).
+  const reloadAll = async () => {
+    fetchEvents();
+    fetchPastEvents();
+    try {
+      const tz = encodeURIComponent(appTz());
+      const [today, weekend] = await Promise.all([
+        fetch(`/api/events/window?range=today&tz=${tz}`).then(r => r.ok ? r.json() : null),
+        fetch(`/api/events/window?range=weekend&tz=${tz}`).then(r => r.ok ? r.json() : null)
+      ]);
+      setWindowData({ today, weekend });
+    } catch (err) {
+      console.error('Error reloading event windows:', err);
+    }
+  };
+
+  // Recurring (series-linked) events are managed as a series, not per occurrence.
+  const openSeriesEdit = async (seriesId) => {
+    try {
+      const res = await fetch('/api/admin/event-series', { credentials: 'include' });
+      if (!res.ok) return;
+      const all = await res.json();
+      const series = all.find(s => s.id === seriesId);
+      if (series) setSeriesEditData(series);
+    } catch (err) {
+      console.error('Error loading series for edit:', err);
+    }
+  };
+
+  const deleteSeries = async (seriesId) => {
+    if (!window.confirm('Delete this recurring event? Future occurrences are removed; past ones are kept as history.')) return;
+    try {
+      const res = await fetch(`/api/admin/event-series/${seriesId}`, { method: 'DELETE', credentials: 'include' });
+      if (res.ok) reloadAll();
+    } catch (err) {
+      console.error('Error deleting series:', err);
+    }
+  };
+
   let currentBounds;
   if (bypassViewportFilter) {
     currentBounds = DEFAULT_PARK_BOUNDS;
@@ -112,7 +192,10 @@ function ParkEvents({ isAdmin, editMode, onSelectPoi, onEditEventItem, filteredD
 
   const thumbnailBounds = stableBoundsRef.current;
 
-  const sourceEvents = activeSubTab === 'future' ? events : pastEvents;
+  const sourceEvents =
+    activeSubTab === 'past' ? pastEvents :
+    activeSubTab === 'future' ? events :
+    (windowData[activeSubTab]?.events || []);
   const filteredEvents = React.useMemo(() => {
     const hasDestinations = Array.isArray(filteredDestinations);
     const hasLinearFeatures = Array.isArray(filteredLinearFeatures);
@@ -196,29 +279,32 @@ END:VCALENDAR`;
     URL.revokeObjectURL(url);
   };
 
-  const isLoading = activeSubTab === 'future' ? loading : pastLoading;
+  const isLoading =
+    activeSubTab === 'future' ? loading :
+    activeSubTab === 'past' ? pastLoading :
+    windowLoading;
   const tabLabel = 'Events';
+
+  const renderSubTabs = () => (
+    <div className="results-subtabs" onKeyDown={(e) => handleRovingKeyDown(e, '.results-subtab')}>
+      {SUBTABS.map(t => (
+        <button
+          key={t.key}
+          className={`results-subtab ${activeSubTab === t.key ? 'active' : ''}`}
+          onClick={() => { setActiveSubTab(t.key); setCurrentPage(1); }}
+          tabIndex={activeSubTab === t.key ? 0 : -1}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
 
   if (isLoading) {
     return (
       <div className="park-events-tab">
         <h2>{tabLabel}</h2>
-        <div className="results-subtabs" onKeyDown={(e) => handleRovingKeyDown(e, '.results-subtab')}>
-          <button
-            className={`results-subtab ${activeSubTab === 'future' ? 'active' : ''}`}
-            onClick={() => setActiveSubTab('future')}
-            tabIndex={activeSubTab === 'future' ? 0 : -1}
-          >
-            Future
-          </button>
-          <button
-            className={`results-subtab ${activeSubTab === 'past' ? 'active' : ''}`}
-            onClick={() => setActiveSubTab('past')}
-            tabIndex={activeSubTab === 'past' ? 0 : -1}
-          >
-            Past
-          </button>
-        </div>
+        {renderSubTabs()}
         <div className="loading-indicator">Loading events...</div>
       </div>
     );
@@ -250,27 +336,22 @@ END:VCALENDAR`;
           mode="create"
           contentType="event"
           pois={mod.pois}
-          onCreate={() => fetchEvents()}
+          onCreate={() => reloadAll()}
           onClose={() => setShowNewForm(false)}
         />
       )}
 
-      <div className="results-subtabs" onKeyDown={(e) => handleRovingKeyDown(e, '.results-subtab')}>
-        <button
-          className={`results-subtab ${activeSubTab === 'future' ? 'active' : ''}`}
-          onClick={() => { setActiveSubTab('future'); setCurrentPage(1); }}
-          tabIndex={activeSubTab === 'future' ? 0 : -1}
-        >
-          Future
-        </button>
-        <button
-          className={`results-subtab ${activeSubTab === 'past' ? 'active' : ''}`}
-          onClick={() => { setActiveSubTab('past'); setCurrentPage(1); }}
-          tabIndex={activeSubTab === 'past' ? 0 : -1}
-        >
-          Past
-        </button>
-      </div>
+      {seriesEditData && (
+        <ContentFormModal
+          contentType="event"
+          seriesEdit={seriesEditData}
+          pois={mod.pois}
+          onCreate={() => reloadAll()}
+          onClose={() => setSeriesEditData(null)}
+        />
+      )}
+
+      {renderSubTabs()}
 
       <div className="results-filters">
         <input
@@ -313,6 +394,8 @@ END:VCALENDAR`;
             <p className="no-content">
               {sourceEvents.length > 0
                 ? 'No events match the current filters. Try adjusting the type filters above or the map view.'
+                : activeSubTab === 'today' ? 'Nothing happening today.'
+                : activeSubTab === 'weekend' ? 'Nothing happening this weekend.'
                 : activeSubTab === 'future' ? 'No upcoming events found.' : 'No past events found.'}
             </p>
           ) : (
@@ -352,7 +435,7 @@ END:VCALENDAR`;
               </div>
             }
           >
-            {editMode && isAdmin && (
+            {editMode && isAdmin && !item.is_recurring && (
               <ModerationExtras
                 item={{ ...item, content_type: 'event' }}
                 isPending={false}
@@ -384,6 +467,16 @@ END:VCALENDAR`;
                 onAddUrl={mod.handleAddUrl}
                 onRemoveUrl={mod.handleRemoveUrl}
               />
+            )}
+            {editMode && isAdmin && item.is_recurring && item.series_id && (
+              <div className="recur-admin-controls">
+                <button type="button" className="recur-edit-btn" onClick={() => openSeriesEdit(item.series_id)}>
+                  Edit recurring event
+                </button>
+                <button type="button" className="recur-delete-btn" onClick={() => deleteSeries(item.series_id)}>
+                  Delete
+                </button>
+              </div>
             )}
           </EventCardBody>
             ))}

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -433,6 +433,13 @@ check = "verbose_comments"
 path = "backend/services/mcpServer.js"
 justification = "Load-bearing comment only: MCP SDK constraint at lines 801-802 — `Server.connect()` takes exclusive ownership of a transport, forcing per-request server+transport creation in stateless mode."
 
+# Event series service (#436) — exported recurring-event helpers used cross-module
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "backend/services/eventSeriesService.js"
+justification = "Flagged: cadenceLabel (41) and getActiveSeriesForPois (144). Both are exported. cadenceLabel is called from server.js:/api/events/recurring in addition to the internal expandSeries call — false positive (gourmand only sees the one internal call site). getActiveSeriesForPois is called from server.js (/api/pois/:id/events projection and /api/pois/:id/tab-counts) plus internally by getSeriesOccurrencesForPois — also a cross-module false positive on the call-site count."
+
 [[exceptions]]
 check = "verbose_comments"
 path = "backend/services/moderationService.js"


### PR DESCRIPTION
## Summary

Adds a first-class **"This Weekend / Today"** surface (#436, child of UX 1.0 #141) and the data foundation beneath it: **rule-based recurring events** and an **organizer-vs-venue** split so operators like the Cuyahoga Valley Farmers Market (CVFM) can run events at venues they don't own.

### Recurring events = real events
A series (`poi_event_series`) is the editable rule; a generator **materializes** its occurrences as real `poi_events` rows (linked by `series_id`, with a denormalized cadence label). So recurring events show up **everywhere regular events do** — Today/This Weekend, Future, Past, newsletter, notifications, search, permalinks — with no per-consumer code. Generation runs on series create/update/delete and on backend boot; it's bounded by each series' season (~26 rows/market), regenerates **future** occurrences, and keeps **past** ones as history.

### Organizer vs venue (no cross-bleed)
`poi_id` = who runs it, `venue_poi_id` = where it's held. A venue's page surfaces events whose `venue_poi_id` points at it:
- **Howe Meadow** → summer market only
- **Old Trail School** → winter market only
- **CVFM** (organizer) → both

### UX
- Events tab: **Today | This Weekend | Future | Past** (defaults to Today, else This Weekend).
- Card shows a **Weekly: Saturdays** cadence line and a green **venue** link.
- Admin: a **"Repeats"** dropdown in the Events "+ New" form creates a series; recurring cards get **Edit / Delete** (delete removes future occurrences, keeps past).

## Migrations (run on deploy)
- `081_poi_event_series.sql` — series table; `poi_events` `venue_poi_id`/`series_id`/`recurrence_label` + unique `(series_id, start_date)`; widen `chk_events_content_source` to allow `recurring`.
- `082_cvfm_overlay_org.sql` — CVFM org + Old Trail School POI + two series (weekly Saturdays, seasons/times/exdates from cvfm.org).

Both idempotent; verified to auto-materialize 52 occurrences on a clean boot.

## Test plan
- [x] Expander unit tests (cadence, biweekly anchor, season bounds, exdates, venue) — `backend/tests/eventSeries.unit.test.js`
- [x] Clean-boot auto-materialization (52 occurrences, 27 summer / 25 winter after 3 exdates)
- [x] Venue precision (no cross-bleed); past/window surfaces; tz correct (9am ET → 13:00Z)
- [x] Gourmand clean; container build passes
- [ ] Browser: This Weekend tab, recurring card, series create/edit/delete

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)