### PR TITLE
Water taxi landing points as full POIs + linear-feature photo fix (035)

### DIFF
--- a/.specify/specs/035-water-taxi-stop-pois/plan.md
+++ b/.specify/specs/035-water-taxi-stop-pois/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Water Taxi Landing Points as Full POIs
+
+> **Spec ID:** 035-water-taxi-stop-pois
+> **Status:** Planning
+> **Last Updated:** 2026-06-13
+> **Estimated Effort:** M
+
+## Summary
+
+Promote the four Harbor Hopper landing points into full point POIs via an
+idempotent migration, add a reusable **Food & Drink** POI/icon type, link each
+stop back to its route through `pois.stops[].poi_id` (so the map shows one marker,
+the route lists its stops, and each stop shows its serving taxi), and fix the
+linear-feature photo-upload defect by rendering the upload modal on the
+linear-feature sidebar branch.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. **Migration 083** inserts the `food_drink` icon type, inserts the 4 stop point
+   POIs at their landing-point coordinates, and writes `poi_id` back into the
+   Harbor Hopper `stops` JSONB (matching by stop name).
+2. **Map** renders stop POIs as ordinary POI markers; the decorative water-taxi
+   circle is skipped for any stop whose entry now has a `poi_id`.
+3. **Route sidebar** (Harbor Hopper) reads its `stops` array and renders an ordered,
+   clickable "Stops" list (links resolve to the stop POIs).
+4. **Stop sidebar** calls a served-by lookup that finds water-taxi POIs whose
+   `stops` contain this POI's id, and renders a "Served by …" link back to the route.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Stop link | `pois.stops[].poi_id` JSONB | Single source of truth; preserves route order; avoids the org-only `poi_associations` UI |
+| POI type | new `icons` row + `frontend/public/icons/food_drink.svg` | Same pattern as playground/restroom amenity types (spec 027) |
+| Photo fix | render `MediaUploadModal` in the linear-feature branch | Mirrors the existing point-POI modal wiring |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Data (migration + asset)
+
+- [ ] Add `frontend/public/icons/food_drink.svg` (simple fork/knife or mug glyph, matching existing icon style).
+- [ ] `backend/migrations/083_water_taxi_stop_pois.sql`:
+  - [ ] `INSERT INTO icons (food_drink, 'Food & Drink', 'food_drink.svg', <broad keywords>) ON CONFLICT (name) DO NOTHING`.
+  - [ ] Insert 4 point POIs (Cleveland Water Taxi Main Hub, Flats East Bank, Collision Bend Brewing Company, BrewDog Cleveland Outpost) with `poi_roles='{point}'` + lat/lng from the Harbor Hopper `stops`. Idempotent (`WHERE NOT EXISTS` on name+point role).
+  - [ ] Update the Harbor Hopper `stops` JSONB so each entry gains `poi_id` (subquery by stop `name` → new POI id). Idempotent (only set when missing).
+
+### Phase 2: Backend (served-by lookup)
+
+- [ ] Add `served_by` to the POI detail response (or a small `GET /api/pois/:id/serving-taxis`) returning `{id,name}` for any `water_taxi` POI whose `stops @>` `[{"poi_id": :id}]`. Read-only, public.
+
+### Phase 3: Frontend (map + sidebar)
+
+- [ ] `Map.jsx`: in the water-taxi stop loop, `if (stop.poi_id) return null;` so converted stops don't double-render.
+- [ ] `iconUtils.js` / icon config: ensure `food_drink` resolves to its marker + add to the grouped legend (spec 015) with a "Food & Drink" toggle.
+- [ ] Route sidebar (`ReadOnlyView` for linear features): render an ordered "Stops" list from `stops`, each clickable → `onSelectPoi`/destination.
+- [ ] Stop sidebar (point `ReadOnlyView`): render "Served by <taxi>" from the served-by data, clickable → linear feature.
+
+### Phase 4: Defect fix (linear-feature photo upload)
+
+- [ ] `Sidebar.jsx`: inside the `if (isLinearFeature)` return block, render
+  `{uploadModalOpen && linearFeature?.id && <MediaUploadModal poiId={linearFeature.id} … />}`,
+  mirroring the point-POI block at ~line 1236. Mark with a `// Fix:` note.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/083_water_taxi_stop_pois.sql` | Food & Drink type, 4 stop POIs, stops[].poi_id backfill |
+| `frontend/public/icons/food_drink.svg` | Food & Drink map/legend icon |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/server.js` | served-by lookup; ensure new columns/`stops.poi_id` reach the linear-feature serializer |
+| `frontend/src/components/Map.jsx` | skip decorative circle when `stop.poi_id` set |
+| `frontend/src/components/Sidebar.jsx` | render `MediaUploadModal` on linear-feature branch (defect fix) |
+| `frontend/src/components/sidebar/ReadOnlyView.jsx` | route "Stops" list + stop "Served by" link |
+| `frontend/src/utils/iconUtils.js` + legend config | `food_drink` marker + "Food & Drink" legend group |
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Harbor Hopper route shows 4 clickable stops in order; clicking opens each stop POI.
+2. Collision Bend / BrewDog render with the Food & Drink icon; no leftover circle under the marker.
+3. Each stop POI sidebar shows "Served by Harbor Hopper", clickable back to the route.
+4. Upload a photo to the Harbor Hopper (and a river/trail) — modal opens, upload succeeds.
+5. eLCee2 + its two docks are unchanged (still circles, no POIs).
+6. Re-run the container (migration re-applies) — no duplicate POIs, no errors.
+
+### Automated
+
+- [ ] Existing Playwright/Vitest suites still pass (`./run.sh test`, run by `/deploy`).
+- [ ] Add a unit test for the served-by query if a clean seam exists.
+
+---
+
+## Rollback Plan
+
+1. Migration is idempotent and additive; to revert, delete the 4 stop POIs and the
+   `food_drink` icon row, and null out `stops[].poi_id` (the circles return automatically).
+2. Frontend changes are isolated; revert the branch.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Dock POIs (Main Hub, Flats East Bank) look generic as default pins | Low | Acceptable per spec Open Q1; revisit with a dock icon later |
+| New POIs pull irrelevant Serper news | Low | No `news_url` (no Phase I); Phase II is grounded; can exclude later |
+| Double markers if `poi_id` backfill misses a name | Med | Migration matches exact stop names; verified against migration 062 data |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-13 | Initial plan |
+</content>

