### PR TITLE
fix: dedupe newsletter events/news and stop dev/test preview sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Duplicate events in weekly newsletter**: "Steam in the Valley!" ran twice in issue #15
+  - Save-time dedup required an exact `start_date` match, so a bare-date variant (noon fallback) and a timed variant of the same event both saved
+  - Title match now compares the calendar day in Eastern time; digest rendering also dedupes by POI + title + day as a safety net for rows collected before the fix
+- **Duplicate news stories in weekly newsletter**: the Summit Metro Parks fishing-derby story ran twice (parks site + Spectrum News)
+  - Same story from two outlets has a different URL and headline, dodging save-time dedup
+  - Digest rendering now collapses same-POI stories whose significant title+summary vocabulary mostly overlaps; both digest paths overfetch so dedup does not shrink the issue below its slot count
+- **Preview/digest emails sent from dev and test containers** (regression of #440)
+  - `~/.rotv/environment-dev` is long-lived and only generated when missing, so files created before #440 never received `NEWSLETTER_SEND_ENABLED=false`; the test ENVFILE block never included it at all
+  - run.sh now appends the kill switch to existing dev env files and includes it in the test env file; three [PREVIEW] copies on May 28 and June 11 came from prod + dev + test containers all sharing the prod Buttondown key
 - **News date year corruption**: Fixed systematic 2025→2026 year shift in publication dates (#228)
   - Root cause: pg library returns `date` columns as JavaScript Date objects; `String(dateObj).slice(0,10)` produces `"Sat May 31"` (no year), which chrono-node re-parses as the next future occurrence
   - Fix: global pg type parsers (`types.setTypeParser`) for OID 1082/1114/1184 now return raw ISO strings

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1338,11 +1338,16 @@ export async function saveEventItems(pool, poiId, eventItems, options = {}) {
 
       const normalizedEventUrl = normalizeUrl(resolvedUrl);
       const normalizedEventTitle = normalizeTitle(item.title);
+      // Title match compares calendar day (Eastern), not exact timestamp: the
+      // same event collected once with a bare date (noon fallback) and once
+      // with a real start time would otherwise dodge dedup and dup the digest.
       const existing = await pool.query(
         `SELECT id, title, source_url, poi_id FROM poi_events
          WHERE (
            ($1::text IS NOT NULL AND LOWER(REGEXP_REPLACE(source_url, '/+$', '')) = $1::text)
-           OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3 AND start_date = $4)
+           OR (poi_id = $2 AND ${SQL_NORMALIZE_TITLE} = $3
+               AND (start_date AT TIME ZONE 'America/New_York')::date =
+                   ($4::timestamptz AT TIME ZONE 'America/New_York')::date)
          )`,
         [normalizedEventUrl, effectivePoiId, normalizedEventTitle, item.start_date]
       );

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -1,5 +1,80 @@
 import { sendEmail, sendDraftToRecipients } from './buttondownClient.js';
 
+const DIGEST_EVENT_LIMIT = 15;
+const DIGEST_NEWS_LIMIT = 5;
+
+// Mirrors normalizeTitle in newsService.js (kept local so this module stays
+// importable without pulling in the whole collection pipeline).
+function normalizeEventTitle(title) {
+  if (!title) return '';
+  return title.toLowerCase().replace(/^the\s+/i, '').trim();
+}
+
+function dayInTimezone(date, tz) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit'
+  }).format(new Date(date));
+}
+
+// Collapse rows that are the same event on the same calendar day at the same
+// POI. Save-time dedup now catches these going forward, but rows collected
+// before that fix (and any that slip through) must not reach subscribers.
+// Input is sorted by start_date ASC, so the variant with a real start time
+// wins over a bare-date noon fallback.
+export function dedupeDigestEvents(events, tz = 'America/New_York') {
+  const seen = new Set();
+  return events.filter(event => {
+    const key = `${event.poi_id}|${normalizeEventTitle(event.title)}|${dayInTimezone(event.start_date, tz)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+const NEWS_STOPWORDS = new Set([
+  'the', 'and', 'for', 'are', 'will', 'with', 'its', 'has', 'have', 'had',
+  'this', 'that', 'these', 'those', 'from', 'they', 'their', 'been', 'was',
+  'were', 'which', 'also', 'more', 'than', 'into', 'about', 'after', 'before',
+  'host', 'hosts', 'hosting', 'held', 'hold', 'holds', 'new', 'news',
+  'announce', 'announces', 'announced', 'including', 'include', 'includes'
+]);
+
+function newsTokens(item) {
+  const poiTokens = new Set(
+    (item.poi_name || '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  );
+  const stem = (word) => word.replace(/ies$/, 'y').replace(/(ing|ed|es|s)$/, '');
+  return new Set(
+    `${item.title || ''} ${item.summary || ''}`
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(w => w.length >= 3 && !NEWS_STOPWORDS.has(w) && !poiTokens.has(w))
+      .map(stem)
+  );
+}
+
+// Two stories about the same POI count as one story when their significant
+// vocabulary (title + summary, minus stopwords and the POI's own name) mostly
+// overlaps. Catches the same announcement collected from two outlets, which
+// URL- and title-based dedup at save time cannot (different source, different
+// headline). Input is sorted most-recent-first, so the freshest copy wins.
+export function dedupeDigestNews(news) {
+  const kept = [];
+  for (const item of news) {
+    const tokens = newsTokens(item);
+    const isDup = kept.some(other => {
+      if (other.poi_id !== item.poi_id) return false;
+      const otherTokens = newsTokens(other);
+      let shared = 0;
+      for (const t of tokens) if (otherTokens.has(t)) shared++;
+      const smaller = Math.min(tokens.size, otherTokens.size);
+      return smaller > 0 && shared >= 4 && shared / smaller >= 0.4;
+    });
+    if (!isDup) kept.push(item);
+  }
+  return kept;
+}
+
 export function upcomingFridayISO(tz = 'America/New_York') {
   const now = new Date();
   const weekdayShort = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' }).format(now);
@@ -24,7 +99,7 @@ async function fetchDigestContent(pool, tz, asOfDate) {
       AND (e.start_date AT TIME ZONE $1)::date <= (COALESCE($2::timestamptz, CURRENT_TIMESTAMP) AT TIME ZONE $1)::date + 2
       AND e.moderation_status IN ('published', 'auto_approved')
     ORDER BY e.start_date ASC, e.id ASC
-    LIMIT 15
+    LIMIT ${DIGEST_EVENT_LIMIT * 2}
   `;
 
   const newsQuery = `
@@ -35,7 +110,7 @@ async function fetchDigestContent(pool, tz, asOfDate) {
     WHERE n.moderation_status IN ('published', 'auto_approved')
       AND COALESCE(n.publication_date, n.collection_date) > COALESCE($1::timestamptz, NOW()) - INTERVAL '7 days'
     ORDER BY COALESCE(n.publication_date, n.collection_date) DESC, n.id DESC
-    LIMIT 5
+    LIMIT ${DIGEST_NEWS_LIMIT * 2}
   `;
 
   const [eventsResult, newsResult] = await Promise.all([
@@ -43,7 +118,10 @@ async function fetchDigestContent(pool, tz, asOfDate) {
     pool.query(newsQuery, [asOfDate])
   ]);
 
-  return { events: eventsResult.rows, news: newsResult.rows };
+  return {
+    events: dedupeDigestEvents(eventsResult.rows, tz).slice(0, DIGEST_EVENT_LIMIT),
+    news: dedupeDigestNews(newsResult.rows).slice(0, DIGEST_NEWS_LIMIT)
+  };
 }
 
 function renderDigestHtml(events, news, tz = 'America/New_York') {
@@ -534,14 +612,18 @@ export async function sendPersonalizedDigests(pool, pgBossJobId = null) {
     const friday = dayInTz(asOf);
     const sunday = dayInTz(new Date(new Date(asOf).getTime() + 2 * 86400000));
 
-    const userNews = newsResult.rows.filter(n => poiSet.has(n.poi_id)).slice(0, 5);
-    const userEvents = eventsResult.rows
-      .filter(e => poiSet.has(e.poi_id))
-      .filter(e => {
-        const day = dayInTz(e.start_date);
-        return day >= friday && day <= sunday;
-      })
-      .slice(0, 10);
+    const userNews = dedupeDigestNews(
+      newsResult.rows.filter(n => poiSet.has(n.poi_id))
+    ).slice(0, 5);
+    const userEvents = dedupeDigestEvents(
+      eventsResult.rows
+        .filter(e => poiSet.has(e.poi_id))
+        .filter(e => {
+          const day = dayInTz(e.start_date);
+          return day >= friday && day <= sunday;
+        }),
+      tz
+    ).slice(0, 10);
 
     const html = renderDigestHtml(userEvents, userNews, tz);
     if (!html) {

--- a/backend/tests/newsletterDigestDedup.unit.test.js
+++ b/backend/tests/newsletterDigestDedup.unit.test.js
@@ -1,0 +1,111 @@
+/**
+ * Digest-time dedup for the weekly newsletter (issue #15 regressions).
+ * Event case: "Steam in the Valley!" appeared twice — once with a bare date
+ * (noon fallback) and once at 10:00 AM, with slightly different URLs.
+ * News case: the Summit Metro Parks fishing-derby story ran twice, collected
+ * from the parks' own site and from Spectrum News.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../services/buttondownClient.js', () => ({
+  sendEmail: vi.fn(),
+  sendDraftToRecipients: vi.fn()
+}));
+
+const { dedupeDigestEvents, dedupeDigestNews } = await import('../services/newsletterDigestService.js');
+
+const TZ = 'America/New_York';
+
+describe('dedupeDigestEvents', () => {
+  const steamTimed = {
+    id: 1, poi_id: 42, poi_name: 'Cuyahoga Valley Scenic Railroad',
+    title: 'Steam in the Valley!',
+    start_date: '2026-06-05T14:00:00Z', // 10:00 AM Eastern
+    source_url: 'https://www.cvsr.org/excursions/steam-in-the-valley/steam-in-the-valley'
+  };
+  const steamNoonFallback = {
+    id: 2, poi_id: 42, poi_name: 'Cuyahoga Valley Scenic Railroad',
+    title: 'Steam in the Valley!',
+    start_date: '2026-06-05T16:00:00Z', // noon Eastern date-only fallback
+    source_url: 'https://www.cvsr.org/excursions/steam-in-the-valley'
+  };
+
+  it('collapses the same title at the same POI on the same day', () => {
+    const result = dedupeDigestEvents([steamTimed, steamNoonFallback], TZ);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1); // earliest start (the timed variant) wins
+  });
+
+  it('treats "The" prefix and case as the same title', () => {
+    const result = dedupeDigestEvents([
+      steamTimed,
+      { ...steamNoonFallback, title: 'The STEAM IN THE VALLEY!' }
+    ], TZ);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps the same event on different days (recurring series)', () => {
+    const saturdayRun = { ...steamNoonFallback, id: 3, start_date: '2026-06-06T16:00:00Z' };
+    expect(dedupeDigestEvents([steamTimed, saturdayRun], TZ)).toHaveLength(2);
+  });
+
+  it('keeps identical titles at different POIs', () => {
+    const otherPoi = { ...steamNoonFallback, id: 4, poi_id: 99 };
+    expect(dedupeDigestEvents([steamTimed, otherPoi], TZ)).toHaveLength(2);
+  });
+
+  it('compares days in the digest timezone, not UTC', () => {
+    // 11 PM Friday Eastern is 3 AM Saturday UTC — still the same Friday event
+    const lateNight = { ...steamTimed, id: 5, start_date: '2026-06-06T03:00:00Z' };
+    const lateNightDup = { ...steamTimed, id: 6, start_date: '2026-06-06T03:00:00Z' };
+    expect(dedupeDigestEvents([lateNight, lateNightDup], TZ)).toHaveLength(1);
+  });
+});
+
+describe('dedupeDigestNews', () => {
+  const derbyFromParks = {
+    id: 10, poi_id: 7, poi_name: 'Summit Metro Parks',
+    title: 'Summit Metro Parks Promotes Native Fish Conservation and Fishing Programs',
+    summary: 'Summit Metro Parks is promoting its free fishing programs, including Kids\' and Special Needs Fishing Derbies, which will take place in June. The park district has prioritized stocking native fish in its inland lakes and ponds since 2025, aiming to conserve biodiversity and improve aquatic ecosystems.'
+  };
+  const derbyFromSpectrum = {
+    id: 11, poi_id: 7, poi_name: 'Summit Metro Parks',
+    title: 'Summit Metro Parks to host annual fishing derbies',
+    summary: 'Summit Metro Parks will hold its annual Kids\' Fishing Derby on June 20 and a Special Needs Fishing Derby on June 23 at Little Turtle Pond in Firestone Metro Park. The parks are also enhancing their fish stocking with native species, aiming for larger catches in the derbies.'
+  };
+  const corpseFlower = {
+    id: 12, poi_id: 8, poi_name: 'Cleveland Metroparks',
+    title: '32-year-old corpse flower expected to bloom soon at Cleveland Metroparks Zoo',
+    summary: 'It could soon be time to visit the Cleveland Metroparks Zoo for a rare blooming -- or stay far, far away, depending on your preference.'
+  };
+  const mothNight = {
+    id: 13, poi_id: 7, poi_name: 'Summit Metro Parks',
+    title: 'Moth Night returns to Summit Metro Parks',
+    summary: 'Join a naturalist to explore the nighttime world of moths, observing various species that come in different shapes, colors, and sizes at the Nature Realm.'
+  };
+
+  it('collapses the same story collected from two outlets', () => {
+    const result = dedupeDigestNews([derbyFromParks, derbyFromSpectrum]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(10); // first in sort order (most recent) wins
+  });
+
+  it('keeps unrelated stories from the same POI', () => {
+    expect(dedupeDigestNews([derbyFromParks, mothNight])).toHaveLength(2);
+  });
+
+  it('keeps similar-vocabulary stories from different POIs', () => {
+    const otherPoiCopy = { ...derbyFromSpectrum, id: 14, poi_id: 8, poi_name: 'Cleveland Metroparks' };
+    expect(dedupeDigestNews([derbyFromParks, otherPoiCopy])).toHaveLength(2);
+  });
+
+  it('passes through a mixed digest untouched except for the dup', () => {
+    const result = dedupeDigestNews([corpseFlower, derbyFromParks, derbyFromSpectrum, mothNight]);
+    expect(result.map(n => n.id)).toEqual([12, 10, 13]);
+  });
+
+  it('handles items with no summary', () => {
+    const bare = { id: 15, poi_id: 7, poi_name: 'Summit Metro Parks', title: 'Trail closure announced', summary: null };
+    expect(dedupeDigestNews([derbyFromParks, bare])).toHaveLength(2);
+  });
+});

--- a/run.sh
+++ b/run.sh
@@ -170,6 +170,14 @@ NEWSLETTER_SEND_ENABLED=${NEWSLETTER_SEND_ENABLED:-false}
 ENVFILE
         fi
 
+        # The env file is long-lived, so files created before the
+        # NEWSLETTER_SEND_ENABLED kill switch existed (#440) never got it and
+        # kept sending real newsletter email from dev containers.
+        if ! grep -q '^NEWSLETTER_SEND_ENABLED=' ~/.rotv/environment-dev; then
+            echo "Adding NEWSLETTER_SEND_ENABLED=false to existing ~/.rotv/environment-dev"
+            echo "NEWSLETTER_SEND_ENABLED=${NEWSLETTER_SEND_ENABLED:-false}" >> ~/.rotv/environment-dev
+        fi
+
         # Use host network for default instance, bridge network for alternate ports
         if [ "$HOST_PORT" = "8080" ]; then
             NETWORK_ARGS="--network=host"
@@ -247,6 +255,7 @@ FACEBOOK_APP_ID=$FACEBOOK_APP_ID
 FACEBOOK_APP_SECRET=$FACEBOOK_APP_SECRET
 ADMIN_EMAIL=$ADMIN_EMAIL
 DISABLE_LIVE_BOAT_TRACKER=true
+NEWSLETTER_SEND_ENABLED=${NEWSLETTER_SEND_ENABLED:-false}
 ENVFILE
 
         # Start container with ephemeral storage and seed data (use :test tag)


### PR DESCRIPTION
## Summary

Three newsletter pipeline fixes, all root-caused from issue #15 (June 5) and the June 11 triple-preview:

- **Event dedup**: `saveEventItems` title-match required an exact `start_date`, so a bare-date variant (noon fallback) and a timed variant of the same event both saved — "Steam in the Valley!" ran twice. Title match now compares the calendar day in Eastern time, and digest rendering dedupes by POI + title + day as a safety net for rows collected before the fix. This also merges web-collected copies of series-materialized events (#468) instead of duplicating them.
- **News dedup**: the same story from two outlets (different URL, different headline) dodged save-time dedup — the Summit Metro Parks fishing-derby story ran twice. Digest rendering now collapses same-POI stories whose significant title+summary vocabulary mostly overlaps. Both digest paths overfetch so dedup doesn't shrink an issue below its slot count.
- **Preview sends (regression of #440)**: the kill switch only landed in freshly generated env files; `~/.rotv/environment-dev` is long-lived and the test ENVFILE block never included the variable, so prod + dev + test containers each emailed a [PREVIEW] every Thursday. run.sh now appends `NEWSLETTER_SEND_ENABLED=false` to existing dev env files and includes it in the test env file.

## Test plan

- [x] 10 new unit tests in `newsletterDigestDedup.unit.test.js` using the actual June 5 duplicates as fixtures
- [x] `./run.sh build` passes
- [x] Full container suite: all newsletter/news/events tests pass (2 runs). Known unrelated failure: ogShareImages (#475, pre-existing, seed-data-dependent); one-off Playwright flakes (slot hook timeout, SSL test) each passed on the other run
- [x] Unit tests re-run green after rebase onto v1.37.0 (no overlap with #468 series work)

Closes the dedup half of the issue-#15 quality report. Known issue #475 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)