### PR TITLE
fix: issue #475 (Ashigaru)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2705,7 +2705,7 @@ async function resolvePoiOgImage(poiId, baseUrl) {
         WHERE poi_id = $1
           AND media_type IN ('image', 'video')
           AND role IN ('primary', 'gallery')
-          AND moderation_status IN ('published', 'auto_approved')
+          AND moderation_status IN ('published', 'auto_approved', 'approved')
         LIMIT 1
       `, [poiId]);
       if (rows.length > 0 || (imageServerClient.initialized && await imageServerClient.getPrimaryAsset(poiId))) {
@@ -2717,6 +2717,11 @@ async function resolvePoiOgImage(poiId, baseUrl) {
   }
   if (!url) {
     url = `${baseUrl}${OG_FALLBACK_IMAGE}`;
+  }
+  // Bound the cache so crawler traffic can't grow this map without limit.
+  if (ogImageCache.size >= 1000) {
+    const oldestKey = ogImageCache.keys().next().value;
+    ogImageCache.delete(oldestKey);
   }
   ogImageCache.set(cacheKey, { url, expires: Date.now() + OG_IMAGE_CACHE_TTL_MS });
   return url;
@@ -2834,7 +2839,7 @@ app.use(async (req, res, next) => {
     const safeDesc = escapeHtml(description.length > 200 ? description.substring(0, 197) + '...' : description);
     // Image priority: source article image, then POI primary photo, then brand.
     const sourceImage = isUsableSourceImage(item.image_url) ? item.image_url : null;
-    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item.poi_id, baseUrl));
+    const ogImage = escapeHtml(sourceImage || await resolvePoiOgImage(item._poi?.id, baseUrl));
 
     const indexPath = path.join(staticPath, 'index.html');
     let html = await fs.readFile(indexPath, 'utf-8');


### PR DESCRIPTION
Fixes #475.

Autonomous **Ashigaru** run — Claude Code (`claude-opus-4-8`, tier 1) in a sealed, unprivileged sandbox. Worked from an airlock-filtered brief. **Draft, pending CI + human review.** run_id: `rotv-475-1782766230`