### PR TITLE
fix: return image_url from news and events list endpoints (#562)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1949,7 +1949,7 @@ app.get('/api/pois/:id/news', async (req, res) => {
     const newsQuery = await pool.query(`
       SELECT n.id, n.title, n.summary, n.source_url, n.source_name, n.news_type,
              n.publication_date, n.date_consensus_score, n.collection_date,
-             n.poi_id, src.name AS poi_name,
+             n.poi_id, n.image_url, src.name AS poi_name,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_news n
       LEFT JOIN poi_news_urls u ON u.news_id = n.id
@@ -1979,7 +1979,7 @@ app.get('/api/pois/:id/events', async (req, res) => {
     const poiIds = await getRollupPoiIds(pool, id);
     let query = `
       SELECT e.id, e.title, e.description, e.start_date, e.end_date, e.event_type, e.location_details, e.source_url, e.collection_date,
-             e.poi_id, src.name AS poi_name, e.venue_poi_id, vp.name AS venue_name,
+             e.poi_id, e.image_url, src.name AS poi_name, e.venue_poi_id, vp.name AS venue_name,
              e.series_id, e.recurrence_label AS cadence_label, (e.series_id IS NOT NULL) AS is_recurring,
              COALESCE(json_agg(json_build_object('url', u.url, 'source_name', u.source_name)) FILTER (WHERE u.id IS NOT NULL), '[]'::json) AS additional_urls
       FROM poi_events e

--- a/backend/tests/newsEvents.integration.test.js
+++ b/backend/tests/newsEvents.integration.test.js
@@ -32,6 +32,9 @@ describe('News & Events API Integration Tests', () => {
         expect(newsItem).toHaveProperty('poi_id');
         expect(newsItem).toHaveProperty('title');
         expect(newsItem).toHaveProperty('url');
+        // image_url carries the source-article thumbnail to the frontend (#562);
+        // may be null, but the field must be present.
+        expect(newsItem).toHaveProperty('image_url');
       }
     }, 10000);
 
@@ -70,6 +73,9 @@ describe('News & Events API Integration Tests', () => {
         expect(event).toHaveProperty('poi_id');
         expect(event).toHaveProperty('title');
         expect(event).toHaveProperty('event_date');
+        // image_url carries the source-article thumbnail to the frontend (#562);
+        // may be null, but the field must be present.
+        expect(event).toHaveProperty('image_url');
       }
     }, 10000);
 


### PR DESCRIPTION
## Summary
- `GET /api/pois/:id/news` and `GET /api/pois/:id/events` omitted `image_url` from their SELECT lists, so the list endpoints never carried source-article images to the frontend — any caller reading `image_url` got `undefined`.
- Add `n.image_url` / `e.image_url` to both queries. The OG permalink resolver (`findItemBySlugs`) already selects these, confirming the column exists on both `poi_news` and `poi_events`. Both queries `GROUP BY` the primary key, so the functionally-dependent column needs no GROUP BY change.

Closes #562

## Test plan
- [x] `./run.sh build` — passes
- [x] Verified on isolated feature container (`rotv-562`, :8081): both endpoints now include `image_url`; a news item that previously returned no image now carries its source URL
- [x] Confirmed `image_url` column exists on `poi_news` and `poi_events`
- [ ] Full `./run.sh test` — run post-merge by /deploy

Note: this is an API-only change. Rendering the thumbnails in the frontend news/event cards is deferred separately (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)