### PR TITLE
feat: shareable URL for legend filter state (#531)

### DIFF
--- a/.specify/specs/039-shareable-legend-filters/plan.md
+++ b/.specify/specs/039-shareable-legend-filters/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Shareable Legend Filters
+
+> **Spec ID:** 039-shareable-legend-filters
+> **Status:** Planning
+> **Last Updated:** 2026-06-24
+> **Estimated Effort:** S
+
+## Summary
+
+Frontend-only change. Read `?types=` and `?boundaries=` on page load to override the default filter state, then update the URL via `replaceState` whenever the user toggles legend items.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. Page loads → existing URL-parsing `useEffect` reads `types` and `boundaries` query params
+2. Store parsed values in refs (`urlTypes`, `urlBoundaries`) for the init effects to consume
+3. Existing `hasInitializedVisibleTypes` and `hasInitializedBoundaries` effects check refs and use URL values instead of defaults when present
+4. Every `setVisibleTypes` / `setVisibleBoundaries` call triggers a new `useEffect` that syncs the current state back to the URL via `replaceState`
+
+---
+
+## Implementation Steps
+
+### Phase 1: Read URL params on load
+
+- [ ] In App.jsx URL-parsing effect (~line 731), parse `types` and `boundaries` query params
+- [ ] Store in refs so the init effects can read them without re-triggering
+- [ ] Consume `types` param in the `hasInitializedVisibleTypes` effect: if URL specified types, use those instead of computing from iconConfig
+- [ ] Consume `boundaries` param in the `hasInitializedBoundaries` effect: if URL specified boundary IDs, use those instead of defaulting to CVNP
+
+### Phase 2: Sync state back to URL
+
+- [ ] Add a `useEffect` watching `[visibleTypes, visibleBoundaries]` that computes the URL params
+- [ ] Compare against defaults — only include params when state differs from defaults
+- [ ] Call `window.history.replaceState()` with the updated URL (preserving other existing params like `tab`, `poi`)
+
+### Phase 3: Handle edge cases
+
+- [ ] "Show all" / "Hide all" buttons (Map.jsx) trigger `setVisibleTypes` → URL updates automatically
+- [ ] Boundary "All" / "None" buttons trigger `setVisibleBoundaries` → URL updates automatically
+- [ ] When a shared URL includes both `?poi=` and `?types=`, both work independently
+- [ ] Invalid type names in URL are silently ignored (intersection with known types)
+- [ ] Invalid boundary IDs in URL are silently ignored
+
+---
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/App.jsx` | Parse URL params, store in refs, override init effects, add sync-to-URL effect |
+
+No new files needed. No backend changes. No database migrations.
+
+---
+
+## Testing Strategy
+
+### Manual Testing
+
+1. Open `/?types=trail,historic` → verify only trail and historic POIs shown
+2. Open `/?boundaries=<CVNP_ID>` → verify only CVNP boundary shown
+3. Toggle a POI type in legend → verify URL updates in address bar
+4. Toggle a boundary → verify URL updates
+5. Copy URL → open in new tab → verify same filter state
+6. Open `/?types=trail&poi=stanford-hostel` → verify both POI deep-link and filter work
+7. Open clean `/` → verify default behavior (no params in URL)
+8. Open `/?types=nonexistent` → verify graceful handling (empty map, no crash)
+9. Click "All" / "None" on POI types → verify URL updates
+10. Click "All" / "None" on boundary sections → verify URL updates
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| URL gets very long with many types | Low | Only include params when state differs from defaults |
+| Race between URL parse and data fetch | Med | Use refs consumed by init effects — they run after data arrives |
+| Breaking existing `?poi=` or `?tab=` params | High | Preserve all existing params, only add/remove `types`/`boundaries` |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-24 | Initial plan |

--- a/.specify/specs/039-shareable-legend-filters/spec.md
+++ b/.specify/specs/039-shareable-legend-filters/spec.md
@@ -1,0 +1,94 @@
+# Specification: Shareable Legend Filters
+
+> **Spec ID:** 039-shareable-legend-filters
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-24
+
+## Overview
+
+Users can select/unselect POI types and boundaries in the legend, then share the URL so recipients see exactly the same filter state. This enables focused map views like "just playgrounds" or "show the Train route" to be shared with friends.
+
+---
+
+## User Stories
+
+### Sharing Filtered Views
+
+**US-039-1: Share POI type filters via URL**
+> As a user, I want my POI type selections in the legend to be reflected in the URL so that I can share a focused view with friends.
+
+Acceptance Criteria:
+- [ ] Toggling POI types in the legend updates `?types=` in the URL without page reload
+- [ ] Opening a URL with `?types=trail,historic` shows only those POI types
+- [ ] Omitting `?types=` uses the default visible set (current behavior)
+
+**US-039-2: Share boundary selections via URL**
+> As a user, I want my boundary selections in the legend to be reflected in the URL so that I can share a view showing specific park boundaries.
+
+Acceptance Criteria:
+- [ ] Toggling boundaries in the legend updates `?boundaries=` in the URL without page reload
+- [ ] Opening a URL with `?boundaries=123,456` shows only those boundaries
+- [ ] Omitting `?boundaries=` uses the default (CVNP only, current behavior)
+
+**US-039-3: Compose with existing URL features**
+> As a user, I want filter params to work alongside POI deep-links and tab params so that I don't lose context.
+
+Acceptance Criteria:
+- [ ] `/?poi=stanford-hostel&types=trail` deep-links to the POI with trail-only filter
+- [ ] `/cuyahoga-valley-scenic-railroad?types=train` works with path-based POI URLs
+- [ ] `?tab=settings&types=trail` both open the settings tab and apply the filter
+
+---
+
+## URL Parameter Design
+
+### Query Parameters
+
+| Parameter | Format | Example | Behavior |
+|-----------|--------|---------|----------|
+| `types` | Comma-separated type names | `?types=trail,historic,playground` | Show only these POI types |
+| `boundaries` | Comma-separated boundary IDs | `?boundaries=123,456` | Show only these boundaries |
+
+### Semantics
+
+- **`types` present** → use exactly the listed types (override defaults)
+- **`types` absent** → use the default visible types (from iconConfig + DEFAULT_ICON_TYPES, filtering default_hidden)
+- **`boundaries` present** → use exactly the listed boundary IDs
+- **`boundaries` absent** → use the default (CVNP boundary)
+- Parameters are consumed on load, then updated live as the user interacts with the legend
+
+---
+
+## Non-Functional Requirements
+
+**NFR-039-1: URL cleanliness**
+- When all filters match the default state, the `types` and `boundaries` params should be absent (clean URL)
+- Only add params when the state differs from defaults
+
+**NFR-039-2: No page reloads**
+- Use `window.history.replaceState()` to update the URL without triggering navigation
+
+---
+
+## Dependencies
+
+- Depends on: existing legend toggle infrastructure (Map.jsx, App.jsx)
+- No database changes required
+- No new API endpoints required
+
+---
+
+## Open Questions
+
+1. ~~Should we use type names or type IDs in the URL?~~ Type names — they're human-readable and stable.
+2. Should "show all" / "hide all" buttons also update the URL? Yes, for consistency.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-24 | Initial draft |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -117,6 +117,13 @@ function AppContent() {
   const trainPosition = useTrainPosition();
   const [visibleBoundaries, setVisibleBoundaries] = useState(new Set()); // Set of boundary IDs
 
+  // URL-specified legend filters (#531): parsed on load, consumed by init effects
+  const urlTypesRef = useRef(null);
+  const urlBoundariesRef = useRef(null);
+  const urlLayersRef = useRef(null);
+  const defaultTypesRef = useRef(null);
+  const defaultBoundaryIdsRef = useRef(null);
+
   const [mapState, setMapState] = useState({
     center: [41.26, -81.55],  // Park center default
     zoom: 11,
@@ -739,6 +746,23 @@ function AppContent() {
       window.history.replaceState({}, '', newUrl);
     }
 
+    // Shareable legend filters (#531)
+    const typesParam = params.get('types');
+    if (typesParam) {
+      urlTypesRef.current = new Set(typesParam.split(',').map(t => t.trim()).filter(Boolean));
+    }
+    const boundariesParam = params.get('boundaries');
+    if (boundariesParam) {
+      urlBoundariesRef.current = new Set(
+        boundariesParam.split(',').map(b => parseInt(b.trim(), 10)).filter(id => !isNaN(id))
+      );
+    }
+    const layersParam = params.get('layers');
+    if (typesParam || layersParam) {
+      const layers = layersParam ? new Set(layersParam.split(',').map(l => l.trim()).filter(Boolean)) : new Set();
+      urlLayersRef.current = layers;
+    }
+
     let poiSlug = null;
     const pathParts = window.location.pathname.split('/').filter(Boolean);
 
@@ -1179,7 +1203,21 @@ function AppContent() {
       enabledTypes.add('boundary');
       enabledTypes.add('organization');
 
-      setVisibleTypes(enabledTypes);
+      defaultTypesRef.current = new Set(enabledTypes);
+
+      if (urlTypesRef.current) {
+        setVisibleTypes(urlTypesRef.current);
+        urlTypesRef.current = null;
+      } else {
+        setVisibleTypes(enabledTypes);
+      }
+      if (urlLayersRef.current !== null) {
+        const layers = urlLayersRef.current;
+        setShowTrails(layers.has('trails'));
+        setShowRivers(layers.has('rivers'));
+        setShowWaterTaxis(layers.has('water-taxis'));
+        urlLayersRef.current = null;
+      }
       hasInitializedVisibleTypes.current = true;
     }
   }, [iconConfig]);
@@ -1191,11 +1229,75 @@ function AppContent() {
         f => f.poi_roles?.includes('boundary') && f.name === 'Cuyahoga Valley National Park'
       );
       if (cvnpBoundary) {
+        defaultBoundaryIdsRef.current = new Set([cvnpBoundary.id]);
+      }
+
+      if (urlBoundariesRef.current) {
+        setVisibleBoundaries(urlBoundariesRef.current);
+        urlBoundariesRef.current = null;
+      } else if (cvnpBoundary) {
         setVisibleBoundaries(new Set([cvnpBoundary.id]));
       }
       hasInitializedBoundaries.current = true;
     }
   }, [linearFeatures]);
+
+  // Sync legend filter state to URL query params (#531)
+  useEffect(() => {
+    if (!hasInitializedVisibleTypes.current || !hasInitializedBoundaries.current) return;
+
+    const params = new URLSearchParams(window.location.search);
+    let changed = false;
+
+    const defaultTypes = defaultTypesRef.current;
+    const typesDefault = defaultTypes && visibleTypes.size === defaultTypes.size &&
+      [...visibleTypes].every(t => defaultTypes.has(t));
+    const layersDefault = showTrails && showRivers && showWaterTaxis;
+    const allPoiDefault = typesDefault && layersDefault;
+
+    if (allPoiDefault) {
+      if (params.has('types')) { params.delete('types'); changed = true; }
+      if (params.has('layers')) { params.delete('layers'); changed = true; }
+    } else {
+      if (defaultTypes) {
+        if (typesDefault) {
+          if (params.has('types')) { params.delete('types'); changed = true; }
+        } else {
+          const sorted = [...visibleTypes].sort().join(',');
+          if (params.get('types') !== sorted) { params.set('types', sorted); changed = true; }
+        }
+      }
+      const activeLayers = [
+        showTrails && 'trails', showRivers && 'rivers', showWaterTaxis && 'water-taxis'
+      ].filter(Boolean);
+      if (layersDefault) {
+        if (params.has('layers')) { params.delete('layers'); changed = true; }
+      } else if (activeLayers.length === 0) {
+        if (params.get('layers') !== '') { params.set('layers', ''); changed = true; }
+      } else {
+        const val = activeLayers.sort().join(',');
+        if (params.get('layers') !== val) { params.set('layers', val); changed = true; }
+      }
+    }
+
+    const defaultBoundaries = defaultBoundaryIdsRef.current;
+    if (defaultBoundaries) {
+      const sameAsDefault = visibleBoundaries.size === defaultBoundaries.size &&
+        [...visibleBoundaries].every(id => defaultBoundaries.has(id));
+      if (sameAsDefault) {
+        if (params.has('boundaries')) { params.delete('boundaries'); changed = true; }
+      } else {
+        const sorted = [...visibleBoundaries].sort((a, b) => a - b).join(',');
+        if (params.get('boundaries') !== sorted) { params.set('boundaries', sorted); changed = true; }
+      }
+    }
+
+    if (changed) {
+      const search = params.toString();
+      const newUrl = window.location.pathname + (search ? `?${search}` : '');
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, [visibleTypes, visibleBoundaries, showTrails, showRivers, showWaterTaxis]);
 
   useEffect(() => {
     const isMobile = window.innerWidth <= 768;


### PR DESCRIPTION
## Summary

- Legend filter state (POI types, boundaries, map layers) is now encoded in URL query parameters
- Users can copy the URL and share it — recipients see the same legend filters applied
- URL updates in real-time as legend items are toggled (no page reload)
- When filters match defaults, parameters are omitted for clean URLs
- Composes with existing `?poi=` and `?tab=` URL features

### URL Parameters

| Parameter | Example | Purpose |
|-----------|---------|---------|
| `types` | `?types=trail,historic` | Show only listed POI types |
| `boundaries` | `?boundaries=123,456` | Show only listed boundary IDs |
| `layers` | `?layers=trails,rivers` | Toggle trail/river/water-taxi overlays |

Closes #531

## Test plan
- [x] `/?types=trail,historic` shows only those POI types
- [x] Toggling legend items updates URL in address bar
- [x] Copy URL → new tab → same filter state
- [x] `/?poi=stanford-hostel&types=trail` composes correctly
- [x] Clean `/` works as normal (no params, default state)
- [x] Verified in browser on localhost:8081

🤖 Generated with [Claude Code](https://claude.com/claude-code)