### PR TITLE
fix: always show POI photos and unify mobile detail/lightbox chrome (#473)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -832,7 +832,7 @@ body {
   padding: 1rem 1.5rem;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .sidebar-header h2 {
@@ -1437,44 +1437,6 @@ body {
 }
 
 /* Image navigation chevrons - faded grey */
-.image-nav-btn {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: rgba(128, 128, 128, 0.3);
-  border: none;
-  padding: 0;
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background 0.2s;
-  z-index: 5;
-}
-
-.image-nav-btn:hover {
-  background: rgba(128, 128, 128, 0.5);
-}
-
-.image-nav-prev {
-  left: 8px;
-  border-radius: 0 4px 4px 0;
-}
-
-.image-nav-next {
-  right: 8px;
-  border-radius: 4px 0 0 4px;
-}
-
-.image-nav-chevron {
-  font-size: 32px;
-  font-weight: 300;
-  color: rgba(255, 255, 255, 0.8);
-  line-height: 1;
-}
-
 /* Swipe direction indicators - blue like Chrome's */
 .swipe-indicator {
   position: fixed;

--- a/frontend/src/components/Lightbox.css
+++ b/frontend/src/components/Lightbox.css
@@ -31,29 +31,14 @@
   align-items: center;
 }
 
-/* Close Button */
-.lightbox-close {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  color: white;
-  font-size: 32px;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  cursor: pointer;
+/* Header bar — reuses .sidebar-header + .close-btn (App.css) for identical size/font/X.
+   Only the background colour differs, to signal a different navigational context. */
+.sidebar-header.lightbox-header {
+  background: #4a4a4a;
+  width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
   z-index: 10002;
-  transition: background-color 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
-
-.lightbox-close:hover {
-  background: rgba(255, 255, 255, 0.3);
 }
 
 /* Navigation Arrows */
@@ -96,16 +81,6 @@
   align-items: center;
   padding: 10px 0;
   flex-shrink: 0;
-}
-
-/* Counter */
-.lightbox-counter {
-  background: rgba(0, 0, 0, 0.6);
-  color: white;
-  padding: 6px 14px;
-  border-radius: 20px;
-  font-size: 13px;
-  margin-bottom: 8px;
 }
 
 /* Thumbnail Strip */

--- a/frontend/src/components/Lightbox.jsx
+++ b/frontend/src/components/Lightbox.jsx
@@ -218,41 +218,21 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
       onTouchEnd={handleTouchEnd}
     >
       <div className="lightbox-container" onClick={(e) => e.stopPropagation()}>
-        {/* Close Button */}
-        <button
-          className="lightbox-close"
-          onClick={onClose}
-          aria-label="Close lightbox"
-        >
-          ✕
-        </button>
+        {/* Header bar — reuses .sidebar-header + .close-btn for identical size/font; only colour + text differ to signal a different navigational context */}
+        <div className="sidebar-header lightbox-header">
+          <h2>{currentIndex + 1} / {media.length}</h2>
+          <button
+            className="close-btn"
+            onClick={onClose}
+            aria-label="Close lightbox"
+          >
+            &times;
+          </button>
+        </div>
 
-        {/* Navigation Arrows */}
+        {/* Thumbnail strip */}
         {media.length > 1 && (
-          <>
-            <button
-              className="lightbox-arrow lightbox-arrow-left"
-              onClick={handlePrevious}
-              aria-label="Previous"
-            >
-              ‹
-            </button>
-            <button
-              className="lightbox-arrow lightbox-arrow-right"
-              onClick={handleNext}
-              aria-label="Next"
-            >
-              ›
-            </button>
-          </>
-        )}
-
-        {/* Top bar: counter + thumbnail strip */}
-        <div className="lightbox-top-bar">
-          <div className="lightbox-counter">
-            {currentIndex + 1} / {media.length}
-          </div>
-          {media.length > 1 && (
+          <div className="lightbox-top-bar">
             <div className="lightbox-thumbnails" ref={thumbnailsRef}>
               {media.map((item, index) => (
                 <div
@@ -287,11 +267,31 @@ function Lightbox({ media, initialIndex = 0, onClose, poiId, user, onMediaUpdate
                 </div>
               ))}
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Main Media with badges overlaid */}
         <div className="lightbox-main">
+          {/* Navigation Arrows — centered on the media area */}
+          {media.length > 1 && (
+            <>
+              <button
+                className="lightbox-arrow lightbox-arrow-left"
+                onClick={handlePrevious}
+                aria-label="Previous"
+              >
+                ‹
+              </button>
+              <button
+                className="lightbox-arrow lightbox-arrow-right"
+                onClick={handleNext}
+                aria-label="Next"
+              >
+                ›
+              </button>
+            </>
+          )}
+
           {renderMedia()}
 
           {/* Badges positioned over the image */}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -76,7 +76,6 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
   const [hasGauges, setHasGauges] = useState(null);
   const [servingTaxis, setServingTaxis] = useState([]);
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(() => window.innerWidth < 768);
-  const [mobilePhotosVisible, setMobilePhotosVisible] = useState(false);
   const [hasNavigatedPoi, setHasNavigatedPoi] = useState(false);
 
   useEffect(() => {
@@ -118,18 +117,6 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isSwipingHorizontally, setIsSwipingHorizontally] = useState(false);
 
-  const lastNavigationTime = React.useRef(0);
-  const NAVIGATION_DEBOUNCE_MS = 300;
-
-  const debouncedNavigate = (direction) => {
-    const now = Date.now();
-    if (now - lastNavigationTime.current < NAVIGATION_DEBOUNCE_MS) {
-      return; // Ignore rapid taps
-    }
-    lastNavigationTime.current = now;
-    onNavigate(direction);
-  };
-
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
@@ -139,10 +126,9 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
   const handleTouchStart = (e) => {
     const target = e.target;
     const isCarousel = target.closest('.thumbnail-carousel-wrapper, .thumbnail-carousel');
-    const isNavButton = target.closest('.image-nav-btn');
     const isGaugeCarousel = target.closest('.river-levels-tab');
 
-    if (isCarousel || isNavButton || isGaugeCarousel) {
+    if (isCarousel || isGaugeCarousel) {
       touchStartX.current = null;
       touchStartY.current = null;
       return;
@@ -285,7 +271,6 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
       const shouldEnterEditMode = (isAdmin && editMode) || isNewPOI;
       setIsEditing(shouldEnterEditMode);
       setIsSidebarExpanded(isMobile);
-      setMobilePhotosVisible(false);
       // Respect a deep-linked subtab (e.g. /poi/river_levels) instead of forcing Info.
       if (!permalinkInfo && !initialSidebarTab) setSidebarTab('view');
     } else {
@@ -705,39 +690,12 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
                 ←
               </button>
             )}
-            {isMobile && !isEditing && (
-              <button
-                className="sidebar-expand-btn"
-                onClick={() => { setIsSidebarExpanded(prev => { if (prev) setMobilePhotosVisible(false); return !prev; }); }}
-                title={isSidebarExpanded ? 'Collapse panel' : 'Expand panel'}
-                aria-label={isSidebarExpanded ? 'Collapse panel' : 'Expand panel'}
-              >
-                {isSidebarExpanded ? (
-                  <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                    <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>
-                  </svg>
-                ) : (
-                  <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                    <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
-                  </svg>
-                )}
-              </button>
-            )}
             <button className="close-btn" onClick={onClose}>&times;</button>
           </div>
         </div>
 
         <div style={{ position: 'relative' }}>
-          {isMobile && !mobilePhotosVisible && !isEditing ? (
-            media.length > 0 ? (
-              <button
-                className="sidebar-show-photos-btn"
-                onClick={() => setMobilePhotosVisible(true)}
-              >
-                Show Photos
-              </button>
-            ) : null
-          ) : (
+          {(
             <>
               {isEditing && linearFeature?.id ? (
                 <ImageUploader
@@ -764,45 +722,6 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
                   </button>
                 </div>
               ) : null}
-
-              {isMobile && !isEditing && !permalinkInfo && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
-                <>
-                  {currentIndex > 0 && (
-                    <button
-                      className="image-nav-btn image-nav-prev"
-                      onTouchEnd={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        debouncedNavigate('prev');
-                      }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      aria-label="Previous POI"
-                    >
-                      <span className="image-nav-chevron">‹</span>
-                    </button>
-                  )}
-                  {currentIndex < poiNavigationList.length - 1 && (
-                    <button
-                      className="image-nav-btn image-nav-next"
-                      onTouchEnd={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        debouncedNavigate('next');
-                      }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      aria-label="Next POI"
-                    >
-                      <span className="image-nav-chevron">›</span>
-                    </button>
-                  )}
-                </>
-              )}
             </>
           )}
         </div>
@@ -1035,39 +954,12 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
               </button>
             </>
           )}
-          {isMobile && !isEditing && (
-            <button
-              className="sidebar-expand-btn"
-              onClick={() => { setIsSidebarExpanded(prev => { if (prev) setMobilePhotosVisible(false); return !prev; }); }}
-              title={isSidebarExpanded ? 'Collapse panel' : 'Expand panel'}
-              aria-label={isSidebarExpanded ? 'Collapse panel' : 'Expand panel'}
-            >
-              {isSidebarExpanded ? (
-                <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                  <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>
-                </svg>
-              ) : (
-                <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                  <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
-                </svg>
-              )}
-            </button>
-          )}
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
       </div>
 
       <div style={{ position: 'relative' }}>
-        {isMobile && !mobilePhotosVisible && !isEditing ? (
-          media.length > 0 ? (
-            <button
-              className="sidebar-show-photos-btn"
-              onClick={() => setMobilePhotosVisible(true)}
-            >
-              Show Photos
-            </button>
-          ) : null
-        ) : (
+        {(
           <>
             {permalinkInfo && (sidebarTab === 'news' || sidebarTab === 'events') ? (
               permalinkItem ? (
@@ -1100,45 +992,6 @@ function Sidebar({ tourActive, poi, isLinearPoi, isNewPOI, newOrganization, isNe
                 </button>
               </div>
             ) : null}
-
-            {isMobile && !isEditing && !permalinkInfo && onNavigate && poiNavigationList && poiNavigationList.length > 1 && media.length > 0 && (
-              <>
-                {currentIndex > 0 && (
-                  <button
-                    className="image-nav-btn image-nav-prev"
-                    onTouchEnd={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      debouncedNavigate('prev');
-                    }}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    aria-label="Previous POI"
-                  >
-                    <span className="image-nav-chevron">‹</span>
-                  </button>
-                )}
-                {currentIndex < poiNavigationList.length - 1 && (
-                  <button
-                    className="image-nav-btn image-nav-next"
-                    onTouchEnd={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      debouncedNavigate('next');
-                    }}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    aria-label="Next POI"
-                  >
-                    <span className="image-nav-chevron">›</span>
-                  </button>
-                )}
-              </>
-            )}
           </>
         )}
       </div>

--- a/frontend/src/hooks/usePoiMedia.js
+++ b/frontend/src/hooks/usePoiMedia.js
@@ -15,22 +15,32 @@ export default function usePoiMedia(poi, onPoiUpdate) {
   });
 
   useEffect(() => {
+    // Clear the previous POI's media immediately so we never flash a stale
+    // image while the newly selected POI's media is still loading.
+    setMedia([]);
+    setAllMedia([]);
+
     if (!poiId) return;
 
+    let cancelled = false;
     setMediaLoading(true);
     fetch(`/api/pois/${poiId}/media`, { credentials: 'include' })
       .then(res => res.ok ? res.json() : { mosaic: [], all_media: [] })
       .then(mediaResponse => {
+        if (cancelled) return; // Ignore a response that lands after the POI changed
         setMedia(mediaResponse.mosaic || []);
         setAllMedia(mediaResponse.all_media || []);
         setMediaLoading(false);
       })
       .catch(err => {
+        if (cancelled) return;
         console.error('Failed to load media:', err);
         setMedia([]);
         setAllMedia([]);
         setMediaLoading(false);
       });
+
+    return () => { cancelled = true; };
   }, [poiId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Mobile detail-panel and lightbox cleanup for easier reading on mobile (follow-up polish for #473).

- **POI photos always show** — removed the mobile "Show Photos" gate; the photo mosaic/carousel renders immediately.
- **Header title centered** — sidebar header title is vertically centered, aligned with the close button.
- **Removed the fullscreen/expand button** — the X is sufficient.
- **Removed the on-photo POI prev/next arrows** — they read as photo controls but navigated POIs; swipe + the thumbnail strip remain for POI navigation.
- **No more stale-image flash** — `usePoiMedia` now clears media on POI change and ignores out-of-order responses, so the previous POI's image never flashes before the correct one loads.
- **Unified lightbox header** — the lightbox now reuses the sidebar's `.sidebar-header` + `.close-btn` styling (grey background to signal a different navigational context), and the prev/next arrows are re-centered on the media area.

Files: `Sidebar.jsx`, `App.css`, `usePoiMedia.js`, `Lightbox.jsx`, `Lightbox.css`

## Test plan

- Manually verified in-browser at mobile (390px) and desktop widths across multiple rebuilds:
  - Photos appear immediately on POI open (no "Show Photos" tap)
  - Header title centered and aligned with X
  - No fullscreen button; no on-photo nav arrows
  - Clicking between POIs shows only the correct image (no stale flash)
  - Lightbox header matches the sidebar header (size/font/X), grey; arrows centered on the photo and video
- `./run.sh test`: pre-existing failures only (ogShareImages = #475, thumbnail-carousel mobile tests requiring `hasNavigatedPoi`, flaky satellite-toggle) — none touch the changed code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)