### PR TITLE
fix: neutralize migration 047 bare-hostname matching

### DIFF
--- a/backend/migrations/047_fix_news_url_ownership.sql
+++ b/backend/migrations/047_fix_news_url_ownership.sql
@@ -1,44 +1,13 @@
--- Migration: 047_fix_news_url_ownership
--- Description: Reassign news/events whose source_url domain matches a different
--- POI's news_url or events_url to the domain-owning POI.
-
--- Build a temporary domain→POI mapping from news_url and events_url
-CREATE TEMPORARY TABLE poi_domain_map AS
-SELECT DISTINCT ON (domain)
-  domain,
-  poi_id
-FROM (
-  SELECT
-    id AS poi_id,
-    LOWER(REGEXP_REPLACE(REGEXP_REPLACE(news_url, '^https?://(www\.)?', ''), '/.*$', '')) AS domain
-  FROM pois
-  WHERE news_url IS NOT NULL AND deleted = false
-
-  UNION ALL
-
-  SELECT
-    id AS poi_id,
-    LOWER(REGEXP_REPLACE(REGEXP_REPLACE(events_url, '^https?://(www\.)?', ''), '/.*$', '')) AS domain
-  FROM pois
-  WHERE events_url IS NOT NULL AND deleted = false
-) sub
-WHERE domain IS NOT NULL AND domain != ''
-ORDER BY domain, poi_id;
-
--- Fix news items
-UPDATE poi_news n
-SET poi_id = dm.poi_id
-FROM poi_domain_map dm
-WHERE LOWER(REGEXP_REPLACE(REGEXP_REPLACE(n.source_url, '^https?://(www\.)?', ''), '/.*$', '')) = dm.domain
-  AND n.poi_id != dm.poi_id
-  AND n.source_url IS NOT NULL;
-
--- Fix events
-UPDATE poi_events e
-SET poi_id = dm.poi_id
-FROM poi_domain_map dm
-WHERE LOWER(REGEXP_REPLACE(REGEXP_REPLACE(e.source_url, '^https?://(www\.)?', ''), '/.*$', '')) = dm.domain
-  AND e.poi_id != dm.poi_id
-  AND e.source_url IS NOT NULL;
-
-DROP TABLE poi_domain_map;
+-- Migration: 047_fix_news_url_ownership (SUPERSEDED — no-op)
+--
+-- This migration originally reassigned news/events by bare-hostname matching.
+-- It used REGEXP_REPLACE(url, '/.*$', '') which stripped the entire path,
+-- producing keys like 'facebook.com' instead of 'facebook.com/pagename/events'.
+-- Any POI with a Facebook events_url would "own" ALL facebook.com content.
+--
+-- The runtime URI ownership code (buildUriOwnershipMap + checkUriOwnership in
+-- newsService.js) was fixed in PR #521 to use full URI prefixes (hostname+path).
+-- This migration re-ran on every container start and overwrote those correct
+-- assignments, causing the recurring GVB content misattribution bug.
+--
+-- Removed: 2026-06-26. Runtime handles URI ownership at save time.


### PR DESCRIPTION
## Summary

- Replaces migration `047_fix_news_url_ownership.sql` with a no-op comment
- Root cause of the recurring GVB content misattribution bug: the migration used `REGEXP_REPLACE(url, '/.*$', '')` which stripped the entire URL path, producing bare hostnames like `facebook.com` — since GVB was the only POI with a Facebook `events_url`, every `facebook.com`-sourced news item got reassigned to GVB
- The migration re-ran on every container start (`rotv-init.sh` runs all numbered migrations unconditionally), silently undoing the runtime URI ownership fix from PR #521
- 47 misattributed GVB items rejected in production via MCP

## Test plan
- [x] `./run.sh build` succeeds
- [x] `./run.sh test` passes (2 pre-existing failures only)
- [x] GVB (POI 6372) news list shows only legitimate items after rejection
- [ ] After deploy + container restart, verify migration runs cleanly as no-op
- [ ] Next collection run: Facebook items stay with correct POIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)