### PR TITLE
feat: move USFT tracker token to admin settings (#550)

### DIFF
--- a/.specify/specs/040-usft-token-admin-settings/plan.md
+++ b/.specify/specs/040-usft-token-admin-settings/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: USFT Tracker Token in Admin Settings
+
+> **Spec ID:** 040-usft-token-admin-settings
+> **Status:** Planning
+> **Last Updated:** 2026-07-14
+> **Estimated Effort:** S
+
+## Summary
+
+Add `usft_sharing_token` to `admin_settings`, teach `trainTrackerService.js` to read the
+token lazily from the DB with an env-var fallback, whitelist the key in the admin settings
+route, and surface a masked field in the Data Collection settings UI — mirroring the
+existing Serper API-key plumbing end to end.
+
+---
+
+## Architecture
+
+### Data Flow
+
+1. Admin saves token in Settings → Data Collection → API Keys (`PUT /api/admin/settings/usft_sharing_token`).
+2. Value persists to `admin_settings (key='usft_sharing_token')`.
+3. On each auth cycle, `trainTrackerService.authenticate()` resolves the token via
+   `getSharingToken(pool)`: DB value first, `process.env.USFT_SHARING_TOKEN` fallback.
+4. `run.sh seed` copies the production DB, carrying the token into local/staging automatically.
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Storage | `admin_settings` key/value row | Matches serper/gemini/buttondown keys; syncs with DB |
+| Token read | Lazy DB query per auth, env fallback | Token can no longer be a module-load const; must reflect live DB + rotation |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend
+
+- [ ] Add migration `087_usft_sharing_token.sql` seeding an empty `usft_sharing_token` row (INSERT … ON CONFLICT DO NOTHING).
+- [ ] `trainTrackerService.js`: replace module-const `SHARING_TOKEN` with `getSharingToken(pool)` — `SELECT value FROM admin_settings WHERE key='usft_sharing_token'`, trimmed; fall back to `process.env.USFT_SHARING_TOKEN`.
+- [ ] `authenticate()` uses the resolved token; startup guard (`if (!token) … not starting`) becomes an async check via `getSharingToken`.
+- [ ] Keep the DB-read defensive: a query error resolves to the env fallback, never throws into the poll loop.
+
+### Phase 2: API
+
+- [ ] `admin.js`: add `'usft_sharing_token'` to the `allowedKeys` array in `PUT /settings/:key`.
+- [ ] Add `usft_sharing_token` to the masked GET `/settings` response (`{ isSet }`, like `serper_api_key`).
+- [ ] (Optional, for parity) `POST /settings/usft-sharing-token/test` → calls USFT `/auth/login/shared-view` with the stored token, returns valid/invalid.
+
+### Phase 3: Frontend
+
+- [ ] `DataCollectionSettings.jsx`: add `usftToken` / `usftTokenSet` state, a masked input, Save handler (`PUT usft_sharing_token`), and Configured/Not-configured indicator inside the existing **API Keys** section (clone the Serper block). Add a Test button only if the `/test` endpoint is included.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/087_usft_sharing_token.sql` | Seed the `usft_sharing_token` admin setting |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/services/trainTrackerService.js` | DB-first token resolution with env fallback; async startup guard |
+| `backend/routes/admin.js` | Whitelist key; masked GET; optional test endpoint |
+| `frontend/src/components/DataCollectionSettings.jsx` | USFT token field in API Keys section |
+
+---
+
+## Database Migrations
+
+```sql
+-- Migration: 087_usft_sharing_token
+-- Description: Move the USFT (CVSR train tracker) sharing token into admin_settings (#550)
+
+INSERT INTO admin_settings (key, value, updated_at)
+VALUES ('usft_sharing_token', '', NOW())
+ON CONFLICT (key) DO NOTHING;
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- [ ] `trainTrackerService` token resolution: DB value wins; empty DB falls back to env; neither → declines to start.
+
+### Manual Testing
+
+1. With no env var and an empty DB setting, tracker logs "no token — not starting".
+2. Save a token in Settings → Data Collection → API Keys; confirm the marker begins updating without an app restart.
+3. Set only the env var (empty DB setting) → tracker still authenticates (backward compat).
+4. Confirm GET settings never returns the raw token (only `isSet`).
+
+---
+
+## Rollback Plan
+
+1. Revert the branch; the env-var path is untouched, so production keeps working.
+2. The seeded empty `admin_settings` row is inert (`ON CONFLICT DO NOTHING`) and needs no cleanup.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| DB read for token throws inside the poll loop | Med | Wrap in try/catch, fall back to env, never rethrow — preserves spec-038 self-healing |
+| Token logged in plaintext | Med | GET returns only `isSet`; never log the value |
+| Production env var removed before DB set | High | Keep env fallback; only remove the env var after confirming the DB setting drives auth |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-14 | Initial plan |

--- a/.specify/specs/040-usft-token-admin-settings/spec.md
+++ b/.specify/specs/040-usft-token-admin-settings/spec.md
@@ -1,0 +1,121 @@
+# Specification: USFT Tracker Token in Admin Settings
+
+> **Spec ID:** 040-usft-token-admin-settings
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-07-14
+
+## Overview
+
+The CVSR live train tracker authenticates to the US Fleet Tracking (USFT) API with a
+sharing token that today lives only in the production container's environment file
+(`USFT_SHARING_TOKEN`). Because it never comes down with a `run.sh seed` DB sync, local
+and staging environments can't drive the live tracker without hand-copying the secret.
+This feature moves the token into the `admin_settings` table — the same place Serper,
+Gemini, and Buttondown keys already live — so it syncs with the database, is rotatable
+from the admin UI, and no longer requires a redeploy to change.
+
+---
+
+## User Stories
+
+### Configuration
+
+**US-040-1: Configure the token from the admin UI**
+> As an admin, I want to set and rotate the USFT sharing token in Settings → Data Collection
+> so that I can change it without editing an env file or redeploying the container.
+
+Acceptance Criteria:
+- [ ] Settings → Data Collection → API Keys shows a "USFT Tracker Token" field
+- [ ] Saving a value persists it to `admin_settings` under key `usft_sharing_token`
+- [ ] The field masks the stored value and shows a "Configured / Not configured" indicator, matching the Serper key field
+- [ ] The train tracker picks up a newly-saved token without an app restart
+
+**US-040-2: Token travels with the database**
+> As a developer, I want the token to arrive with a `run.sh seed` production DB sync
+> so that a local environment can drive the live tracker without copying secrets by hand.
+
+Acceptance Criteria:
+- [ ] After a production DB sync, `admin_settings` contains the current token
+- [ ] The tracker authenticates using the DB value with no env var set
+
+### Backward Compatibility
+
+**US-040-3: Env var still works during transition**
+> As an operator, I want the existing `USFT_SHARING_TOKEN` env var to keep working
+> so that production keeps running before and during the migration.
+
+Acceptance Criteria:
+- [ ] When the DB setting is empty, the tracker falls back to `process.env.USFT_SHARING_TOKEN`
+- [ ] When the DB setting is present, it takes precedence over the env var
+- [ ] With neither configured, the tracker declines to start and logs the reason (current behavior preserved)
+
+---
+
+## Data Model
+
+### Schema Changes
+
+No table or column changes. One new row in the existing `admin_settings` key/value table:
+
+```sql
+-- Seed an empty setting so the admin UI has a row to render/edit.
+INSERT INTO admin_settings (key, value, updated_at)
+VALUES ('usft_sharing_token', '', NOW())
+ON CONFLICT (key) DO NOTHING;
+```
+
+---
+
+## API Endpoints
+
+Reuses the existing generic settings endpoints — no new routes required for save/read.
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| PUT | `/api/admin/settings/usft_sharing_token` | Save the token (key added to `allowedKeys`) | Admin |
+| GET | `/api/admin/settings` | Returns `usft_sharing_token: { isSet }` (masked, like other secrets) | Admin |
+| POST | `/api/admin/settings/usft-sharing-token/test` | Optional: validate the token against USFT auth | Admin |
+
+---
+
+## UI/UX Requirements
+
+### Modified Components
+
+- `DataCollectionSettings.jsx` — add a "USFT Tracker Token" field inside the existing
+  **API Keys** section, cloning the Serper key pattern (masked input, Save button,
+  Configured/Not-configured indicator, optional Test button).
+
+---
+
+## Non-Functional Requirements
+
+**NFR-040-1: Secret handling**
+- The token value is never returned in plaintext by the GET settings endpoint — only an `isSet` boolean, consistent with `serper_api_key`, `gemini_api_key`, and `buttondown_api_key`.
+
+**NFR-040-2: Resilience preserved**
+- The tracker's self-healing poll loop (spec 038 follow-up) must be unaffected: a DB read failure while fetching the token must not crash the poller, and lazy auth/retry behavior stays intact.
+
+---
+
+## Dependencies
+
+- Depends on: `038-cvsr-train-tracker` (the tracker being configured)
+- Blocks: none
+
+---
+
+## Open Questions
+
+1. Include the optional `/test` endpoint + Test button now, or defer? (Serper and GitHub keys have one; leaning yes for parity.)
+2. Should future tracker keys (e.g., a water-taxi key) share an "API Keys → Trackers" grouping? Out of scope here; the single key slots into the existing API Keys section.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-07-14 | Initial draft |

--- a/.specify/specs/040-usft-token-admin-settings/spec.md
+++ b/.specify/specs/040-usft-token-admin-settings/spec.md
@@ -40,6 +40,15 @@ Acceptance Criteria:
 - [ ] After a production DB sync, `admin_settings` contains the current token
 - [ ] The tracker authenticates using the DB value with no env var set
 
+**US-040-4: One Save updates both the map marker and the button**
+> As an admin, I want saving the token to update both the live map marker and the green
+> "Live Tracker" button so that rotating the key takes effect everywhere without a restart.
+
+Acceptance Criteria:
+- [ ] The map marker and the CVSR "Live Tracker" button are both driven by the single `usft_sharing_token` (the lvgps view URL embeds the same token the USFT API authenticates with)
+- [ ] Saving the token invalidates the tracker's cached JWT so the next poll re-authenticates with the new token
+- [ ] Saving the token rewrites `live_tracker_url` to `https://www.lvgps.net/view/<token>` for POIs using the lvgps view, and leaves other trackers (e.g. the water-taxi `trackmyshuttle.com` URL) untouched
+
 ### Backward Compatibility
 
 **US-040-3: Env var still works during transition**

--- a/backend/migrations/087_usft_sharing_token.sql
+++ b/backend/migrations/087_usft_sharing_token.sql
@@ -1,0 +1,9 @@
+-- Migration: 087_usft_sharing_token
+-- Description: Move the USFT (CVSR train tracker) sharing token into admin_settings (#550)
+-- so it syncs with `run.sh seed`, is rotatable from the admin UI, and no longer requires
+-- a redeploy to change. The tracker falls back to process.env.USFT_SHARING_TOKEN while
+-- this setting is empty, so production keeps running before the value is filled in.
+
+INSERT INTO admin_settings (key, value, updated_at)
+VALUES ('usft_sharing_token', '', NOW())
+ON CONFLICT (key) DO NOTHING;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -595,8 +595,9 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
       const settingsRows = await pool.query('SELECT key, value, updated_at FROM admin_settings');
       const settings = {};
       for (const row of settingsRows.rows) {
-        // Redact API key/token values; expose isSet flag only
-        if (row.key.includes('api_key') || row.key.includes('api_token')) {
+        // Redact API key/token values; expose isSet flag only.
+        // Matches *_api_key and any *_token key (api_token, usft_sharing_token, ...).
+        if (row.key.includes('api_key') || row.key.includes('token')) {
           settings[row.key] = {
             isSet: !!row.value,
             updatedAt: row.updated_at
@@ -622,6 +623,7 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     const allowedKeys = [
       'gemini_api_key',
       'serper_api_key',
+      'usft_sharing_token',
       'gemini_prompt_brief',
       'gemini_prompt_historical',
       'ai_search_primary',
@@ -680,6 +682,14 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
         console.log('Buttondown API key cache cleared');
       }
 
+      if (key === 'usft_sharing_token') {
+        // Re-auth the map marker and refresh the CVSR "Live Tracker" button URL so
+        // saving the token updates both consumers at once (#550).
+        const { onSharingTokenChanged } = await import('../services/trainTrackerService.js');
+        await onSharingTokenChanged(pool);
+        console.log('USFT sharing token updated — tracker re-auth queued, Live Tracker URL synced');
+      }
+
       console.log(`Admin ${req.user.email} updated setting: ${key}`);
       res.json({ success: true });
     } catch (error) {
@@ -701,6 +711,17 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
     } catch (error) {
       console.error('Error testing Serper API key:', error);
       res.status(500).json({ success: false, message: 'Failed to test API key', error: error.message });
+    }
+  });
+
+  router.post('/settings/usft-sharing-token/test', isAdmin, async (req, res) => {
+    try {
+      const { testSharingToken } = await import('../services/trainTrackerService.js');
+      const result = await testSharingToken(pool);
+      res.json({ success: result.valid, message: result.message });
+    } catch (error) {
+      console.error('Error testing USFT sharing token:', error);
+      res.status(500).json({ success: false, message: 'Failed to test token', error: error.message });
     }
   });
 

--- a/backend/services/trainTrackerService.js
+++ b/backend/services/trainTrackerService.js
@@ -18,7 +18,10 @@
  */
 
 const USFT_API_URL = process.env.USFT_API_URL || 'https://hades.usft.com';
-const SHARING_TOKEN = process.env.USFT_SHARING_TOKEN || '';
+// Public LiveViewGPS share page fronting the same USFT sharing token. The CVSR POI's
+// green "Live Tracker" button is this base + the current token, so rotating the token
+// in admin settings updates both the map marker (API auth) and the button URL (#550).
+const LVGPS_VIEW_BASE = 'https://www.lvgps.net/view/';
 const POLL_INTERVAL_MS = parseInt(process.env.USFT_POLL_INTERVAL_MS, 10) || 5000;
 const JWT_REFRESH_MS = 24 * 60 * 60 * 1000;
 // Serve null once we haven't had a successful device fetch in this long. Well
@@ -35,14 +38,76 @@ let lastError = null;
 let pool = null;
 let enabled = false;
 
+// Resolve the USFT sharing token: admin_settings first (so `run.sh seed` carries it
+// and it's rotatable from the admin UI without a redeploy), env var as fallback for
+// backward compat while production migrates off USFT_SHARING_TOKEN (#550). A DB hiccup
+// must never throw into the poll loop, so a query failure falls back to the env var.
+async function getSharingToken(dbPool = pool) {
+  const envToken = (process.env.USFT_SHARING_TOKEN || '').trim();
+  if (!dbPool) return envToken;
+  try {
+    const { rows } = await dbPool.query(
+      `SELECT value FROM admin_settings WHERE key = 'usft_sharing_token'`
+    );
+    return (rows[0]?.value || '').trim() || envToken;
+  } catch (err) {
+    console.warn(`[TrainTracker] Could not read usft_sharing_token, using env fallback: ${err.message}`);
+    return envToken;
+  }
+}
+
+// Validate the configured sharing token by attempting a USFT shared-view login.
+// Used by the admin "Test" button. Does not touch the live poller's JWT/state.
+export async function testSharingToken(dbPool) {
+  const token = await getSharingToken(dbPool);
+  if (!token) return { valid: false, message: 'No USFT sharing token configured' };
+  try {
+    const res = await fetch(`${USFT_API_URL}/auth/login/shared-view`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'RootsOfTheValley/1.0 (+https://rootsofthevalley.org)',
+      },
+      body: JSON.stringify({ token }),
+    });
+    if (res.ok) return { valid: true, message: 'USFT sharing token is valid' };
+    return { valid: false, message: `USFT auth rejected the token (${res.status})` };
+  } catch (err) {
+    return { valid: false, message: `Could not reach USFT: ${err.message}` };
+  }
+}
+
+// Called when the admin saves the USFT sharing token. Propagates the new token to
+// BOTH consumers so a single Save updates everything (#550):
+//   1. Map marker — clears the cached JWT so the next poll re-authenticates with the
+//      new token (otherwise the old JWT keeps working until it expires ~30h later).
+//   2. Green "Live Tracker" button — rewrites live_tracker_url to the lvgps view URL
+//      carrying the new token, scoped by the lvgps prefix so other trackers (e.g. the
+//      water taxi's trackmyshuttle URL) are never touched.
+// Never throws — a save must succeed even if this propagation hiccups.
+export async function onSharingTokenChanged(dbPool = pool) {
+  jwt = null;  // force re-auth on the next poll cycle
+  const token = await getSharingToken(dbPool);
+  if (!token || !dbPool) return;
+  try {
+    await dbPool.query(
+      `UPDATE pois SET live_tracker_url = $1 WHERE live_tracker_url LIKE $2`,
+      [LVGPS_VIEW_BASE + token, LVGPS_VIEW_BASE + '%']
+    );
+  } catch (err) {
+    console.warn(`[TrainTracker] Could not sync live_tracker_url after token change: ${err.message}`);
+  }
+}
+
 async function authenticate() {
+  const token = await getSharingToken();
   const res = await fetch(`${USFT_API_URL}/auth/login/shared-view`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'RootsOfTheValley/1.0 (+https://rootsofthevalley.org)',
     },
-    body: JSON.stringify({ token: SHARING_TOKEN }),
+    body: JSON.stringify({ token }),
   });
 
   if (!res.ok) {
@@ -141,8 +206,8 @@ export async function startTrainTracker(dbPool) {
     console.warn(`[TrainTracker] Could not read admin setting, proceeding: ${err.message}`);
   }
 
-  if (!SHARING_TOKEN) {
-    console.log('[TrainTracker] No USFT_SHARING_TOKEN configured — not starting');
+  if (!(await getSharingToken())) {
+    console.log('[TrainTracker] No USFT sharing token configured (admin setting or env) — not starting');
     return;
   }
 

--- a/frontend/src/components/DataCollectionSettings.jsx
+++ b/frontend/src/components/DataCollectionSettings.jsx
@@ -35,6 +35,12 @@ function DataCollectionSettings() {
   const [serperSaving, setSerperSaving] = useState(false);
   const [serperTesting, setSerperTesting] = useState(false);
 
+  const [usftToken, setUsftToken] = useState('');
+  const [usftTokenSet, setUsftTokenSet] = useState(false);
+  const [usftSaving, setUsftSaving] = useState(false);
+  const [usftTesting, setUsftTesting] = useState(false);
+  const [usftResult, setUsftResult] = useState(null);
+
   const [githubToken, setGithubToken] = useState('');
   const [githubTokenSet, setGithubTokenSet] = useState(false);
   const [githubSaving, setGithubSaving] = useState(false);
@@ -115,6 +121,7 @@ function DataCollectionSettings() {
     fetchGeminiStatus();
     fetchApifyStatus();
     fetchSerperStatus();
+    fetchUsftStatus();
     fetchGithubStatus();
     fetchPlaywrightStatus();
     fetchModerationConfig();
@@ -141,6 +148,12 @@ function DataCollectionSettings() {
     const timer = setTimeout(() => setSerperResult(null), 5000);
     return () => clearTimeout(timer);
   }, [serperResult]);
+
+  useEffect(() => {
+    if (!usftResult) return;
+    const timer = setTimeout(() => setUsftResult(null), 5000);
+    return () => clearTimeout(timer);
+  }, [usftResult]);
 
   useEffect(() => {
     if (!apifyResult) return;
@@ -278,6 +291,47 @@ function DataCollectionSettings() {
       }
     } catch (err) { setSerperResult({ type: 'error', message: `Test failed: ${err.message}` }); }
     finally { setSerperTesting(false); }
+  };
+
+  const fetchUsftStatus = async () => {
+    try {
+      const response = await fetch('/api/admin/settings', { credentials: 'include' });
+      if (response.ok) { const settings = await response.json(); setUsftTokenSet(settings.usft_sharing_token?.isSet || false); }
+    } catch (err) { console.error('Error fetching USFT status:', err); }
+  };
+
+  const handleSaveUsftToken = async () => {
+    if (!usftToken.trim()) { setUsftResult({ type: 'error', message: 'Token cannot be empty' }); return; }
+    setUsftSaving(true); setUsftResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/usft_sharing_token', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+        body: JSON.stringify({ value: usftToken })
+      });
+      if (response.ok) {
+        setUsftResult({ type: 'success', message: 'Saved successfully' });
+        setUsftToken('');
+        setUsftTokenSet(true);
+        await fetchUsftStatus();
+      } else { const error = await response.json(); throw new Error(error.error || 'Failed to save token'); }
+    } catch (err) { setUsftResult({ type: 'error', message: `Save failed: ${err.message}` }); }
+    finally { setUsftSaving(false); }
+  };
+
+  const handleTestUsftToken = async () => {
+    setUsftTesting(true); setUsftResult(null);
+    try {
+      const response = await fetch('/api/admin/settings/usft-sharing-token/test', {
+        method: 'POST', credentials: 'include'
+      });
+      const data = await response.json();
+      if (data.success) {
+        setUsftResult({ type: 'success', message: 'Test passed ✓' });
+      } else {
+        setUsftResult({ type: 'error', message: data.message || 'Test failed' });
+      }
+    } catch (err) { setUsftResult({ type: 'error', message: `Test failed: ${err.message}` }); }
+    finally { setUsftTesting(false); }
   };
 
   const fetchGithubStatus = async () => {
@@ -680,6 +734,102 @@ function DataCollectionSettings() {
 
 
         <div style={{ marginTop: '1.5rem', paddingBottom: '1.5rem', borderBottom: '1px solid #e0e0e0' }}>
+          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>Apify</h5>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
+            <span className={`status-indicator ${apifyTokenSet ? 'configured' : 'not-configured'}`}></span>
+            <span style={{ fontSize: '0.9rem' }}>{apifyTokenSet ? 'Configured' : 'Not configured'}</span>
+            {apifyResult && (
+              <span
+                style={{
+                  marginLeft: '12px',
+                  padding: '4px 10px',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  fontWeight: '500',
+                  backgroundColor: apifyResult.type === 'success' ? '#d4edda' : '#f8d7da',
+                  color: apifyResult.type === 'success' ? '#155724' : '#721c24',
+                  cursor: 'pointer'
+                }}
+                onClick={() => setApifyResult(null)}
+                title="Click to dismiss"
+              >
+                {apifyResult.message}
+              </span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch', marginBottom: '0.5rem' }}>
+            <input
+              type="password"
+              value={apifyToken || (apifyTokenSet ? '••••••••••••••••••••••••' : '')}
+              onChange={e => setApifyToken(e.target.value)}
+              placeholder="Enter API token..."
+              disabled={apifySaving}
+              style={{ flex: 1, padding: '8px', fontSize: '0.9rem', border: '1px solid #ccc', borderRadius: '4px', minWidth: 0 }}
+            />
+            <button className="action-btn primary" onClick={handleSaveApifyToken} disabled={apifySaving || !apifyToken.trim()}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {apifySaving ? 'Saving...' : 'Save'}
+            </button>
+            <button className="action-btn secondary" onClick={handleTestApifyToken} disabled={apifyTesting || !apifyTokenSet}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {apifyTesting ? 'Testing...' : 'Test'}
+            </button>
+          </div>
+          <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
+            Twitter/X and Facebook scraping. Get token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
+          </p>
+        </div>
+
+
+        <div style={{ marginTop: '1.5rem', paddingBottom: '1.5rem', borderBottom: '1px solid #e0e0e0' }}>
+          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>GitHub</h5>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
+            <span className={`status-indicator ${githubTokenSet ? 'configured' : 'not-configured'}`}></span>
+            <span style={{ fontSize: '0.9rem' }}>{githubTokenSet ? 'Configured' : 'Not configured'}</span>
+            {githubResult && (
+              <span
+                style={{
+                  marginLeft: '12px',
+                  padding: '4px 10px',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  fontWeight: '500',
+                  backgroundColor: githubResult.type === 'success' ? '#d4edda' : '#f8d7da',
+                  color: githubResult.type === 'success' ? '#155724' : '#721c24',
+                  cursor: 'pointer'
+                }}
+                onClick={() => setGithubResult(null)}
+                title="Click to dismiss"
+              >
+                {githubResult.message}
+              </span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch', marginBottom: '0.5rem' }}>
+            <input
+              type="password"
+              value={githubToken || (githubTokenSet ? '••••••••••••••••••••••••' : '')}
+              onChange={e => setGithubToken(e.target.value)}
+              placeholder="Enter GitHub token..."
+              disabled={githubSaving}
+              style={{ flex: 1, padding: '8px', fontSize: '0.9rem', border: '1px solid #ccc', borderRadius: '4px', minWidth: 0 }}
+            />
+            <button className="action-btn primary" onClick={handleSaveGithubToken} disabled={githubSaving || !githubToken.trim()}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {githubSaving ? 'Saving...' : 'Save'}
+            </button>
+            <button className="action-btn secondary" onClick={handleTestGithubToken} disabled={githubTesting || !githubTokenSet}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {githubTesting ? 'Testing...' : 'Test'}
+            </button>
+          </div>
+          <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
+            Feedback form creates GitHub Issues. Use a fine-grained PAT with <code>issues:write</code> scope for <code>crunchtools/rotv</code>.
+          </p>
+        </div>
+
+
+        <div style={{ marginTop: '1.5rem', paddingBottom: '1.5rem', borderBottom: '1px solid #e0e0e0' }}>
           <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>Google Gemini</h5>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
             <span className={`status-indicator ${geminiApiKeySet ? 'configured' : 'not-configured'}`}></span>
@@ -776,11 +926,11 @@ function DataCollectionSettings() {
 
 
         <div style={{ marginTop: '1.5rem' }}>
-          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>Apify</h5>
+          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>US Fleet Tracking</h5>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
-            <span className={`status-indicator ${apifyTokenSet ? 'configured' : 'not-configured'}`}></span>
-            <span style={{ fontSize: '0.9rem' }}>{apifyTokenSet ? 'Configured' : 'Not configured'}</span>
-            {apifyResult && (
+            <span className={`status-indicator ${usftTokenSet ? 'configured' : 'not-configured'}`}></span>
+            <span style={{ fontSize: '0.9rem' }}>{usftTokenSet ? 'Configured' : 'Not configured'}</span>
+            {usftResult && (
               <span
                 style={{
                   marginLeft: '12px',
@@ -788,85 +938,37 @@ function DataCollectionSettings() {
                   borderRadius: '4px',
                   fontSize: '0.85rem',
                   fontWeight: '500',
-                  backgroundColor: apifyResult.type === 'success' ? '#d4edda' : '#f8d7da',
-                  color: apifyResult.type === 'success' ? '#155724' : '#721c24',
+                  backgroundColor: usftResult.type === 'success' ? '#d4edda' : '#f8d7da',
+                  color: usftResult.type === 'success' ? '#155724' : '#721c24',
                   cursor: 'pointer'
                 }}
-                onClick={() => setApifyResult(null)}
+                onClick={() => setUsftResult(null)}
                 title="Click to dismiss"
               >
-                {apifyResult.message}
+                {usftResult.message}
               </span>
             )}
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch', marginBottom: '0.5rem' }}>
             <input
               type="password"
-              value={apifyToken || (apifyTokenSet ? '••••••••••••••••••••••••' : '')}
-              onChange={e => setApifyToken(e.target.value)}
-              placeholder="Enter API token..."
-              disabled={apifySaving}
+              value={usftToken || (usftTokenSet ? '••••••••••••••••••••••••' : '')}
+              onChange={e => setUsftToken(e.target.value)}
+              placeholder="Enter sharing token..."
+              disabled={usftSaving}
               style={{ flex: 1, padding: '8px', fontSize: '0.9rem', border: '1px solid #ccc', borderRadius: '4px', minWidth: 0 }}
             />
-            <button className="action-btn primary" onClick={handleSaveApifyToken} disabled={apifySaving || !apifyToken.trim()}
+            <button className="action-btn primary" onClick={handleSaveUsftToken} disabled={usftSaving || !usftToken.trim()}
               style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-              {apifySaving ? 'Saving...' : 'Save'}
+              {usftSaving ? 'Saving...' : 'Save'}
             </button>
-            <button className="action-btn secondary" onClick={handleTestApifyToken} disabled={apifyTesting || !apifyTokenSet}
+            <button className="action-btn secondary" onClick={handleTestUsftToken} disabled={usftTesting || !usftTokenSet}
               style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-              {apifyTesting ? 'Testing...' : 'Test'}
+              {usftTesting ? 'Testing...' : 'Test'}
             </button>
           </div>
           <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
-            Twitter/X and Facebook scraping. Get token from <a href="https://console.apify.com/account/integrations" target="_blank" rel="noopener noreferrer">Apify Console</a>
-          </p>
-        </div>
-
-
-        <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid #e0e0e0' , paddingBottom: '1.5rem' }}>
-          <h5 style={{ fontSize: '0.95rem', marginBottom: '0.5rem' }}>GitHub</h5>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '0.75rem' }}>
-            <span className={`status-indicator ${githubTokenSet ? 'configured' : 'not-configured'}`}></span>
-            <span style={{ fontSize: '0.9rem' }}>{githubTokenSet ? 'Configured' : 'Not configured'}</span>
-            {githubResult && (
-              <span
-                style={{
-                  marginLeft: '12px',
-                  padding: '4px 10px',
-                  borderRadius: '4px',
-                  fontSize: '0.85rem',
-                  fontWeight: '500',
-                  backgroundColor: githubResult.type === 'success' ? '#d4edda' : '#f8d7da',
-                  color: githubResult.type === 'success' ? '#155724' : '#721c24',
-                  cursor: 'pointer'
-                }}
-                onClick={() => setGithubResult(null)}
-                title="Click to dismiss"
-              >
-                {githubResult.message}
-              </span>
-            )}
-          </div>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch', marginBottom: '0.5rem' }}>
-            <input
-              type="password"
-              value={githubToken || (githubTokenSet ? '••••••••••••••••••••••••' : '')}
-              onChange={e => setGithubToken(e.target.value)}
-              placeholder="Enter GitHub token..."
-              disabled={githubSaving}
-              style={{ flex: 1, padding: '8px', fontSize: '0.9rem', border: '1px solid #ccc', borderRadius: '4px', minWidth: 0 }}
-            />
-            <button className="action-btn primary" onClick={handleSaveGithubToken} disabled={githubSaving || !githubToken.trim()}
-              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-              {githubSaving ? 'Saving...' : 'Save'}
-            </button>
-            <button className="action-btn secondary" onClick={handleTestGithubToken} disabled={githubTesting || !githubTokenSet}
-              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-              {githubTesting ? 'Testing...' : 'Test'}
-            </button>
-          </div>
-          <p style={{ fontSize: '0.85rem', color: '#666', margin: 0 }}>
-            Feedback form creates GitHub Issues. Use a fine-grained PAT with <code>issues:write</code> scope for <code>crunchtools/rotv</code>.
+            US Fleet Tracking (USFT) sharing token for the CVSR live train tracker. Falls back to the <code>USFT_SHARING_TOKEN</code> env var when unset.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Moves the CVSR train tracker's **USFT (US Fleet Tracking) sharing token** out of the container env file into `admin_settings`, matching the serper/gemini/buttondown key pattern — so it syncs with `run.sh seed` and is rotatable from the admin UI without a redeploy.
- `trainTrackerService` now reads the token lazily (**DB first, `USFT_SHARING_TOKEN` env fallback**) instead of a module-load const. A DB hiccup falls back to env and never throws into the self-healing poll loop.
- **One Save updates both consumers:** saving the token invalidates the cached JWT (map marker re-auths on the next poll) and rewrites `live_tracker_url` to the lvgps view URL carrying the new token — scoped by the lvgps prefix so the water-taxi tracker (`trackmyshuttle.com`) is untouched.
- Admin route whitelists the key, **masks it in GET settings** (`isSet` only, never plaintext), and adds a **Test** button that validates against USFT shared-view login.
- API Keys settings section **alphabetized**; USFT spelled out as **US Fleet Tracking**.
- Migration `087` seeds an empty `usft_sharing_token` row.

Backward compatible: with the DB setting empty, prod keeps running on the existing `USFT_SHARING_TOKEN` env var. The env var can be removed only after the DB setting is confirmed.

Spec: `.specify/specs/040-usft-token-admin-settings/`

Closes #550

## Test plan
- [x] Full `./run.sh build` passes
- [x] Migration seeds `usft_sharing_token`; tracker falls back to env when DB empty (authenticated live)
- [x] GET `/api/admin/settings` returns `usft_sharing_token: { isSet }` — never the raw value
- [x] Rotating the token via API updates CVSR `live_tracker_url` to the new lvgps URL and leaves Harbor Hopper (water taxi) untouched; tracker re-auths; health endpoint green
- [x] User verified in browser (settings field, Test button, green Live Tracker button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)