### PR TITLE
feat: keep crime stories out of the weekly digest (news topic deny list)

### DIFF
--- a/backend/migrations/086_news_topic_blocklist.sql
+++ b/backend/migrations/086_news_topic_blocklist.sql
@@ -1,0 +1,10 @@
+-- News topic deny list (filterLists.js DENY_LISTS).
+-- Crime/violence stories from trusted news domains (fox8, news5, beaconjournal)
+-- auto-approve and attach to park POIs on loose city/county name matches, landing
+-- in the weekly digest. This list hard-rejects news whose title/summary contains
+-- one of these terms (whole-word match). NEWS ONLY — events are never filtered by
+-- it, so "murder mystery" / "vintage base ball" events are safe.
+-- Admin-editable under Data Collection → News & Events Filters.
+INSERT INTO admin_settings (key, value)
+  VALUES ('news_topic_blocklist', '["manhunt","homicide","murder","attempted murder","shooter","gunman","gunmen","gunfire","shots fired","stabbing","standoff","carjacking","kidnapping","abduction","fugitive","police pursuit","police chase","high-speed chase","armed robbery","sexual assault"]')
+  ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -650,6 +650,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       'news_collection_excluded_pois',
       'blocklist_urls',
       'event_content_blocklist',
+      'news_topic_blocklist',
       'moderation_trusted_domains',
       'trusted_content_paths',
       'github_api_token',

--- a/backend/services/filterLists.js
+++ b/backend/services/filterLists.js
@@ -29,6 +29,13 @@ function normalizeBlocklistPrefix(prefix) {
   return String(prefix).toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/+$/, '');
 }
 
