### PR TITLE
fix: stop commercial POIs over-collecting and rejecting their own news

### DIFF
--- a/backend/migrations/043_add_collection_tier.sql
+++ b/backend/migrations/043_add_collection_tier.sql
@@ -3,45 +3,68 @@
 -- Default is 'weekly' (safe middle ground)
 -- The collection_tier column is the single source of truth for scheduling.
 -- Admins can change any POI's tier at any time via the admin panel.
+--
+-- IMPORTANT: entrypoint.sh re-applies every migration on each container start,
+-- so the one-time data backfill below MUST only run when the column is first
+-- introduced. If it ran every boot it would revert admin tier changes on every
+-- restart — which is exactly what kept forcing commercial POIs that have a
+-- Facebook events_url (e.g. Green Valley Brewing Co.) back to 'daily'.
 
-ALTER TABLE pois ADD COLUMN IF NOT EXISTS collection_tier TEXT DEFAULT 'weekly';
-
--- Add CHECK constraint for valid values
 DO $$
+DECLARE
+  col_existed boolean;
 BEGIN
+  -- Capture whether the column already exists BEFORE we add it. On an existing
+  -- database (every prod restart) this is true and the backfill is skipped, so
+  -- tiers set by an admin are preserved. On a fresh database it is false and the
+  -- backfill runs exactly once.
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'pois' AND column_name = 'collection_tier'
+  ) INTO col_existed;
+
+  -- DDL — idempotent, safe on every re-run.
+  ALTER TABLE pois ADD COLUMN IF NOT EXISTS collection_tier TEXT DEFAULT 'weekly';
+
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint WHERE conname = 'pois_collection_tier_check'
   ) THEN
     ALTER TABLE pois ADD CONSTRAINT pois_collection_tier_check
       CHECK (collection_tier IN ('daily', 'weekly', 'monthly'));
   END IF;
+
+  -- One-time data backfill — only on first introduction of the column.
+  IF NOT col_existed THEN
+    -- Daily: POIs with a dedicated NEWS feed, plus Cleveland Metroparks.
+    -- events_url is intentionally NOT a daily trigger: a Facebook events page is
+    -- common for small/commercial POIs and causes daily over-collection. Such
+    -- POIs default to 'weekly' and an admin can promote them if warranted.
+    UPDATE pois SET collection_tier = 'daily'
+    WHERE (news_url IS NOT NULL AND news_url != '')
+       OR id = 5658;  -- Cleveland Metroparks (ToS prevents crawling, but Serper coverage is frequent)
+
+    -- Monthly: known low-activity POIs (0-1 published items, no dedicated URLs)
+    -- still at the default.
+    UPDATE pois SET collection_tier = 'monthly'
+    WHERE collection_tier = 'weekly'  -- only demote POIs still at default, not ones just set to daily
+      AND id IN (
+      5475, 5477, 5478, 5480, 5482, 5486, 5491, 5492, 5494, 5495,
+      5496, 5497, 5498, 5500, 5501, 5502, 5504, 5506, 5513, 5514,
+      5516, 5517, 5518, 5519, 5522, 5525, 5526, 5529, 5530, 5532,
+      5534, 5535, 5536, 5538, 5540, 5542, 5546, 5547, 5551, 5554,
+      5555, 5556, 5558, 5560, 5564, 5565, 5566, 5569, 5570, 5571,
+      5572, 5573, 5574, 5576, 5578, 5579, 5581, 5582, 5584, 5586,
+      5587, 5591, 5592, 5595, 5596, 5597, 5598, 5599, 5601, 5607,
+      5609, 5610, 5611, 5616, 5618, 5623, 5624, 5625, 5627, 5628,
+      5631, 5632, 5633, 5634, 5636, 5639, 5640, 5642, 5643, 5644,
+      5645, 5646, 5647, 5650, 5651, 5652, 5655, 5657, 5661, 5664,
+      5666, 5668, 5670, 5675, 5688, 5689, 5690, 5691, 5692, 5693,
+      5694, 5695, 5696, 5697, 5698, 5699, 5700, 5703, 5704, 5705,
+      5706, 5710, 5711, 5712, 5716, 5717, 5718, 5719, 5721, 5724,
+      5725, 5726, 5727, 5730, 5731, 5732, 5736, 5738, 5741
+    );
+  END IF;
 END $$;
 
