### PR TITLE
fix: trip tour navigates through My Valley to Trips tab (#526)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -532,6 +532,12 @@ function AppContent() {
         }
         break;
       }
+      case 'tripTourOpenMyValley': {
+        setShowUserDropdown(false);
+        setShowLoginDropdown(false);
+        setShowMyValley(true);
+        break;
+      }
     }
   }, [destinations, isAuthenticated, isAdmin, navigate, tripAddStop, tripSetShowBuilder]);
 

--- a/frontend/src/components/GuidedTour.jsx
+++ b/frontend/src/components/GuidedTour.jsx
@@ -50,13 +50,23 @@ export const TRIP_TOUR_STEPS = [
     mobile: { mobilePositionAbove: true }
   },
   {
-    selector: '.my-trips-menu-item',
-    title: 'My Trips Anywhere',
-    description: 'Your trip library is reachable any time from the user menu too. Sign in to save trips, share them publicly (after a quick review), or — if you’re an admin — feature them for everyone.',
+    selector: '.my-valley-menu-item',
+    title: 'My Valley',
+    description: 'Your saved places, visited spots, and trips live in My Valley. Open it from the user menu any time.',
     position: 'left',
     action: 'tripTourEndDemo',
-    spotlightSelector: '.my-trips-menu-item',
+    spotlightSelector: '.my-valley-menu-item',
     delay: 400,
+    mobile: { position: 'bottom' }
+  },
+  {
+    selector: '.my-valley-trips-tab',
+    title: 'Your Trips',
+    description: 'Inside My Valley, tap the Trips tab to find saved trips, browse Featured Routes, or share a trip publicly.',
+    position: 'bottom',
+    action: 'tripTourOpenMyValley',
+    spotlightSelector: '.my-valley-trips-tab',
+    delay: 500,
     mobile: { position: 'bottom' }
   }
 ];

--- a/frontend/src/components/MyValley.jsx
+++ b/frontend/src/components/MyValley.jsx
@@ -206,7 +206,7 @@ export default function MyValley({ open, onClose, destinations = [] }) {
             🧭 Visited ({isAuthenticated ? visitedList.length : visited.length})
           </button>
           <button
-            className={`settings-tab-btn ${view === 'trips' ? 'active' : ''}`}
+            className={`settings-tab-btn my-valley-trips-tab ${view === 'trips' ? 'active' : ''}`}
             onClick={() => selectView('trips')}
           >
             🗺️ Trips ({tripCount})


### PR DESCRIPTION
## Summary

- Replace stale `.my-trips-menu-item` tour step with `.my-valley-menu-item` (My Valley in user menu)
- Add new final step that opens My Valley and highlights the Trips tab
- Add `.my-valley-trips-tab` CSS class to the Trips button in MyValley.jsx for tour targeting
- Add `tripTourOpenMyValley` action handler in App.jsx

Closes #526

## Test plan
- [x] Trip planning tour step 5 highlights "My Valley" in user dropdown
- [x] Trip planning tour step 6 opens My Valley and spotlights the Trips tab
- [x] Tour completes cleanly with Finish button on last step

🤖 Generated with [Claude Code](https://claude.com/claude-code)