+// Escape a user-supplied term so it is a regex literal. Same metacharacter set
+// works for JS RegExp and Postgres POSIX regex (~*), which we use for the
+// word-boundary topic match below.
+function escapeRegex(term) {
+  return String(term).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Registry of hard-reject deny lists, applied during moderation.
 // - matches(row, values): per-item test.
 // - sweepFragment(values, textCols): SQL WHERE fragment for the retroactive
@@ -56,6 +63,32 @@ export const DENY_LISTS = [
       if (!valid.length) return null;
       const conds = valid.flatMap((_, i) => textCols.map(c => `${c} ILIKE $${i + 1}`)).join(' OR ');
       return { sql: `(${conds})`, params: valid.map(p => `%${p.trim()}%`) };
+    }
+  },
+  {
+    // News topic deny list. Crime/violence stories from trusted news domains
+    // (fox8, news5, beaconjournal) auto-approve and attach to park POIs on loose
+    // city/county name matches, landing in the weekly digest. Reject news whose
+    // title/summary contains one of these terms. NEWS ONLY — a "murder mystery"
+    // or "vintage base ball" event must not be caught, so events are excluded.
+    // Matching is word-boundary (\y / \b) so "shooting" does not fire on
+    // "overshooting" and "arrest" does not fire on "arresting".
+    key: 'news_topic_blocklist',
+    reason: 'Rejected: matches news topic deny list',
+    contentTypes: ['news'],
+    matches: (row, terms) => {
+      const haystack = [row.title, row.summary].filter(Boolean).join(' ');
+      return terms.some(t => {
+        if (typeof t !== 'string' || !t.trim()) return false;
+        return new RegExp(`\\b${escapeRegex(t.trim())}\\b`, 'i').test(haystack);
+      });
+    },
+    sweepFragment: (terms, textCols) => {
+      const valid = terms.filter(t => typeof t === 'string' && t.trim());
+      if (!valid.length) return null;
+      const pattern = `\\y(${valid.map(t => escapeRegex(t.trim())).join('|')})\\y`;
+      const conds = textCols.map(c => `${c} ~* $1`).join(' OR ');
+      return { sql: `(${conds})`, params: [pattern] };
     }
   },
   {
@@ -98,8 +131,8 @@ export async function denyReason(pool, contentType, row) {
 // list, so adding to a list cleans up already-approved items. Returns counts.
 export async function sweepDenyLists(pool, { runId, logInfo } = {}) {
   const tables = [
-    { name: 'poi_events', textCols: ['title', 'description'] },
-    { name: 'poi_news', textCols: ['title', 'summary'] }
+    { name: 'poi_events', textCols: ['title', 'description'], contentType: 'event' },
+    { name: 'poi_news', textCols: ['title', 'summary'], contentType: 'news' }
   ];
   let events = 0;
   let news = 0;
@@ -107,6 +140,9 @@ export async function sweepDenyLists(pool, { runId, logInfo } = {}) {
     const values = await loadListSetting(pool, list.key);
     if (!values.length) continue;
     for (const table of tables) {
+      // Respect the list's contentTypes so the sweep matches the per-item check
+      // (e.g. a news-only list must not retroactively reject events).
+      if (!list.contentTypes.includes(table.contentType)) continue;
       const frag = list.sweepFragment(values, table.textCols);
       if (!frag) continue;
       const reasonIdx = frag.params.length + 1;

--- a/backend/tests/newsTopicBlocklist.unit.test.js
+++ b/backend/tests/newsTopicBlocklist.unit.test.js
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the news_topic_blocklist deny list (filterLists.js).
+ * Crime/violence stories from trusted news domains auto-approve and attach to
+ * park POIs; this list hard-rejects them. News-only, whole-word matching.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DENY_LISTS, denyReason } from '../services/filterLists.js';
+
+const entry = DENY_LISTS.find(l => l.key === 'news_topic_blocklist');
+const TERMS = ['manhunt', 'murder', 'attempted murder', 'shooting', 'arrest'];
+
+// Mock pool where only news_topic_blocklist is populated; every other setting
+// resolves empty so denyReason exercises just this list.
+const poolWith = (terms) => ({
+  query: vi.fn(async (_sql, params) =>
+    params?.[0] === 'news_topic_blocklist'
+      ? { rows: [{ value: JSON.stringify(terms) }] }
+      : { rows: [] }
+  )
+});
+
+describe('news_topic_blocklist registry entry', () => {
+  it('is registered and scoped to news only', () => {
+    expect(entry).toBeTruthy();
+    expect(entry.contentTypes).toEqual(['news']);
+  });
+
+  it('matches a crime term in the title', () => {
+    expect(entry.matches({ title: 'Inside multi-county manhunt and chase' }, TERMS)).toBe(true);
+  });
+
+  it('matches a multi-word phrase in the summary', () => {
+    expect(entry.matches({ title: 'Morning Digest', summary: 'attempted murder suspect arrested' }, TERMS)).toBe(true);
+  });
+
+  it('matches on whole words only — no substring false positives', () => {
+    // "arrest" must not fire on "arresting", "shooting" must not fire on "overshooting"
+    expect(entry.matches({ title: 'An arresting sunset over the valley' }, TERMS)).toBe(false);
+    expect(entry.matches({ title: 'Overshooting the trailhead by a mile' }, TERMS)).toBe(false);
+  });
+
+  it('ignores the description field (news uses title + summary)', () => {
+    expect(entry.matches({ title: 'Trail cleanup', description: 'a murder of crows' }, TERMS)).toBe(false);
+  });
+
+  it('does not match with an empty term list or clean content', () => {
+    expect(entry.matches({ title: 'Guided kayak trips this weekend' }, TERMS)).toBe(false);
+    expect(entry.matches({ title: 'manhunt' }, [])).toBe(false);
+  });
+
+  it('sweepFragment builds a word-boundary regex over the text columns', () => {
+    const frag = entry.sweepFragment(TERMS, ['title', 'summary']);
+    expect(frag.sql).toBe('(title ~* $1 OR summary ~* $1)');
+    expect(frag.params).toHaveLength(1);
+    expect(frag.params[0]).toBe('\\y(manhunt|murder|attempted murder|shooting|arrest)\\y');
+  });
+
+  it('sweepFragment returns null when no valid terms', () => {
+    expect(entry.sweepFragment([], ['title', 'summary'])).toBeNull();
+    expect(entry.sweepFragment(['', '  '], ['title', 'summary'])).toBeNull();
+  });
+});
+
+describe('denyReason integration', () => {
+  it('rejects a matching news item', async () => {
+    const reason = await denyReason(poolWith(TERMS), 'news', { title: 'multi-county manhunt' });
+    expect(reason).toBe('Rejected: matches news topic deny list');
+  });
+
+  it('does not reject an event with the same wording (news-only)', async () => {
+    const reason = await denyReason(poolWith(TERMS), 'event', { title: 'Murder Mystery Dinner Theater' });
+    expect(reason).toBeNull();
+  });
+
+  it('passes clean news through', async () => {
+    const reason = await denyReason(poolWith(TERMS), 'news', { title: 'Summit Metro Parks shredding event July 24' });
+    expect(reason).toBeNull();
+  });
+});

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -58,6 +58,8 @@ function DataCollectionSettings() {
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('');
   const [contentBlocklist, setContentBlocklist] = useState([]);
   const [newContentPhrase, setNewContentPhrase] = useState('');
+  const [newsTopicBlocklist, setNewsTopicBlocklist] = useState([]);
+  const [newNewsTopic, setNewNewsTopic] = useState('');
   const [trustedEventPaths, setTrustedEventPaths] = useState([]);
   const [newTrustedEventPath, setNewTrustedEventPath] = useState('');
 
@@ -401,12 +403,15 @@ function DataCollectionSettings() {
         const blocklist = settings.blocklist_urls?.value || '[]';
         const eventPaths = settings.trusted_content_paths?.value || '[]';
         const contentBlock = settings.event_content_blocklist?.value || '[]';
+        const newsTopics = settings.news_topic_blocklist?.value || '[]';
         try {
           const parsedTrusted = JSON.parse(trusted);
           const parsedBlocklist = JSON.parse(blocklist);
           const parsedEventPaths = JSON.parse(eventPaths);
           const parsedContentBlock = JSON.parse(contentBlock);
+          const parsedNewsTopics = JSON.parse(newsTopics);
           setContentBlocklist(Array.isArray(parsedContentBlock) ? parsedContentBlock.filter(p => typeof p === 'string') : []);
+          setNewsTopicBlocklist(Array.isArray(parsedNewsTopics) ? parsedNewsTopics.filter(p => typeof p === 'string') : []);
           setDomainLists({
             trusted: Array.isArray(parsedTrusted) ? parsedTrusted.filter(d => typeof d === 'string') : [],
             competitor: Array.isArray(parsedBlocklist) ? parsedBlocklist.filter(d => typeof d === 'string') : []
@@ -425,7 +430,7 @@ function DataCollectionSettings() {
   };
 
   // Single save for the unified News & Events Filters section — persists all
-  // five allow/block lists in one click.
+  // allow/block lists in one click.
   const handleSaveAllFilters = async () => {
     setFiltersSaving(true); setResult(null);
     try {
@@ -434,7 +439,8 @@ function DataCollectionSettings() {
         { key: 'blocklist_urls', value: JSON.stringify(domainLists.competitor) },
         { key: 'trusted_content_paths', value: JSON.stringify(trustedEventPaths) },
         { key: 'news_collection_excluded_pois', value: JSON.stringify(excludedPois.map(p => p.id)) },
-        { key: 'event_content_blocklist', value: JSON.stringify(contentBlocklist) }
+        { key: 'event_content_blocklist', value: JSON.stringify(contentBlocklist) },
+        { key: 'news_topic_blocklist', value: JSON.stringify(newsTopicBlocklist) }
       ];
       for (const setting of settings) {
         const response = await fetch(`/api/admin/settings/${setting.key}`, {
@@ -495,6 +501,19 @@ function DataCollectionSettings() {
 
   const handleRemoveContentPhrase = (phrase) => {
     setContentBlocklist(contentBlocklist.filter(p => p !== phrase));
+  };
+
+  const handleAddNewsTopic = () => {
+    const term = newNewsTopic.trim();
+    if (!term) return;
+    if (!newsTopicBlocklist.some(t => t.toLowerCase() === term.toLowerCase())) {
+      setNewsTopicBlocklist([...newsTopicBlocklist, term]);
+      setNewNewsTopic('');
+    }
+  };
+
+  const handleRemoveNewsTopic = (term) => {
+    setNewsTopicBlocklist(newsTopicBlocklist.filter(t => t !== term));
   };
 
   const handleAddTrustedEventPath = () => {
@@ -1053,6 +1072,19 @@ function DataCollectionSettings() {
               onAdd={handleAddContentPhrase}
               onRemove={handleRemoveContentPhrase}
               placeholder="Cuyahoga Valley Art Center"
+              disabled={filtersSaving}
+            />
+
+            <FilterList
+              title="News Topic Deny List"
+              type="deny"
+              hint="Reject any news item whose title or summary contains one of these words or phrases (whole-word match). Catches crime/violence stories that trusted news domains auto-approve and attach to nearby park POIs. News only — events are never filtered by this list, so 'murder mystery' and 'vintage base ball' events are safe."
+              items={newsTopicBlocklist}
+              value={newNewsTopic}
+              onValueChange={setNewNewsTopic}
+              onAdd={handleAddNewsTopic}
+              onRemove={handleRemoveNewsTopic}
+              placeholder="manhunt"
               disabled={filtersSaving}
             />
 


### PR DESCRIPTION
## Problem

Crime/violence stories from trusted news domains (fox8, news5, beaconjournal) auto-approve and get attached to park POIs on loose city/county name matches, then flow into the weekly digest. The 2026-07-09 preview carried a multi-county manhunt and an "attempted murder" digest tagged to Summit Metro Parks / Old Trail School.

## Change

Adds a `news_topic_blocklist` deny list to the existing `filterLists.js` registry:

- **News-only, whole-word matching** — a "murder mystery" or "vintage base ball" *event* is never filtered; "arrest" won't fire on "arresting."
- **Hard-rejects at moderation time**, overriding trusted-domain auto-approval (the reason these slipped through), and cleans the backlog via the daily deny-list sweep (which now respects each list's `contentTypes` per table).
- **Admin-editable** under Data Collection → News & Events Filters (chip UI mirrors the existing content blocklist).
- **Migration `086`** seeds a conservative default set (manhunt, homicide, murder, shooter, gunfire, stabbing, carjacking, etc.) on deploy — deliberately excludes broad words (shooting/arrest/pursuit/chase) to avoid nature/community false positives.

## Test plan

- `backend/tests/newsTopicBlocklist.unit.test.js` — 11 unit tests: whole-word matching, news-only scope (events untouched), sweep SQL, and `denyReason` integration. Green via `./run.sh test`.
- Gourmand clean; rebased on master so CI validates alongside the tracker-resilience changes.

**Deploy note:** carries a new DB migration (`086_news_topic_blocklist.sql`) that must run on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)