### PR TITLE
feat: smooth marker animation for train and water taxi

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11565,12 +11565,11 @@ body {
 }
 
 /* Live boat marker (#408) */
-.boat-marker-icon {
+.boat-marker-icon.leaflet-div-icon {
   background: none;
   border: none;
 }
 .boat-marker-inner {
-  transition: transform 0.5s ease;
 }
 .boat-status-badge {
   display: inline-block;
@@ -11597,7 +11596,7 @@ body {
   background: #e3f2fd;
   color: #1565c0;
 }
-.train-marker-icon {
+.train-marker-icon.leaflet-div-icon {
   background: none;
   border: none;
   display: flex;
@@ -11605,7 +11604,6 @@ body {
   justify-content: center;
 }
 .train-marker-inner {
-  transition: transform 0.5s ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -6,7 +6,7 @@ import VirtualPoiCreator from './VirtualPoiCreator';
 import { getDestinationIconTypeFromConfig, poiMatchesActivityForTypes, trailPassesActivityFilter, matchesWholeWord } from '../utils/iconUtils';
 import { getBoatStatus } from '../utils/boatStatus';
 import { getTrainStatus } from '../utils/trainStatus';
-import { snapToLine } from '../utils/snapToLine';
+import useAnimatedTrackerPosition from '../hooks/useAnimatedTrackerPosition';
 import { useTrip } from '../hooks/useTrip';
 import { useNavigate } from 'react-router-dom';
 import { generateSlug } from './sidebar/helpers';
@@ -559,6 +559,18 @@ function MapMoveTracker({ onMapMove }) {
     };
   }, [map, onMapMove]);
 
+  return null;
+}
+
+function ZoomReporter({ onZoomChange }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    onZoomChange(map.getZoom());
+    const handler = () => onZoomChange(map.getZoom());
+    map.on('zoom', handler);
+    return () => map.off('zoom', handler);
+  }, [map, onZoomChange]);
   return null;
 }
 
@@ -1205,6 +1217,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     return () => document.removeEventListener('pointerdown', handlePointerDown, true);
   }, [isLegendExpanded, setIsLegendExpanded]);
 
+  const [mapZoom, setMapZoom] = useState(13);
   const [useSatellite, setUseSatellite] = useState(false);
   const [measureMode, setMeasureMode] = useState(false);
   // Fix: stable callbacks so ZoomLocateControl's effect doesn't tear down and
@@ -1500,34 +1513,38 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     () => linearFeatures?.find(f => f.poi_roles?.includes('water_taxi') && /^https?:\/\//i.test(f.live_tracker_url || '')),
     [linearFeatures]
   );
+  const boatLineCoords = boatFeature?.geometry?.coordinates;
+  const animatedBoat = useAnimatedTrackerPosition(boatPosition, boatLineCoords, mapZoom, { pollIntervalMs: 10000, iconHalfPx: 19, snapPosition: false });
   const { label: boatStatusLabel, className: boatStatusClass } = getBoatStatus(boatPosition);
 
   const trainFeature = useMemo(
     () => linearFeatures?.find(f => f.poi_roles?.includes('railroad')),
     [linearFeatures]
   );
+  const trainLineCoords = trainFeature?.geometry?.coordinates;
+  const animatedTrain = useAnimatedTrackerPosition(trainPosition, trainLineCoords, mapZoom, { pollIntervalMs: 5000, iconHalfPx: 32 });
   const { label: trainStatusLabel, className: trainStatusClass } = getTrainStatus(trainPosition);
 
