### PR TITLE
fix(og): news permalink resolves share image via rollup parent POI (#475)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2635,6 +2635,7 @@ async function findItemBySlugs(type, poiSlug, titleSlug) {
     `, [poi.id]);
     rows = q.rows;
   } else {
+    const poiIds = await getRollupPoiIds(pool, poi.id);
     const q = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.publication_date, n.collection_date, n.image_url, p.name AS poi_name, p.id AS poi_id,
@@ -2642,10 +2643,10 @@ async function findItemBySlugs(type, poiSlug, titleSlug) {
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
       LEFT JOIN poi_news_urls u ON u.news_id = n.id
-      WHERE n.poi_id = $1 AND n.moderation_status IN ('published', 'auto_approved')
+      WHERE n.poi_id = ANY($1) AND n.moderation_status IN ('published', 'auto_approved')
       GROUP BY n.id, p.name, p.id
       ORDER BY COALESCE(n.publication_date, n.collection_date) DESC
-    `, [poi.id]);
+    `, [poiIds]);
     rows = q.rows;
   }
 
@@ -2803,7 +2804,7 @@ app.use(async (req, res, next) => {
     const safeDesc = escapeHtml(description.length > 200 ? description.substring(0, 197) + '...' : description);
     // Image priority: source article image, then POI primary photo, then brand.
     const sourceImage = isUsableSourceImage(item.image_url) ? item.image_url : null;
-    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item.poi_id, baseUrl));
+    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item._poi.id, baseUrl));
 
     const indexPath = path.join(staticPath, 'index.html');
     let html = await fs.readFile(indexPath, 'utf-8');


### PR DESCRIPTION
Fixes #475.

## Root cause
`findItemBySlugs` filtered news with a direct `WHERE n.poi_id = $1`, while `/api/pois/:id/news` expands boundary/org parents via `getRollupPoiIds`. After the 2026-06-09 seed refresh, the first POI in the test loop with both media and news is a boundary/org POI whose news exists **only** via rollup from child POIs. So `findItemBySlugs` returned `null`, the news-permalink middleware fell through to `next()`, Express served the static `index.html` (absolute brand-fallback og:image), and `ogImages[0].endsWith(FALLBACK_IMAGE_PATH)` was `true` — failing the assertion at line 125.

## Changes (`backend/server.js`, 4 lines)
1. **`findItemBySlugs` (news branch):** expand to `getRollupPoiIds(pool, poi.id)` and `WHERE n.poi_id = ANY($1)`, matching the news API.
2. **News-permalink middleware:** resolve og:image against `item._poi.id` (slug-resolved parent POI) instead of `item.poi_id`.

## Provenance
🤖 Maiden autonomous run of **Ashigaru** — Kagetora dispatched Claude (Sonnet) in an unprivileged sandbox; diagnosed by code-reading only (no DB). **Not verified locally — relying on this PR's CI to run `ogShareImages`.** Draft, pending CI + human review.
