### PR TITLE
fix: flip CVSR train icon based on GPS heading (#532)

### DIFF
--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1510,10 +1510,14 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
 
   const snappedTrain = useMemo(() => {
     if (!trainPosition || !trainFeature?.geometry?.coordinates) return null;
-    return snapToLine(
+    const snap = snapToLine(
       [trainPosition.latitude, trainPosition.longitude],
       trainFeature.geometry.coordinates
     );
+    const gpsHeading = trainPosition.heading || 0;
+    const diff = Math.abs(((snap.bearing - gpsHeading + 540) % 360) - 180);
+    if (diff > 90) snap.bearing = (snap.bearing + 180) % 360;
+    return snap;
   }, [trainPosition, trainFeature]);
 
   const getLinearFeatureStyle = useCallback((feature, isSelected) => {


### PR DESCRIPTION
## Summary

- Train icon now faces the direction of travel instead of always following the track linestring digitization direction
- Compares the snap-to-line bearing against the GPS heading from the USFT tracker
- If they differ by more than 90°, flips the bearing by 180°
- 3-line change in the `snappedTrain` useMemo in Map.jsx

Closes #532

## Test plan
- [ ] Verify train icon faces north when train is heading northbound
- [ ] Verify train icon faces south when train is heading southbound
- [ ] Verify icon still snaps to track geometry (no floating off the line)
- [ ] Verify smooth rotation transition when direction changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)