-  const prevTrainPosRef = useRef(null);
-  const snappedTrain = useMemo(() => {
-    if (!trainPosition || !trainFeature?.geometry?.coordinates) return null;
-    const snap = snapToLine(
-      [trainPosition.latitude, trainPosition.longitude],
-      trainFeature.geometry.coordinates
-    );
-    const prev = prevTrainPosRef.current;
-    if (prev) {
-      const dLat = trainPosition.latitude - prev.latitude;
-      const dLng = trainPosition.longitude - prev.longitude;
-      if (Math.abs(dLat) > 1e-6 || Math.abs(dLng) > 1e-6) {
-        const heading = ((Math.atan2(dLng, dLat) * 180 / Math.PI) + 360) % 360;
-        const diff = Math.abs(((snap.bearing - heading + 540) % 360) - 180);
-        if (diff > 90) snap.bearing = (snap.bearing + 180) % 360;
-      }
-    }
-    prevTrainPosRef.current = { latitude: trainPosition.latitude, longitude: trainPosition.longitude };
-    return snap;
-  }, [trainPosition, trainFeature]);
+  const boatMarkerRef = useRef(null);
+  const trainMarkerRef = useRef(null);
+  const boatIconRef = useRef(null);
+  const trainIconRef = useRef(null);
+  if (!boatIconRef.current && animatedBoat) {
+    boatIconRef.current = createBoatIcon(animatedBoat.bearing);
+  }
+  if (!trainIconRef.current && animatedTrain) {
+    trainIconRef.current = createTrainIcon(animatedTrain.bearing);
+  }
+
+  useEffect(() => {
+    const el = boatMarkerRef.current?.getElement()?.querySelector('.boat-marker-inner');
+    if (el && animatedBoat) el.style.transform = `rotate(${animatedBoat.bearing || 0}deg)`;
+  }, [animatedBoat?.bearing]);
+
+  useEffect(() => {
+    const el = trainMarkerRef.current?.getElement()?.querySelector('.train-marker-inner');
+    if (el && animatedTrain) el.style.transform = `rotate(${animatedTrain.bearing || 0}deg)`;
+  }, [animatedTrain?.bearing]);
 
   const getLinearFeatureStyle = useCallback((feature, isSelected) => {
     const editSelectedColor = '#FF8C00';
@@ -1870,10 +1887,11 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           });
         })}
 
