### PR TITLE
fix: cap marker bearing chord span at 150m (#554 follow-up)

### DIFF
--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -2,8 +2,16 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { snapToLine } from '../utils/snapToLine';
 import { extractSubPath, cumulativeDistances, interpolateAlongPath, dualSnapBearing } from '../utils/trackInterpolation';
 
+// At wide zooms the icon's ground footprint spans kilometers of track, and a
+// chord that long cuts across curves — the icon reads visibly crooked against
+// the track line under it (14° off at z11 near the CVSR yard), then rotates
+// into place as the zoom shrinks the span (#554). The eye judges alignment
+// against the LOCAL track direction, so cap the span; below the cap the
+// zoom-scaled footprint behavior is unchanged.
+const MAX_BEARING_SPAN_M = 150;
+
 function pixelsToMeters(halfPx, zoom) {
-  return halfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** zoom);
+  return Math.min(halfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** zoom), MAX_BEARING_SPAN_M);
 }
 
 function lerpAngle(a, b, t) {


### PR DESCRIPTION
## Summary
Follow-up to #555. The train still drew slightly crooked at the wide initial zoom and rotated into alignment during the permalink zoom-in. Root cause: the bearing chord is scaled to the icon's ground footprint, which at z11 spans ±1.8km of curving track — the chord pointed 14° off the local track direction (measured against the real geometry: 325.3° at z11 vs 339.4° at z14+).

Fix: cap the chord half-span at 150m. Verified against the CVSR geometry that the capped bearing is constant (339.4°) across z11–z16 at the yard, so the train draws aligned at first paint and nothing rotates during the zoom. Zoom-scaled footprint behavior at z15+ (spans already under the cap) is unchanged.

## Test plan
- [x] Numeric verification against production track geometry: capped bearing identical across z11–z16
- [x] User-verified locally: train draws aligned, no pivot during zoom-in
- [x] `./run.sh build` + `./run.sh test`: 433 passed (3 pre-existing OG-image failures, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)