### PR TITLE
fix: point pre-push Gatehouse hook at the public crunchtools image

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@
 
 set -e
 
-GATEHOUSE_IMAGE="quay.io/fatherlinux/gatehouse:latest"
+GATEHOUSE_IMAGE="quay.io/crunchtools/gatehouse:latest"
 ENV_FILE="$HOME/.config/mcp-env/gatehouse.env"
 
 # Load API key from env file


### PR DESCRIPTION
## Summary

The `.githooks/pre-push` Gatehouse review referenced `quay.io/fatherlinux/gatehouse` (private — anonymous pulls return 401), so every push failed at the advisory step and required `--no-verify`. The image is published at `quay.io/crunchtools/gatehouse`, which is public and pulls anonymously.

Verified: with the corrected image, the hook runs Gatehouse (advisory, exit 0) and the push succeeds normally.

## Test plan

- `git push` on this branch ran the hook successfully (no `--no-verify`).