### PR TITLE
feat: newsletter source management (#524)

### DIFF
--- a/.specify/specs/037-newsletter-sources/plan.md
+++ b/.specify/specs/037-newsletter-sources/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: Newsletter Source Management
+
+> **Spec ID:** 037-newsletter-sources
+> **Status:** Planning
+> **Last Updated:** 2026-06-22
+> **Estimated Effort:** M
+
+## Summary
+
+Evolve `poi_newsletter_sources` into a proper source entity with status/display_name columns, add REST endpoints for source CRUD, auto-discover new senders in the newsletter service, and replace the per-email UI with a per-source management interface.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. Email arrives at SMTP → stored in `newsletter_emails`
+2. Newsletter service checks `poi_newsletter_sources` for matching `from_pattern`
+3. **No match:** inserts a `poi_newsletter_sources` row with `status='new'`, `poi_id=NULL` (auto-discovery)
+4. **Match + accepted:** processes through standard collection pipeline → content queue
+5. **Match + blocked:** marks email processed, skips extraction
+6. **Match + new:** email sits unprocessed, source appears on settings page for admin triage
+7. Admin accepts/blocks/deletes via settings UI → updates `poi_newsletter_sources`
+
+---
+
+## Implementation Steps
+
+### Phase 1: Database Migration
+
+- [ ] Create migration `061_newsletter_source_entity.sql`
+  - Drop the composite PK `(poi_id, from_pattern)`, add PK on `from_pattern`
+  - Make `poi_id` nullable
+  - Add `display_name TEXT` column
+  - Add `status TEXT NOT NULL DEFAULT 'accepted'` column
+  - Backfill existing rows with `status = 'accepted'`
+
+### Phase 2: Backend — Auto-Discovery in Newsletter Service
+
+- [ ] Modify `newsletterService.js` `processNewsletterById()`:
+  - When no `poi_newsletter_sources` match exists for the sender, INSERT a row with `status='new'`, `poi_id=NULL`
+  - When match exists but `status='blocked'`, mark email processed and skip extraction
+  - When match exists and `status='new'`, leave email unprocessed (waiting for admin)
+
+### Phase 3: Backend — Source CRUD Endpoints
+
+- [ ] Add `GET /api/newsletter/sources` in `newsletter.js`:
+  - Query `poi_newsletter_sources` joined with aggregated `newsletter_emails` counts
+  - Return: from_pattern, display_name, status, poi_id, poi_name, email_count, last_received, total_news, total_events
+  - Order: new first, then accepted, then blocked
+
+- [ ] Add `PUT /api/newsletter/sources/:pattern`:
+  - Update status, poi_id, display_name
+  - When changing to `accepted` with a poi_id: queue all unprocessed emails from that sender
+  - When changing to `blocked`: no reprocessing needed
+
+- [ ] Add `DELETE /api/newsletter/sources/:pattern`:
+  - Delete the `poi_newsletter_sources` row
+  - Delete all `newsletter_emails` where `from_address` matches the pattern
+
+### Phase 4: Frontend — Replace Per-Email List with Source Management
+
+- [ ] Rewrite the "Inbound Newsletters" section in `NewsletterSettings.jsx`:
+  - Fetch from `/api/newsletter/sources` instead of `/api/newsletter/inbound`
+  - Group sources by status: new → accepted → blocked
+  - New sources: POI dropdown + Accept/Block/Delete buttons
+  - Accepted sources: show POI name, email/extraction counts, Edit/Block buttons
+  - Blocked sources: collapsible section with Unblock/Delete buttons
+  - Remove all per-email state (`inbound`, `assignSel`, `handleReprocess`, `handleAssign`)
+
+### Phase 5: MCP Server Updates
+
+- [ ] Add `newsletter_sources` MCP tool (list sources with stats)
+- [ ] Keep existing `newsletter_list`, `newsletter_detail`, `newsletter_reprocess` tools unchanged
+- [ ] Update `newsletter_assign_poi` to set `status='accepted'` when creating/updating a source
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/061_newsletter_source_entity.sql` | Schema evolution for source entity |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/routes/newsletter.js` | Add source CRUD endpoints, deprecate `/inbound` |
+| `backend/services/newsletterService.js` | Auto-discover new senders, respect blocked status |
+| `backend/services/mcpServer.js` | Add `newsletter_sources` tool, update `newsletter_assign_poi` |
+| `frontend/src/components/NewsletterSettings.jsx` | Replace per-email list with source management UI |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 061_newsletter_source_entity.sql
+-- Evolve poi_newsletter_sources from mapping table to source entity
+
+-- 1. Add new columns
+ALTER TABLE poi_newsletter_sources
+  ADD COLUMN IF NOT EXISTS display_name TEXT,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'accepted';
+
+-- 2. Make poi_id nullable (blocked sources have no POI)
+ALTER TABLE poi_newsletter_sources ALTER COLUMN poi_id DROP NOT NULL;
+
+-- 3. Change primary key from (poi_id, from_pattern) to just from_pattern
+--    A sender can only map to one destination.
+ALTER TABLE poi_newsletter_sources DROP CONSTRAINT IF EXISTS poi_newsletter_sources_pkey;
+ALTER TABLE poi_newsletter_sources ADD PRIMARY KEY (from_pattern);
+
+-- 4. Add unique constraint to prevent duplicate patterns
+--    (PK already handles this, but explicit for clarity)
+```
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Start the app, navigate to Settings → Newsletter
+2. Verify existing sources appear with "accepted" status and their POI assignments
+3. Forward a new email to news@rootsofthevalley.org from an unknown sender
+4. Verify the new sender appears as "new" on the settings page
+5. Accept it by assigning a POI — verify emails get processed into content queue
+6. Block a source — verify future emails from it are skipped
+7. Delete a source — verify the source and all its emails are purged
+8. Verify MCP `newsletter_list` and `newsletter_detail` still work for individual emails
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| PK migration fails on existing data | High | Use IF NOT EXISTS, handle conflicts |
+| Blocked senders re-appear as "new" | Med | Check for blocked status before auto-inserting |
+| Pattern matching ambiguity (substring vs exact) | Low | Keep existing substring matching, it works |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-22 | Initial plan |

--- a/.specify/specs/037-newsletter-sources/spec.md
+++ b/.specify/specs/037-newsletter-sources/spec.md
@@ -1,0 +1,208 @@
+# Specification: Newsletter Source Management
+
+> **Spec ID:** 037-newsletter-sources
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-22
+
+## Overview
+
+Redesign the "Inbound Newsletters" section on the settings/newsletter page to manage newsletter **sources** (unique senders) instead of individual emails. A source is identified by its sender email address and can be accepted (mapped to a POI), blocked, or deleted. Once accepted, all emails from that source flow through the standard content/moderation queue automatically and never appear on the settings page. Individual email details remain accessible via the MCP server for debugging.
+
+---
+
+## User Stories
+
+### Source Management
+
+**US-037-1: View Newsletter Sources**
+> As an admin, I want to see a list of newsletter sources (unique senders) so that I can manage which organizations feed content into ROTV.
+
+Acceptance Criteria:
+- [ ] Settings page shows one row per unique sender, not one row per email
+- [ ] Each source shows: sender email, display name (editable), status, assigned POI, email count, last received date
+- [ ] Sources are grouped by status: new/pending first, then accepted, then blocked
+
+**US-037-2: Accept a Newsletter Source**
+> As an admin, I want to assign a new sender to a POI so that all its emails are processed through the standard collection pipeline.
+
+Acceptance Criteria:
+- [ ] Admin selects a POI from a dropdown and clicks "Accept"
+- [ ] A `poi_newsletter_sources` row is created mapping the sender to the POI
+- [ ] All unprocessed emails from that sender are queued for reprocessing
+- [ ] The source moves from "new" to "accepted" status
+
+**US-037-3: Block a Newsletter Source**
+> As an admin, I want to block a sender so that its emails are silently ignored and don't clutter the queue.
+
+Acceptance Criteria:
+- [ ] Admin clicks "Block" on a source
+- [ ] The source is marked as blocked in `poi_newsletter_sources`
+- [ ] Future emails from that sender are not queued for processing
+- [ ] Blocked sources appear in a collapsed section at the bottom
+
+**US-037-4: Delete a Newsletter Source**
+> As an admin, I want to delete a source and all its emails so that spam/junk senders are fully purged.
+
+Acceptance Criteria:
+- [ ] Admin clicks "Delete" with a confirmation prompt
+- [ ] The source mapping row is deleted
+- [ ] All `newsletter_emails` rows from that sender are deleted
+- [ ] The source disappears from the list entirely
+
+---
+
+## Data Model
+
+### Schema Changes
+
+Evolve `poi_newsletter_sources` from a simple mapping table into a proper source entity:
+
+```sql
+-- Add columns to poi_newsletter_sources
+ALTER TABLE poi_newsletter_sources
+  ADD COLUMN IF NOT EXISTS display_name TEXT,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'accepted';
+
+-- Allow blocked sources (no POI required) by making poi_id nullable
+-- and changing the primary key to from_pattern alone
+```
+
+**Key change:** Currently `poi_newsletter_sources` has a composite PK of `(poi_id, from_pattern)` and `poi_id NOT NULL`. Blocked sources have no POI, so `poi_id` must become nullable. The primary key changes to just `from_pattern` (a sender can only map to one destination).
+
+New schema for `poi_newsletter_sources`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `from_pattern` | TEXT PK | Sender email pattern (case-insensitive substring match) |
+| `poi_id` | INTEGER NULL FK | Assigned POI (NULL for blocked sources) |
+| `display_name` | TEXT NULL | Admin-friendly name (e.g., "Akron Zoo Newsletter") |
+| `status` | TEXT NOT NULL | `accepted`, `blocked`, or `new` |
+| `created_at` | TIMESTAMPTZ | When the source was first seen |
+
+### Auto-Discovery of New Sources
+
+When a new email arrives and no `poi_newsletter_sources` row matches its `from_address`, the newsletter service inserts a row with `status = 'new'` and `poi_id = NULL`. This surfaces the sender on the settings page for admin triage.
+
+---
+
+## API Endpoints
+
+### New Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/newsletter/sources` | List all newsletter sources with email counts | Admin |
+| PUT | `/api/newsletter/sources/:pattern` | Update a source (assign POI, block, rename) | Admin |
+| DELETE | `/api/newsletter/sources/:pattern` | Delete a source and its emails | Admin |
+
+### Deprecated Endpoints
+
+| Method | Path | Replacement |
+|--------|------|-------------|
+| GET | `/api/newsletter/inbound` | `/api/newsletter/sources` |
+| POST | `/api/newsletter/inbound/:id/assign-poi` | `PUT /api/newsletter/sources/:pattern` |
+| POST | `/api/newsletter/inbound/:id/reprocess` | Kept (still useful for individual email retry via MCP) |
+
+### GET /api/newsletter/sources
+
+Returns sources with aggregated email stats:
+
+```json
+[
+  {
+    "from_pattern": "news@akronzoo.org",
+    "display_name": "Akron Zoo",
+    "status": "accepted",
+    "poi_id": 42,
+    "poi_name": "Akron Zoo",
+    "email_count": 23,
+    "last_received": "2026-06-20T14:30:00Z",
+    "total_news": 45,
+    "total_events": 12
+  }
+]
+```
+
+### PUT /api/newsletter/sources/:pattern
+
+Request body (all fields optional):
+
+```json
+{
+  "poi_id": 42,
+  "status": "accepted",
+  "display_name": "Akron Zoo Newsletter"
+}
+```
+
+Setting `status` to `accepted` with a `poi_id` queues all unprocessed emails from that sender for reprocessing.
+
+---
+
+## UI/UX Requirements
+
+### Redesigned "Inbound Newsletters" Section
+
+Replace the per-email list with a source management table:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  📥 Newsletter Sources                                      │
+│  Manage which organizations can send content via email.     │
+│                                                              │
+│  ⚠ NEW (2)                                                  │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │ unknown@cvnpa.org          3 emails · last: Jun 20     ││
+│  │ [Select POI ▼] [Accept] [Block] [Delete]               ││
+│  ├─────────────────────────────────────────────────────────┤│
+│  │ alerts@summitcounty.gov    1 email · last: Jun 18      ││
+│  │ [Select POI ▼] [Accept] [Block] [Delete]               ││
+│  └─────────────────────────────────────────────────────────┘│
+│                                                              │
+│  ✓ ACCEPTED (4)                                             │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │ news@akronzoo.org          23 emails → Akron Zoo       ││
+│  │ "Akron Zoo"     45 news, 12 events      [Edit] [Block] ││
+│  ├─────────────────────────────────────────────────────────┤│
+│  │ info@metroparks.cc         15 emails → Summit Metro... ││
+│  │ "Summit Metro Parks"  22 news, 8 events [Edit] [Block] ││
+│  └─────────────────────────────────────────────────────────┘│
+│                                                              │
+│  ✗ BLOCKED (1) ▸                                            │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │ spam@example.com           2 emails     [Unblock] [Del]││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Non-Functional Requirements
+
+**NFR-037-1: Backward Compatibility**
+- Existing `poi_newsletter_sources` rows (status-less) are treated as `accepted`
+- The MCP `newsletter_assign_poi` tool continues to work (creates source with `accepted` status)
+- The reprocess endpoint stays for MCP individual-email operations
+
+---
+
+## Dependencies
+
+- Depends on: 060_add_poi_newsletter_sources.sql (existing migration)
+- Blocks: none
+
+---
+
+## Open Questions
+
+1. ~~Should we support regex patterns in `from_pattern` or keep substring matching?~~ Keep substring — simpler, covers all real cases.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-22 | Initial draft |

--- a/backend/migrations/084_newsletter_source_entity.sql
+++ b/backend/migrations/084_newsletter_source_entity.sql
@@ -1,0 +1,41 @@
+-- 084_newsletter_source_entity.sql
+-- Evolve poi_newsletter_sources from a POI->sender mapping table into a
+-- first-class newsletter source entity (spec 037, issue #524).
+--
+-- Changes:
+--   1. Change PK from (poi_id, from_pattern) to (from_pattern) alone
+--   2. Make poi_id nullable (blocked/new sources have no POI)
+--   3. Add display_name and status columns
+--
+-- Idempotent: safe to re-run on every container start.
+
+-- Step 1: Add new columns (idempotent via IF NOT EXISTS)
+ALTER TABLE poi_newsletter_sources
+  ADD COLUMN IF NOT EXISTS display_name TEXT,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'accepted';
+
+-- Step 2: Restructure primary key BEFORE dropping NOT NULL.
+-- PostgreSQL won't allow DROP NOT NULL on a PK column, so we must
+-- remove poi_id from the PK first.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'poi_newsletter_sources_pkey'
+      AND conrelid = 'poi_newsletter_sources'::regclass
+  ) THEN
+    IF (
+      SELECT COUNT(*) FROM pg_attribute a
+      JOIN pg_constraint c ON a.attrelid = c.conrelid
+        AND a.attnum = ANY(c.conkey)
+      WHERE c.conname = 'poi_newsletter_sources_pkey'
+        AND c.conrelid = 'poi_newsletter_sources'::regclass
+    ) > 1 THEN
+      ALTER TABLE poi_newsletter_sources DROP CONSTRAINT poi_newsletter_sources_pkey;
+      ALTER TABLE poi_newsletter_sources ADD PRIMARY KEY (from_pattern);
+    END IF;
+  END IF;
+END $$;
+
+-- Step 3: Make poi_id nullable (now safe since it's no longer in the PK)
+ALTER TABLE poi_newsletter_sources ALTER COLUMN poi_id DROP NOT NULL;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4965,6 +4965,28 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     }
   });
 
