### PR TITLE
Reduce Apify to Facebook trail status only

### DIFF
--- a/.specify/specs/036-apify-social-dates/spec.md
+++ b/.specify/specs/036-apify-social-dates/spec.md
@@ -1,10 +1,18 @@
 # Specification: Apify Social Date Capture (Facebook & Instagram)
 
 > **Spec ID:** 036-apify-social-dates
-> **Status:** In Progress
+> **Status:** Superseded (news-pipeline social scraping removed by #551 / PR #559, 2026-07-15)
 > **Version:** 0.1.0
 > **Author:** Scott McCarty (with Josui)
 > **Date:** 2026-06-19
+
+> **Superseded:** The news-collection social scraping described here (Facebook + Instagram
+> via Apify in `renderPage`, gated by `social_apify_collection_enabled`) was removed in #551 /
+> PR #559 — Serper snippet recovery covers dated social results well enough that the per-run
+> Apify cost wasn't justified. Apify is now scoped to **Facebook trail status only**
+> (`apifyService.fetchFacebookPosts`, used by `trailStatusService`); see
+> `docs/TRAIL_STATUS_ARCHITECTURE.md`. US-036-1/2 no longer apply; US-036-3's carve-out
+> (trail-status Facebook scraping unaffected) is the surviving behavior.
 
 ## Overview
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -639,7 +639,6 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'moderation_sweep_batch_size',
       'photo_submissions_enabled',
       'apify_api_token',
-      'social_apify_collection_enabled',
       'news_collection_prompt',
       'trail_status_prompt',
       'results_subtabs_config',

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -1,6 +1,5 @@
 const APIFY_BASE_URL = 'https://api.apify.com/v2';
 const FACEBOOK_ACTOR_ID = 'apify~facebook-posts-scraper';
-const INSTAGRAM_ACTOR_ID = 'apify~instagram-scraper';
 const SOCIAL_MAX_POSTS = 10;
 
 async function getApifyToken(pool) {
@@ -44,22 +43,6 @@ export function isFacebookUrl(url) {
   return typeof url === 'string' && url.includes('facebook.com');
 }
 
-export function isInstagramUrl(url) {
-  return typeof url === 'string' && url.includes('instagram.com');
-}
-
-export function isSocialUrl(url) {
-  return isFacebookUrl(url) || isInstagramUrl(url);
-}
-
-// The Apify Instagram scraper accepts profile, post, and reel URLs directly as directUrls.
-function extractInstagramUrl(url) {
-  return isInstagramUrl(url) ? url : null;
-}
-
-// Normalize an Apify post timestamp to YYYY-MM-DD. Handles ISO 8601 strings (Instagram
-// `timestamp`, Facebook `time`) and unix epoch in seconds or milliseconds (Facebook
-// `timestamp`, `taken_at`). Returns null for anything unparseable.
 export function toIsoDate(raw) {
   if (raw == null) return null;
   const str = String(raw).trim();
@@ -68,7 +51,7 @@ export function toIsoDate(raw) {
   if (/^\d+$/.test(str)) {
     let n = Number(str);
     if (!Number.isFinite(n) || n <= 0) return null;
-    if (n < 1e12) n *= 1000; // epoch seconds → milliseconds
+    if (n < 1e12) n *= 1000;
     const d = new Date(n);
     return Number.isNaN(d.getTime()) ? null : d.toISOString().substring(0, 10);
   }
@@ -77,85 +60,49 @@ export function toIsoDate(raw) {
   return Number.isNaN(d.getTime()) ? null : d.toISOString().substring(0, 10);
 }
 
-function socialFailure(reason) {
-  return { markdown: null, rawText: null, ogDates: {}, ogImage: null, links: [], reachable: false, reason };
-}
-
-// Fetch posts from a Facebook page or Instagram profile/post via Apify and return a result
-// shaped like contentExtractor's so renderPage can use it transparently. The post timestamps
-// are surfaced as ogDates.socialDates (YYYY-MM-DD), the authoritative `social` date signal that
-// logged-out headless rendering can't see. (spec 036)
-export async function fetchSocialPosts(pool, url, maxItems = SOCIAL_MAX_POSTS) {
-  const instagram = isInstagramUrl(url);
-
+export async function fetchFacebookPosts(pool, statusUrl, maxItems = SOCIAL_MAX_POSTS) {
   const token = await getApifyToken(pool);
   if (!token) {
     console.log('[Apify] No API token configured');
-    return socialFailure('Apify API token not configured');
+    return { markdown: null, reachable: false, reason: 'Apify API token not configured' };
   }
 
-  let actorId, input, target;
-  if (instagram) {
-    target = extractInstagramUrl(url);
-    if (!target) return socialFailure('invalid Instagram URL');
-    actorId = INSTAGRAM_ACTOR_ID;
-    input = { directUrls: [target], resultsType: 'posts', resultsLimit: maxItems };
-  } else {
-    target = extractFacebookPageUrl(url);
-    if (!target) {
-      console.log(`[Apify] Could not extract Facebook page from: ${url}`);
-      return socialFailure('invalid Facebook URL');
-    }
-    actorId = FACEBOOK_ACTOR_ID;
-    input = { startUrls: [{ url: target }], maxPosts: maxItems };
+  const target = extractFacebookPageUrl(statusUrl);
+  if (!target) {
+    console.log(`[Apify] Could not extract Facebook page from: ${statusUrl}`);
+    return { markdown: null, reachable: false, reason: 'invalid Facebook URL' };
   }
 
-  console.log(`[Apify] Fetching ${instagram ? 'Instagram' : 'Facebook'} posts for ${target} (max ${maxItems})...`);
+  console.log(`[Apify] Fetching Facebook posts for ${target} (max ${maxItems})...`);
 
   try {
-    const items = await runActorSync(actorId, input, token);
+    const items = await runActorSync(FACEBOOK_ACTOR_ID, { startUrls: [{ url: target }], maxPosts: maxItems }, token);
     if (!items || items.length === 0) {
       console.log(`[Apify] No posts found for ${target}`);
-      return { markdown: null, rawText: null, ogDates: {}, ogImage: null, links: [], reachable: true, reason: 'no posts found' };
+      return { markdown: null, reachable: true, reason: 'no posts found' };
     }
 
     const posts = items
       .map(item => {
-        const text = item.caption || item.text || item.message || item.postText || '';
-        const rawTs = item.timestamp ?? item.time ?? item.date
-          ?? item.takenAt ?? item.takenAtTimestamp ?? item.taken_at ?? item.publishedTime ?? null;
+        const text = item.text || item.message || item.postText || '';
+        const rawTs = item.timestamp ?? item.time ?? item.date ?? item.publishedTime ?? null;
         return { text: String(text).trim(), isoDate: toIsoDate(rawTs) };
       })
       .filter(p => p.text.length > 0);
 
     if (posts.length === 0) {
       console.log(`[Apify] Posts returned but no text content for ${target}`);
-      return { markdown: null, rawText: null, ogDates: {}, ogImage: null, links: [], reachable: true, reason: 'posts found but no text content' };
+      return { markdown: null, reachable: true, reason: 'posts found but no text content' };
     }
 
     const markdown = posts.map(p => (p.isoDate ? `[${p.isoDate}] ${p.text}` : p.text)).join('\n\n---\n\n');
-    const socialDates = [...new Set(posts.map(p => p.isoDate).filter(Boolean))];
-    console.log(`[Apify] Got ${posts.length} posts for ${target} (${socialDates.length} dated, ${markdown.length} chars)`);
+    console.log(`[Apify] Got ${posts.length} posts for ${target} (${markdown.length} chars)`);
 
-    return {
-      markdown,
-      rawText: markdown,
-      title: null,
-      ogDates: { socialDates },
-      ogImage: null,
-      links: [],
-      reachable: true
-    };
+    return { markdown, reachable: true, reason: null };
   } catch (err) {
-    console.error(`[Apify] Social fetch error for ${target}:`, err.message);
-    return socialFailure(`Apify error: ${err.message}`);
+    console.error(`[Apify] Facebook fetch error for ${target}:`, err.message);
+    return { markdown: null, reachable: false, reason: `Apify error: ${err.message}` };
   }
-}
-
-// Trail status entry point — preserves the original { markdown, reachable, reason } contract.
-export async function fetchFacebookPosts(pool, statusUrl, maxItems = SOCIAL_MAX_POSTS) {
-  const r = await fetchSocialPosts(pool, statusUrl, maxItems);
-  return { markdown: r.markdown, reachable: r.reachable, reason: r.reason };
 }
 
 export async function testApifyToken(pool) {

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -1,23 +1,17 @@
+// Fix: scope module to Facebook-only trail status scraping (PR #559 review)
 // Apify Facebook scraper — used exclusively by trailStatusService for POIs
 // with a Facebook status_url (e.g. Reagan-Huffman MTB / medinaTRAILS).
 const APIFY_BASE_URL = 'https://api.apify.com/v2';
 const FACEBOOK_ACTOR_ID = 'apify~facebook-posts-scraper';
 const SOCIAL_MAX_POSTS = 10;
 
-let _cachedToken = null;
-let _tokenFetchedAt = 0;
-const TOKEN_TTL_MS = 5 * 60 * 1000;
-
 async function getApifyToken(pool) {
-  if (_cachedToken && (Date.now() - _tokenFetchedAt) < TOKEN_TTL_MS) return _cachedToken;
   try {
     const tokenRow = await pool.query(
       `SELECT value FROM admin_settings WHERE key = 'apify_api_token'`
     );
     if (tokenRow.rows.length > 0 && tokenRow.rows[0].value) {
-      _cachedToken = tokenRow.rows[0].value;
-      _tokenFetchedAt = Date.now();
-      return _cachedToken;
+      return tokenRow.rows[0].value;
     }
   } catch (err) {
     console.error('[Apify] Error loading API token:', err.message);
@@ -69,6 +63,9 @@ export function toIsoDate(raw) {
   return Number.isNaN(d.getTime()) ? null : d.toISOString().substring(0, 10);
 }
 
+// Fetch Facebook posts via Apify for trail status collection.
+// Returns { markdown, reachable, reason } matching the contract
+// expected by trailStatusService.
 export async function fetchFacebookPosts(pool, statusUrl, maxItems = SOCIAL_MAX_POSTS) {
   const token = await getApifyToken(pool);
   if (!token) {

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -1,6 +1,15 @@
+/**
+ * Apify Facebook scraper — scoped to trail-status collection only.
+ *
+ * Used exclusively by `trailStatusService` for POIs with a Facebook `status_url`
+ * (e.g. Reagan-Huffman MTB / medinaTRAILS). Public entry point:
+ * `fetchFacebookPosts(pool, statusUrl, maxItems)`. Also exports `isFacebookUrl`,
+ * `toIsoDate`, and `testApifyToken` (used by the admin settings Test button).
+ *
+ * News-pipeline social scraping (Instagram + general social-date capture in
+ * `renderPage`) was removed in #551 / PR #559; see spec 036 (superseded).
+ */
 // Fix: scope module to Facebook-only trail status scraping (PR #559 review)
-// Apify Facebook scraper — used exclusively by trailStatusService for POIs
-// with a Facebook status_url (e.g. Reagan-Huffman MTB / medinaTRAILS).
 const APIFY_BASE_URL = 'https://api.apify.com/v2';
 const FACEBOOK_ACTOR_ID = 'apify~facebook-posts-scraper';
 const SOCIAL_MAX_POSTS = 10;
@@ -54,7 +63,7 @@ export function toIsoDate(raw) {
   if (/^\d+$/.test(str)) {
     let n = Number(str);
     if (!Number.isFinite(n) || n <= 0) return null;
-    if (n < 1e12) n *= 1000;
+    if (n < 1e12) n *= 1000;  // epoch seconds → milliseconds
     const d = new Date(n);
     return Number.isNaN(d.getTime()) ? null : d.toISOString().substring(0, 10);
   }

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -1,14 +1,23 @@
+// Apify Facebook scraper — used exclusively by trailStatusService for POIs
+// with a Facebook status_url (e.g. Reagan-Huffman MTB / medinaTRAILS).
 const APIFY_BASE_URL = 'https://api.apify.com/v2';
 const FACEBOOK_ACTOR_ID = 'apify~facebook-posts-scraper';
 const SOCIAL_MAX_POSTS = 10;
 
+let _cachedToken = null;
+let _tokenFetchedAt = 0;
+const TOKEN_TTL_MS = 5 * 60 * 1000;
+
 async function getApifyToken(pool) {
+  if (_cachedToken && (Date.now() - _tokenFetchedAt) < TOKEN_TTL_MS) return _cachedToken;
   try {
     const tokenRow = await pool.query(
       `SELECT value FROM admin_settings WHERE key = 'apify_api_token'`
     );
     if (tokenRow.rows.length > 0 && tokenRow.rows[0].value) {
-      return tokenRow.rows[0].value;
+      _cachedToken = tokenRow.rows[0].value;
+      _tokenFetchedAt = Date.now();
+      return _cachedToken;
     }
   } catch (err) {
     console.error('[Apify] Error loading API token:', err.message);

--- a/backend/services/renderPage.js
+++ b/backend/services/renderPage.js
@@ -1,15 +1,4 @@
 import { extractPageContent } from './contentExtractor.js';
-import { fetchSocialPosts, isSocialUrl } from './apifyService.js';
-
-// Social (Facebook/Instagram) collection via Apify is on by default; absence of the setting
-// means enabled. Read only for social URLs so non-social renders pay no extra query. (spec 036)
-async function isApifySocialEnabled(pool) {
-  try {
-    const r = await pool.query(`SELECT value FROM admin_settings WHERE key = 'social_apify_collection_enabled'`);
-    if (r.rows.length > 0 && r.rows[0].value != null) return String(r.rows[0].value).toLowerCase() !== 'false';
-  } catch { /* default enabled on read failure */ }
-  return true;
-}
 
 const TTL_MS = {
   detail: Infinity,
@@ -51,18 +40,7 @@ export async function renderPage(pool, url, options = {}) {
     }
   } catch (err) { console.error('[Cache] Read failure:', err.message); }
 
-  // Facebook/Instagram pages don't render usefully logged-out, so route them through Apify to
-  // capture the real post timestamp (ogDates.socialDates). If disabled or no token, fall back to
-  // the headless renderer + embedded-timestamp harvest in contentExtractor. (spec 036)
-  const useApify = isSocialUrl(url) && await isApifySocialEnabled(pool);
-  let rendered = useApify
-    ? await fetchSocialPosts(pool, url, 10)
-    : await extractPageContent(url, extractOptions);
-
-  // Apify attempted but unavailable (no token / unreachable) — fall back to the headless renderer.
-  if (useApify && (!rendered || rendered.reachable === false)) {
-    rendered = await extractPageContent(url, extractOptions);
-  }
+  const rendered = await extractPageContent(url, extractOptions);
 
   if (rendered.reachable && rendered.markdown) {
     try {

--- a/backend/tests/apifyService.unit.test.js
+++ b/backend/tests/apifyService.unit.test.js
@@ -1,10 +1,6 @@
-/**
- * Unit tests for Apify social fetching (spec 036).
- * apifyService uses the global fetch, so we stub it directly.
- */
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
-  isFacebookUrl, isInstagramUrl, isSocialUrl, toIsoDate, fetchSocialPosts
+  isFacebookUrl, toIsoDate, fetchFacebookPosts
 } from '../services/apifyService.js';
 
 const tokenPool = () => ({ query: vi.fn().mockResolvedValue({ rows: [{ value: 'tok-123' }] }) });
@@ -14,14 +10,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('social URL detection', () => {
-  it('detects Facebook, Instagram, and neither', () => {
+describe('isFacebookUrl', () => {
+  it('detects Facebook URLs', () => {
     expect(isFacebookUrl('https://www.facebook.com/SummitMetroParks')).toBe(true);
-    expect(isInstagramUrl('https://www.instagram.com/cuyahogavalleynps/')).toBe(true);
-    expect(isSocialUrl('https://www.facebook.com/x')).toBe(true);
-    expect(isSocialUrl('https://www.instagram.com/p/ABC/')).toBe(true);
-    expect(isSocialUrl('https://clevelandmagazine.com/article')).toBe(false);
-    expect(isSocialUrl(null)).toBe(false);
+    expect(isFacebookUrl('https://www.facebook.com/medinaTRAILS/')).toBe(true);
+    expect(isFacebookUrl('https://clevelandmagazine.com/article')).toBe(false);
+    expect(isFacebookUrl(null)).toBe(false);
   });
 });
 
@@ -45,23 +39,8 @@ describe('toIsoDate', () => {
   });
 });
 
-describe('fetchSocialPosts', () => {
-  it('extracts Instagram caption + timestamp into socialDates', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ([
-        { caption: 'Sunrise over the Ledges', timestamp: '2025-07-11T10:00:00.000Z' },
-        { caption: 'Fall hiking spree kicks off', timestamp: '2025-09-23T12:00:00.000Z' }
-      ])
-    }));
-    const r = await fetchSocialPosts(tokenPool(), 'https://www.instagram.com/cuyahogavalleynps/', 5);
-    expect(r.reachable).toBe(true);
-    expect(r.ogDates.socialDates).toEqual(['2025-07-11', '2025-09-23']);
-    expect(r.markdown).toContain('Sunrise over the Ledges');
-    expect(r.markdown).toContain('[2025-07-11]');
-  });
-
-  it('extracts Facebook message + epoch time into socialDates', async () => {
+describe('fetchFacebookPosts', () => {
+  it('extracts Facebook message + epoch time', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ([
@@ -69,34 +48,22 @@ describe('fetchSocialPosts', () => {
         { message: 'Trail closure update', timestamp: 1700000000 }
       ])
     }));
-    const r = await fetchSocialPosts(tokenPool(), 'https://www.facebook.com/SummitMetroParks/posts/123', 5);
+    const r = await fetchFacebookPosts(tokenPool(), 'https://www.facebook.com/medinaTRAILS/', 5);
     expect(r.reachable).toBe(true);
-    expect(r.ogDates.socialDates).toContain('2024-01-05');
-    expect(r.ogDates.socialDates).toContain('2023-11-14');
-  });
-
-  it('deduplicates identical post dates', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ([
-        { caption: 'a', timestamp: '2025-07-11T10:00:00Z' },
-        { caption: 'b', timestamp: '2025-07-11T18:00:00Z' }
-      ])
-    }));
-    const r = await fetchSocialPosts(tokenPool(), 'https://www.instagram.com/x/', 5);
-    expect(r.ogDates.socialDates).toEqual(['2025-07-11']);
+    expect(r.markdown).toContain('Main entrance reopens');
+    expect(r.markdown).toContain('Trail closure update');
   });
 
   it('returns reachable:false when no Apify token is configured', async () => {
     const pool = { query: vi.fn().mockResolvedValue({ rows: [] }) };
-    const r = await fetchSocialPosts(pool, 'https://www.facebook.com/x');
+    const r = await fetchFacebookPosts(pool, 'https://www.facebook.com/x');
     expect(r.reachable).toBe(false);
     expect(r.reason).toMatch(/token/i);
   });
 
   it('reports reachable:true with reason when no posts are returned', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ([]) }));
-    const r = await fetchSocialPosts(tokenPool(), 'https://www.instagram.com/x/');
+    const r = await fetchFacebookPosts(tokenPool(), 'https://www.facebook.com/medinaTRAILS/');
     expect(r.reachable).toBe(true);
     expect(r.reason).toMatch(/no posts/i);
   });

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -776,7 +776,7 @@ function DataCollectionSettings() {
             </button>
           </div>
           <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
-            Twitter/X and Facebook scraping. Get token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
+            Facebook trail status scraping. Get token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove Apify from the news collection pipeline (`renderPage.js`) — Facebook/Instagram URLs from Serper results now fall through to Playwright/Readability or snippet recovery like any other URL
- Strip Instagram scraper, `isSocialUrl`, `fetchSocialPosts` from `apifyService.js`
- Remove `social_apify_collection_enabled` admin setting
- Update frontend help text to reflect reduced scope
- Trim unit tests to Facebook-only

## What stays
- `fetchFacebookPosts` + `isFacebookUrl` — used by `trailStatusService.js` for Reagan-Huffman MTB (POI 5680, medinaTRAILS Facebook page)
- `apify_api_token` admin setting + test endpoint
- Apify token config UI in Settings > Data Collection

## Impact
- Eliminates Facebook Posts Scraper ($16/mo) and Instagram Scraper usage from the daily 19-POI news collection job
- Only remaining Apify usage: 1 trail status POI checking medinaTRAILS Facebook page
- Expected savings: ~$25/month

Closes #551 (partially — Apify retained for trail status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)