### PR TITLE
fix: schedule newsletter digest with a future publish_date

### DIFF
--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -192,8 +192,10 @@ export async function sendEmail(subject, htmlBody, pool = null, { existingEmailI
   }
 
   return retryRequest(async () => {
+    // Buttondown rejects a publish_date at or before "now" (publish_date_invalid),
+    // so schedule a few minutes out to satisfy its future-date requirement.
     const payload = {
-      publish_date: new Date().toISOString(),
+      publish_date: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
       status: 'scheduled'
     };
 
@@ -206,13 +208,18 @@ export async function sendEmail(subject, htmlBody, pool = null, { existingEmailI
       console.log(`Scheduled email for sending: ${emailId} (status: ${sendResponse.data.status})`);
       return sendResponse.data;
     } catch (error) {
+      // Scrub the API token from the error so it never lands in logs or the
+      // pg-boss job output (which serializes the thrown error's request config).
+      if (error.config?.headers?.Authorization) {
+        error.config.headers.Authorization = '[REDACTED]';
+      }
+
       const errorDetails = {
         emailId,
         status: error.response?.status,
         statusText: error.response?.statusText,
         buttondownError: error.response?.data,
-        requestPayload: payload,
-        requestHeaders: error.config?.headers
+        requestPayload: payload
       };
 
       console.error(`Buttondown PATCH failed:`, JSON.stringify(errorDetails, null, 2));


### PR DESCRIPTION
## Summary

The weekly newsletter **digest failed to send** (Fri 2026-06-19 08:00 ET). The job fired on schedule but Buttondown rejected the request with `publish_date_invalid`.

Root cause: `buttondownClient.js` scheduled the email with `publish_date = new Date()` (now) and `status = 'scheduled'`. Buttondown requires a scheduled email's `publish_date` to be in the **future**. Fixed by scheduling 5 minutes out.

Also a **security fix**: the thrown Axios error carried the `Authorization` header (Buttondown API token) into logs and the pg-boss `job.output`. Now scrubbed before logging/propagating; `requestHeaders` dropped from the logged error detail.

Note: the currently-exposed token should be rotated separately (it leaked into the DB/journal before this fix).

## Test plan

- `node --check` passes; `isSendEnabled` gate untouched (unit tests unaffected).
- Post-deploy: re-trigger the digest and confirm the Buttondown email moves to scheduled/sent and the pg-boss `newsletter-digest` job completes.