--- a/.specify/specs/035-water-taxi-stop-pois/spec.md
+++ b/.specify/specs/035-water-taxi-stop-pois/spec.md
@@ -75,8 +75,9 @@ Acceptance Criteria:
 
 ### New Tables
 
-None. Stops reuse the existing `pois` table (point POIs) and the existing
-`poi_associations` table for the route↔stop relationship.
+None. Stops reuse the existing `pois` table (point POIs). The route↔stop
+relationship is modeled via `pois.stops[].poi_id` plus a served-by lookup —
+**not** `poi_associations` (see Open Questions).
 
 ### Schema Changes
 
@@ -93,11 +94,11 @@ ON CONFLICT (name) DO NOTHING;
 -- 2. Promote each Harbor Hopper stop to a full point POI (idempotent on name+point role).
 --    Coordinates come from the existing Harbor Hopper pois.stops JSONB.
 
--- 3. Associate each new stop POI with the Harbor Hopper route POI
---    (poi_associations, association_type = 'water_taxi_stop').
-
--- 4. Link the route's ordered stops to their POIs: extend each stops entry with poi_id
+-- 3. Link the route's ordered stops to their POIs: extend each stops entry with poi_id
 --    so the route can list stops in order and the map can suppress the duplicate circle.
+--    (No poi_associations — the served-by direction is a stops @> poi_id lookup.)
+
+-- 4. GIN index on pois.stops for the served-by lookup (stops @> {poi_id}).
 ```
 
 - Stop POIs use `poi_roles = '{point}'`. The two breweries classify as `food_drink`

--- a/.specify/specs/035-water-taxi-stop-pois/spec.md
+++ b/.specify/specs/035-water-taxi-stop-pois/spec.md
@@ -1,0 +1,190 @@
+# Specification: Water Taxi Landing Points as Full POIs
+
+> **Spec ID:** 035-water-taxi-stop-pois
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-13
+
+## Overview
+
+The Harbor Hopper water taxi (spec 023) currently carries its landing points —
+Cleveland Water Taxi Main Hub, Flats East Bank, Collision Bend Brewing Company,
+and BrewDog Cleveland Outpost — as a decorative `stops` JSONB array rendered as
+plain circles on the route line. These are real destinations (breweries, docks)
+that deserve their own pages. This feature promotes each Harbor Hopper stop into
+a full point POI with its own sidebar, photos, news, and events, introduces a
+reusable **Food & Drink** POI type for the breweries/restaurants, and links each
+stop back to the route it is served by.
+
+It also fixes a defect that surfaced while testing this work: photos cannot be
+uploaded to a linear-feature POI (the Harbor Hopper itself, rivers, trails) —
+the "Add Photo/Video" button does nothing because the upload modal is never
+rendered on the linear-feature code path.
+
+---
+
+## User Stories
+
+### Landing Points as Destinations
+
+**US-035-1: Explore a landing point as a full destination**
+> As a map visitor, I want each Harbor Hopper stop to be a real place I can open
+> so that I can see its photos, news, events, and details — not just a dot on a line.
+
+Acceptance Criteria:
+- [ ] Each of the four Harbor Hopper stops exists as a full point POI (own marker, sidebar, tabs).
+- [ ] Stop POIs sit at their existing landing-point coordinates.
+- [ ] Stop POIs support photos, news, and events through the existing POI flows.
+- [ ] No duplicate marker: a stop that is now a POI no longer also renders as a decorative route circle.
+
+**US-035-2: A reusable Food & Drink POI type**
+> As an admin, I want a "Food & Drink" POI type so that breweries, pubs, and
+> restaurants (Collision Bend, BrewDog, Noisy Oyster, Fishers Pub, Winking Lizard,
+> Green Valley Brewing Co., …) get a recognizable icon and legend toggle.
+
+Acceptance Criteria:
+- [ ] A new `Food & Drink` icon type is added with its own map icon and legend entry.
+- [ ] Its `title_keywords` are broad enough to classify the listed venues by name (brewing, brewery, pub, tavern, taproom, grill, eatery, restaurant, bar, oyster, lizard, …).
+- [ ] Collision Bend Brewing Company and BrewDog Cleveland Outpost classify as Food & Drink.
+- [ ] The type is selectable when creating/editing any POI, not just water-taxi stops.
+
+**US-035-3: Navigate between a route and its stops**
+> As a visitor, I want the Harbor Hopper route and its stops to be linked so that
+> I can jump from the route to a stop and see which taxi serves a stop.
+
+Acceptance Criteria:
+- [ ] The Harbor Hopper sidebar lists its stops in route order, each clickable to open the stop POI.
+- [ ] Each stop POI's sidebar shows that it is served by the Harbor Hopper (association), clickable back to the route.
+- [ ] Clicking a stop marker on the map opens the stop POI sidebar.
+
+### Defect Fix
+
+**US-035-4: Upload a photo to a linear-feature POI**
+> As a signed-in user, I want to add a photo to the Harbor Hopper (and any river
+> or trail) so that the gallery is not silently broken for linear features.
+
+Acceptance Criteria:
+- [ ] On a linear-feature POI sidebar, clicking "+ Add Photo/Video" opens the upload modal.
+- [ ] Uploading succeeds and the new media appears after moderation, same as for point POIs.
+- [ ] The fix is marked with a `// Fix: <desc> (PR #N review)`-style inline note per the constitution.
+
+---
+
+## Data Model
+
+### New Tables
+
+None. Stops reuse the existing `pois` table (point POIs) and the existing
+`poi_associations` table for the route↔stop relationship.
+
+### Schema Changes
+
+```sql
+-- Migration 0NN: water taxi stops as full POIs (#035)
+
+-- 1. New reusable Food & Drink icon/POI type (broad name keywords).
+INSERT INTO icons (name, label, svg_filename, title_keywords, activity_fallbacks, sort_order)
+VALUES ('food_drink', 'Food & Drink', 'food_drink.svg',
+        'brewing,brewery,brewpub,taproom,pub,tavern,bar,grill,kitchen,eatery,restaurant,diner,cafe,oyster,lizard,ale,distillery,winery',
+        NULL, <sort_order>)
+ON CONFLICT (name) DO NOTHING;
+
+-- 2. Promote each Harbor Hopper stop to a full point POI (idempotent on name+point role).
+--    Coordinates come from the existing Harbor Hopper pois.stops JSONB.
+
+-- 3. Associate each new stop POI with the Harbor Hopper route POI
+--    (poi_associations, association_type = 'water_taxi_stop').
+
+-- 4. Link the route's ordered stops to their POIs: extend each stops entry with poi_id
+--    so the route can list stops in order and the map can suppress the duplicate circle.
+```
+
+- Stop POIs use `poi_roles = '{point}'`. The two breweries classify as `food_drink`
+  by name; the two dock terminals (Main Hub, Flats East Bank) fall back to the
+  default point marker (see Open Questions).
+- `pois.stops` entries gain an optional `poi_id`: `[{name,lat,lng,poi_id}]`. When
+  `poi_id` is set, the map renders the real POI marker instead of the decorative circle.
+- The eLCee2 shuttle and its two docks are unchanged.
+
+---
+
+## API Endpoints
+
+No new endpoints.
+
+- Stop POIs are served by the existing `/api/pois`, `/api/pois/:id`, news/events,
+  and media endpoints like any point POI.
+- The existing associations endpoints surface the route↔stop relationship in both
+  directions (route lists stops; stop shows serving route).
+- The Food & Drink type flows to the frontend through the existing icon-config
+  endpoint with no code change.
+
+---
+
+## UI/UX Requirements
+
+### Map / Legend
+
+- New **Food & Drink** legend toggle and map icon (grouped legend, spec 015).
+- Harbor Hopper stops render as their POI markers; the decorative route circle is
+  suppressed for any stop that now has a `poi_id`. eLCee2 circles are untouched.
+
+### Sidebar
+
+- **Harbor Hopper (route) sidebar:** lists its stops in route order, each clickable.
+- **Stop POI sidebar:** standard point-POI sidebar (view/news/events/photos) plus a
+  "Served by Harbor Hopper" association link.
+- **Linear-feature photo upload (defect):** render the `MediaUploadModal` on the
+  linear-feature sidebar branch so "+ Add Photo/Video" works for water taxis,
+  rivers, and trails.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-035-1: Idempotent migration**
+- Re-runs cleanly on every container start (guarded inserts, `ON CONFLICT DO NOTHING`,
+  `WHERE NOT EXISTS`), per the project migration rules.
+
+**NFR-035-2: No regressions for existing water taxis**
+- eLCee2 and its docks, and the Harbor Hopper route line itself, render exactly as before.
+
+**NFR-035-3: Collection eligibility**
+- Food & Drink POIs are eligible for news/events collection (breweries host events);
+  the type is NOT added to `news_collection_excluded_types`.
+
+---
+
+## Dependencies
+
+- Depends on: water taxis (spec 023), amenity POI types / icon system (spec 027),
+  grouped legend (spec 015), POI associations.
+- Blocks: none.
+
+---
+
+## Open Questions
+
+1. **Dock stop typing** — "Cleveland Water Taxi Main Hub" and "Flats East Bank" are
+   transit docks, not food/drink. Default decision: they become point POIs with the
+   default marker (no new dock icon this round). Revisit if a dedicated dock/ferry
+   icon is wanted later.
+2. ~~**Association modeling**~~ **RESOLVED:** Do **not** use `poi_associations`.
+   The associations UI (`AssociationsTabContent.jsx`) is hardwired to the
+   organization↔physical model (`isVirtualPoi = poi_roles.includes('organization')`,
+   and it resolves the other side only from `allVirtualPois` = organizations), so a
+   `water_taxi` route can be neither side and would mislabel the relationship. The
+   route↔stop link is modeled by `pois.stops[].poi_id` (route→stop, already ordered)
+   plus a small served-by lookup that finds `water_taxi` POIs whose `stops` contain a
+   given `poi_id` (stop→route). Single source of truth, no org-system entanglement.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-13 | Initial draft |
+</content>
+</invoke>