+  router.get('/newsletter/subscribers', isAdmin, async (req, res) => {
+    try {
+      const { listSubscribers } = await import('../services/buttondownClient.js');
+      const subscribers = await listSubscribers(pool);
+      res.json(subscribers);
+    } catch (error) {
+      if (error.message === 'BUTTONDOWN_NOT_CONFIGURED') {
+        try {
+          const localRows = await pool.query(
+            'SELECT DISTINCT email, subscribed_at AS created FROM newsletter_subscriptions ORDER BY subscribed_at DESC'
+          );
+          res.json(localRows.rows);
+        } catch (dbErr) {
+          res.status(500).json({ error: 'Failed to fetch local subscribers' });
+        }
+      } else {
+        console.error('Subscriber list error:', error);
+        res.status(500).json({ error: 'Failed to fetch subscribers' });
+      }
+    }
+  });
+
   router.post('/moderation/sweep', isAdmin, async (req, res) => {
     try {
       console.log(`Admin ${req.user.email} triggered manual moderation sweep`);

--- a/backend/routes/newsletter.js
+++ b/backend/routes/newsletter.js
@@ -138,28 +138,172 @@ export function createNewsletterRouter(pool) {
     }
   });
 
-  router.get('/inbound', isAdmin, async (req, res) => {
+  router.get('/sources', isAdmin, async (req, res) => {
     try {
-      const limit = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
       const rows = await pool.query(
-        `SELECT e.id, e.from_address, e.subject, e.received_at, e.processed, e.processed_at,
-                e.error_message, e.news_extracted, e.events_extracted,
-                s.poi_id, p.name AS poi_name
-         FROM newsletter_emails e
-         LEFT JOIN LATERAL (
-           SELECT src.poi_id FROM poi_newsletter_sources src
-           WHERE POSITION(LOWER(src.from_pattern) IN LOWER(e.from_address)) > 0
-           ORDER BY LENGTH(src.from_pattern) DESC LIMIT 1
-         ) s ON TRUE
+        `SELECT s.from_pattern, s.poi_id, s.display_name, s.status, s.created_at,
+                p.name AS poi_name,
+                COUNT(e.id)::int AS email_count,
+                MAX(e.received_at) AS last_received,
+                COALESCE(SUM(e.news_extracted), 0)::int AS total_news,
+                COALESCE(SUM(e.events_extracted), 0)::int AS total_events
+         FROM poi_newsletter_sources s
          LEFT JOIN pois p ON p.id = s.poi_id
-         ORDER BY e.received_at DESC
-         LIMIT $1`,
-        [limit]
+         LEFT JOIN newsletter_emails e
+           ON POSITION(LOWER(s.from_pattern) IN LOWER(e.from_address)) > 0
+         GROUP BY s.from_pattern, s.poi_id, s.display_name, s.status, s.created_at, p.name
+         ORDER BY
+           CASE s.status WHEN 'new' THEN 0 WHEN 'accepted' THEN 1 WHEN 'blocked' THEN 2 END,
+           s.created_at DESC`
       );
       res.json(rows.rows);
     } catch (error) {
-      console.error('Inbound newsletter list error:', error);
-      res.status(500).json({ error: 'Failed to list inbound newsletters' });
+      console.error('Newsletter sources list error:', error);
+      res.status(500).json({ error: 'Failed to list newsletter sources' });
+    }
+  });
+
+  router.put('/sources/:pattern', isAdmin, async (req, res) => {
+    const pattern = decodeURIComponent(req.params.pattern);
+    const { poi_id, status, display_name } = req.body;
+    try {
+      const existing = await pool.query(
+        'SELECT from_pattern, status FROM poi_newsletter_sources WHERE from_pattern = $1', [pattern]
+      );
+      if (existing.rows.length === 0) return res.status(404).json({ error: 'Source not found' });
+
+      const sets = [];
+      const vals = [];
+      let idx = 1;
+
+      if (poi_id !== undefined) { sets.push(`poi_id = $${idx++}`); vals.push(poi_id); }
+      if (status !== undefined) { sets.push(`status = $${idx++}`); vals.push(status); }
+      if (display_name !== undefined) { sets.push(`display_name = $${idx++}`); vals.push(display_name); }
+
+      if (sets.length === 0) return res.status(400).json({ error: 'No fields to update' });
+
+      vals.push(pattern);
+      await pool.query(
+        `UPDATE poi_newsletter_sources SET ${sets.join(', ')} WHERE from_pattern = $${idx}`,
+        vals
+      );
+
+      if (status === 'accepted' && poi_id) {
+        const unprocessed = await pool.query(
+          `SELECT id FROM newsletter_emails
+           WHERE POSITION(LOWER($1) IN LOWER(from_address)) > 0 AND processed = FALSE`,
+          [pattern]
+        );
+        for (const row of unprocessed.rows) {
+          await pool.query('UPDATE newsletter_emails SET error_message = NULL WHERE id = $1', [row.id]);
+          await queueNewsletterJob(row.id);
+        }
+        res.json({ success: true, message: `Source accepted → POI ${poi_id}; ${unprocessed.rows.length} email(s) queued` });
+      } else {
+        res.json({ success: true, message: 'Source updated' });
+      }
+    } catch (error) {
+      console.error('Newsletter source update error:', error);
+      res.status(500).json({ error: 'Failed to update source' });
+    }
+  });
+
+  router.get('/sources/:pattern/emails', isAdmin, async (req, res) => {
+    const pattern = decodeURIComponent(req.params.pattern);
+    try {
+      const rows = await pool.query(
+        `SELECT id, from_address, subject, received_at, processed, processed_at,
+                error_message, news_extracted, events_extracted
+         FROM newsletter_emails
+         WHERE POSITION(LOWER($1) IN LOWER(from_address)) > 0
+         ORDER BY received_at DESC
+         LIMIT 50`,
+        [pattern]
+      );
+      res.json(rows.rows);
+    } catch (error) {
+      console.error('Newsletter source emails error:', error);
+      res.status(500).json({ error: 'Failed to list emails for source' });
+    }
+  });
+
+  router.get('/sources/discover', isAdmin, async (_req, res) => {
+    try {
+      const rows = await pool.query(
+        `SELECT e.from_address,
+                COUNT(e.id)::int AS email_count,
+                MAX(e.received_at) AS last_received,
+                MIN(e.received_at) AS first_received
+         FROM newsletter_emails e
+         WHERE NOT EXISTS (
+           SELECT 1 FROM poi_newsletter_sources s
+           WHERE POSITION(LOWER(s.from_pattern) IN LOWER(e.from_address)) > 0
+         )
+         GROUP BY e.from_address
+         ORDER BY MAX(e.received_at) DESC`
+      );
+      res.json(rows.rows);
+    } catch (error) {
+      console.error('Newsletter source discover error:', error);
+      res.status(500).json({ error: 'Failed to discover sources' });
+    }
+  });
+
+  router.post('/sources', isAdmin, async (req, res) => {
+    const { from_pattern, status } = req.body;
+    if (!from_pattern) return res.status(400).json({ error: 'from_pattern required' });
+    try {
+      await pool.query(
+        `INSERT INTO poi_newsletter_sources (from_pattern, poi_id, status)
+         VALUES ($1, NULL::integer, $2)
+         ON CONFLICT (from_pattern) DO NOTHING`,
+        [from_pattern, status || 'new']
+      );
+      res.json({ success: true, message: `Source "${from_pattern}" added` });
+    } catch (error) {
+      console.error('Newsletter source create error:', error);
+      res.status(500).json({ error: 'Failed to create source' });
+    }
+  });
+
+  router.delete('/sources/:pattern', isAdmin, async (req, res) => {
+    const pattern = decodeURIComponent(req.params.pattern);
+    try {
+      const deleted = await pool.query(
+        'DELETE FROM poi_newsletter_sources WHERE from_pattern = $1 RETURNING from_pattern', [pattern]
+      );
+      if (deleted.rows.length === 0) return res.status(404).json({ error: 'Source not found' });
+
+      const emails = await pool.query(
+        'DELETE FROM newsletter_emails WHERE POSITION(LOWER($1) IN LOWER(from_address)) > 0 RETURNING id',
+        [pattern]
+      );
+
+      res.json({ success: true, message: `Deleted source and ${emails.rows.length} email(s)` });
+    } catch (error) {
+      console.error('Newsletter source delete error:', error);
+      res.status(500).json({ error: 'Failed to delete source' });
+    }
+  });
+
+  router.get('/emails/:id/view', isAdmin, async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    try {
+      const row = await pool.query(
+        'SELECT subject, body_html, body_text FROM newsletter_emails WHERE id = $1', [id]
+      );
+      if (row.rows.length === 0) return res.status(404).send('Not found');
+      const email = row.rows[0];
+      if (email.body_html) {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.send(email.body_html);
+      } else {
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.send(email.body_text || '(empty)');
+      }
+    } catch (error) {
+      console.error('Newsletter email view error:', error);
+      res.status(500).send('Failed to load email');
     }
   });
 
@@ -172,29 +316,6 @@ export function createNewsletterRouter(pool) {
     } catch (error) {
       console.error('Inbound newsletter reprocess error:', error);
       res.status(500).json({ error: 'Failed to reprocess' });
-    }
-  });
-
-  router.post('/inbound/:id/assign-poi', isAdmin, async (req, res) => {
-    const id = parseInt(req.params.id, 10);
-    const { poi_id, from_pattern } = req.body;
-    if (!poi_id) return res.status(400).json({ error: 'poi_id required' });
-    try {
-      const emailRow = await pool.query('SELECT from_address FROM newsletter_emails WHERE id = $1', [id]);
-      if (emailRow.rows.length === 0) return res.status(404).json({ error: 'Not found' });
-      const pattern = (from_pattern && from_pattern.trim()) || emailRow.rows[0].from_address;
-      if (!pattern) return res.status(400).json({ error: 'No sender pattern available' });
-      await pool.query(
-        `INSERT INTO poi_newsletter_sources (poi_id, from_pattern)
-         VALUES ($1, $2) ON CONFLICT (poi_id, from_pattern) DO NOTHING`,
-        [poi_id, pattern]
-      );
-      await pool.query('UPDATE newsletter_emails SET processed = FALSE, error_message = NULL WHERE id = $1', [id]);
-      await queueNewsletterJob(id);
-      res.json({ success: true, message: `Mapped "${pattern}" → POI ${poi_id}` });
-    } catch (error) {
-      console.error('Inbound newsletter assign-poi error:', error);
-      res.status(500).json({ error: 'Failed to assign POI' });
     }
   });
 

