### PR TITLE
fix: issue #475 (Ashigaru)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2650,6 +2650,12 @@ async function findItemBySlugs(type, poiSlug, titleSlug) {
   const poi = poisQuery.rows.find(p => generateSlug(p.name) === poiSlug);
   if (!poi) return null;
 
+  // Roll up boundary/org POIs to include contained/owned POIs (#406) so a permalink
+  // resolves the same items the /api/pois/:id/{news,events} list endpoints surface.
+  // Without this, rolled-up items 404 here and the OG middleware falls through to the
+  // brand fallback image instead of the source/POI photo.
+  const poiIds = await getRollupPoiIds(pool, poi.id);
+
   let rows;
   if (type === 'event') {
     const q = await pool.query(`
@@ -2660,10 +2666,10 @@ async function findItemBySlugs(type, poiSlug, titleSlug) {
       FROM poi_events e
       JOIN pois p ON e.poi_id = p.id
       LEFT JOIN poi_event_urls u ON u.event_id = e.id
-      WHERE e.poi_id = $1 AND e.moderation_status IN ('published', 'auto_approved')
+      WHERE (e.poi_id = ANY($1) OR e.venue_poi_id = ANY($1)) AND e.moderation_status IN ('published', 'auto_approved')
       GROUP BY e.id, p.name, p.id
       ORDER BY e.start_date DESC
-    `, [poi.id]);
+    `, [poiIds]);
     rows = q.rows;
   } else {
     const q = await pool.query(`
@@ -2673,10 +2679,10 @@ async function findItemBySlugs(type, poiSlug, titleSlug) {
       FROM poi_news n
       JOIN pois p ON n.poi_id = p.id
       LEFT JOIN poi_news_urls u ON u.news_id = n.id
-      WHERE n.poi_id = $1 AND n.moderation_status IN ('published', 'auto_approved')
+      WHERE n.poi_id = ANY($1) AND n.moderation_status IN ('published', 'auto_approved')
       GROUP BY n.id, p.name, p.id
       ORDER BY COALESCE(n.publication_date, n.collection_date) DESC
-    `, [poi.id]);
+    `, [poiIds]);
     rows = q.rows;
   }
 
@@ -2833,8 +2839,11 @@ app.use(async (req, res, next) => {
     const safeTitle = escapeHtml(`${item.title} | ${item._poi.name}`);
     const safeDesc = escapeHtml(description.length > 200 ? description.substring(0, 197) + '...' : description);
     // Image priority: source article image, then POI primary photo, then brand.
+    // Photo fallback uses the permalink's landing POI (item._poi) rather than the
+    // item's own poi_id — for rolled-up items these differ, and the share preview
+    // should show the photo of the page the link opens.
     const sourceImage = isUsableSourceImage(item.image_url) ? item.image_url : null;
-    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item.poi_id, baseUrl));
+    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item._poi.id, baseUrl));
 
     const indexPath = path.join(staticPath, 'index.html');
     let html = await fs.readFile(indexPath, 'utf-8');


### PR DESCRIPTION
Fixes #475.

Autonomous **Ashigaru** run — Claude Code (`claude-opus-4-8`, tier 1) in a sealed, unprivileged sandbox. Worked from an airlock-filtered brief. **Draft, pending CI + human review.** run_id: `rotv-475-1782762582`