--- a/backend/migrations/083_water_taxi_stop_pois.sql
+++ b/backend/migrations/083_water_taxi_stop_pois.sql
@@ -81,6 +81,8 @@ SET geometry = '{"type":"LineString","coordinates":[[-81.706867,41.497019],[-81.
     updated_at = NOW()
 WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles)
   AND geometry IS NOT NULL
+  AND jsonb_typeof(geometry->'coordinates') = 'array'
+  AND jsonb_array_length(geometry->'coordinates') > 0
   AND (geometry->'coordinates'->0->>0)::numeric = -81.707759;
 
 -- 5. GIN index for the served-by lookup (GET /api/pois/:id/serving-taxis), which

--- a/backend/migrations/083_water_taxi_stop_pois.sql
+++ b/backend/migrations/083_water_taxi_stop_pois.sql
@@ -83,4 +83,9 @@ WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles)
   AND geometry IS NOT NULL
   AND (geometry->'coordinates'->0->>0)::numeric = -81.707759;
 
+-- 5. GIN index for the served-by lookup (GET /api/pois/:id/serving-taxis), which
+--    filters pois.stops with the @> containment operator. Without this the query
+--    full-scans pois on every stop sidebar open (Gatehouse PR #480 review).
+CREATE INDEX IF NOT EXISTS idx_pois_stops_gin ON pois USING GIN (stops);
+
 COMMIT;

--- a/backend/migrations/083_water_taxi_stop_pois.sql
+++ b/backend/migrations/083_water_taxi_stop_pois.sql
@@ -1,0 +1,86 @@
+-- Migration 083: Water taxi landing points as full POIs (#035)
+-- Promotes the four Harbor Hopper stops into full point POIs, adds a reusable
+-- Food & Drink POI/icon type, and links each stop back to its route via
+-- pois.stops[].poi_id (so the map shows one marker, the route lists its stops,
+-- and each stop can show its serving taxi).
+-- Idempotent: re-runs cleanly on every container start.
+
+BEGIN;
+
+-- 1. Reusable Food & Drink POI/icon type. Auto-classified by NAME keyword and
+--    auto-listed in the legend (Map.jsx builds the legend from the icons table).
+--    Keywords are broad enough to catch breweries/pubs/restaurants by name
+--    (Collision Bend Brewing, BrewDog, Noisy Oyster, Fishers Pub, Winking Lizard,
+--    Green Valley Brewing Co., ...). No activity_fallbacks: a POI "is" Food & Drink
+--    only when its name says so, not because a park lists dining among activities.
+--    sort_order 3 keeps it ahead of the generic park types for classification; the
+--    legend itself sorts by label, so this does not affect legend order.
+INSERT INTO icons (name, label, svg_filename, title_keywords, activity_fallbacks, sort_order)
+VALUES ('food_drink', 'Food & Drink', 'food_drink.svg',
+        'brewing,brewery,brewpub,brewdog,taproom,pub,tavern,alehouse,grill,kitchen,eatery,restaurant,diner,bistro,cafe,oyster,lizard,distillery,winery',
+        NULL, 3)
+ON CONFLICT (name) DO NOTHING;
+
+-- Keep keywords/priority correct even if the row already existed from a prior run.
+UPDATE icons
+SET label = 'Food & Drink',
+    svg_filename = 'food_drink.svg',
+    title_keywords = 'brewing,brewery,brewpub,brewdog,taproom,pub,tavern,alehouse,grill,kitchen,eatery,restaurant,diner,bistro,cafe,oyster,lizard,distillery,winery',
+    activity_fallbacks = NULL,
+    sort_order = 3
+WHERE name = 'food_drink';
+
+-- 2. Promote each Harbor Hopper stop to a full point POI at its landing-point
+--    coordinates (sourced from the Harbor Hopper pois.stops seeded in migration 062).
+--    Guarded by NOT EXISTS on (name, point role) so re-runs are no-ops.
+INSERT INTO pois (name, poi_roles, latitude, longitude, brief_description)
+SELECT v.name, ARRAY['point']::text[], v.lat, v.lng, v.brief
+FROM (VALUES
+  ('Cleveland Water Taxi Main Hub', 41.49701884, -81.70686722,
+   'Primary Harbor Hopper water taxi dock in the Cleveland Flats.'),
+  ('Flats East Bank', 41.499108, -81.705831,
+   'Harbor Hopper water taxi landing at the Flats East Bank entertainment district.'),
+  ('Collision Bend Brewing Company', 41.498449, -81.703964,
+   'Riverside brewpub on the Cuyahoga''s Collision Bend in the Flats, a Harbor Hopper water taxi stop.'),
+  ('BrewDog Cleveland Outpost', 41.493053, -81.699054,
+   'Craft beer bar and kitchen on the Cuyahoga in the Flats, served by the Harbor Hopper water taxi.')
+) AS v(name, lat, lng, brief)
+WHERE NOT EXISTS (
+  SELECT 1 FROM pois p WHERE p.name = v.name AND 'point' = ANY(p.poi_roles)
+);
+
+-- 3. Link the Harbor Hopper route's ordered stops to their new POIs: stamp poi_id
+--    onto each stops entry (matched by stop name). The map suppresses the
+--    decorative circle when a stop has a poi_id, and the route lists its stops.
+--    Rebuilds the array preserving order; re-runs set the same poi_id (idempotent).
+UPDATE pois ht
+SET stops = (
+      SELECT jsonb_agg(
+               CASE WHEN sp.id IS NOT NULL
+                    THEN e.elem || jsonb_build_object('poi_id', sp.id)
+                    ELSE e.elem END
+               ORDER BY e.ord)
+      FROM jsonb_array_elements(ht.stops) WITH ORDINALITY AS e(elem, ord)
+      LEFT JOIN pois sp ON sp.name = (e.elem->>'name') AND 'point' = ANY(sp.poi_roles)
+    ),
+    updated_at = NOW()
+WHERE ht.name = 'Harbor Hopper' AND 'water_taxi' = ANY(ht.poi_roles)
+  AND ht.stops IS NOT NULL;
+
+-- 4. Fix the Harbor Hopper route terminal. The OSM ferry geometry seeded in
+--    migration 062 already follows the water and connects the stops (Flats East
+--    Bank, Collision Bend, BrewDog) correctly, but its west-bank tail curved along
+--    the south shore to a wrong Main Hub ~85m off the real dock (confirmed by
+--    riding the taxi). This keeps the entire OSM route and only drops that last
+--    curve to the old hub, extending straight to the corrected Main Hub dock — the
+--    new hub sits SE so the extension continues the same heading without a kink.
+--    Guarded to the shipped-bad geometry (old start longitude) so it applies once
+--    on existing deployments, stays idempotent, and never clobbers a hand edit.
+UPDATE pois
+SET geometry = '{"type":"LineString","coordinates":[[-81.706867,41.497019],[-81.70809,41.497307],[-81.708376,41.497354],[-81.708678,41.497425],[-81.708797,41.497495],[-81.708846,41.49759],[-81.708836,41.497727],[-81.708778,41.497827],[-81.707897,41.498698],[-81.707753,41.49877],[-81.707323,41.498839],[-81.706654,41.498896],[-81.7062,41.498947],[-81.705969,41.499026],[-81.705831,41.499108],[-81.705819,41.499035],[-81.705751,41.498916],[-81.70564,41.498829],[-81.705324,41.498698],[-81.705094,41.49861],[-81.704837,41.498533],[-81.7045,41.498458],[-81.704191,41.498415],[-81.703964,41.498449],[-81.703978,41.498356],[-81.703924,41.49823],[-81.703709,41.49803],[-81.702738,41.497537],[-81.702438,41.497366],[-81.702137,41.497105],[-81.701968,41.496859],[-81.701876,41.496638],[-81.701886,41.496304],[-81.701978,41.496025],[-81.702617,41.494919],[-81.70388,41.492931],[-81.704059,41.492605],[-81.704176,41.492239],[-81.704384,41.491484],[-81.704447,41.491017],[-81.704423,41.49056],[-81.704297,41.490121],[-81.704074,41.489841],[-81.70357,41.489461],[-81.702936,41.489054],[-81.702316,41.488757],[-81.701755,41.488547],[-81.701169,41.488456],[-81.700636,41.48842],[-81.700225,41.488434],[-81.699915,41.488529],[-81.699687,41.488645],[-81.699421,41.488891],[-81.699087,41.489268],[-81.698879,41.48962],[-81.698787,41.489867],[-81.698768,41.49015],[-81.69885,41.490436],[-81.699198,41.490984],[-81.699416,41.491379],[-81.699557,41.491934],[-81.699547,41.492405],[-81.699484,41.492696],[-81.699363,41.492942],[-81.699286,41.493019],[-81.699176,41.493056],[-81.699054,41.493053]]}'::jsonb,
+    updated_at = NOW()
+WHERE name = 'Harbor Hopper' AND 'water_taxi' = ANY(poi_roles)
+  AND geometry IS NOT NULL
+  AND (geometry->'coordinates'->0->>0)::numeric = -81.707759;
+
+COMMIT;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1721,6 +1721,32 @@ app.get('/api/pois/:id/associations', async (req, res) => {
   }
 });
 
+/**
+ * GET /api/pois/:id/serving-taxis
+ * Water-taxi POIs whose stops include this POI id — powers the stop POI sidebar's
+ * "Served by <taxi>" link (spec 035). Read-only, public.
+ */
+app.get('/api/pois/:id/serving-taxis', async (req, res) => {
+  try {
+    const poiId = parseInt(req.params.id, 10);
+    if (Number.isNaN(poiId)) {
+      return res.status(400).json({ error: 'Invalid POI id' });
+    }
+    const servingTaxisQuery = await pool.query(`
+      SELECT id, name
+      FROM pois
+      WHERE poi_roles @> ARRAY['water_taxi']::text[]
+        AND stops @> jsonb_build_array(jsonb_build_object('poi_id', $1::int))
+        AND (deleted IS NULL OR deleted = FALSE)
+      ORDER BY name
+    `, [poiId]);
+    res.json(servingTaxisQuery.rows);
+  } catch (error) {
+    console.error('Error fetching serving taxis:', error);
+    res.status(500).json({ error: 'Failed to fetch serving taxis' });
+  }
+});
+
 app.get('/api/associations', async (req, res) => {
   try {
     const associationsQuery = await pool.query(`

--- a/frontend/public/icons/food_drink.svg
+++ b/frontend/public/icons/food_drink.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="15" fill="#6d4c41" stroke="white" stroke-width="2"/>
+  <rect x="9.5" y="11" width="9" height="12" rx="1.5" fill="none" stroke="white" stroke-width="1.8"/>
+  <path d="M18.5 13.5 q4 0 4 3.5 t-4 3.5" fill="none" stroke="white" stroke-width="1.8"/>
+  <line x1="9.5" y1="15" x2="18.5" y2="15" stroke="white" stroke-width="1.6"/>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15470,3 +15470,47 @@ button.feedback-link-inline {
   cursor: pointer;
 }
 .river-gauge-dot-btn.active { background: #1e6fb8; }
+
+/* Water taxi route stops list + stop "served by" link (spec 035) */
+.water-taxi-stops {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+.water-taxi-stops li {
+  margin: 0.2rem 0;
+}
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #4a7c23;
+  font: inherit;
+  text-align: left;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.link-button:hover {
+  color: #2d5016;
+}
+.served-by {
+  margin: 0;
+}
+
+/* Boat live-status badge: in the hover tooltip it sits next to the title; in the
+   Info panel it joins the other service badges at service-badge size (spec 035) */
+.tooltip-title-row {
+  display: flex;
+  align-items: center;
+}
+.service-badge.live {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+.service-badge.docked {
+  background: #fff3e0;
+  color: #e65100;
+}
+.service-badge.offline {
+  background: #f5f5f5;
+  color: #999;
+}

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1478,6 +1478,18 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     }
   };
 
+  // The live boat and its route are the same POI: find the Harbor Hopper linear
+  // feature (the only water_taxi with a tracker) so the boat marker shares its
+  // tooltip and opens the same Info panel (spec 035).
+  const boatFeature = useMemo(
+    () => linearFeatures?.find(f => f.poi_roles?.includes('water_taxi') && /^https?:\/\//i.test(f.live_tracker_url || '')),
+    [linearFeatures]
+  );
+  const boatStatusLabel = boatPosition?.status === 'active' ? 'Live'
+    : boatPosition?.status === 'docked' ? 'Docked' : 'Offline';
+  const boatStatusClass = boatPosition?.status === 'active' ? 'live'
+    : boatPosition?.status === 'docked' ? 'docked' : 'offline';
+
   const getLinearFeatureStyle = useCallback((feature, isSelected) => {
     const editSelectedColor = '#FF8C00';
     const viewSelectedColor = '#0066CC';
@@ -1796,28 +1808,45 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             ? feature.name?.toLowerCase().includes(searchQuery.toLowerCase())
             : showWaterTaxis;
           if (!stopsVisible) return null;
-          return feature.stops.map((stop, i) => (
-            <CircleMarker
-              key={`wt-stop-${feature.id}-${i}`}
-              center={[stop.lat, stop.lng]}
-              radius={5}
-              pathOptions={{ color: '#ffffff', weight: 2, fillColor: '#0E9E9E', fillOpacity: 1 }}
-            >
-              <Tooltip direction="top" offset={[0, -4]}>{stop.name}</Tooltip>
-            </CircleMarker>
-          ));
+          return feature.stops.map((stop, i) => {
+            if (stop.poi_id) return null;
+            return (
+              <CircleMarker
+                key={`wt-stop-${feature.id}-${i}`}
+                center={[stop.lat, stop.lng]}
+                radius={5}
+                pathOptions={{ color: '#ffffff', weight: 2, fillColor: '#0E9E9E', fillOpacity: 1 }}
+              >
+                <Tooltip direction="top" offset={[0, -4]}>{stop.name}</Tooltip>
+              </CircleMarker>
+            );
+          });
         })}
 
-        {showWaterTaxis && boatPosition && (
+        {showWaterTaxis && boatPosition && boatFeature && (
           <Marker
             position={[boatPosition.latitude, boatPosition.longitude]}
             icon={createBoatIcon(boatPosition.heading, boatPosition.status)}
             zIndexOffset={500}
             keyboard={false}
+            eventHandlers={{ click: () => handleLinearFeatureClick(boatFeature) }}
           >
-            <Tooltip direction="top" offset={[0, -14]}>
-              {boatPosition.status === 'docked' ? 'Harbor Hopper (Docked)' : 'Harbor Hopper (Live)'}
-            </Tooltip>
+            {selectedLinearFeature?.id !== boatFeature.id && (
+              <Tooltip direction="top" offset={[0, -14]} className="destination-tooltip">
+                <div className="tooltip-content">
+                  {boatFeature.has_primary_image && (
+                    <div className="tooltip-thumbnail">
+                      <img src={`/api/pois/${boatFeature.id}/thumbnail?size=medium`} alt="" />
+                    </div>
+                  )}
+                  <div className="tooltip-title-row">
+                    <strong>{boatFeature.name}</strong>
+                    <span className={`boat-status-badge ${boatStatusClass}`}>{boatStatusLabel}</span>
+                  </div>
+                  {boatFeature.brief_description && <p>{boatFeature.brief_description}</p>}
+                </div>
+              </Tooltip>
+            )}
           </Marker>
         )}
 

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -4,6 +4,7 @@ import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents
 import L from 'leaflet';
 import VirtualPoiCreator from './VirtualPoiCreator';
 import { getDestinationIconTypeFromConfig, poiMatchesActivityForTypes, trailPassesActivityFilter, matchesWholeWord } from '../utils/iconUtils';
+import { getBoatStatus } from '../utils/boatStatus';
 import { useTrip } from '../hooks/useTrip';
 import { useNavigate } from 'react-router-dom';
 import { generateSlug } from './sidebar/helpers';
@@ -1485,10 +1486,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     () => linearFeatures?.find(f => f.poi_roles?.includes('water_taxi') && /^https?:\/\//i.test(f.live_tracker_url || '')),
     [linearFeatures]
   );
-  const boatStatusLabel = boatPosition?.status === 'active' ? 'Live'
-    : boatPosition?.status === 'docked' ? 'Docked' : 'Offline';
-  const boatStatusClass = boatPosition?.status === 'active' ? 'live'
-    : boatPosition?.status === 'docked' ? 'docked' : 'offline';
+  const { label: boatStatusLabel, className: boatStatusClass } = getBoatStatus(boatPosition);
 
   const getLinearFeatureStyle = useCallback((feature, isSelected) => {
     const editSelectedColor = '#FF8C00';

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -83,7 +83,7 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
     fetch(`/api/pois/${pointId}/serving-taxis`)
       .then(r => (r.ok ? r.json() : []))
       .then(data => { if (!cancelled) setServingTaxis(Array.isArray(data) ? data : []); })
-      .catch(() => { if (!cancelled) setServingTaxis([]); });
+      .catch((err) => { if (!cancelled) { console.error('Error fetching serving taxis:', err); setServingTaxis([]); } });
     return () => { cancelled = true; };
   }, [destination?.id, destination?.poi_roles]);
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -74,6 +74,18 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
   const [trailStatus, setTrailStatus] = useState(null);
   const [tabCounts, setTabCounts] = useState({ news_count: null, events_count: null });
   const [hasGauges, setHasGauges] = useState(null);
+  const [servingTaxis, setServingTaxis] = useState([]);
+
+  useEffect(() => {
+    const pointId = destination?.id;
+    if (!pointId || !destination?.poi_roles?.includes('point')) { setServingTaxis([]); return undefined; }
+    let cancelled = false;
+    fetch(`/api/pois/${pointId}/serving-taxis`)
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => { if (!cancelled) setServingTaxis(Array.isArray(data) ? data : []); })
+      .catch(() => { if (!cancelled) setServingTaxis([]); });
+    return () => { cancelled = true; };
+  }, [destination?.id, destination?.poi_roles]);
 
   const [selectedPoiIds, setSelectedPoiIds] = useState(new Set());
 
@@ -804,6 +816,11 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
                 trailStatus={trailStatus}
                 onCollectStatus={handleCollectStatusInline}
                 boatPosition={boatPosition}
+                stops={linearFeature.stops}
+                onSelectStop={(poiId) => {
+                  const d = allDestinations?.find(dest => dest.id === poiId);
+                  if (d) onSelectPoi(d);
+                }}
               />
             )
           )}
@@ -871,6 +888,18 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
           )}
         </div>
         </div> {/* End sidebar-content-wrapper */}
+
+        {/* Fix: render the upload modal on the linear-feature branch so "+ Add Photo/Video" works for water taxis, rivers, and trails (PR #035 review) */}
+        {uploadModalOpen && linearFeature?.id && (
+          <MediaUploadModal
+            poiId={linearFeature.id}
+            onClose={() => setUploadModalOpen(false)}
+            onSuccess={() => {
+              setUploadModalOpen(false);
+              handleMediaUpdate();
+            }}
+          />
+        )}
 
         <ShareModal
           isOpen={showShareModal}
@@ -1093,6 +1122,11 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
               trailStatus={trailStatus}
               onCollectStatus={handleCollectStatusInline}
               boatPosition={boatPosition}
+              servingTaxis={servingTaxis}
+              onSelectServingTaxi={(taxiId) => {
+                const f = allLinearFeatures?.find(feat => feat.id === taxiId);
+                if (f) onSelectPoi(f);
+              }}
             />
           )
         )}

--- a/frontend/src/components/sidebar/ReadOnlyView.jsx
+++ b/frontend/src/components/sidebar/ReadOnlyView.jsx
@@ -5,16 +5,14 @@ import FavoriteToggle from '../FavoriteToggle';
 import VisitedToggle from '../VisitedToggle';
 import CellSignal from './CellSignal';
 import { getNavigationStops, getOwnerClass, formatCoordinate, WHEELCHAIR_LABELS, FEE_LABELS, humanizeOpeningHours } from './helpers';
+import { getBoatStatus } from '../../utils/boatStatus';
 
 function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, onCollectStatus, boatPosition, stops = null, onSelectStop = null, servingTaxis = null, onSelectServingTaxi = null }) {
   // Fix: only honor http(s) tracker URLs so a stored javascript: URL can't run on click (PR #405 review)
   const liveTrackerUrl = /^https?:\/\//i.test(destination.live_tracker_url || '')
     ? destination.live_tracker_url
     : null;
-  const boatStatusLabel = boatPosition?.status === 'active' ? 'Live'
-    : boatPosition?.status === 'docked' ? 'Docked' : 'Offline';
-  const boatStatusClass = boatPosition?.status === 'active' ? 'live'
-    : boatPosition?.status === 'docked' ? 'docked' : 'offline';
+  const { label: boatStatusLabel, className: boatStatusClass } = getBoatStatus(boatPosition);
   return (
     <div className="view-container">
       <div className="view-scroll">

--- a/frontend/src/components/sidebar/ReadOnlyView.jsx
+++ b/frontend/src/components/sidebar/ReadOnlyView.jsx
@@ -6,11 +6,15 @@ import VisitedToggle from '../VisitedToggle';
 import CellSignal from './CellSignal';
 import { getNavigationStops, getOwnerClass, formatCoordinate, WHEELCHAIR_LABELS, FEE_LABELS, humanizeOpeningHours } from './helpers';
 
-function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, onCollectStatus, boatPosition }) {
+function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare, moreInfoLink, trailStatus = null, onCollectStatus, boatPosition, stops = null, onSelectStop = null, servingTaxis = null, onSelectServingTaxi = null }) {
   // Fix: only honor http(s) tracker URLs so a stored javascript: URL can't run on click (PR #405 review)
   const liveTrackerUrl = /^https?:\/\//i.test(destination.live_tracker_url || '')
     ? destination.live_tracker_url
     : null;
+  const boatStatusLabel = boatPosition?.status === 'active' ? 'Live'
+    : boatPosition?.status === 'docked' ? 'Docked' : 'Offline';
+  const boatStatusClass = boatPosition?.status === 'active' ? 'live'
+    : boatPosition?.status === 'docked' ? 'docked' : 'offline';
   return (
     <div className="view-container">
       <div className="view-scroll">
@@ -54,6 +58,11 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
           {destination.is_bike_friendly && (
             <span className="service-badge bike" title="Bike-friendly">
               Bike-friendly
+            </span>
+          )}
+          {liveTrackerUrl && (
+            <span className={`service-badge ${boatStatusClass}`} title="Live boat status">
+              {boatStatusLabel}
             </span>
           )}
           {destination.era_name && !destination.poi_roles?.includes('organization') && (
@@ -117,6 +126,46 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
           <div className="section">
             <h3>Overview</h3>
             <p>{destination.brief_description}</p>
+          </div>
+        )}
+
+        {isLinearFeature && Array.isArray(stops) && stops.length > 0 && (
+          <div className="section">
+            <h3>Stops</h3>
+            <ol className="water-taxi-stops">
+              {stops.map((stop, i) => (
+                <li key={`${stop.name}-${i}`}>
+                  {stop.poi_id && onSelectStop ? (
+                    <button type="button" className="link-button" onClick={() => onSelectStop(stop.poi_id)}>
+                      {stop.name}
+                    </button>
+                  ) : (
+                    <span>{stop.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        {!isLinearFeature && Array.isArray(servingTaxis) && servingTaxis.length > 0 && (
+          <div className="section">
+            <h3>Water Taxi</h3>
+            <p className="served-by">
+              Served by{' '}
+              {servingTaxis.map((taxi, i) => (
+                <span key={taxi.id}>
+                  {i > 0 && ', '}
+                  {onSelectServingTaxi ? (
+                    <button type="button" className="link-button" onClick={() => onSelectServingTaxi(taxi.id)}>
+                      {taxi.name}
+                    </button>
+                  ) : (
+                    taxi.name
+                  )}
+                </span>
+              ))}
+            </p>
           </div>
         )}
 
@@ -207,9 +256,6 @@ function ReadOnlyView({ destination, isLinearFeature, isAdmin, editMode, onShare
                 <path fill="currentColor" d="M12,8A4,4 0 0,0 8,12A4,4 0 0,0 12,16A4,4 0 0,0 16,12A4,4 0 0,0 12,8M12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z" />
               </svg>
             </a>
-            <span className={`boat-status-badge ${boatPosition?.status === 'active' ? 'live' : boatPosition?.status === 'docked' ? 'docked' : 'offline'}`}>
-              {boatPosition?.status === 'active' ? 'Live' : boatPosition?.status === 'docked' ? 'Docked' : 'Offline'}
-            </span>
           </div>
         )}
 

--- a/frontend/src/utils/boatStatus.js
+++ b/frontend/src/utils/boatStatus.js
@@ -1,0 +1,12 @@
+/**
+ * Map a live boat position's status to a display label + CSS modifier class.
+ * Shared by the map tooltip (Map.jsx) and the sidebar badge (ReadOnlyView.jsx)
+ * so the two stay in sync (#035).
+ * @param {{status?: string}|null} boatPosition
+ * @returns {{label: string, className: string}}
+ */
+export function getBoatStatus(boatPosition) {
+  if (boatPosition?.status === 'active') return { label: 'Live', className: 'live' };
+  if (boatPosition?.status === 'docked') return { label: 'Docked', className: 'docked' };
+  return { label: 'Offline', className: 'offline' };
+}


### PR DESCRIPTION
## Summary
- **Landing points → full POIs** (migration 083): the 4 Harbor Hopper stops (Cleveland Water Taxi Main Hub, Flats East Bank, Collision Bend Brewing Company, BrewDog Cleveland Outpost) become full point POIs with their own sidebar, photos, news, and events.
- **New reusable "Food & Drink" POI type** — broad name keywords so it classifies breweries/pubs/restaurants (Collision Bend, BrewDog, and future venues like Winking Lizard, Noisy Oyster, Fishers Pub, Green Valley Brewing Co.).
- **Route ↔ stop linkage** via `stops[].poi_id`: the map renders each stop's POI marker (no duplicate circle), the route sidebar lists its stops, and each stop shows a "Served by Harbor Hopper" link (`GET /api/pois/:id/serving-taxis`).
- **Defect fix:** `MediaUploadModal` now renders on the linear-feature sidebar branch — photo upload was a dead button for water taxis, rivers, and trails.
- **Boat ↔ route unification:** the live boat marker opens the same Info panel as the route on click and shows the same image/description + live status on hover; the live status badge sits with the other sidebar badges.
- **Main Hub + route geometry:** relocated the Main Hub to the real dock; kept the OSM ferry route (which connects all stops) and replaced only the tail that curved to the old hub with a straight extension to the new hub.

Spec: `.specify/specs/035-water-taxi-stop-pois/`

Closes #28 (follow-up work)

## Test plan
- [x] Build passes (`./run.sh build`)
- [x] Migration 083 idempotent; 4 POIs + Food & Drink type + stops[].poi_id verified
- [x] Photo upload verified working on the Harbor Hopper (user-confirmed)
- [x] Route follows OSM data, connects all stops, extends to the new hub (user-confirmed)
- [x] gourmand clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)