--- a/backend/services/buttondownClient.js
+++ b/backend/services/buttondownClient.js
@@ -250,6 +250,30 @@ export async function sendDraftToRecipients(subject, htmlBody, recipients, pool 
   return { emailId };
 }
 
+export async function listSubscribers(pool = null) {
+  const apiKey = await getApiKey(pool);
+  const client = createClient(apiKey);
+
+  const subscribers = [];
+  let url = '/v1/subscribers?status=regular';
+
+  while (url) {
+    const response = await client.get(url);
+    const data = response.data;
+    if (Array.isArray(data.results)) {
+      for (const sub of data.results) {
+        subscribers.push({
+          email: sub.email_address,
+          created: sub.creation_date,
+        });
+      }
+    }
+    url = data.next ? new URL(data.next).pathname + new URL(data.next).search : null;
+  }
+
+  return subscribers;
+}
+
 export async function testApiKey(pool = null) {
   const apiKey = await getApiKey(pool);
   const client = createClient(apiKey);

--- a/backend/services/mcpServer.js
+++ b/backend/services/mcpServer.js
@@ -561,6 +561,31 @@ function registerTools(server, pool, boss, mcpUserId) {
   );
 
   server.tool(
+    'newsletter_sources',
+    'List newsletter sources (unique senders) with status, POI assignment, and email counts',
+    {},
+    async () => {
+      const rows = await pool.query(
+        `SELECT s.from_pattern, s.poi_id, s.display_name, s.status, s.created_at,
+                p.name AS poi_name,
+                COUNT(e.id)::int AS email_count,
+                MAX(e.received_at) AS last_received,
+                COALESCE(SUM(e.news_extracted), 0)::int AS total_news,
+                COALESCE(SUM(e.events_extracted), 0)::int AS total_events
+         FROM poi_newsletter_sources s
+         LEFT JOIN pois p ON p.id = s.poi_id
+         LEFT JOIN newsletter_emails e
+           ON POSITION(LOWER(s.from_pattern) IN LOWER(e.from_address)) > 0
+         GROUP BY s.from_pattern, s.poi_id, s.display_name, s.status, s.created_at, p.name
+         ORDER BY
+           CASE s.status WHEN 'new' THEN 0 WHEN 'accepted' THEN 1 WHEN 'blocked' THEN 2 END,
+           s.created_at DESC`
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(rows.rows, null, 2) }] };
+    }
+  );
+
+  server.tool(
     'newsletter_assign_poi',
     'Map a newsletter sender to a POI so its emails are scoped to that POI, then reprocess the email',
     {
@@ -578,13 +603,14 @@ function registerTools(server, pool, boss, mcpUserId) {
         return { content: [{ type: 'text', text: 'No sender pattern available to map' }], isError: true };
       }
       await pool.query(
-        `INSERT INTO poi_newsletter_sources (poi_id, from_pattern)
-         VALUES ($1, $2) ON CONFLICT (poi_id, from_pattern) DO NOTHING`,
+        `INSERT INTO poi_newsletter_sources (poi_id, from_pattern, status)
+         VALUES ($1, $2, 'accepted')
+         ON CONFLICT (from_pattern) DO UPDATE SET poi_id = $1, status = 'accepted'`,
         [poi_id, pattern]
       );
       await pool.query(`UPDATE newsletter_emails SET processed = FALSE, error_message = NULL WHERE id = $1`, [id]);
       await queueNewsletterJob(id);
-      return { content: [{ type: 'text', text: `Mapped "${pattern}" → POI ${poi_id}; queued email #${id} for reprocessing` }] };
+      return { content: [{ type: 'text', text: `Mapped "${pattern}" → POI ${poi_id} (accepted); queued email #${id} for reprocessing` }] };
     }
   );
 

