### PR TITLE
fix: highlight route on CVSR permalink + eliminate train bearing pivot (#554)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,6 +42,12 @@ import { handleRovingKeyDown } from './utils/a11yUtils';
 
 const DEFAULT_ICON_TYPES = new Set(['visitor-center', 'waterfall', 'trail', 'mtb-trailhead', 'historic', 'bridge', 'train', 'nature', 'skiing', 'biking', 'picnic', 'camping', 'music', 'default', 'lighthouse', 'cemetery']);
 
+// Linear roles whose geometry is a followable route; a slug matching one of
+// these must select as linear (highlighted path), even when the same POI also
+// carries the organization role. Boundaries are deliberately excluded — org
+// boundaries render as destinations (#412).
+const ROUTE_ROLES = ['trail', 'river', 'water_taxi', 'railroad'];
+
 function generateSlug(name) {
   if (!name) return '';
   return name
@@ -1037,9 +1043,12 @@ function AppContent() {
         // POIs too, not just destinations — notification/shared links to org
         // news & events were navigating but rendering nothing (#412)
         const destination = destinations.find(d => generateSlug(d.name) === poiSlug);
-        const virtualPoi = !destination && virtualPois.find(v => generateSlug(v.name) === poiSlug);
-        const linearFeature = !destination && !virtualPoi
+        const linearFeature = !destination
           && linearFeatures.find(f => generateSlug(f.name) === poiSlug);
+        // Route-role POIs win over their org copy — see the length-1 branch (#554)
+        const isRoutePoi = linearFeature && linearFeature.poi_roles?.some(r => ROUTE_ROLES.includes(r));
+        const virtualPoi = !destination && !isRoutePoi
+          && virtualPois.find(v => generateSlug(v.name) === poiSlug);
         const pointPoi = destination || virtualPoi;
         if (pointPoi) {
           setSelectedDestination(pointPoi);
@@ -1082,7 +1091,14 @@ function AppContent() {
         return;
       }
 
-      const virtualPoi = virtualPois.find(v => generateSlug(v.name) === poiSlug);
+      // Dual-role org POIs (e.g. CVSR = organization + railroad) exist in BOTH
+      // virtualPois and linearFeatures; the route copy must win the slug match
+      // or the permalink selects the org as a destination and the route never
+      // highlights (#554). Boundary orgs stay destinations (#412).
+      const linearFeature = linearFeatures.find(f => generateSlug(f.name) === poiSlug);
+      const isRoutePoi = linearFeature?.poi_roles?.some(r => ROUTE_ROLES.includes(r));
+
+      const virtualPoi = !isRoutePoi && virtualPois.find(v => generateSlug(v.name) === poiSlug);
       if (virtualPoi) {
         setSelectedDestination(virtualPoi);
         setSelectedLinearFeature(null);
@@ -1092,7 +1108,6 @@ function AppContent() {
         return;
       }
 
-      const linearFeature = linearFeatures.find(f => generateSlug(f.name) === poiSlug);
       if (linearFeature) {
         setSelectedLinearFeature(linearFeature);
         setSelectedDestination(null);
@@ -1112,6 +1127,8 @@ function AppContent() {
           setShowRivers(true);
         } else if (linearFeature.poi_roles?.includes('water_taxi')) {
           setShowWaterTaxis(true);
+        } else if (linearFeature.poi_roles?.includes('railroad')) {
+          setVisibleTypes(prev => prev.has('train') ? prev : new Set(prev).add('train'));
         }
         setTimeout(() => { isLoadingFromUrlRef.current = false; }, 0);
         return;

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { MapContainer, TileLayer, Marker, Tooltip, useMap, GeoJSON, useMapEvents, CircleMarker } from 'react-leaflet';
 import L from 'leaflet';
@@ -1536,12 +1536,15 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     trainIconRef.current = createTrainIcon(animatedTrain.bearing);
   }
 
-  useEffect(() => {
+  // Layout effects, not plain effects: the bearing tracks the zoom level, and a
+  // post-paint rotation lands a frame after the camera — the marker visibly
+  // pivots as a zoom settles (#554). Pre-paint keeps icon and track in lockstep.
+  useLayoutEffect(() => {
     const el = boatMarkerRef.current?.getElement()?.querySelector('.boat-marker-inner');
     if (el && animatedBoat) el.style.transform = `rotate(${animatedBoat.bearing || 0}deg)`;
   }, [animatedBoat?.bearing]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = trainMarkerRef.current?.getElement()?.querySelector('.train-marker-inner');
     if (el && animatedTrain) el.style.transform = `rotate(${animatedTrain.bearing || 0}deg)`;
   }, [animatedTrain?.bearing]);

--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -11,6 +11,12 @@ function lerpAngle(a, b, t) {
   return ((a + diff * t) + 360) % 360;
 }
 
+// Track-following mode keeps { position, snap, direction } in state and derives
+// the bearing DURING RENDER from the current zoom. The bearing depends on zoom
+// (front/back snap points span the icon's ground footprint), and computing it in
+// an effect chain paints a frame or more behind the camera — the train visibly
+// pivots after a zoom settles (#554). Render-time derivation means every painted
+// frame carries the bearing that matches that frame's zoom.
 export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom, { pollIntervalMs = 5000, iconHalfPx = 32, snapPosition = true } = {}) {
   const [animated, setAnimated] = useState(null);
   const prevSnapRef = useRef(null);
@@ -20,14 +26,9 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
   const distsRef = useRef(null);
   const startTimeRef = useRef(0);
   const directionRef = useRef(1);
+  const movingRef = useRef(false);
   const rafRef = useRef(null);
-  const latestSnapRef = useRef(null);
-  const zoomRef = useRef(zoom || 13);
   const intervalRef = useRef(pollIntervalMs);
-  const halfPxRef = useRef(iconHalfPx);
-  const prevBearingRef = useRef(0);
-
-  useEffect(() => { zoomRef.current = zoom || 13; }, [zoom]);
 
   useEffect(() => {
     if (!rawPosition || !lineCoords || lineCoords.length < 2) {
@@ -39,38 +40,30 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
       [rawPosition.latitude, rawPosition.longitude],
       lineCoords
     );
-    latestSnapRef.current = newSnap;
 
     if (!prevSnapRef.current) {
       prevSnapRef.current = newSnap;
       prevRawRef.current = rawPosition;
       targetRawRef.current = rawPosition;
-      pathRef.current = [newSnap.position, newSnap.position];
-      distsRef.current = [0, 0];
-      startTimeRef.current = performance.now();
-      let bearing;
-      if (snapPosition) {
-        const halfDist = pixelsToMeters(halfPxRef.current, zoomRef.current);
-        bearing = dualSnapBearing(lineCoords, newSnap, halfDist);
-        if (rawPosition.heading != null) {
-          const diff = Math.abs(((bearing - rawPosition.heading + 540) % 360) - 180);
-          if (diff > 90) {
-            bearing = (bearing + 180) % 360;
-            directionRef.current = -1;
-          }
-        }
-      } else {
-        bearing = rawPosition.heading || 0;
+      movingRef.current = false;
+      // Until movement disambiguates travel direction, trust the upstream
+      // GPS heading to decide which way the icon faces along the track.
+      if (rawPosition.heading != null) {
+        const diff = Math.abs(((newSnap.bearing - rawPosition.heading + 540) % 360) - 180);
+        directionRef.current = diff > 90 ? -1 : 1;
       }
-      const pos = snapPosition ? newSnap.position : [rawPosition.latitude, rawPosition.longitude];
-      setAnimated({ position: pos, bearing });
+      setAnimated(snapPosition
+        ? { position: newSnap.position, snap: newSnap, direction: directionRef.current }
+        : { position: [rawPosition.latitude, rawPosition.longitude], heading: rawPosition.heading || 0 });
       return;
     }
 
     const prev = prevSnapRef.current;
     const dLat = rawPosition.latitude - (prev.position[0] || 0);
     const dLng = rawPosition.longitude - (prev.position[1] || 0);
-    if (Math.abs(dLat) > 1e-6 || Math.abs(dLng) > 1e-6) {
+    const hasMoved = Math.abs(dLat) > 1e-6 || Math.abs(dLng) > 1e-6;
+
+    if (hasMoved) {
       const heading = ((Math.atan2(dLng, dLat) * 180 / Math.PI) + 360) % 360;
       const diff = Math.abs(((newSnap.bearing - heading + 540) % 360) - 180);
       directionRef.current = diff > 90 ? -1 : 1;
@@ -79,17 +72,29 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
     prevRawRef.current = targetRawRef.current || rawPosition;
     targetRawRef.current = rawPosition;
 
-    const subPath = extractSubPath(lineCoords, prev, newSnap);
-    pathRef.current = subPath;
-    distsRef.current = cumulativeDistances(subPath);
+    if (hasMoved) {
+      pathRef.current = extractSubPath(lineCoords, prev, newSnap);
+      distsRef.current = cumulativeDistances(pathRef.current);
+      movingRef.current = true;
+    } else {
+      // Stationary: hold the last committed position — no path, no tick work,
+      // nothing to drift (#554)
+      pathRef.current = null;
+      distsRef.current = null;
+      movingRef.current = false;
+    }
+
     startTimeRef.current = performance.now();
     prevSnapRef.current = newSnap;
   }, [rawPosition, lineCoords, snapPosition]);
 
   const tick = useCallback(() => {
-    const t = Math.min(1, (performance.now() - startTimeRef.current) / intervalRef.current);
+    if (!movingRef.current) {
+      rafRef.current = requestAnimationFrame(tick);
+      return;
+    }
 
-    let position, bearing;
+    const t = Math.min(1, (performance.now() - startTimeRef.current) / intervalRef.current);
 
     if (snapPosition) {
       const path = pathRef.current;
@@ -98,13 +103,9 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
         rafRef.current = requestAnimationFrame(tick);
         return;
       }
-      position = interpolateAlongPath(path, dists, t).position;
+      const position = interpolateAlongPath(path, dists, t).position;
       const reSnap = snapToLine(position, lineCoords);
-      const halfDist = pixelsToMeters(halfPxRef.current, zoomRef.current);
-      bearing = dualSnapBearing(lineCoords, reSnap, halfDist);
-      if (directionRef.current === -1) {
-        bearing = (bearing + 180) % 360;
-      }
+      setAnimated({ position, snap: reSnap, direction: directionRef.current });
     } else {
       const prev = prevRawRef.current;
       const target = targetRawRef.current;
@@ -112,14 +113,15 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
         rafRef.current = requestAnimationFrame(tick);
         return;
       }
-      position = [
-        prev.latitude + t * (target.latitude - prev.latitude),
-        prev.longitude + t * (target.longitude - prev.longitude),
-      ];
-      bearing = lerpAngle(prev.heading || 0, target.heading || 0, t);
+      setAnimated({
+        position: [
+          prev.latitude + t * (target.latitude - prev.latitude),
+          prev.longitude + t * (target.longitude - prev.longitude),
+        ],
+        heading: lerpAngle(prev.heading || 0, target.heading || 0, t),
+      });
     }
 
-    setAnimated({ position, bearing });
     rafRef.current = requestAnimationFrame(tick);
   }, [lineCoords, snapPosition]);
 
@@ -128,5 +130,11 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
     return () => cancelAnimationFrame(rafRef.current);
   }, [tick]);
 
-  return animated;
+  if (!animated) return null;
+  if (!snapPosition) return { position: animated.position, bearing: animated.heading };
+
+  const halfDist = pixelsToMeters(iconHalfPx, zoom || 13);
+  let bearing = dualSnapBearing(lineCoords, animated.snap, halfDist);
+  if (animated.direction === -1) bearing = (bearing + 180) % 360;
+  return { position: animated.position, bearing };
 }


### PR DESCRIPTION
## Summary

Fixes #554 and #553. Two independent root causes, both diagnosed against production data:

### 1. Route not highlighted on permalink (fixes #553 too)
CVSR (POI 5660) is a dual-role `['organization', 'railroad']` POI, so it is returned by **both** the `role=organization` fetch (virtualPois) and the `role=railroad` fetch (linearFeatures). The browser-nav effect — which also runs on initial page load because its deps include the data arrays — matched the virtualPois copy first, selected it as a *destination*, and clobbered the correct linear selection made by the initial-load effect. Destinations never highlight the route polyline.

Fix: a slug that matches a linear feature carrying a route role (`trail`/`river`/`water_taxi`/`railroad`) now wins over the org copy, in both the main slug branch and the news/events subtab branch. Boundary orgs keep resolving as destinations (#412 behavior preserved). A railroad selection also enables the `train` icon type so the route can always render.

### 2. Train pivots after the camera settles
The marker bearing is zoom-dependent by design (the front/back snap points span the icon's ground footprint at the current zoom). But bearing updates flowed through two post-paint `useEffect` hops (`zoom` event → `setMapZoom` → hook zoom effect → `setAnimated` → rotation effect), so the rotation always landed frames **after** the camera stopped — a visible pivot at the end of every zoom, worst on permalink load where the initial bearing was computed at the wide valley zoom.

Fix: `useAnimatedTrackerPosition` now stores `{position, snap, direction}` and derives the bearing **during render** as a pure function of the current zoom; Map.jsx applies the rotation in a `useLayoutEffect` (pre-paint). Every painted frame carries the bearing that matches that frame's zoom — there is nothing left to correct after the camera settles.

## Test plan
- [x] `/cuyahoga-valley-scenic-railroad` permalink: route highlighted (selected style) on load, verified via DOM inspection
- [x] Train marker bearing tracked the camera from 325.3° @ z11 → 159.4° @ z15 with zero post-settle corrections (rAF-granularity sampling)
- [x] Sidebar opens from permalink; train fit zooms to the live train position
- [x] `./run.sh build` + `./run.sh test`: 433 passed (3 pre-existing OG-image failures, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)