### PR TITLE
fix: make newsletter send gate fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Newsletter send gate is now fail-closed**: `isSendEnabled()` requires an explicit `NEWSLETTER_SEND_ENABLED=true`
+  - Previously fail-open (`!== 'false'`), so a missing variable meant sends were ENABLED — the root condition behind the duplicate [PREVIEW] emails (#440/#476)
+  - A forgotten or mislocated env file now means NO send by default; only production sets the flag to `true` (added explicitly to lotor's env before this shipped). Also closes the latent risk of CI containers (which carry the prod Buttondown key via seed data) being nominally send-enabled
+
 ### Fixed
 - **Duplicate events in weekly newsletter**: "Steam in the Valley!" ran twice in issue #15
   - Save-time dedup required an exact `start_date` match, so a bare-date variant (noon fallback) and a timed variant of the same event both saved

--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -2,8 +2,13 @@ import axios from 'axios';
 
 const BUTTONDOWN_API_BASE = 'https://api.buttondown.email';
 
-function isSendEnabled() {
-  return process.env.NEWSLETTER_SEND_ENABLED !== 'false';
+// Fail-closed: sending requires an explicit NEWSLETTER_SEND_ENABLED=true.
+// A missing or unset variable means NO send, so a forgotten env file (the
+// regression behind the triple [PREVIEW] emails, #440/#476) can never email
+// real subscribers by default. Production sets the flag explicitly in its
+// env file; dev/test set it to 'false' (or leave it unset).
+export function isSendEnabled() {
+  return process.env.NEWSLETTER_SEND_ENABLED === 'true';
 }
 
 let apiKeyCache = null;
@@ -87,7 +92,7 @@ async function retryRequest(requestFn, maxRetries = 3) {
 
 export async function addSubscriber(email, pool = null) {
   if (!isSendEnabled()) {
-    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED=false), skipping addSubscriber');
+    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED is not "true"), skipping addSubscriber');
     return { email, status: 'send_disabled', skipped: true };
   }
 
@@ -151,7 +156,7 @@ export async function getSubscriberCount(pool = null) {
 
 export async function sendEmail(subject, htmlBody, pool = null, { existingEmailId, onDraftCreated } = {}) {
   if (!isSendEnabled()) {
-    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED=false), skipping sendEmail');
+    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED is not "true"), skipping sendEmail');
     return { skipped: true, reason: 'send_disabled' };
   }
 
@@ -220,7 +225,7 @@ export async function sendEmail(subject, htmlBody, pool = null, { existingEmailI
 
 export async function sendDraftToRecipients(subject, htmlBody, recipients, pool = null) {
   if (!isSendEnabled()) {
-    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED=false), skipping sendDraftToRecipients');
+    console.log('Newsletter send disabled (NEWSLETTER_SEND_ENABLED is not "true"), skipping sendDraftToRecipients');
     return { emailId: null, skipped: true, reason: 'send_disabled' };
   }
 

--- a/backend/tests/buttondownSendGate.unit.test.js
+++ b/backend/tests/buttondownSendGate.unit.test.js
@@ -1,0 +1,43 @@
+/**
+ * Fail-closed contract for the newsletter send gate (PR #476 follow-up).
+ * A missing NEWSLETTER_SEND_ENABLED must mean NO send, so a forgotten env
+ * file can never email real subscribers — the regression behind the triple
+ * [PREVIEW] emails (#440). Sending requires the exact string "true".
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// buttondownClient imports axios (used only inside a function); stub it so the
+// module loads on the host without a full backend node_modules.
+vi.mock('axios', () => ({ default: { create: vi.fn(() => ({})) } }));
+
+const { isSendEnabled } = await import('../services/buttondownClient.js');
+
+describe('isSendEnabled — fail-closed newsletter gate', () => {
+  const original = process.env.NEWSLETTER_SEND_ENABLED;
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEWSLETTER_SEND_ENABLED;
+    else process.env.NEWSLETTER_SEND_ENABLED = original;
+  });
+
+  it('is disabled when the variable is unset (the safety default)', () => {
+    delete process.env.NEWSLETTER_SEND_ENABLED;
+    expect(isSendEnabled()).toBe(false);
+  });
+
+  it('is enabled for the exact string "true"', () => {
+    process.env.NEWSLETTER_SEND_ENABLED = 'true';
+    expect(isSendEnabled()).toBe(true);
+  });
+
+  it('is disabled for "false"', () => {
+    process.env.NEWSLETTER_SEND_ENABLED = 'false';
+    expect(isSendEnabled()).toBe(false);
+  });
+
+  it('is disabled for truthy-looking but non-"true" values', () => {
+    for (const v of ['TRUE', 'True', '1', 'yes', 'on', ' true ', 'true ', '']) {
+      process.env.NEWSLETTER_SEND_ENABLED = v;
+      expect(isSendEnabled(), `value ${JSON.stringify(v)} must not enable sending`).toBe(false);
+    }
+  });
+});

--- a/backend/tests/buttondownSendGate.unit.test.js
+++ b/backend/tests/buttondownSendGate.unit.test.js
@@ -6,8 +6,8 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
-// buttondownClient imports axios (used only inside a function); stub it so the
-// module loads on the host without a full backend node_modules.
+// buttondownClient imports axios (used only inside a function); mock it so the
+// module imports cleanly on the host without a full backend node_modules.
 vi.mock('axios', () => ({ default: { create: vi.fn(() => ({})) } }));
 
 const { isSendEnabled } = await import('../services/buttondownClient.js');


### PR DESCRIPTION
## Summary

Follow-up hardening to #476. The newsletter send gate (`isSendEnabled()` in `buttondownClient.js`) was **fail-open** — `process.env.NEWSLETTER_SEND_ENABLED !== 'false'` — so a *missing* variable meant sends were ENABLED. That was the root condition behind the duplicate `[PREVIEW]` emails: every container that lacked the kill switch (long-lived dev env files, the lotor test instance, CI containers carrying the prod Buttondown key via seed data) defaulted to send-enabled.

Now **fail-closed**: sending requires an explicit `NEWSLETTER_SEND_ENABLED=true`. A forgotten or mislocated env file means NO send by default.

- `isSendEnabled()` → `=== 'true'`, exported for testing
- Reason strings updated from `=false` to `is not "true"` (unset is now also a disabled state)
- New `buttondownSendGate.unit.test.js` locks the contract: unset / `false` / truthy-but-not-`true` (`TRUE`, `1`, `yes`, ` true `, …) all disable sending
- Production env on lotor already has `NEWSLETTER_SEND_ENABLED=true` set explicitly and verified live **before** this ships, so prod keeps sending

Consistency: `BYPASS_AUTH` (the other security-sensitive flag) is already fail-closed, so this aligns the pattern. `DISABLE_LIVE_BOAT_TRACKER` stays as-is (disable-toggle, benign failure mode).

## Test plan

- [x] `buttondownSendGate.unit.test.js` — 4 cases pass (host)
- [x] `./run.sh build` passes
- [x] Existing dedup tests still pass (14 total across both newsletter unit files)
- [x] Gatehouse review: 1 finding endorsing the fix, 1 advisory (consistency) justified
- [x] Prod env verified `=true` live before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)