--- Index for efficient tier-based queries
+-- Index for efficient tier-based queries (idempotent).
 CREATE INDEX IF NOT EXISTS idx_pois_collection_tier ON pois (collection_tier);
-
--- Set daily tier for POIs with dedicated news/events URLs + Cleveland Metroparks
-UPDATE pois SET collection_tier = 'daily'
-WHERE (news_url IS NOT NULL AND news_url != '')
-   OR (events_url IS NOT NULL AND events_url != '')
-   OR id = 5658;  -- Cleveland Metroparks (ToS prevents crawling, but Serper coverage is frequent)
-
--- Set monthly tier for low-activity POIs (0-1 published items, no dedicated URLs)
-UPDATE pois SET collection_tier = 'monthly'
-WHERE collection_tier = 'weekly'  -- only demote POIs still at default, not ones just set to daily
-  AND id IN (
-  5475, 5477, 5478, 5480, 5482, 5486, 5491, 5492, 5494, 5495,
-  5496, 5497, 5498, 5500, 5501, 5502, 5504, 5506, 5513, 5514,
-  5516, 5517, 5518, 5519, 5522, 5525, 5526, 5529, 5530, 5532,
-  5534, 5535, 5536, 5538, 5540, 5542, 5546, 5547, 5551, 5554,
-  5555, 5556, 5558, 5560, 5564, 5565, 5566, 5569, 5570, 5571,
-  5572, 5573, 5574, 5576, 5578, 5579, 5581, 5582, 5584, 5586,
-  5587, 5591, 5592, 5595, 5596, 5597, 5598, 5599, 5601, 5607,
-  5609, 5610, 5611, 5616, 5618, 5623, 5624, 5625, 5627, 5628,
-  5631, 5632, 5633, 5634, 5636, 5639, 5640, 5642, 5643, 5644,
-  5645, 5646, 5647, 5650, 5651, 5652, 5655, 5657, 5661, 5664,
-  5666, 5668, 5670, 5675, 5688, 5689, 5690, 5691, 5692, 5693,
-  5694, 5695, 5696, 5697, 5698, 5699, 5700, 5703, 5704, 5705,
-  5706, 5710, 5711, 5712, 5716, 5717, 5718, 5719, 5721, 5724,
-  5725, 5726, 5727, 5730, 5731, 5732, 5736, 5738, 5741
-);

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -467,14 +467,21 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     }
 
     let relevanceVotes = [];
+    // Fix: a vote counts as affirmative if the content is relevant to the guide's
+    // mission OR specifically about this POI. Content genuinely about a mapped POI
+    // belongs even when the topic isn't a classic outdoor/nature/history match —
+    // otherwise a commercial POI's own news (e.g. a brewery) is wrongly rejected
+    // while regional content passes. The POI gate still handles reassignment when
+    // about_poi is false. (PR #483 follow-up)
+    const isAffirmativeVote = v => v.relevant || v.about_poi;
     try {
       relevanceVotes = await runContentRelevanceVotes(pool, {
         title: row.title, description: row.description,
         poiName: row.poi_name, contentType
       });
 
-      const yesCount = relevanceVotes.filter(v => v.relevant).length;
-      const noCount = relevanceVotes.filter(v => !v.relevant).length;
+      const yesCount = relevanceVotes.filter(isAffirmativeVote).length;
+      const noCount = relevanceVotes.filter(v => !isAffirmativeVote(v)).length;
       console.log(`[Moderation] ${contentType} #${contentId}: relevance votes ${yesCount}/${relevanceVotes.length} yes`);
       logInfo(itemRunId, 'moderation', null, row.title,
         `Relevance ${contentType} #${contentId}: ${yesCount}/${relevanceVotes.length} yes`);
@@ -483,8 +490,8 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       logError(itemRunId, 'moderation', null, row.title, `Relevance voting failed: ${err.message}`);
     }
 
-    const yesCount = relevanceVotes.filter(v => v.relevant).length;
-    const noCount = relevanceVotes.filter(v => !v.relevant).length;
+    const yesCount = relevanceVotes.filter(isAffirmativeVote).length;
+    const noCount = relevanceVotes.filter(v => !isAffirmativeVote(v)).length;
     const unanimousYes = relevanceVotes.length >= 3 && yesCount === relevanceVotes.length;
     const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
 

