### PR TITLE
fix: rotate train icon 180° — USFT sprite is drawn nose-down

### DIFF
--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -60,11 +60,14 @@ function createTripStopIcon(n) {
   });
 }
 
+// The USFT sprite is drawn nose-DOWN (cab/windshield at the bottom), so the
+// img carries a fixed 180° flip; the inner div's rotate() stays "bearing =
+// direction of travel" for both writers (initial html + zoom layout effect).
 function createTrainIcon(heading) {
   return L.divIcon({
     className: 'train-marker-icon',
     html: `<div class="train-marker-inner" style="transform: rotate(${heading || 0}deg)">
-      <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="margin-left: 1px" alt="" />
+      <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="margin-left: 1px; transform: rotate(180deg)" alt="" />
     </div>`,
     iconSize: [64, 64],
     iconAnchor: [32, 32],


### PR DESCRIPTION
## Summary
- The bearing pipeline from #554/#558 is correct, but the train icon still rode backwards: the USFT sprite artwork has the cab/windshield/nose at the BOTTOM of the image (south-facing at 0° rotation), while our CSS `rotate(bearing)` assumes north-facing artwork.
- Bakes a fixed 180° flip into the marker's inner `<img>` so both rotation writers (initial icon html and the zoom layout effect) keep meaning "bearing = direction of travel". Verified against a photo of the CVSR FPA-4 the sprite is modeled on.

## Test plan
- `./run.sh build` — passes
- `./run.sh test` — 2 pre-existing failures (ogShareImages og:image premise, satellite-toggle timeout); plain `origin/master` fails the same suite with 3 files, so neither is introduced by this change
- User-verified in browser at localhost:8080: train animates smoothly and the nose leads in the direction of travel

🤖 Generated with [Claude Code](https://claude.com/claude-code)