--- a/backend/services/newsletterService.js
+++ b/backend/services/newsletterService.js
@@ -122,27 +122,67 @@ export async function processNewsletterById(pool, emailId) {
   const from = email.from_address || '';
   const subject = email.subject || '(no subject)';
 
-  const poiResult = await pool.query(
-    `SELECT p.* FROM poi_newsletter_sources s
-       JOIN pois p ON p.id = s.poi_id
+  const sourceResult = await pool.query(
+    `SELECT s.from_pattern, s.poi_id, s.status, s.display_name, p.*
+       FROM poi_newsletter_sources s
+       LEFT JOIN pois p ON p.id = s.poi_id
       WHERE POSITION(LOWER(s.from_pattern) IN LOWER($1)) > 0
       ORDER BY LENGTH(s.from_pattern) DESC
       LIMIT 1`,
     [from]
   );
 
-  if (poiResult.rows.length === 0) {
+  if (sourceResult.rows.length === 0) {
+    await pool.query(
+      `INSERT INTO poi_newsletter_sources (from_pattern, poi_id, status)
+       VALUES ($1, NULL, 'new')
+       ON CONFLICT (from_pattern) DO NOTHING`,
+      [from]
+    );
     await pool.query(
       `UPDATE newsletter_emails
-         SET processed = FALSE, error_message = $1, processed_at = CURRENT_TIMESTAMP
-       WHERE id = $2`,
-      [`unassigned: no POI mapped for sender ${from}`, emailId]
+         SET processed = FALSE, error_message = 'new source — awaiting admin triage', processed_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailId]
     );
-    console.log(`[Newsletter] Quarantined #${emailId} — no POI mapping for "${from}"`);
+    console.log(`[Newsletter] New source discovered: "${from}" — awaiting admin triage`);
     return;
   }
 
-  const poi = poiResult.rows[0];
+  const source = sourceResult.rows[0];
+
+  if (source.status === 'blocked') {
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = TRUE, error_message = 'blocked source', news_extracted = 0, events_extracted = 0, processed_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailId]
+    );
+    console.log(`[Newsletter] Skipped #${emailId} — source "${from}" is blocked`);
+    return;
+  }
+
+  if (source.status === 'new') {
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = FALSE, error_message = 'new source — awaiting admin triage', processed_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailId]
+    );
+    return;
+  }
+
+  if (!source.poi_id) {
+    await pool.query(
+      `UPDATE newsletter_emails
+         SET processed = FALSE, error_message = 'accepted source has no POI assigned', processed_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailId]
+    );
+    return;
+  }
+
+  const poi = source;
   const { markdown, links, viewInBrowserUrl } = extractEmailParts(email.body_html || '');
 
   let entryUrl = viewInBrowserUrl;

--- a/frontend/src/components/NewsletterSettings.jsx
+++ b/frontend/src/components/NewsletterSettings.jsx
@@ -13,10 +13,17 @@ function NewsletterSettings({ user }) {
   const [testing, setTesting] = useState(false);
   const [testMessage, setTestMessage] = useState(null);
 
-  const [inbound, setInbound] = useState([]);
+  const [sources, setSources] = useState([]);
   const [pois, setPois] = useState([]);
-  const [assignSel, setAssignSel] = useState({});
-  const [inboundMsg, setInboundMsg] = useState(null);
+  const [sourceEdits, setSourceEdits] = useState({});
+  const [sourceMsg, setSourceMsg] = useState(null);
+  const [showBlocked, setShowBlocked] = useState(false);
+  const [subscribers, setSubscribers] = useState(null);
+  const [loadingSubscribers, setLoadingSubscribers] = useState(false);
+  const [expandedEmails, setExpandedEmails] = useState({});
+  const [sourceEmails, setSourceEmails] = useState({});
+  const [orphans, setOrphans] = useState(null);
+  const [loadingOrphans, setLoadingOrphans] = useState(false);
 
   useEffect(() => {
     if (user?.email) {
@@ -24,7 +31,7 @@ function NewsletterSettings({ user }) {
     }
     loadAdminSettings();
     loadStats();
-    loadInbound();
+    loadSources();
     loadPois();
   }, [user]);
 
@@ -63,12 +70,12 @@ function NewsletterSettings({ user }) {
     }
   };
 
-  const loadInbound = async () => {
+  const loadSources = async () => {
     try {
-      const res = await fetch('/api/newsletter/inbound', { credentials: 'include' });
-      if (res.ok) setInbound(await res.json());
+      const res = await fetch('/api/newsletter/sources', { credentials: 'include' });
+      if (res.ok) setSources(await res.json());
     } catch (err) {
-      console.error('Failed to load inbound newsletters:', err);
+      console.error('Failed to load newsletter sources:', err);
     }
   };
 
@@ -84,38 +91,122 @@ function NewsletterSettings({ user }) {
     }
   };
 
-  const handleReprocess = async (id) => {
-    setInboundMsg(null);
+  const toggleSubscribers = async () => {
+    if (subscribers) {
+      setSubscribers(null);
+      return;
+    }
+    setLoadingSubscribers(true);
     try {
-      const res = await fetch(`/api/newsletter/inbound/${id}/reprocess`, { method: 'POST', credentials: 'include' });
-      const data = await res.json();
-      setInboundMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
-      setTimeout(loadInbound, 1500);
+      const res = await fetch('/api/admin/newsletter/subscribers', { credentials: 'include' });
+      if (res.ok) setSubscribers(await res.json());
     } catch (err) {
-      setInboundMsg({ type: 'error', text: 'Reprocess failed' });
+      console.error('Failed to load subscribers:', err);
+    } finally {
+      setLoadingSubscribers(false);
     }
   };
 
-  const handleAssign = async (id) => {
-    const sel = assignSel[id] || {};
-    if (!sel.poiId) {
-      setInboundMsg({ type: 'error', text: 'Pick a POI first' });
+  const toggleEmails = async (pattern) => {
+    if (expandedEmails[pattern]) {
+      setExpandedEmails((prev) => { const next = { ...prev }; delete next[pattern]; return next; });
       return;
     }
-    setInboundMsg(null);
     try {
-      const res = await fetch(`/api/newsletter/inbound/${id}/assign-poi`, {
+      const res = await fetch(`/api/newsletter/sources/${encodeURIComponent(pattern)}/emails`, { credentials: 'include' });
+      if (res.ok) {
+        const emails = await res.json();
+        setSourceEmails((prev) => ({ ...prev, [pattern]: emails }));
+        setExpandedEmails((prev) => ({ ...prev, [pattern]: true }));
+      }
+    } catch (err) {
+      console.error('Failed to load emails for source:', err);
+    }
+  };
+
+  const toggleDiscover = async () => {
+    if (orphans) {
+      setOrphans(null);
+      return;
+    }
+    setLoadingOrphans(true);
+    try {
+      const res = await fetch('/api/newsletter/sources/discover', { credentials: 'include' });
+      if (res.ok) setOrphans(await res.json());
+    } catch (err) {
+      console.error('Failed to discover sources:', err);
+    } finally {
+      setLoadingOrphans(false);
+    }
+  };
+
+  const addSource = async (fromAddress) => {
+    setSourceMsg(null);
+    try {
+      const res = await fetch('/api/newsletter/sources', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ poi_id: parseInt(sel.poiId, 10), from_pattern: sel.pattern || undefined }),
+        body: JSON.stringify({ from_pattern: fromAddress, status: 'new' }),
         credentials: 'include'
       });
       const data = await res.json();
-      setInboundMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
-      setTimeout(loadInbound, 1500);
+      setSourceMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
+      if (res.ok) {
+        setOrphans((prev) => prev ? prev.filter(o => o.from_address !== fromAddress) : null);
+        loadSources();
+      }
     } catch (err) {
-      setInboundMsg({ type: 'error', text: 'Assign failed' });
+      setSourceMsg({ type: 'error', text: 'Failed to add source' });
     }
+  };
+
+  const updateSource = async (pattern, body) => {
+    setSourceMsg(null);
+    try {
+      const res = await fetch(`/api/newsletter/sources/${encodeURIComponent(pattern)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        credentials: 'include'
+      });
+      const data = await res.json();
+      setSourceMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
+      if (res.ok) {
+        setSourceEdits((prev) => { const next = { ...prev }; delete next[pattern]; return next; });
+        loadSources();
+      }
+    } catch (err) {
+      setSourceMsg({ type: 'error', text: 'Update failed' });
+    }
+  };
+
+  const deleteSource = async (pattern) => {
+    if (!window.confirm(`Delete source "${pattern}" and all its emails?`)) return;
+    setSourceMsg(null);
+    try {
+      const res = await fetch(`/api/newsletter/sources/${encodeURIComponent(pattern)}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+      const data = await res.json();
+      setSourceMsg(res.ok ? { type: 'success', text: data.message } : { type: 'error', text: data.error });
+      if (res.ok) loadSources();
+    } catch (err) {
+      setSourceMsg({ type: 'error', text: 'Delete failed' });
+    }
+  };
+
+  const handleAccept = (pattern) => {
+    const edit = sourceEdits[pattern] || {};
+    if (!edit.poiId) {
+      setSourceMsg({ type: 'error', text: 'Select a POI first' });
+      return;
+    }
+    updateSource(pattern, {
+      poi_id: parseInt(edit.poiId, 10),
+      status: 'accepted',
+      display_name: edit.displayName || undefined
+    });
   };
 
   const handleSubscribe = async (e) => {
@@ -136,7 +227,7 @@ function NewsletterSettings({ user }) {
       if (res.ok) {
         setStatus('success');
         setMessage(data.message);
-        loadStats(); // Refresh stats
+        loadStats();
       } else {
         setStatus('error');
         setMessage(data.error || 'Subscription failed');
@@ -200,12 +291,12 @@ function NewsletterSettings({ user }) {
       if (data.success) {
         setTestMessage({
           type: 'success',
-          text: `✓ API key is valid! You have ${data.subscriberCount} subscriber${data.subscriberCount !== 1 ? 's' : ''}.`
+          text: `API key is valid! You have ${data.subscriberCount} subscriber${data.subscriberCount !== 1 ? 's' : ''}.`
         });
       } else {
         setTestMessage({
           type: 'error',
-          text: `✗ ${data.error || 'API key test failed'}`
+          text: data.error || 'API key test failed'
         });
       }
 
@@ -213,7 +304,7 @@ function NewsletterSettings({ user }) {
     } catch (err) {
       setTestMessage({
         type: 'error',
-        text: '✗ Failed to test API key. Please try again.'
+        text: 'Failed to test API key. Please try again.'
       });
       setTimeout(() => setTestMessage(null), 5000);
     } finally {
@@ -221,11 +312,147 @@ function NewsletterSettings({ user }) {
     }
   };
 
+  const newSources = sources.filter(s => s.status === 'new');
+  const acceptedSources = sources.filter(s => s.status === 'accepted');
+  const blockedSources = sources.filter(s => s.status === 'blocked');
+
+  const cardStyle = (bg) => ({
+    border: '1px solid #ddd',
+    borderRadius: '6px',
+    padding: '12px',
+    backgroundColor: bg
+  });
+
+  const renderSourceCard = (src, actions) => {
+    const edit = sourceEdits[src.from_pattern] || {};
+    const isExpanded = expandedEmails[src.from_pattern];
+    const emails = sourceEmails[src.from_pattern] || [];
+    return (
+      <div key={src.from_pattern} style={cardStyle(src.status === 'new' ? '#fff8e1' : src.status === 'blocked' ? '#f5f5f5' : '#fff')}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div>
+            <div style={{ fontWeight: 'bold', fontSize: '0.95rem' }}>
+              {src.display_name || src.from_pattern}
+            </div>
+            {src.display_name && (
+              <div style={{ fontSize: '0.85rem', color: '#666' }}>{src.from_pattern}</div>
+            )}
+          </div>
+          <div style={{ fontSize: '0.8rem', color: '#999', textAlign: 'right', whiteSpace: 'nowrap' }}>
+            <span
+              style={{ cursor: 'pointer', textDecoration: 'underline', textDecorationStyle: 'dotted' }}
+              onClick={() => toggleEmails(src.from_pattern)}
+              title="Click to show individual emails"
+            >
+              {src.email_count} email{src.email_count !== 1 ? 's' : ''}
+            </span>
+            {src.last_received && (
+              <div>{new Date(src.last_received).toLocaleDateString()}</div>
+            )}
+          </div>
+        </div>
+
+        {src.status === 'accepted' && (
+          <div style={{ fontSize: '0.85rem', marginTop: '4px' }}>
+            POI: <strong>{src.poi_name}</strong> · {src.total_news} news, {src.total_events} events
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '8px', marginTop: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {actions === 'new' && (
+            <>
+              <select
+                value={edit.poiId || ''}
+                onChange={(ev) => setSourceEdits({ ...sourceEdits, [src.from_pattern]: { ...edit, poiId: ev.target.value } })}
+              >
+                <option value="">Select POI...</option>
+                {pois.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+              <button className="save-settings-btn" onClick={() => handleAccept(src.from_pattern)}>Accept</button>
+              <button className="save-settings-btn" onClick={() => updateSource(src.from_pattern, { status: 'blocked' })}>Block</button>
+              <button className="save-settings-btn" onClick={() => deleteSource(src.from_pattern)}>Delete</button>
+            </>
+          )}
+          {actions === 'accepted' && (
+            <>
+              <button className="save-settings-btn" onClick={() => updateSource(src.from_pattern, { status: 'blocked' })}>Block</button>
+              <button className="save-settings-btn" onClick={() => deleteSource(src.from_pattern)}>Delete</button>
+            </>
+          )}
+          {actions === 'blocked' && (
+            <>
+              <select
+                value={edit.poiId || ''}
+                onChange={(ev) => setSourceEdits({ ...sourceEdits, [src.from_pattern]: { ...edit, poiId: ev.target.value } })}
+              >
+                <option value="">Select POI...</option>
+                {pois.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+              <button className="save-settings-btn" onClick={() => handleAccept(src.from_pattern)}>Accept</button>
+              <button className="save-settings-btn" onClick={() => deleteSource(src.from_pattern)}>Delete</button>
+            </>
+          )}
+          <button className="save-settings-btn" onClick={() => toggleEmails(src.from_pattern)}>
+            {isExpanded ? 'Hide Emails' : 'Emails'}
+          </button>
+        </div>
+
+        {isExpanded && (
+          <div style={{ marginTop: '10px', borderTop: '1px solid #e0e0e0', paddingTop: '8px', maxHeight: '250px', overflowY: 'auto' }}>
+            {emails.length === 0 ? (
+              <p style={{ color: '#666', margin: 0, fontSize: '0.85rem' }}>No emails found for this source.</p>
+            ) : (
+              <table style={{ width: '100%', fontSize: '0.8rem', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid #e0e0e0', textAlign: 'left' }}>
+                    <th style={{ padding: '4px 6px' }}>Subject</th>
+                    <th style={{ padding: '4px 6px' }}>Date</th>
+                    <th style={{ padding: '4px 6px' }}>Status</th>
+                    <th style={{ padding: '4px 6px' }}>Extracted</th>
+                    <th style={{ padding: '4px 6px' }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {emails.map((em) => (
+                    <tr key={em.id} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                      <td style={{ padding: '4px 6px', maxWidth: '300px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {em.subject || '(no subject)'}
+                      </td>
+                      <td style={{ padding: '4px 6px', whiteSpace: 'nowrap', color: '#666' }}>
+                        {em.received_at ? new Date(em.received_at).toLocaleDateString() : '—'}
+                      </td>
+                      <td style={{ padding: '4px 6px' }}>
+                        {em.processed ? (
+                          <span style={{ color: '#2c5f2d' }}>Processed</span>
+                        ) : em.error_message ? (
+                          <span style={{ color: '#b8860b' }} title={em.error_message}>Pending</span>
+                        ) : (
+                          <span style={{ color: '#666' }}>Queued</span>
+                        )}
+                      </td>
+                      <td style={{ padding: '4px 6px', color: '#666' }}>
+                        {em.news_extracted ?? 0}N / {em.events_extracted ?? 0}E
+                      </td>
+                      <td style={{ padding: '4px 6px' }}>
+                        <a href={`/api/newsletter/emails/${em.id}/view`} target="_blank" rel="noopener noreferrer"
+                           style={{ fontSize: '0.8rem' }}>View</a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="newsletter-settings">
       {/* User Section - Subscribe to Newsletter */}
       <div className="settings-section">
-        <h3>📧 Newsletter Subscription</h3>
+        <h3>Newsletter Subscription</h3>
         <p className="settings-description">
           Get a weekly digest of valley events and news every Friday morning.
         </p>
@@ -253,7 +480,7 @@ function NewsletterSettings({ user }) {
               disabled={status === 'loading'}
               className="save-settings-btn"
             >
-              {status === 'loading' ? '📨 Subscribing...' : '📨 Subscribe to Weekly Digest'}
+              {status === 'loading' ? 'Subscribing...' : 'Subscribe to Weekly Digest'}
             </button>
           </div>
 
@@ -268,7 +495,7 @@ function NewsletterSettings({ user }) {
               fontSize: '0.9rem',
               maxWidth: '600px'
             }}>
-              ✓ {message}
+              {message}
             </div>
           )}
           {status === 'error' && (
@@ -282,7 +509,7 @@ function NewsletterSettings({ user }) {
               fontSize: '0.9rem',
               maxWidth: '600px'
             }}>
-              ✗ {message}
+              {message}
             </div>
           )}
         </form>
@@ -292,7 +519,7 @@ function NewsletterSettings({ user }) {
 
       {/* Admin Section - Configuration */}
       <div className="settings-section">
-        <h3>⚙️ Admin Configuration</h3>
+        <h3>Admin Configuration</h3>
         <p className="settings-description">
           Configure Buttondown API integration and newsletter settings.
         </p>
@@ -301,7 +528,6 @@ function NewsletterSettings({ user }) {
         {stats && (
           <div className="settings-info-box" style={{ marginBottom: '24px' }}>
             <div className="info-box-header">
-              <span className="info-icon">📊</span>
               <strong>Subscriber Statistics</strong>
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', marginTop: '12px' }}>
@@ -318,9 +544,37 @@ function NewsletterSettings({ user }) {
                 <div style={{ color: '#666', fontSize: '0.9rem' }}>New This Week</div>
               </div>
             </div>
-            <p style={{ marginTop: '12px', fontSize: '0.85rem', color: '#666' }}>
-              Source: {stats.source === 'buttondown' ? 'Buttondown API' : 'Local Database'}
-            </p>
+            <div style={{ marginTop: '12px' }}>
+              <button className="save-settings-btn" onClick={toggleSubscribers} disabled={loadingSubscribers}>
+                {loadingSubscribers ? 'Loading...' : subscribers ? 'Hide Subscribers' : 'Subscribers'}
+              </button>
+            </div>
+            {subscribers && (
+              <div style={{ marginTop: '10px', maxHeight: '250px', overflowY: 'auto', border: '1px solid #e0e0e0', borderRadius: '4px', padding: '8px' }}>
+                {subscribers.length === 0 ? (
+                  <p style={{ color: '#666', margin: 0 }}>No subscribers found.</p>
+                ) : (
+                  <table style={{ width: '100%', fontSize: '0.85rem', borderCollapse: 'collapse' }}>
+                    <thead>
+                      <tr style={{ borderBottom: '1px solid #e0e0e0' }}>
+                        <th style={{ textAlign: 'left', padding: '4px 8px' }}>Email</th>
+                        <th style={{ textAlign: 'left', padding: '4px 8px' }}>Subscribed</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {subscribers.map((sub, i) => (
+                        <tr key={i} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                          <td style={{ padding: '4px 8px' }}>{sub.email}</td>
+                          <td style={{ padding: '4px 8px', color: '#666' }}>
+                            {sub.created ? new Date(sub.created).toLocaleDateString() : '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -338,7 +592,7 @@ function NewsletterSettings({ user }) {
             onChange={(e) => setApiKey(e.target.value)}
           />
           <p className="field-hint">
-            Get your API key from <a href="https://buttondown.com/settings/api" target="_blank" rel="noopener noreferrer">Buttondown Settings → API</a>
+            Get your API key from <a href="https://buttondown.com/settings/api" target="_blank" rel="noopener noreferrer">Buttondown Settings &rarr; API</a>
           </p>
         </div>
 
@@ -362,7 +616,7 @@ function NewsletterSettings({ user }) {
             disabled={adminSaving}
             className="save-settings-btn"
           >
-            {adminSaving ? '💾 Saving...' : '💾 Save Admin Settings'}
+            {adminSaving ? 'Saving...' : 'Save Admin Settings'}
           </button>
 
           <button
@@ -371,7 +625,7 @@ function NewsletterSettings({ user }) {
             className="save-settings-btn"
             style={{ marginLeft: '12px' }}
           >
-            {testing ? '🔍 Testing...' : '🔍 Test API Key'}
+            {testing ? 'Testing...' : 'Test API Key'}
           </button>
 
           {adminMessage && (
@@ -390,67 +644,105 @@ function NewsletterSettings({ user }) {
 
       <div className="settings-divider"></div>
 
-      {/* Admin Section - Inbound Newsletters */}
+      {/* Admin Section - Newsletter Sources */}
       <div className="settings-section">
-        <h3>📥 Inbound Newsletters</h3>
+        <h3>Newsletter Sources</h3>
         <p className="settings-description">
-          Newsletters forwarded to news@rootsofthevalley.org are crawled through the standard
-          collection pipeline and scoped to one POI by sender. Unassigned senders are quarantined
-          here until you map them to a POI.
+          Organizations that send newsletters to news@rootsofthevalley.org. Accept a source to
+          map it to a POI and process its content. Block or delete unwanted senders.
         </p>
 
-        {inboundMsg && (
-          <div className={`save-message ${inboundMsg.type}`} style={{ marginBottom: '12px' }}>
-            {inboundMsg.type === 'success' ? '✓' : '✗'} {inboundMsg.text}
+        <div style={{ marginBottom: '12px' }}>
+          <button className="save-settings-btn" onClick={toggleDiscover} disabled={loadingOrphans}>
+            {loadingOrphans ? 'Loading...' : orphans ? 'Hide Discovered' : 'Discover Sources'}
+          </button>
+        </div>
+
+        {orphans && (
+          <div style={{ marginBottom: '16px', border: '1px solid #e0e0e0', borderRadius: '6px', padding: '10px' }}>
+            {orphans.length === 0 ? (
+              <p style={{ color: '#666', margin: 0, fontSize: '0.85rem' }}>No unmapped senders found. All emails have a source.</p>
+            ) : (
+              <div style={{ maxHeight: '250px', overflowY: 'auto' }}>
+                <table style={{ width: '100%', fontSize: '0.85rem', borderCollapse: 'collapse' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '1px solid #e0e0e0', textAlign: 'left' }}>
+                      <th style={{ padding: '4px 8px' }}>Sender</th>
+                      <th style={{ padding: '4px 8px' }}>Emails</th>
+                      <th style={{ padding: '4px 8px' }}>Last Received</th>
+                      <th style={{ padding: '4px 8px' }}></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {orphans.map((o) => (
+                      <tr key={o.from_address} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                        <td style={{ padding: '4px 8px', maxWidth: '280px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {o.from_address}
+                        </td>
+                        <td style={{ padding: '4px 8px', color: '#666' }}>{o.email_count}</td>
+                        <td style={{ padding: '4px 8px', color: '#666', whiteSpace: 'nowrap' }}>
+                          {o.last_received ? new Date(o.last_received).toLocaleDateString() : '—'}
+                        </td>
+                        <td style={{ padding: '4px 8px' }}>
+                          <button className="save-settings-btn" onClick={() => addSource(o.from_address)}>Add</button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         )}
 
-        {inbound.length === 0 ? (
-          <p style={{ color: '#666' }}>No inbound newsletters yet.</p>
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-            {inbound.map((item) => {
-              const unassigned = !item.poi_id;
-              const sel = assignSel[item.id] || {};
-              return (
-                <div key={item.id} style={{
-                  border: '1px solid #ddd',
-                  borderRadius: '6px',
-                  padding: '12px',
-                  backgroundColor: unassigned ? '#fff8e1' : '#fff'
-                }}>
-                  <div style={{ fontWeight: 'bold' }}>{item.subject || '(no subject)'}</div>
-                  <div style={{ fontSize: '0.85rem', color: '#666' }}>{item.from_address}</div>
-                  <div style={{ fontSize: '0.85rem', marginTop: '4px' }}>
-                    {unassigned ? (
-                      <span style={{ color: '#b8860b' }}>⚠ Unassigned — map a POI to ingest</span>
-                    ) : (
-                      <span>POI: <strong>{item.poi_name}</strong> · {item.news_extracted ?? 0} news, {item.events_extracted ?? 0} events</span>
-                    )}
-                    {item.error_message && <span style={{ color: '#721c24' }}> · {item.error_message}</span>}
-                  </div>
-                  <div style={{ display: 'flex', gap: '8px', marginTop: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                    <select
-                      value={sel.poiId ?? (item.poi_id || '')}
-                      onChange={(ev) => setAssignSel({ ...assignSel, [item.id]: { ...sel, poiId: ev.target.value } })}
-                    >
-                      <option value="">Select POI…</option>
-                      {pois.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                    </select>
-                    <input
-                      type="text"
-                      placeholder="match pattern (optional)"
-                      value={sel.pattern ?? ''}
-                      onChange={(ev) => setAssignSel({ ...assignSel, [item.id]: { ...sel, pattern: ev.target.value } })}
-                      style={{ flex: '1', minWidth: '160px' }}
-                    />
-                    <button className="save-settings-btn" onClick={() => handleAssign(item.id)}>Assign &amp; Reprocess</button>
-                    <button className="save-settings-btn" onClick={() => handleReprocess(item.id)}>Reprocess</button>
-                  </div>
-                </div>
-              );
-            })}
+        {sourceMsg && (
+          <div className={`save-message ${sourceMsg.type}`} style={{ marginBottom: '12px' }}>
+            {sourceMsg.type === 'success' ? '✓' : '✗'} {sourceMsg.text}
           </div>
+        )}
+
+        {sources.length === 0 && !orphans ? (
+          <p style={{ color: '#666' }}>No newsletter sources yet. Click "Discover Sources" to find senders from existing emails.</p>
+        ) : (
+          <>
+            {newSources.length > 0 && (
+              <div style={{ marginBottom: '16px' }}>
+                <h4 style={{ margin: '0 0 8px', fontSize: '0.9rem', color: '#b8860b' }}>
+                  New ({newSources.length})
+                </h4>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {newSources.map(s => renderSourceCard(s, 'new'))}
+                </div>
+              </div>
+            )}
+
+            {acceptedSources.length > 0 && (
+              <div style={{ marginBottom: '16px' }}>
+                <h4 style={{ margin: '0 0 8px', fontSize: '0.9rem', color: '#2c5f2d' }}>
+                  Accepted ({acceptedSources.length})
+                </h4>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {acceptedSources.map(s => renderSourceCard(s, 'accepted'))}
+                </div>
+              </div>
+            )}
+
+            {blockedSources.length > 0 && (
+              <div>
+                <h4
+                  style={{ margin: '0 0 8px', fontSize: '0.9rem', color: '#999', cursor: 'pointer' }}
+                  onClick={() => setShowBlocked(!showBlocked)}
+                >
+                  Blocked ({blockedSources.length}) {showBlocked ? '▾' : '▸'}
+                </h4>
+                {showBlocked && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                    {blockedSources.map(s => renderSourceCard(s, 'blocked'))}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -459,16 +751,15 @@ function NewsletterSettings({ user }) {
       {/* Info Section */}
       <div className="settings-info-box">
         <div className="info-box-header">
-          <span className="info-icon">ℹ️</span>
           <strong>Newsletter Configuration Guide</strong>
         </div>
         <ul className="info-list">
           <li><strong>Buttondown Setup:</strong> Sign up at <a href="https://buttondown.com" target="_blank" rel="noopener noreferrer">buttondown.com</a> (free for up to 100 subscribers)</li>
           <li><strong>Verify Email:</strong> Verify your sender email in Buttondown before sending</li>
-          <li><strong>Get API Key:</strong> Generate an API key from Buttondown Settings → API</li>
+          <li><strong>Get API Key:</strong> Generate an API key from Buttondown Settings &rarr; API</li>
           <li><strong>Schedule:</strong> Digest sends automatically every Friday at 8 AM EST</li>
           <li><strong>Content:</strong> Includes events (Fri-Sun) and recent news (last 7 days)</li>
-          <li><strong>Testing:</strong> Use Settings → Jobs → Newsletter Digest → "Run Now" to test</li>
+          <li><strong>Testing:</strong> Use Settings &rarr; Jobs &rarr; Newsletter Digest &rarr; "Run Now" to test</li>
         </ul>
       </div>
 
@@ -476,7 +767,6 @@ function NewsletterSettings({ user }) {
 
       <div className="settings-info-box">
         <div className="info-box-header">
-          <span className="info-icon">⚠️</span>
           <strong>Important Notes</strong>
         </div>
         <ul className="info-list">


### PR DESCRIPTION
## Summary

- Redesigns "Inbound Newsletters" settings page to manage **sources** (unique senders) instead of individual emails
- Sources can be accepted (mapped to a POI), blocked, or deleted
- "Discover Sources" button scans for unmapped senders from existing emails
- "Emails" button per source expands to show individual emails with "View" links for full HTML content
- "Subscribers" button on stats section shows Buttondown subscriber email list
- Auto-discovers new senders in the newsletter processing pipeline
- Migration 084 evolves `poi_newsletter_sources` into a proper source entity with status, display_name, nullable poi_id
- Adds `newsletter_sources` MCP tool for source management

Closes #524

## Test plan
- [ ] Settings > Newsletter shows sources grouped by status (new/accepted/blocked)
- [ ] "Discover Sources" reveals orphan senders in a table with "Add" buttons
- [ ] Accepting a source with a POI queues unprocessed emails
- [ ] "Emails" button expands to show individual emails per source
- [ ] "View" link opens full HTML email content in new tab
- [ ] "Subscribers" button shows Buttondown subscriber list
- [ ] Blocking a source prevents future email processing
- [ ] Deleting a source purges it and all its emails
- [ ] Migration runs cleanly on fresh start with production seed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)