### PR TITLE
fix: smooth train marker animation and stop direction flips

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -72,8 +72,12 @@ RUN if [ "$BUILD_ENV" = "test" ]; then npm install; else npm install --omit=dev;
 # Copy backend code
 COPY backend/ ./
 
-# Move built frontend to public directory
-RUN mv frontend/dist public && rm -rf frontend
+# Move built frontend to public directory. Test builds keep the frontend
+# source at /frontend so backend unit tests can import pure frontend utils
+# (tests/*.unit.test.js -> ../../frontend/src/... matches the host layout).
+RUN mv frontend/dist public && \
+    if [ "$BUILD_ENV" = "test" ]; then mkdir -p /frontend && mv frontend/src /frontend/src; fi && \
+    rm -rf frontend
 
 # Copy systemd units and scripts
 COPY rootfs/ /

--- a/backend/services/newsletterDigestService.js
+++ b/backend/services/newsletterDigestService.js
@@ -94,10 +94,10 @@ export async function generateDigest(pool, tz = 'America/New_York', asOfDate = n
 
 async function fetchDigestGreeting(pool) {
   try {
-    const result = await pool.query(
+    const greetingQuery = await pool.query(
       "SELECT value FROM admin_settings WHERE key = 'digest_greeting'"
     );
-    const val = result.rows[0]?.value?.trim();
+    const val = greetingQuery.rows[0]?.value?.trim();
     return val || null;
   } catch (err) {
     console.error('Failed to fetch digest greeting:', err.message);

--- a/backend/tests/newsEvents.integration.test.js
+++ b/backend/tests/newsEvents.integration.test.js
@@ -103,7 +103,7 @@ describe('News & Events API Integration Tests', () => {
   describe('GET /api/pois (with news/events counts)', () => {
     it('should return POIs with news and events counts', async () => {
       const response = await request(BASE_URL)
-        .get('/api/destinations')
+        .get('/api/pois?role=point')
         .expect(200);
 
       expect(Array.isArray(response.body)).toBe(true);
@@ -122,7 +122,7 @@ describe('News & Events API Integration Tests', () => {
   describe('Health Check', () => {
     it('should verify container is running', async () => {
       const response = await request(BASE_URL)
-        .get('/api/destinations')
+        .get('/api/pois?role=point')
         .expect(200);
 
       expect(response.status).toBe(200);

--- a/backend/tests/ogShareImages.integration.test.js
+++ b/backend/tests/ogShareImages.integration.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import request from 'supertest';
+import { isUsableSourceImage } from '../utils/sourceImage.js';
 
 const BASE_URL = process.env.TEST_BASE_URL || 'http://localhost:8080';
 const FALLBACK_IMAGE_PATH = '/brand/rotv-og-share-1200x630.jpg';
@@ -101,14 +102,19 @@ describe('Open Graph share images', () => {
     // Priority is source article image -> POI primary photo -> brand fallback
     // (server.js). For a POI that has a photo, the permalink must resolve to one
     // of the first two, never the brand card.
+    // The server resolves a non-brand image only from (a) a usable source
+    // article image or (b) the POI primary photo (thumbnail endpoint) — a
+    // gallery mosaic alone is NOT sufficient (resolvePoiOgImage requires a
+    // primary/poi_media asset). Select a target the server can actually
+    // resolve, mirroring that priority.
     let target = null;
     for (const poi of (poiWithPhoto ? [poiWithPhoto, ...pois] : pois).slice(0, 80)) {
       const news = await request(BASE_URL).get(`/api/pois/${poi.id}/news`);
-      if (news.status === 200 && Array.isArray(news.body) && news.body.length > 0) {
-        const media = await request(BASE_URL).get(`/api/pois/${poi.id}/media`);
-        const hasPhoto = media.status === 200 && Array.isArray(media.body.mosaic) && media.body.mosaic.length > 0;
-        if (hasPhoto) { target = { poi, news: news.body[0] }; break; }
-      }
+      if (news.status !== 200 || !Array.isArray(news.body) || news.body.length === 0) continue;
+      const withSourceImage = news.body.find(n => isUsableSourceImage(n.image_url));
+      if (withSourceImage) { target = { poi, news: withSourceImage }; break; }
+      const thumb = await request(BASE_URL).get(`/api/pois/${poi.id}/thumbnail?size=large`);
+      if (thumb.status === 200) { target = { poi, news: news.body[0] }; break; }
     }
 
     if (!target) {

--- a/backend/tests/trackInterpolation.unit.test.js
+++ b/backend/tests/trackInterpolation.unit.test.js
@@ -1,0 +1,100 @@
+/**
+ * Track Interpolation Unit Tests
+ * Covers the arc-distance direction logic that replaced GPS-heading-vs-track-
+ * bearing comparison (train icon flipping backwards) and the arc-based frame
+ * positioning used by the marker tween.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  lineCumulativeDistances, arcDistanceAt, snapAtArc,
+} from '../../frontend/src/utils/trackInterpolation.js';
+import { snapToLine } from '../../frontend/src/utils/snapToLine.js';
+
+// North-south track at CVSR longitude: GeoJSON [lng, lat], ~111m per vertex
+const TRACK = [
+  [-81.625, 41.380],
+  [-81.625, 41.381],
+  [-81.625, 41.382],
+  [-81.625, 41.383],
+  [-81.625, 41.384],
+];
+
+describe('lineCumulativeDistances', () => {
+  it('is zero at the start and strictly increasing', () => {
+    const dists = lineCumulativeDistances(TRACK);
+    expect(dists[0]).toBe(0);
+    for (let i = 1; i < dists.length; i++) {
+      expect(dists[i]).toBeGreaterThan(dists[i - 1]);
+    }
+  });
+
+  it('matches haversine scale (~111m per 0.001° latitude)', () => {
+    const dists = lineCumulativeDistances(TRACK);
+    expect(dists[1]).toBeGreaterThan(105);
+    expect(dists[1]).toBeLessThan(117);
+    expect(dists[4]).toBeCloseTo(dists[1] * 4, 0);
+  });
+});
+
+describe('arcDistanceAt — travel direction from arc delta', () => {
+  // ~9m east of the track: the raw GPS never sits ON the line geometry
+  const OFF_TRACK_LNG = -81.62489;
+
+  it('northbound travel gives a positive arc delta despite the offset', () => {
+    const a = snapToLine([41.3805, OFF_TRACK_LNG], TRACK);
+    const b = snapToLine([41.3825, OFF_TRACK_LNG], TRACK);
+    const dists = lineCumulativeDistances(TRACK);
+    expect(arcDistanceAt(dists, b) - arcDistanceAt(dists, a)).toBeGreaterThan(100);
+  });
+
+  it('southbound travel gives a negative arc delta despite the offset', () => {
+    const a = snapToLine([41.3825, OFF_TRACK_LNG], TRACK);
+    const b = snapToLine([41.3805, OFF_TRACK_LNG], TRACK);
+    const dists = lineCumulativeDistances(TRACK);
+    expect(arcDistanceAt(dists, b) - arcDistanceAt(dists, a)).toBeLessThan(-100);
+  });
+
+  it('an identical off-track fix re-delivered yields zero arc delta', () => {
+    // Regression: the old raw-vs-snapped comparison saw the 9m perpendicular
+    // offset as movement on every poll and re-tossed direction from it.
+    const a = snapToLine([41.3815, OFF_TRACK_LNG], TRACK);
+    const b = snapToLine([41.3815, OFF_TRACK_LNG], TRACK);
+    const dists = lineCumulativeDistances(TRACK);
+    expect(arcDistanceAt(dists, b) - arcDistanceAt(dists, a)).toBe(0);
+  });
+
+  it('flipping the offset side of the track does not flip the arc delta sign', () => {
+    const eastA = snapToLine([41.3805, -81.62489], TRACK);
+    const westB = snapToLine([41.3825, -81.62511], TRACK);
+    const dists = lineCumulativeDistances(TRACK);
+    expect(arcDistanceAt(dists, westB) - arcDistanceAt(dists, eastA)).toBeGreaterThan(100);
+  });
+});
+
+describe('snapAtArc', () => {
+  it('round-trips with arcDistanceAt', () => {
+    const dists = lineCumulativeDistances(TRACK);
+    const snap = snapToLine([41.3815, -81.62489], TRACK);
+    const arc = arcDistanceAt(dists, snap);
+    const located = snapAtArc(TRACK, dists, arc);
+    expect(located.position[0]).toBeCloseTo(snap.position[0], 8);
+    expect(located.position[1]).toBeCloseTo(snap.position[1], 8);
+    expect(arcDistanceAt(dists, located)).toBeCloseTo(arc, 6);
+  });
+
+  it('clamps below zero and beyond the line end', () => {
+    const dists = lineCumulativeDistances(TRACK);
+    expect(snapAtArc(TRACK, dists, -50).position).toEqual([41.380, -81.625]);
+    const end = snapAtArc(TRACK, dists, dists[dists.length - 1] + 500);
+    expect(end.position[0]).toBeCloseTo(41.384, 8);
+    expect(end.position[1]).toBeCloseTo(-81.625, 8);
+  });
+
+  it('places the halfway arc at the geometric midpoint', () => {
+    const dists = lineCumulativeDistances(TRACK);
+    const mid = snapAtArc(TRACK, dists, dists[dists.length - 1] / 2);
+    expect(mid.position[0]).toBeCloseTo(41.382, 4);
+    expect(mid.bearing).toBeCloseTo(0, 0);
+  });
+});
+

--- a/docs/CI_CD_TESTING.md
+++ b/docs/CI_CD_TESTING.md
@@ -243,7 +243,8 @@ era VARCHAR(255),  // Column type doesn't match queries!
 LEFT JOIN eras e ON p.era_id = e.id  // Expects INTEGER era_id!
 ```
 
-This caused 500 errors from `/api/destinations` endpoint.
+This caused 500 errors from the `/api/destinations` endpoint (since
+consolidated into `/api/pois?role=point` in #546; the old path 301-redirects).
 
 ### Solution
 

--- a/docs/DEVELOPMENT_ARCHITECTURE.md
+++ b/docs/DEVELOPMENT_ARCHITECTURE.md
@@ -422,8 +422,9 @@ sleep 10
 podman exec rotv psql -U postgres -d rotv -c "SELECT COUNT(*) FROM pois;"
 # Expected: 371
 
-# Check API
-curl -s http://localhost:8080/api/destinations | jq -r 'length'
+# Check API (/api/destinations was consolidated into /api/pois in #546;
+# the old path now 301-redirects to /api/pois?role=point)
+curl -s http://localhost:8080/api/pois?role=point | jq -r 'length'
 # Expected: 178
 ```
 

--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { snapToLine } from '../utils/snapToLine';
-import { extractSubPath, cumulativeDistances, interpolateAlongPath, dualSnapBearing } from '../utils/trackInterpolation';
+import {
+  dualSnapBearing, lineCumulativeDistances, arcDistanceAt, snapAtArc, haversineDist,
+} from '../utils/trackInterpolation';
 
 // At wide zooms the icon's ground footprint spans kilometers of track, and a
 // chord that long cuts across curves — the icon reads visibly crooked against
@@ -10,49 +12,97 @@ import { extractSubPath, cumulativeDistances, interpolateAlongPath, dualSnapBear
 // zoom-scaled footprint behavior is unchanged.
 const MAX_BEARING_SPAN_M = 150;
 
-function pixelsToMeters(halfPx, zoom) {
-  return Math.min(halfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** zoom), MAX_BEARING_SPAN_M);
+// The GPS device reports on its own cadence (measured ~10-20s for the CVSR
+// unit), while the frontend polls every few seconds and re-delivers the same
+// fix. Raw coordinates sit meters off the track geometry, so any comparison
+// against a SNAPPED point reads as phantom movement on every poll — the old
+// 1e-6° (11cm) gate fired constantly and re-derived travel direction from the
+// perpendicular raw-vs-snap offset, a coin flip that made the icon face
+// backwards at random. Gate on raw-to-raw displacement at GPS-noise scale
+// instead, and only re-decide direction after real along-track travel.
+const MIN_MOVE_M = 3;
+const MIN_DIRECTION_M = 5;
+
+// Tween duration adapts to the measured gap between accepted fixes — a fixed
+// duration shorter than the device cadence sprints then freezes ("moves for a
+// while, then stops"). Clamped so a data outage neither snaps (min) nor
+// crawls across the map for minutes (max); beyond TELEPORT_M jump instead of
+// animating through a long outage.
+const MIN_TWEEN_MS = 4000;
+const MAX_TWEEN_MS = 30000;
+const TELEPORT_M = 1000;
+
+/**
+ * Timestamp of a GPS fix in epoch ms. Prefers the device's own fix time —
+ * arrival times carry 0-10s of poll-phase jitter from the two unsynchronized
+ * 5s polls (device→backend→frontend).
+ * @param {{updatedAt?: string}} rawPosition tracker API position
+ * @returns {number} epoch ms (falls back to now when updatedAt is absent)
+ */
+function fixEpochMs(rawPosition) {
+  const parsed = Date.parse(rawPosition.updatedAt || '');
+  return Number.isFinite(parsed) ? parsed : Date.now();
 }
 
-function lerpAngle(a, b, t) {
-  let diff = ((b - a + 540) % 360) - 180;
-  return ((a + diff * t) + 360) % 360;
-}
-
-// Track-following mode keeps { position, snap, direction } in state and derives
-// the bearing DURING RENDER from the current zoom. The bearing depends on zoom
-// (front/back snap points span the icon's ground footprint), and computing it in
-// an effect chain paints a frame or more behind the camera — the train visibly
-// pivots after a zoom settles (#554). Render-time derivation means every painted
-// frame carries the bearing that matches that frame's zoom.
+/**
+ * Animate a polled GPS tracker position for a map marker.
+ *
+ * Track-following mode (snapPosition=true) snaps fixes to the line geometry
+ * and tweens the ARC DISTANCE between them, so each frame is an O(log n)
+ * table lookup rather than a re-snap against the full geometry. It keeps
+ * { position, snap, direction } in state and derives the icon bearing DURING
+ * RENDER from the current zoom: the bearing depends on zoom (front/back snap
+ * points span the icon's ground footprint), and computing it in an effect
+ * chain paints a frame or more behind the camera — the marker visibly pivots
+ * after a zoom settles (#554). Raw mode (snapPosition=false) lerps positions
+ * and headings directly (water taxi).
+ *
+ * @param {{latitude: number, longitude: number, heading?: number, updatedAt?: string}|null} rawPosition
+ *   latest polled fix (re-delivered unchanged between device reports)
+ * @param {Array<[number, number]>|null} lineCoords route geometry, GeoJSON [lng, lat]
+ * @param {number} zoom current map zoom (bearing footprint scaling)
+ * @param {{pollIntervalMs?: number, iconHalfPx?: number, snapPosition?: boolean}} [opts]
+ * @returns {{position: [number, number], bearing: number}|null}
+ */
 export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom, { pollIntervalMs = 5000, iconHalfPx = 32, snapPosition = true } = {}) {
   const [animated, setAnimated] = useState(null);
-  const prevSnapRef = useRef(null);
-  const prevRawRef = useRef(null);
-  const targetRawRef = useRef(null);
-  const pathRef = useRef(null);
-  const distsRef = useRef(null);
+  const lastRawRef = useRef(null);
+  const lastFixMsRef = useRef(0);
+  const prevArcRef = useRef(0);
+  const lineDistsRef = useRef({ coords: null, dists: null });
+  const displayedRef = useRef(null);
+  const tweenStartRef = useRef(null);
+  const tweenStartArcRef = useRef(0);
+  const tweenTargetArcRef = useRef(0);
   const startTimeRef = useRef(0);
+  const durationRef = useRef(pollIntervalMs);
   const directionRef = useRef(1);
   const movingRef = useRef(false);
   const rafRef = useRef(null);
-  const intervalRef = useRef(pollIntervalMs);
 
   useEffect(() => {
     if (!rawPosition || !lineCoords || lineCoords.length < 2) {
       setAnimated(null);
+      lastRawRef.current = null;
+      movingRef.current = false;
       return;
     }
+
+    if (lineDistsRef.current.coords !== lineCoords) {
+      lineDistsRef.current = { coords: lineCoords, dists: lineCumulativeDistances(lineCoords) };
+    }
+    const lineDists = lineDistsRef.current.dists;
 
     const newSnap = snapToLine(
       [rawPosition.latitude, rawPosition.longitude],
       lineCoords
     );
+    const newArc = arcDistanceAt(lineDists, newSnap);
 
-    if (!prevSnapRef.current) {
-      prevSnapRef.current = newSnap;
-      prevRawRef.current = rawPosition;
-      targetRawRef.current = rawPosition;
+    if (!lastRawRef.current) {
+      lastRawRef.current = rawPosition;
+      lastFixMsRef.current = fixEpochMs(rawPosition);
+      prevArcRef.current = newArc;
       movingRef.current = false;
       // Until movement disambiguates travel direction, trust the upstream
       // GPS heading to decide which way the icon faces along the track.
@@ -60,40 +110,61 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
         const diff = Math.abs(((newSnap.bearing - rawPosition.heading + 540) % 360) - 180);
         directionRef.current = diff > 90 ? -1 : 1;
       }
-      setAnimated(snapPosition
+      const initial = snapPosition
         ? { position: newSnap.position, snap: newSnap, direction: directionRef.current }
-        : { position: [rawPosition.latitude, rawPosition.longitude], heading: rawPosition.heading || 0 });
+        : { position: [rawPosition.latitude, rawPosition.longitude], heading: rawPosition.heading || 0 };
+      displayedRef.current = initial;
+      setAnimated(initial);
       return;
     }
 
-    const prev = prevSnapRef.current;
-    const dLat = rawPosition.latitude - (prev.position[0] || 0);
-    const dLng = rawPosition.longitude - (prev.position[1] || 0);
-    const hasMoved = Math.abs(dLat) > 1e-6 || Math.abs(dLng) > 1e-6;
+    const prevRaw = lastRawRef.current;
+    const movedM = haversineDist(
+      prevRaw.latitude, prevRaw.longitude,
+      rawPosition.latitude, rawPosition.longitude
+    );
 
-    if (hasMoved) {
-      const heading = ((Math.atan2(dLng, dLat) * 180 / Math.PI) + 360) % 360;
-      const diff = Math.abs(((newSnap.bearing - heading + 540) % 360) - 180);
-      directionRef.current = diff > 90 ? -1 : 1;
+    // Same fix re-delivered by the poll, or sub-noise jitter: hold. An
+    // in-flight tween keeps its runway; direction is NOT re-derived (#554
+    // follow-up — jitter-derived direction is what flipped the icon).
+    if (movedM < MIN_MOVE_M) return;
+
+    const arcDelta = newArc - prevArcRef.current;
+    if (Math.abs(arcDelta) >= MIN_DIRECTION_M) {
+      directionRef.current = arcDelta > 0 ? 1 : -1;
     }
 
-    prevRawRef.current = targetRawRef.current || rawPosition;
-    targetRawRef.current = rawPosition;
+    const fixMs = fixEpochMs(rawPosition);
+    durationRef.current = Math.min(MAX_TWEEN_MS, Math.max(MIN_TWEEN_MS, fixMs - lastFixMsRef.current));
+    lastFixMsRef.current = fixMs;
+    lastRawRef.current = rawPosition;
+    prevArcRef.current = newArc;
 
-    if (hasMoved) {
-      pathRef.current = extractSubPath(lineCoords, prev, newSnap);
-      distsRef.current = cumulativeDistances(pathRef.current);
-      movingRef.current = true;
+    const displayed = displayedRef.current;
+
+    if (snapPosition) {
+      if (Math.abs(arcDelta) > TELEPORT_M) {
+        movingRef.current = false;
+        const jumped = { position: newSnap.position, snap: newSnap, direction: directionRef.current };
+        displayedRef.current = jumped;
+        setAnimated(jumped);
+        return;
+      }
+      // Tween from where the marker IS, not from the previous fix's target —
+      // a fix landing mid-tween otherwise restarts with a visible jump. The
+      // displayed snap came from snapAtArc/snapToLine, so its arc is exact.
+      tweenStartArcRef.current = displayed?.snap
+        ? arcDistanceAt(lineDists, displayed.snap)
+        : newArc;
+      tweenTargetArcRef.current = newArc;
     } else {
-      // Stationary: hold the last committed position — no path, no tick work,
-      // nothing to drift (#554)
-      pathRef.current = null;
-      distsRef.current = null;
-      movingRef.current = false;
+      // Raw-lerp mode tweens from where the marker currently IS (same
+      // mid-tween restart rule as the track path above).
+      tweenStartRef.current = displayed;
     }
 
     startTimeRef.current = performance.now();
-    prevSnapRef.current = newSnap;
+    movingRef.current = true;
   }, [rawPosition, lineCoords, snapPosition]);
 
   const tick = useCallback(() => {
@@ -102,33 +173,41 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
       return;
     }
 
-    const t = Math.min(1, (performance.now() - startTimeRef.current) / intervalRef.current);
+    const t = Math.min(1, (performance.now() - startTimeRef.current) / durationRef.current);
 
     if (snapPosition) {
-      const path = pathRef.current;
-      const dists = distsRef.current;
-      if (!path || !dists || path.length < 2 || !lineCoords) {
+      const lineDists = lineDistsRef.current.dists;
+      if (!lineCoords || !lineDists) {
         rafRef.current = requestAnimationFrame(tick);
         return;
       }
-      const position = interpolateAlongPath(path, dists, t).position;
-      const reSnap = snapToLine(position, lineCoords);
-      setAnimated({ position, snap: reSnap, direction: directionRef.current });
+      const arc = tweenStartArcRef.current + t * (tweenTargetArcRef.current - tweenStartArcRef.current);
+      const snap = snapAtArc(lineCoords, lineDists, arc);
+      const frame = { position: snap.position, snap, direction: directionRef.current };
+      displayedRef.current = frame;
+      setAnimated(frame);
     } else {
-      const prev = prevRawRef.current;
-      const target = targetRawRef.current;
+      const prev = tweenStartRef.current;
+      const target = lastRawRef.current;
       if (!prev || !target) {
         rafRef.current = requestAnimationFrame(tick);
         return;
       }
-      setAnimated({
+      // Shortest-arc heading interpolation (never swings the long way round)
+      const headingDiff = (((target.heading || 0) - (prev.heading || 0) + 540) % 360) - 180;
+      const frame = {
         position: [
-          prev.latitude + t * (target.latitude - prev.latitude),
-          prev.longitude + t * (target.longitude - prev.longitude),
+          prev.position[0] + t * (target.latitude - prev.position[0]),
+          prev.position[1] + t * (target.longitude - prev.position[1]),
         ],
-        heading: lerpAngle(prev.heading || 0, target.heading || 0, t),
-      });
+        heading: (((prev.heading || 0) + headingDiff * t) + 360) % 360,
+      };
+      displayedRef.current = frame;
+      setAnimated(frame);
     }
+
+    // Tween complete: stop emitting frames until the next accepted fix.
+    if (t >= 1) movingRef.current = false;
 
     rafRef.current = requestAnimationFrame(tick);
   }, [lineCoords, snapPosition]);
@@ -141,7 +220,12 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
   if (!animated) return null;
   if (!snapPosition) return { position: animated.position, bearing: animated.heading };
 
-  const halfDist = pixelsToMeters(iconHalfPx, zoom || 13);
+  // Icon half-width in ground meters at this zoom (Web Mercator meters/pixel
+  // at the valley's latitude), capped at MAX_BEARING_SPAN_M.
+  const halfDist = Math.min(
+    iconHalfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** (zoom || 13)),
+    MAX_BEARING_SPAN_M
+  );
   let bearing = dualSnapBearing(lineCoords, animated.snap, halfDist);
   if (animated.direction === -1) bearing = (bearing + 180) % 360;
   return { position: animated.position, bearing };

--- a/frontend/src/utils/trackInterpolation.js
+++ b/frontend/src/utils/trackInterpolation.js
@@ -1,4 +1,10 @@
-function haversineDist(lat1, lng1, lat2, lng2) {
+/**
+ * Great-circle distance between two points.
+ * @param {number} lat1 @param {number} lng1 first point, decimal degrees
+ * @param {number} lat2 @param {number} lng2 second point, decimal degrees
+ * @returns {number} distance in meters
+ */
+export function haversineDist(lat1, lng1, lat2, lng2) {
   const R = 6371000;
   const dLat = (lat2 - lat1) * Math.PI / 180;
   const dLng = (lng2 - lng1) * Math.PI / 180;
@@ -8,52 +14,44 @@ function haversineDist(lat1, lng1, lat2, lng2) {
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-export function extractSubPath(lineCoords, prevSnap, newSnap) {
-  const si = prevSnap.segmentIndex;
-  const ei = newSnap.segmentIndex;
-
-  const startPt = prevSnap.position;
-  const endPt = newSnap.position;
-
-  if (si === ei) {
-    return [startPt, endPt];
-  }
-
-  const forward = si < ei ||
-    (si === ei && prevSnap.segmentT < newSnap.segmentT);
-
-  const path = [startPt];
-  if (forward) {
-    for (let i = si + 1; i <= ei; i++) {
-      path.push([lineCoords[i][1], lineCoords[i][0]]);
-    }
-  } else {
-    for (let i = si; i >= ei + 1; i--) {
-      path.push([lineCoords[i][1], lineCoords[i][0]]);
-    }
-  }
-  path.push(endPt);
-  return path;
-}
-
-export function cumulativeDistances(path) {
+/**
+ * Cumulative meters from the line start to each vertex.
+ * @param {Array<[number, number]>} lineCoords GeoJSON [lng, lat] pairs
+ *   (unlike interpolation paths, which are [lat, lng])
+ * @returns {number[]} one entry per vertex; [0] is 0, last is total length
+ */
+export function lineCumulativeDistances(lineCoords) {
   const dists = [0];
-  for (let i = 1; i < path.length; i++) {
+  for (let i = 1; i < lineCoords.length; i++) {
     dists.push(dists[i - 1] + haversineDist(
-      path[i - 1][0], path[i - 1][1],
-      path[i][0], path[i][1]
+      lineCoords[i - 1][1], lineCoords[i - 1][0],
+      lineCoords[i][1], lineCoords[i][0]
     ));
   }
   return dists;
+}
+
+/**
+ * Arc position (meters along the line) of a snapToLine() result. Travel
+ * direction is the SIGN of the arc delta between two snaps — unlike comparing
+ * a GPS displacement angle to the track bearing, it cannot be flipped by the
+ * perpendicular raw-vs-snapped offset.
+ * @param {number[]} lineDists lineCumulativeDistances(lineCoords)
+ * @param {{segmentIndex: number, segmentT: number}} snap snapToLine() result
+ * @returns {number} meters from the line start
+ */
+export function arcDistanceAt(lineDists, snap) {
+  const i = snap.segmentIndex;
+  return lineDists[i] + snap.segmentT * (lineDists[i + 1] - lineDists[i]);
 }
 
 function segmentBearing(p1, p2) {
   const dLon = (p2[1] - p1[1]) * Math.PI / 180;
   const rlat1 = p1[0] * Math.PI / 180;
   const rlat2 = p2[0] * Math.PI / 180;
-  const y = Math.sin(dLon) * Math.cos(rlat2);
-  const x = Math.cos(rlat1) * Math.sin(rlat2) - Math.sin(rlat1) * Math.cos(rlat2) * Math.cos(dLon);
-  return ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
+  const eastward = Math.sin(dLon) * Math.cos(rlat2);
+  const northward = Math.cos(rlat1) * Math.sin(rlat2) - Math.sin(rlat1) * Math.cos(rlat2) * Math.cos(dLon);
+  return ((Math.atan2(eastward, northward) * 180 / Math.PI) + 360) % 360;
 }
 
 export function walkAlongTrack(lineCoords, snap, distMeters) {
@@ -110,31 +108,39 @@ export function walkAlongTrack(lineCoords, snap, distMeters) {
   }
 }
 
+/**
+ * Point on the line at a given arc distance from its start. O(log n) binary
+ * search over the cumulative-distance table, cheap enough to run every
+ * animation frame — unlike re-snapping a lat/lng against the full geometry.
+ * @param {Array<[number, number]>} lineCoords GeoJSON [lng, lat] vertices
+ * @param {number[]} lineDists lineCumulativeDistances(lineCoords)
+ * @param {number} arcMeters distance along the line; clamped to [0, total]
+ * @returns {{position: [number, number], segmentIndex: number, segmentT: number, bearing: number}}
+ *   same shape as snapToLine() (position is [lat, lng])
+ */
+export function snapAtArc(lineCoords, lineDists, arcMeters) {
+  const total = lineDists[lineDists.length - 1];
+  const arc = Math.max(0, Math.min(total, arcMeters));
+  let lo = 0;
+  let hi = lineDists.length - 1;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (lineDists[mid] <= arc) lo = mid; else hi = mid;
+  }
+  const segLen = lineDists[lo + 1] - lineDists[lo];
+  const segmentT = segLen === 0 ? 0 : (arc - lineDists[lo]) / segLen;
+  const [lng1, lat1] = lineCoords[lo];
+  const [lng2, lat2] = lineCoords[lo + 1];
+  return {
+    position: [lat1 + segmentT * (lat2 - lat1), lng1 + segmentT * (lng2 - lng1)],
+    segmentIndex: lo,
+    segmentT,
+    bearing: segmentBearing([lat1, lng1], [lat2, lng2]),
+  };
+}
+
 export function dualSnapBearing(lineCoords, snap, halfDistMeters) {
   const front = walkAlongTrack(lineCoords, snap, halfDistMeters);
   const back = walkAlongTrack(lineCoords, snap, -halfDistMeters);
   return segmentBearing(back, front);
-}
-
-export function interpolateAlongPath(path, dists, t) {
-  if (path.length < 2) return { position: path[0] || [0, 0], bearing: 0 };
-
-  const totalDist = dists[dists.length - 1];
-  if (totalDist === 0) return { position: path[0], bearing: segmentBearing(path[0], path[path.length - 1]) };
-
-  const targetDist = Math.max(0, Math.min(1, t)) * totalDist;
-
-  let seg = 0;
-  for (let i = 1; i < dists.length; i++) {
-    if (dists[i] >= targetDist) { seg = i - 1; break; }
-    seg = i - 1;
-  }
-
-  const segLen = dists[seg + 1] - dists[seg];
-  const segT = segLen === 0 ? 0 : (targetDist - dists[seg]) / segLen;
-
-  const lat = path[seg][0] + segT * (path[seg + 1][0] - path[seg][0]);
-  const lng = path[seg][1] + segT * (path[seg + 1][1] - path[seg][1]);
-
-  return { position: [lat, lng], bearing: segmentBearing(path[seg], path[seg + 1]) };
 }


### PR DESCRIPTION
## Summary
- **Stutter fix**: train marker tween duration was fixed at 5s while the USFT GPS device reports every 10–20s (measured live in prod) — the marker sprinted then froze between fixes. Duration now adapts to the measured gap between device fixes (`updatedAt`, clamped 4–30s).
- **Backwards-icon fix**: `hasMoved` compared raw GPS to the *snapped* track point with an 11cm threshold — true on every poll (raw GPS always sits meters off the geometry), re-deriving travel direction from the perpendicular offset, a coin flip at the `diff > 90°` boundary. Movement is now gated raw-to-raw at GPS-noise scale (3m) and direction is the **sign of the arc-distance delta** along the track, sticky below 5m.
- Hardening: mid-tween fixes animate from the displayed position (no restart jump); >1km gaps teleport instead of sprinting across outages; frames stop emitting at t=1.
- #554's render-derived zoom-dependent bearing behavior is unchanged.

## Test plan
- [x] `./run.sh build` clean
- [x] `./run.sh test` — 445 passed / 1 skipped, 0 failed
- [x] New `trackInterpolation.unit.test.js` locks the arc-direction regression (perpendicular offset can't flip direction; reverse traversal ordering)
- [x] Verified live in dev against a moving train: 66 samples/65s, continuous motion (no stall >1s), bearing 142°→151° tracking curvature, zero 180° flips
- [x] Test-infra fixes: test image keeps `frontend/src` at `/frontend` for unit-test imports; stale `/api/destinations` tests updated for the 301 redirect; og-share news test premise now mirrors server image priority
- [ ] Prod observation of a northbound (direction = -1) run — Scott watching 7/4 holiday trains

🤖 Generated with [Claude Code](https://claude.com/claude-code)