-        {showWaterTaxis && boatPosition && boatFeature && (
+        {showWaterTaxis && animatedBoat && boatFeature && (
           <Marker
-            position={[boatPosition.latitude, boatPosition.longitude]}
-            icon={createBoatIcon(boatPosition.heading, boatPosition.status)}
+            ref={boatMarkerRef}
+            position={animatedBoat.position}
+            icon={boatIconRef.current}
             zIndexOffset={500}
             keyboard={false}
             eventHandlers={{ click: () => handleLinearFeatureClick(boatFeature) }}
@@ -1897,10 +1915,11 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           </Marker>
         )}
 
-        {visibleTypes.has('train') && snappedTrain && trainFeature && (
+        {visibleTypes.has('train') && animatedTrain && trainFeature && (
           <Marker
-            position={snappedTrain.position}
-            icon={createTrainIcon(snappedTrain.bearing)}
+            ref={trainMarkerRef}
+            position={animatedTrain.position}
+            icon={trainIconRef.current}
             zIndexOffset={500}
             keyboard={false}
             eventHandlers={{ click: () => handleLinearFeatureClick(trainFeature) }}
@@ -1943,6 +1962,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           iconConfig={iconConfig}
         />
         <MapMoveTracker onMapMove={() => setMapMoveCount(c => c + 1)} />
+        <ZoomReporter onZoomChange={setMapZoom} />
         <ZoomTooltipHider />
         <MapClickHandler
           isAdmin={isAdmin}

--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -1,0 +1,132 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { snapToLine } from '../utils/snapToLine';
+import { extractSubPath, cumulativeDistances, interpolateAlongPath, dualSnapBearing } from '../utils/trackInterpolation';
+
+function pixelsToMeters(halfPx, zoom) {
+  return halfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** zoom);
+}
+
+function lerpAngle(a, b, t) {
+  let diff = ((b - a + 540) % 360) - 180;
+  return ((a + diff * t) + 360) % 360;
+}
+
+export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom, { pollIntervalMs = 5000, iconHalfPx = 32, snapPosition = true } = {}) {
+  const [animated, setAnimated] = useState(null);
+  const prevSnapRef = useRef(null);
+  const prevRawRef = useRef(null);
+  const targetRawRef = useRef(null);
+  const pathRef = useRef(null);
+  const distsRef = useRef(null);
+  const startTimeRef = useRef(0);
+  const directionRef = useRef(1);
+  const rafRef = useRef(null);
+  const latestSnapRef = useRef(null);
+  const zoomRef = useRef(zoom || 13);
+  const intervalRef = useRef(pollIntervalMs);
+  const halfPxRef = useRef(iconHalfPx);
+  const prevBearingRef = useRef(0);
+
+  useEffect(() => { zoomRef.current = zoom || 13; }, [zoom]);
+
+  useEffect(() => {
+    if (!rawPosition || !lineCoords || lineCoords.length < 2) {
+      setAnimated(null);
+      return;
+    }
+
+    const newSnap = snapToLine(
+      [rawPosition.latitude, rawPosition.longitude],
+      lineCoords
+    );
+    latestSnapRef.current = newSnap;
+
+    if (!prevSnapRef.current) {
+      prevSnapRef.current = newSnap;
+      prevRawRef.current = rawPosition;
+      targetRawRef.current = rawPosition;
+      pathRef.current = [newSnap.position, newSnap.position];
+      distsRef.current = [0, 0];
+      startTimeRef.current = performance.now();
+      let bearing;
+      if (snapPosition) {
+        const halfDist = pixelsToMeters(halfPxRef.current, zoomRef.current);
+        bearing = dualSnapBearing(lineCoords, newSnap, halfDist);
+        if (rawPosition.heading != null) {
+          const diff = Math.abs(((bearing - rawPosition.heading + 540) % 360) - 180);
+          if (diff > 90) {
+            bearing = (bearing + 180) % 360;
+            directionRef.current = -1;
+          }
+        }
+      } else {
+        bearing = rawPosition.heading || 0;
+      }
+      const pos = snapPosition ? newSnap.position : [rawPosition.latitude, rawPosition.longitude];
+      setAnimated({ position: pos, bearing });
+      return;
+    }
+
+    const prev = prevSnapRef.current;
+    const dLat = rawPosition.latitude - (prev.position[0] || 0);
+    const dLng = rawPosition.longitude - (prev.position[1] || 0);
+    if (Math.abs(dLat) > 1e-6 || Math.abs(dLng) > 1e-6) {
+      const heading = ((Math.atan2(dLng, dLat) * 180 / Math.PI) + 360) % 360;
+      const diff = Math.abs(((newSnap.bearing - heading + 540) % 360) - 180);
+      directionRef.current = diff > 90 ? -1 : 1;
+    }
+
+    prevRawRef.current = targetRawRef.current || rawPosition;
+    targetRawRef.current = rawPosition;
+
+    const subPath = extractSubPath(lineCoords, prev, newSnap);
+    pathRef.current = subPath;
+    distsRef.current = cumulativeDistances(subPath);
+    startTimeRef.current = performance.now();
+    prevSnapRef.current = newSnap;
+  }, [rawPosition, lineCoords, snapPosition]);
+
+  const tick = useCallback(() => {
+    const t = Math.min(1, (performance.now() - startTimeRef.current) / intervalRef.current);
+
+    let position, bearing;
+
+    if (snapPosition) {
+      const path = pathRef.current;
+      const dists = distsRef.current;
+      if (!path || !dists || path.length < 2 || !lineCoords) {
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+      position = interpolateAlongPath(path, dists, t).position;
+      const reSnap = snapToLine(position, lineCoords);
+      const halfDist = pixelsToMeters(halfPxRef.current, zoomRef.current);
+      bearing = dualSnapBearing(lineCoords, reSnap, halfDist);
+      if (directionRef.current === -1) {
+        bearing = (bearing + 180) % 360;
+      }
+    } else {
+      const prev = prevRawRef.current;
+      const target = targetRawRef.current;
+      if (!prev || !target) {
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+      position = [
+        prev.latitude + t * (target.latitude - prev.latitude),
+        prev.longitude + t * (target.longitude - prev.longitude),
+      ];
+      bearing = lerpAngle(prev.heading || 0, target.heading || 0, t);
+    }
+
+    setAnimated({ position, bearing });
+    rafRef.current = requestAnimationFrame(tick);
+  }, [lineCoords, snapPosition]);
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [tick]);
+
+  return animated;
+}

--- a/frontend/src/utils/snapToLine.js
+++ b/frontend/src/utils/snapToLine.js
@@ -5,6 +5,7 @@ export function snapToLine(point, lineCoords) {
   let bestDist = Infinity;
   let bestPoint = point;
   let bestSegIdx = 0;
+  let bestT = 0;
 
   for (let i = 0; i < lineCoords.length - 1; i++) {
     const [ax, ay] = [lineCoords[i][0], lineCoords[i][1]];
@@ -25,6 +26,7 @@ export function snapToLine(point, lineCoords) {
       bestDist = dist;
       bestPoint = [cy, cx];
       bestSegIdx = i;
+      bestT = t;
     }
   }
 
@@ -37,5 +39,5 @@ export function snapToLine(point, lineCoords) {
   const x = Math.cos(rlat1) * Math.sin(rlat2) - Math.sin(rlat1) * Math.cos(rlat2) * Math.cos(dLon);
   const bearing = ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
 
-  return { position: bestPoint, bearing };
+  return { position: bestPoint, bearing, segmentIndex: bestSegIdx, segmentT: bestT };
 }

--- a/frontend/src/utils/trackInterpolation.js
+++ b/frontend/src/utils/trackInterpolation.js
@@ -1,0 +1,140 @@
+function haversineDist(lat1, lng1, lat2, lng2) {
+  const R = 6371000;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+    Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function extractSubPath(lineCoords, prevSnap, newSnap) {
+  const si = prevSnap.segmentIndex;
+  const ei = newSnap.segmentIndex;
+
+  const startPt = prevSnap.position;
+  const endPt = newSnap.position;
+
+  if (si === ei) {
+    return [startPt, endPt];
+  }
+
+  const forward = si < ei ||
+    (si === ei && prevSnap.segmentT < newSnap.segmentT);
+
+  const path = [startPt];
+  if (forward) {
+    for (let i = si + 1; i <= ei; i++) {
+      path.push([lineCoords[i][1], lineCoords[i][0]]);
+    }
+  } else {
+    for (let i = si; i >= ei + 1; i--) {
+      path.push([lineCoords[i][1], lineCoords[i][0]]);
+    }
+  }
+  path.push(endPt);
+  return path;
+}
+
+export function cumulativeDistances(path) {
+  const dists = [0];
+  for (let i = 1; i < path.length; i++) {
+    dists.push(dists[i - 1] + haversineDist(
+      path[i - 1][0], path[i - 1][1],
+      path[i][0], path[i][1]
+    ));
+  }
+  return dists;
+}
+
+function segmentBearing(p1, p2) {
+  const dLon = (p2[1] - p1[1]) * Math.PI / 180;
+  const rlat1 = p1[0] * Math.PI / 180;
+  const rlat2 = p2[0] * Math.PI / 180;
+  const y = Math.sin(dLon) * Math.cos(rlat2);
+  const x = Math.cos(rlat1) * Math.sin(rlat2) - Math.sin(rlat1) * Math.cos(rlat2) * Math.cos(dLon);
+  return ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
+}
+
+export function walkAlongTrack(lineCoords, snap, distMeters) {
+  const si = snap.segmentIndex;
+  const startPt = snap.position;
+
+  if (distMeters >= 0) {
+    const segEnd = [lineCoords[si + 1][1], lineCoords[si + 1][0]];
+    const distToSegEnd = haversineDist(startPt[0], startPt[1], segEnd[0], segEnd[1]);
+    if (distMeters <= distToSegEnd) {
+      const frac = distToSegEnd === 0 ? 0 : distMeters / distToSegEnd;
+      return [
+        startPt[0] + frac * (segEnd[0] - startPt[0]),
+        startPt[1] + frac * (segEnd[1] - startPt[1]),
+      ];
+    }
+    let remaining = distMeters - distToSegEnd;
+    for (let i = si + 1; i < lineCoords.length - 1; i++) {
+      const p1 = [lineCoords[i][1], lineCoords[i][0]];
+      const p2 = [lineCoords[i + 1][1], lineCoords[i + 1][0]];
+      const segLen = haversineDist(p1[0], p1[1], p2[0], p2[1]);
+      if (remaining <= segLen) {
+        const frac = segLen === 0 ? 0 : remaining / segLen;
+        return [p1[0] + frac * (p2[0] - p1[0]), p1[1] + frac * (p2[1] - p1[1])];
+      }
+      remaining -= segLen;
+    }
+    const last = lineCoords[lineCoords.length - 1];
+    return [last[1], last[0]];
+  } else {
+    const segStart = [lineCoords[si][1], lineCoords[si][0]];
+    const distToSegStart = haversineDist(startPt[0], startPt[1], segStart[0], segStart[1]);
+    const absDist = -distMeters;
+    if (absDist <= distToSegStart) {
+      const frac = distToSegStart === 0 ? 0 : absDist / distToSegStart;
+      return [
+        startPt[0] + frac * (segStart[0] - startPt[0]),
+        startPt[1] + frac * (segStart[1] - startPt[1]),
+      ];
+    }
+    let remaining = absDist - distToSegStart;
+    for (let i = si - 1; i >= 0; i--) {
+      const p1 = [lineCoords[i + 1][1], lineCoords[i + 1][0]];
+      const p2 = [lineCoords[i][1], lineCoords[i][0]];
+      const segLen = haversineDist(p1[0], p1[1], p2[0], p2[1]);
+      if (remaining <= segLen) {
+        const frac = segLen === 0 ? 0 : remaining / segLen;
+        return [p1[0] + frac * (p2[0] - p1[0]), p1[1] + frac * (p2[1] - p1[1])];
+      }
+      remaining -= segLen;
+    }
+    const first = lineCoords[0];
+    return [first[1], first[0]];
+  }
+}
+
+export function dualSnapBearing(lineCoords, snap, halfDistMeters) {
+  const front = walkAlongTrack(lineCoords, snap, halfDistMeters);
+  const back = walkAlongTrack(lineCoords, snap, -halfDistMeters);
+  return segmentBearing(back, front);
+}
+
+export function interpolateAlongPath(path, dists, t) {
+  if (path.length < 2) return { position: path[0] || [0, 0], bearing: 0 };
+
+  const totalDist = dists[dists.length - 1];
+  if (totalDist === 0) return { position: path[0], bearing: segmentBearing(path[0], path[path.length - 1]) };
+
+  const targetDist = Math.max(0, Math.min(1, t)) * totalDist;
+
+  let seg = 0;
+  for (let i = 1; i < dists.length; i++) {
+    if (dists[i] >= targetDist) { seg = i - 1; break; }
+    seg = i - 1;
+  }
+
+  const segLen = dists[seg + 1] - dists[seg];
+  const segT = segLen === 0 ? 0 : (targetDist - dists[seg]) / segLen;
+
+  const lat = path[seg][0] + segT * (path[seg + 1][0] - path[seg][0]);
+  const lng = path[seg][1] + segT * (path[seg + 1][1] - path[seg][1]);
+
+  return { position: [lat, lng], bearing: segmentBearing(path[seg], path[seg + 1]) };
+}


### PR DESCRIPTION
## Summary
- Train marker interpolates along track geometry between 5s GPS polls, stays on rails through curves
- Dual-snap bearing (front/back points on track scaled to icon size at current zoom) keeps train aligned during zoom
- Water taxi smoothly lerps raw GPS position and heading between 10s polls
- Shared `useAnimatedTrackerPosition` hook with `snapPosition` option (true=train, false=boat)
- Icons created with initial bearing to prevent rotation flash on first render

## Test plan
- [x] Train sits aligned on track when stationary
- [x] Train bearing adjusts instantly during zoom (no lag/jump)
- [x] Boat moves smoothly on water at raw GPS position
- [x] Boat heading interpolates smoothly between polls
- [x] No rotation animation on initial render for either marker
- [x] Build passes
- [x] Tests pass (3 pre-existing OG image failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)