--- a/backend/services/moderationService.js
+++ b/backend/services/moderationService.js
@@ -474,14 +474,15 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
     // while regional content passes. The POI gate still handles reassignment when
     // about_poi is false. (PR #483 follow-up)
     const isAffirmativeVote = v => v.relevant || v.about_poi;
+    let yesCount = 0, noCount = 0;
     try {
       relevanceVotes = await runContentRelevanceVotes(pool, {
         title: row.title, description: row.description,
         poiName: row.poi_name, contentType
       });
 
-      const yesCount = relevanceVotes.filter(isAffirmativeVote).length;
-      const noCount = relevanceVotes.filter(v => !isAffirmativeVote(v)).length;
+      yesCount = relevanceVotes.filter(isAffirmativeVote).length;
+      noCount = relevanceVotes.filter(v => !isAffirmativeVote(v)).length;
       console.log(`[Moderation] ${contentType} #${contentId}: relevance votes ${yesCount}/${relevanceVotes.length} yes`);
       logInfo(itemRunId, 'moderation', null, row.title,
         `Relevance ${contentType} #${contentId}: ${yesCount}/${relevanceVotes.length} yes`);
@@ -490,8 +491,6 @@ export async function processItem(pool, contentType, contentId, { forceStatus = 
       logError(itemRunId, 'moderation', null, row.title, `Relevance voting failed: ${err.message}`);
     }
 
-    const yesCount = relevanceVotes.filter(isAffirmativeVote).length;
-    const noCount = relevanceVotes.filter(v => !isAffirmativeVote(v)).length;
     const unanimousYes = relevanceVotes.length >= 3 && yesCount === relevanceVotes.length;
     const unanimousNo = relevanceVotes.length >= 3 && noCount === relevanceVotes.length;
 


### PR DESCRIPTION
## Summary

Follow-ups to #483 (Green Valley Brewing news flood). Both fixes target root causes that affect **every** commercial/point POI, not just the brewery.

### 1. Relevance gate ignored `about_poi` (`backend/services/moderationService.js`)
The gate decided pass/fail on the `relevant` vote **alone**. Content genuinely *about* a mapped POI was rejected when its topic wasn't a classic outdoor/nature/history match — a brewery's own news read as "commercial, not relevant" — while generic regional content passed and got reassigned.

**Fix:** a vote is affirmative if `relevant || about_poi`. The POI gate still reassigns when `about_poi` is false, so the regional-news-then-reassign behavior is fully preserved. `about_poi` is already returned (coerced to boolean) by `runContentRelevanceVotes`.

### 2. Tier backfill re-ran every boot + `events_url` forced daily (`backend/migrations/043_add_collection_tier.sql`)
`entrypoint.sh` re-applies **all** migrations on every container start. Migration 043's `UPDATE...SET 'daily' WHERE news_url OR events_url` therefore re-fired on every restart, which (a) **reverted admin tier changes** and (b) forced `daily` on any POI with a Facebook events page. This is why Green Valley (created after 043) was `daily` and why its `weekly` fix would have reverted on the next restart.

**Fix:**
- Guard the data backfill to run **only on first introduction** of the column (capture `col_existed` before `ADD COLUMN`). On existing DBs the backfill is skipped every boot → admin tiers persist. Fresh installs still get a one-time backfill.
- Drop `events_url` as a daily trigger (dedicated `news_url` + Cleveland Metroparks only).
- DDL remains idempotent. Existing prod tiers are intentionally **not** mass-changed.

## Test plan
- [x] Build passes (`./run.sh build`)
- [x] `node --check` on moderationService.js
- [x] Existing-column DB: run new 043 ×2 → tiers unchanged (no clobber), no errors
- [x] Fresh DB (column dropped): one-time backfill runs; events-only POIs → 0 daily (4 weekly, 2 monthly)
- [x] Full suite: only pre-existing/flaky frontend Playwright failures; **zero backend/logic failures**

## Notes
- Companion prod data fix (not in this diff): correct POI 6372 description "Cuyahoga Falls" → "Hudson".
- Also reduces CI migration re-run noise for 043 (the backfill no longer re-fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)