### PR TITLE
fix: issue #490 (Ashigaru)

### DIFF
--- a/backend/tests/issue63Regression.integration.test.js
+++ b/backend/tests/issue63Regression.integration.test.js
@@ -14,6 +14,39 @@ import { chromium } from 'playwright';
  * - Bug #6: Mobile responsive layout (CSS variables, positioning)
  */
 
+// The ThumbnailCarousel only mounts after the user navigates between POIs
+// (Sidebar.jsx gates it on `hasNavigatedPoi`, set true on the first swipe) —
+// opening a POI no longer shows it on first paint. Simulate a horizontal swipe on
+// the open sidebar to trigger navigation so the carousel renders. Tries "next"
+// first, then "prev" in case the open POI is at the start of the navigation list.
+async function showCarouselViaSwipe(page) {
+  const swipe = (direction) => page.evaluate((dir) => {
+    const el = document.querySelector('.sidebar');
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const y = Math.round(rect.top + Math.min(rect.height / 2, 200));
+    const startX = dir === 'next' ? 260 : 110;
+    const endX = dir === 'next' ? 110 : 260;
+    const midX = Math.round((startX + endX) / 2);
+    const mk = (x) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
+    const send = (type, x, list) => el.dispatchEvent(new TouchEvent(type, {
+      bubbles: true, cancelable: true,
+      touches: list, targetTouches: list, changedTouches: [mk(x)],
+    }));
+    send('touchstart', startX, [mk(startX)]);
+    send('touchmove', midX, [mk(midX)]);
+    send('touchend', endX, []);
+  }, direction);
+
+  await swipe('next');
+  await page.waitForTimeout(400);
+  if (await page.locator('.thumbnail-carousel').count() === 0) {
+    await swipe('prev');
+    await page.waitForTimeout(400);
+  }
+  return (await page.locator('.thumbnail-carousel').count()) > 0;
+}
+
 describe('Issue #63 Regression Tests', () => {
   let browser;
   let page;
@@ -138,8 +171,9 @@ describe('Issue #63 Regression Tests', () => {
       await page.waitForSelector('.leaflet-marker-icon', { timeout: 10000 });
       await page.locator('.leaflet-marker-icon').first().click();
 
-      // Wait for sidebar and carousel
+      // Wait for sidebar, then trigger navigation so the carousel renders
       await page.waitForSelector('.sidebar.open', { timeout: 10000 });
+      await showCarouselViaSwipe(page);
       await page.waitForSelector('.thumbnail-carousel', { timeout: 5000 });
 
       // Check carousel bottom padding - this provides the 16px spacing between carousel and content

--- a/backend/tests/issue63Regression.integration.test.js
+++ b/backend/tests/issue63Regression.integration.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chromium } from 'playwright';
+import { showCarouselViaSwipe } from './utils/uiHelpers.js';
 
 /**
  * Issue #63 Regression Tests
@@ -13,39 +14,6 @@ import { chromium } from 'playwright';
  * Validated bugs:
  * - Bug #6: Mobile responsive layout (CSS variables, positioning)
  */
-
-// The ThumbnailCarousel only mounts after the user navigates between POIs
-// (Sidebar.jsx gates it on `hasNavigatedPoi`, set true on the first swipe) —
-// opening a POI no longer shows it on first paint. Simulate a horizontal swipe on
-// the open sidebar to trigger navigation so the carousel renders. Tries "next"
-// first, then "prev" in case the open POI is at the start of the navigation list.
-async function showCarouselViaSwipe(page) {
-  const swipe = (direction) => page.evaluate((dir) => {
-    const el = document.querySelector('.sidebar');
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const y = Math.round(rect.top + Math.min(rect.height / 2, 200));
-    const startX = dir === 'next' ? 260 : 110;
-    const endX = dir === 'next' ? 110 : 260;
-    const midX = Math.round((startX + endX) / 2);
-    const mk = (x) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
-    const send = (type, x, list) => el.dispatchEvent(new TouchEvent(type, {
-      bubbles: true, cancelable: true,
-      touches: list, targetTouches: list, changedTouches: [mk(x)],
-    }));
-    send('touchstart', startX, [mk(startX)]);
-    send('touchmove', midX, [mk(midX)]);
-    send('touchend', endX, []);
-  }, direction);
-
-  await swipe('next');
-  await page.waitForTimeout(400);
-  if (await page.locator('.thumbnail-carousel').count() === 0) {
-    await swipe('prev');
-    await page.waitForTimeout(400);
-  }
-  return (await page.locator('.thumbnail-carousel').count()) > 0;
-}
 
 describe('Issue #63 Regression Tests', () => {
   let browser;

--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -25,6 +25,40 @@ async function openPoiWithMoreInfo(page, baseUrl) {
   return null;
 }
 
+// The ThumbnailCarousel only mounts after the user navigates between POIs
+// (Sidebar.jsx gates it on `hasNavigatedPoi`, set true on the first swipe/chevron
+// navigation) — opening a POI no longer shows it on first paint. Simulate a
+// horizontal swipe on the open sidebar to trigger navigation so the carousel
+// renders. Tries "next" first, then "prev" in case the open POI is at the start
+// of the navigation list. Returns true once the carousel is present.
+async function showCarouselViaSwipe(page) {
+  const swipe = (direction) => page.evaluate((dir) => {
+    const el = document.querySelector('.sidebar');
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const y = Math.round(rect.top + Math.min(rect.height / 2, 200));
+    const startX = dir === 'next' ? 260 : 110;
+    const endX = dir === 'next' ? 110 : 260;
+    const midX = Math.round((startX + endX) / 2);
+    const mk = (x) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
+    const send = (type, x, list) => el.dispatchEvent(new TouchEvent(type, {
+      bubbles: true, cancelable: true,
+      touches: list, targetTouches: list, changedTouches: [mk(x)],
+    }));
+    send('touchstart', startX, [mk(startX)]);
+    send('touchmove', midX, [mk(midX)]);
+    send('touchend', endX, []);
+  }, direction);
+
+  await swipe('next');
+  await page.waitForTimeout(400);
+  if (await page.locator('.thumbnail-carousel').count() === 0) {
+    await swipe('prev');
+    await page.waitForTimeout(400);
+  }
+  return (await page.locator('.thumbnail-carousel').count()) > 0;
+}
+
 describe('UI Integration Tests', () => {
   let browser;
   let page;
@@ -360,6 +394,9 @@ describe('UI Integration Tests', () => {
         state: 'visible'
       });
 
+      // Carousel renders only after the first POI navigation — trigger a swipe.
+      await showCarouselViaSwipe(page);
+
       // Wait for carousel to be visible
       await page.waitForSelector('.thumbnail-carousel', { timeout: 5000 });
 
@@ -659,8 +696,9 @@ describe('UI Integration Tests', () => {
       await page.waitForTimeout(1000);
       await page.locator('.leaflet-marker-icon').first().click();
 
-      // Wait for sidebar and carousel
+      // Wait for sidebar, then trigger navigation so the carousel renders
       await page.waitForSelector('.sidebar.open', { timeout: 10000 });
+      await showCarouselViaSwipe(page);
       await page.waitForSelector('.thumbnail-carousel', { timeout: 5000 });
 
       // Verify carousel has thumbnails

--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chromium } from 'playwright';
+import { showCarouselViaSwipe } from './utils/uiHelpers.js';
 
 // Open a POI that has a More Info link via its bare-path permalink (/<slug>),
 // which reliably opens the sidebar on both mobile and desktop. .more-info-link
@@ -23,40 +24,6 @@ async function openPoiWithMoreInfo(page, baseUrl) {
     if (await page.locator('.more-info-link').count() > 0) return poi;
   }
   return null;
-}
-
-// The ThumbnailCarousel only mounts after the user navigates between POIs
-// (Sidebar.jsx gates it on `hasNavigatedPoi`, set true on the first swipe/chevron
-// navigation) — opening a POI no longer shows it on first paint. Simulate a
-// horizontal swipe on the open sidebar to trigger navigation so the carousel
-// renders. Tries "next" first, then "prev" in case the open POI is at the start
-// of the navigation list. Returns true once the carousel is present.
-async function showCarouselViaSwipe(page) {
-  const swipe = (direction) => page.evaluate((dir) => {
-    const el = document.querySelector('.sidebar');
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const y = Math.round(rect.top + Math.min(rect.height / 2, 200));
-    const startX = dir === 'next' ? 260 : 110;
-    const endX = dir === 'next' ? 110 : 260;
-    const midX = Math.round((startX + endX) / 2);
-    const mk = (x) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
-    const send = (type, x, list) => el.dispatchEvent(new TouchEvent(type, {
-      bubbles: true, cancelable: true,
-      touches: list, targetTouches: list, changedTouches: [mk(x)],
-    }));
-    send('touchstart', startX, [mk(startX)]);
-    send('touchmove', midX, [mk(midX)]);
-    send('touchend', endX, []);
-  }, direction);
-
-  await swipe('next');
-  await page.waitForTimeout(400);
-  if (await page.locator('.thumbnail-carousel').count() === 0) {
-    await swipe('prev');
-    await page.waitForTimeout(400);
-  }
-  return (await page.locator('.thumbnail-carousel').count()) > 0;
 }
 
 describe('UI Integration Tests', () => {

--- a/backend/tests/utils/uiHelpers.js
+++ b/backend/tests/utils/uiHelpers.js
@@ -1,0 +1,35 @@
+// Shared helpers for Playwright-driven UI integration tests.
+
+// The ThumbnailCarousel only mounts after the user navigates between POIs
+// (Sidebar.jsx gates it on `hasNavigatedPoi`, set true on the first swipe/chevron
+// navigation) — opening a POI no longer shows it on first paint. Simulate a
+// horizontal swipe on the open sidebar to trigger navigation so the carousel
+// renders. Tries "next" first, then "prev" in case the open POI is at the start
+// of the navigation list. Returns true once the carousel is present.
+export async function showCarouselViaSwipe(page) {
+  const swipe = (direction) => page.evaluate((dir) => {
+    const el = document.querySelector('.sidebar');
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const y = Math.round(rect.top + Math.min(rect.height / 2, 200));
+    const startX = dir === 'next' ? 260 : 110;
+    const endX = dir === 'next' ? 110 : 260;
+    const midX = Math.round((startX + endX) / 2);
+    const mk = (x) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
+    const send = (type, x, list) => el.dispatchEvent(new TouchEvent(type, {
+      bubbles: true, cancelable: true,
+      touches: list, targetTouches: list, changedTouches: [mk(x)],
+    }));
+    send('touchstart', startX, [mk(startX)]);
+    send('touchmove', midX, [mk(midX)]);
+    send('touchend', endX, []);
+  }, direction);
+
+  await swipe('next');
+  await page.waitForTimeout(400);
+  if (await page.locator('.thumbnail-carousel').count() === 0) {
+    await swipe('prev');
+    await page.waitForTimeout(400);
+  }
+  return (await page.locator('.thumbnail-carousel').count()) > 0;
+}


### PR DESCRIPTION
Fixes #490.

Autonomous **Ashigaru** run — Claude Code (`claude-opus-4-8`, tier 1) in a sealed, unprivileged sandbox. Worked from an airlock-filtered brief. **Draft, pending CI + human review.** run_id: `rotv-490-1782049598`