### PR TITLE
feat: add configurable greeting to newsletter digest

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -655,7 +655,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'github_api_token',
       'about_story_md',
       'about_tutorial_md',
-      'about_privacy_md'
+      'about_privacy_md',
+      'digest_greeting'
     ];
     if (!allowedKeys.includes(key)) {
       return res.status(400).json({ error: 'Invalid setting key' });

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -85,8 +85,23 @@ export function upcomingFridayISO(tz = 'America/New_York') {
 }
 
 export async function generateDigest(pool, tz = 'America/New_York', asOfDate = null) {
-  const { events, news } = await fetchDigestContent(pool, tz, asOfDate);
-  return renderDigestHtml(events, news, tz);
+  const [{ events, news }, greeting] = await Promise.all([
+    fetchDigestContent(pool, tz, asOfDate),
+    fetchDigestGreeting(pool)
+  ]);
+  return renderDigestHtml(events, news, tz, greeting);
+}
+
+async function fetchDigestGreeting(pool) {
+  try {
+    const result = await pool.query(
+      "SELECT value FROM admin_settings WHERE key = 'digest_greeting'"
+    );
+    const val = result.rows[0]?.value?.trim();
+    return val || null;
+  } catch {
+    return null;
+  }
 }
 
 async function fetchDigestContent(pool, tz, asOfDate) {
@@ -124,7 +139,7 @@ async function fetchDigestContent(pool, tz, asOfDate) {
   };
 }
 
-function renderDigestHtml(events, news, tz = 'America/New_York') {
+function renderDigestHtml(events, news, tz = 'America/New_York', greeting = null) {
   if (events.length === 0 && news.length === 0) {
     return '';
   }
@@ -225,6 +240,11 @@ function renderDigestHtml(events, news, tz = 'America/New_York') {
     </a>
     <h1>What's Happening in the Valley This Weekend</h1>
     <p>Your weekly digest from <a href="https://rootsofthevalley.org" style="color: #2d5016 !important; text-decoration: underline;">Roots of The Valley</a></p>
+${greeting ? `
+    <div style="background-color: #f0f7e8; border-left: 4px solid #2d5016; padding: 15px 20px; margin: 20px 0; border-radius: 4px;">
+      <p style="margin: 0; color: #333; font-size: 1em;">${escapeHtml(greeting)}</p>
+    </div>
+` : ''}
 `;
 
   const linkStyle = 'color: #2d5016 !important; text-decoration: underline; font-weight: 500;';
@@ -571,6 +591,7 @@ export async function sendPersonalizedDigests(pool, pgBossJobId = null) {
     return { success: true, sent: 0, skipped: 0, candidates: 0 };
   }
 
+  const greeting = await fetchDigestGreeting(pool);
   const allPoiIds = [...new Set(targets.rows.flatMap(t => t.poi_ids))];
 
   const [newsResult, eventsResult] = await Promise.all([
@@ -625,7 +646,7 @@ export async function sendPersonalizedDigests(pool, pgBossJobId = null) {
       tz
     ).slice(0, 10);
 
-    const html = renderDigestHtml(userEvents, userNews, tz);
+    const html = renderDigestHtml(userEvents, userNews, tz, greeting);
     if (!html) {
       skipped++;
       continue;

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -99,7 +99,8 @@ async function fetchDigestGreeting(pool) {
     );
     const val = result.rows[0]?.value?.trim();
     return val || null;
-  } catch {
+  } catch (err) {
+    console.error('Failed to fetch digest greeting:', err.message);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `digest_greeting` admin setting that renders as a styled callout block in the newsletter digest
- Greeting appears after the "Your weekly digest from ROTV" header and before the events section
- When the setting is empty/null, no greeting appears (preserves current behavior)
- Works for both the general broadcast digest and personalized per-user digests
- Setting is writable via the admin API and MCP `settings_update` tool

## Motivation
The July 4th newsletter preview had no holiday acknowledgment. This provides a permanent solution for seasonal/holiday messaging without code changes each time.

## Test plan
- [ ] Set `digest_greeting` via MCP `settings_update` tool
- [ ] Trigger newsletter preview — verify greeting appears with green callout styling
- [ ] Clear the greeting — verify digest renders without it (no empty block)
- [ ] Verify personalized digest also includes the greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)