### PR TITLE
fix: ship production React build, not development (#556)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -58,10 +58,14 @@ ENV PGHOST=localhost PGPORT=5432 PGDATABASE=rotv PGUSER=postgres PGPASSWORD=rotv
 WORKDIR /app
 
 # Build frontend
+# Fix: force NODE_ENV=production for the Vite build only — the global
+# ENV NODE_ENV=development (set above, required by the backend at runtime)
+# otherwise makes Vite emit a dev React bundle (jsxDEV + StrictMode
+# double-mount, larger/slower). Scoped to this RUN so runtime env is unchanged. (#556)
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm install
 COPY frontend/ ./frontend/
-RUN cd frontend && npm run build
+RUN cd frontend && NODE_ENV=production npm run build
 
 # Install backend dependencies
 # BUILD_ENV=test includes devDependencies (vitest) for CI


### PR DESCRIPTION
Fixes #556.

## Problem
`rootsofthevalley.org` was serving visitors the **development** React build. The global `ENV NODE_ENV=development` in the Containerfile — which the backend legitimately needs at runtime (image-serving fallback, cookie behavior, digest subject) — leaked into the Vite build step. Vite derives `isProduction` from `NODE_ENV`, so `vite build` produced a dev bundle: `jsxDEV` instrumentation, honored `<React.StrictMode>` (double-mount → every startup fetch fired twice), and a larger, slower payload over the wire.

## Fix
Scope `NODE_ENV=production` to the frontend build `RUN` only. Runtime environment is unchanged, so no backend behavior shifts.

```diff
-RUN cd frontend && npm run build
+RUN cd frontend && NODE_ENV=production npm run build
```

## Verification (in the built image)
| | dev build (before) | prod build (after) |
|---|---|---|
| `jsxDEV` occurrences in shipped bundle | 2,570 | **0** |
| `index-*.js` size | 2.0M | **1.3M** (−35%) |

Eliminating the dev build removes the StrictMode double-mount, which was the source of the duplicate startup fetches and the late-resolution race surface described in the issue.

`./run.sh build` succeeds; `./run.sh test` → 458 passed, 1 skipped, 2 pre-existing flakes (login-button-on-tablet, satellite-tile toggle) that pass on retry and are unrelated to a build-mode change.

## Follow-up (separate issue, not this PR)
The production container still runs `NODE_ENV=development` at the system level, which means session cookies ship `secure: false` and image serving uses a dev-only fallback path. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)