### PR TITLE
fix: repair two flaky integration tests (og-share news, satellite toggle)

### DIFF
--- a/backend/tests/ogShareImages.integration.test.js
+++ b/backend/tests/ogShareImages.integration.test.js
@@ -111,10 +111,18 @@ describe('Open Graph share images', () => {
     for (const poi of (poiWithPhoto ? [poiWithPhoto, ...pois] : pois).slice(0, 80)) {
       const news = await request(BASE_URL).get(`/api/pois/${poi.id}/news`);
       if (news.status !== 200 || !Array.isArray(news.body) || news.body.length === 0) continue;
-      const withSourceImage = news.body.find(n => isUsableSourceImage(n.image_url));
+      // The list endpoint rolls up contained/child-POI news (#406), but the
+      // permalink resolver (findItemBySlugs) only searches the slug'd POI's OWN
+      // news — the same news/POI pairing the app's share links use. Pair a news
+      // item with a foreign poi_id and the resolver can't find it, so it serves
+      // the brand fallback. Restrict to this POI's own items so the URL we build
+      // is one the resolver can actually resolve.
+      const own = news.body.filter(n => n.poi_id === poi.id);
+      if (own.length === 0) continue;
+      const withSourceImage = own.find(n => isUsableSourceImage(n.image_url));
       if (withSourceImage) { target = { poi, news: withSourceImage }; break; }
       const thumb = await request(BASE_URL).get(`/api/pois/${poi.id}/thumbnail?size=large`);
-      if (thumb.status === 200) { target = { poi, news: news.body[0] }; break; }
+      if (thumb.status === 200) { target = { poi, news: own[0] }; break; }
     }
 
     if (!target) {

--- a/backend/tests/ui.integration.test.js
+++ b/backend/tests/ui.integration.test.js
@@ -163,8 +163,12 @@ describe('UI Integration Tests', () => {
     it('should switch between OpenStreetMap and Esri satellite tiles', async () => {
       await page.goto(baseUrl, { waitUntil: 'networkidle' });
 
-      // Wait for the map controls to render
+      // Wait for the map controls to render. The satellite button attaches a
+      // beat after .zoom-locate-control; without waiting for it explicitly, the
+      // locator.evaluate() calls below each stack a 30s auto-wait that can blow
+      // the test budget — the sibling toggle test waits for it and passes.
       await page.waitForSelector('.zoom-locate-control', { timeout: 10000 });
+      await page.waitForSelector('.satellite-toggle-button', { timeout: 10000 });
 
       // Close legend if it's overlaying the map controls
       const legend = page.locator('.legend');


### PR DESCRIPTION
## Summary
Two integration tests have been failing on `master` for every PR, independent of any product change. This repairs both — the fixes are to the **tests**, not the app (root-caused and reproduced against seed data).

### 1. og-share news permalink (`ogShareImages.integration.test.js`)
The "emits a real share image for a news permalink (never brand)" test built a permalink pairing a POI slug with a news item the server's resolver cannot resolve:
- `/api/pois/:id/news` rolls up **contained/child-POI** news (#406), so `news.body[0]` often belongs to a *different* POI than the one whose slug the test puts in the URL.
- The permalink resolver (`findItemBySlugs`) only searches the slug'd POI's **own** news — it can't find the rolled-up child item, so it serves the brand fallback og:image, tripping the `endsWith(FALLBACK) === false` assertion.

Fix: restrict target candidates to the POI's own items (`n.poi_id === poi.id`), mirroring the news/POI pairing the app's real share links use.

### 2. satellite tile toggle (`ui.integration.test.js`)
"should switch between OpenStreetMap and Esri satellite tiles" used the satellite button via `locator.evaluate()` **without** first waiting for it to attach — unlike the passing sibling toggle test (which does `waitForSelector('.satellite-toggle-button')`). Each `locator.evaluate()` then stacked a 30s auto-wait; when the button rendered a beat after `.zoom-locate-control`, the stacked waits blew the 40s test budget → timeout.

Fix: add the missing `waitForSelector('.satellite-toggle-button')`.

## Test plan
- `./run.sh test` before: 2 failed (these two)
- `./run.sh test` after: **445 passed, 1 skipped, 0 failed**
- The 12 ESLint errors + Gourmand findings in the run are pre-existing frontend debt, none in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)