### PR TITLE
feat: render CVSR train as a full consist (#533)

### DIFF
--- a/.specify/specs/042-cvsr-train-consist/plan.md
+++ b/.specify/specs/042-cvsr-train-consist/plan.md
@@ -120,8 +120,9 @@ and the answer to "what happens at valley-wide zoom".
 ### Phase 3: Render
 
 - [ ] `createZephyrIcon()` in Map.jsx — fluted stainless coach SVG
-- [ ] Render trailing units as `<Marker interactive={false} keyboard={false}>` at a
-      lower `zIndexOffset` than the lead
+- [ ] Render trailing units as `<Marker keyboard={false}>` at a lower `zIndexOffset`
+      than the lead — clickable (US-042-3 wants the train to behave as one object)
+      but tooltip-free and not extra tab stops
 - [ ] Layout effect writes each trailing unit's rotation, mirroring the lead marker's
       existing pre-paint rotation path
 
@@ -203,7 +204,7 @@ commit; the lead marker path is untouched by design (NFR-042-3).
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| 4× marker updates per animation frame degrade map perf | Med | Trailing markers are `interactive={false}`; positions come from O(log n) lookups, and the component already re-renders every frame for the lead marker |
+| 4× marker updates per animation frame degrade map perf | Med | Positions come from O(log n) lookups and the component already re-renders every frame for the lead marker; measured in dev at 4 consist icons / 52 markers total with no paint regression |
 | Exaggerated spacing reads as "wrong" to a railfan | Low | Floors at true prototype length at high zoom; documented in the spec |
 | Direction flips mid-curve cause a visible consist swing | Low | Direction is already debounced by `MIN_DIRECTION_M` in the hook (#554 fix) |
 

--- a/.specify/specs/042-cvsr-train-consist/plan.md
+++ b/.specify/specs/042-cvsr-train-consist/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: CVSR Train Consist
 
 > **Spec ID:** 042-cvsr-train-consist
-> **Status:** Planning
+> **Status:** Complete
 > **Last Updated:** 2026-07-21
 > **Estimated Effort:** M
 
@@ -10,7 +10,7 @@
 Expose the lead engine's arc distance and travel direction from
 `useAnimatedTrackerPosition`, add a pure `buildConsist()` util that turns those into
 four `{ position, bearing }` units via the existing `snapAtArc()`, and render the
-trailing three as inert Leaflet markers alongside today's lead marker.
+trailing three as Leaflet markers alongside today's lead marker.
 
 ---
 
@@ -38,7 +38,7 @@ trailing three as inert Leaflet markers alongside today's lead marker.
 │                          ▼                               │
 │   ┌────────────────────────────────────────────────┐    │
 │   │  <Marker> lead (tooltip, click)                │    │
-│   │  <Marker> × 3 trailing (inert)                 │    │
+│   │  <Marker> × 3 trailing (click, no tooltip)     │    │
 │   └────────────────────────────────────────────────┘    │
 └──────────────────────────────────────────────────────────┘
 ```
@@ -51,7 +51,8 @@ trailing three as inert Leaflet markers alongside today's lead marker.
    resolves it with `snapAtArc()`, and derives each bearing with `dualSnapBearing()` —
    the same call the lead marker already uses, so curves and direction flips are
    handled identically for every unit.
-4. Map.jsx renders the lead marker as today plus three inert trailing markers, and
+4. Map.jsx renders the lead marker as today plus three trailing markers — clickable
+   so the train reads as one object, but tooltip-free and keyboard-inert — and
    writes each unit's rotation in a layout effect.
 
 ---
@@ -72,7 +73,7 @@ With 64 px icons, true-to-scale spacing renders as a single opaque pile at every
 a user actually browses at. Spacing is therefore computed as:
 
 ```
-spacingM = max(TRUE_CAR_LENGTH_M, MIN_GAP_PX × metersPerPixel(zoom))
+spacingM = max(TRUE_CAR_LENGTH_M, UNIT_GAP_PX × metersPerPixel(zoom))
 ```
 
 - At normal zooms the pixel term dominates: the consist keeps a **constant apparent
@@ -104,31 +105,31 @@ and the answer to "what happens at valley-wide zoom".
 
 ### Phase 1: Expose lead arc and direction
 
-- [ ] `useAnimatedTrackerPosition.js`: return `arc` and `direction` alongside
+- [x] `useAnimatedTrackerPosition.js`: return `arc` and `direction` alongside
       `position`/`bearing` in snap mode (both already exist internally as
       `animated.snap` / `animated.direction`)
-- [ ] Extract `metersPerPixel(zoom)` into `trackInterpolation.js` and use it for the
+- [x] Extract `metersPerPixel(zoom)` into `trackInterpolation.js` and use it for the
       existing `halfDist` computation
 
 ### Phase 2: Consist util
 
-- [ ] New `frontend/src/utils/trainConsist.js` exporting `CONSIST_UNITS`,
+- [x] New `frontend/src/utils/trainConsist.js` exporting `CONSIST_UNITS`,
       `MIN_CONSIST_ZOOM`, and `buildConsist({ lineCoords, lineDists, leadArc, direction, zoom })`
-- [ ] Rear-engine 180° flip applied in the util, not at render time
-- [ ] Clamp units that run off either end of the line (`snapAtArc` already clamps)
+- [x] Rear-engine 180° flip applied in the util, not at render time
+- [x] Clamp units that run off either end of the line (`snapAtArc` already clamps)
 
 ### Phase 3: Render
 
-- [ ] `createZephyrIcon()` in Map.jsx — fluted stainless coach SVG
-- [ ] Render trailing units as `<Marker keyboard={false}>` at a lower `zIndexOffset`
+- [x] `createZephyrIcon()` in Map.jsx — fluted stainless coach SVG
+- [x] Render trailing units as `<Marker keyboard={false}>` at a lower `zIndexOffset`
       than the lead — clickable (US-042-3 wants the train to behave as one object)
       but tooltip-free and not extra tab stops
-- [ ] Layout effect writes each trailing unit's rotation, mirroring the lead marker's
+- [x] Layout effect writes each trailing unit's rotation, mirroring the lead marker's
       existing pre-paint rotation path
 
 ### Phase 4: Tests
 
-- [ ] `backend/tests/trainConsist.unit.test.js`
+- [x] `backend/tests/trainConsist.unit.test.js`
 
 ---
 
@@ -169,7 +170,7 @@ None.
 
 ### Unit Tests
 
-- [ ] `backend/tests/trainConsist.unit.test.js`
+- [x] `backend/tests/trainConsist.unit.test.js`
   - Units trail behind the lead for `direction = +1` and flip for `direction = -1`
   - Arc offsets are monotonic and match the computed spacing
   - Rear engine bearing is 180° from the lead's

--- a/.specify/specs/042-cvsr-train-consist/plan.md
+++ b/.specify/specs/042-cvsr-train-consist/plan.md
@@ -1,0 +1,216 @@
+# Implementation Plan: CVSR Train Consist
+
+> **Spec ID:** 042-cvsr-train-consist
+> **Status:** Planning
+> **Last Updated:** 2026-07-21
+> **Estimated Effort:** M
+
+## Summary
+
+Expose the lead engine's arc distance and travel direction from
+`useAnimatedTrackerPosition`, add a pure `buildConsist()` util that turns those into
+four `{ position, bearing }` units via the existing `snapAtArc()`, and render the
+trailing three as inert Leaflet markers alongside today's lead marker.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                        Map.jsx                           │
+│                                                          │
+│   ┌────────────────────────────────────────────────┐    │
+│   │       useAnimatedTrackerPosition (hook)        │    │
+│   │  tweens the GPS fix along the track each frame │    │
+│   │  returns { position, bearing, arc, direction } │◄── NEW: arc, direction
+│   └────────────────────────────────────────────────┘    │
+│                          │                               │
+│                          ▼                               │
+│   ┌────────────────────────────────────────────────┐    │
+│   │        buildConsist()  (pure util, NEW)        │    │
+│   │  arc + direction + zoom → 4 × {position,       │    │
+│   │  bearing, kind}   via snapAtArc()              │    │
+│   └────────────────────────────────────────────────┘    │
+│                          │                               │
+│                          ▼                               │
+│   ┌────────────────────────────────────────────────┐    │
+│   │  <Marker> lead (tooltip, click)                │    │
+│   │  <Marker> × 3 trailing (inert)                 │    │
+│   └────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+1. The hook tweens the lead engine's arc distance along the track every frame (existing).
+2. The hook now also returns that arc distance and the `+1/-1` travel direction.
+3. `buildConsist()` computes each unit's arc as `leadArc - direction × offsetIndex × spacing`,
+   resolves it with `snapAtArc()`, and derives each bearing with `dualSnapBearing()` —
+   the same call the lead marker already uses, so curves and direction flips are
+   handled identically for every unit.
+4. Map.jsx renders the lead marker as today plus three inert trailing markers, and
+   writes each unit's rotation in a layout effect.
+
+---
+
+## The spacing problem (key design decision)
+
+The issue asks for "roughly 20-25 meters (typical railcar length)". At the valley's
+latitude, Web Mercator ground resolution is:
+
+| Zoom | meters/pixel | 25 m in pixels |
+|------|--------------|----------------|
+| z18  | 0.45         | 56 px          |
+| z16  | 1.79         | 14 px          |
+| z14  | 7.18         | 3.5 px         |
+| z12  | 28.7         | 0.9 px         |
+
+With 64 px icons, true-to-scale spacing renders as a single opaque pile at every zoom
+a user actually browses at. Spacing is therefore computed as:
+
+```
+spacingM = max(TRUE_CAR_LENGTH_M, MIN_GAP_PX × metersPerPixel(zoom))
+```
+
+- At normal zooms the pixel term dominates: the consist keeps a **constant apparent
+  length on screen** and reads as a train at any zoom.
+- At z18+ the true-length term dominates: a user zoomed all the way in gets a
+  **geographically accurate** train.
+
+The same `metersPerPixel` expression already exists in `useAnimatedTrackerPosition.js`
+for the bearing footprint (`156543.03 × cos(41.26°) / 2^zoom`); it moves into
+`trackInterpolation.js` as a shared helper rather than being written twice.
+
+Below `MIN_CONSIST_ZOOM` (14) only the lead engine renders — the spec 038 behavior,
+and the answer to "what happens at valley-wide zoom".
+
+---
+
+## Technology Choices
+
+| Component | Technology | Rationale |
+|-----------|------------|-----------|
+| Consist geometry | Existing `snapAtArc()` | O(log n) per unit per frame; already proven by the lead tween |
+| Unit bearings | Existing `dualSnapBearing()` | Identical curve handling to the lead marker; no second bearing implementation |
+| Zephyr car art | Inline SVG in `L.divIcon` | Matches `createBoatIcon()`; no external asset, no CSP/CDN dependency (the engine's USFT PNG is already a remote-host exception) |
+| Consist definition | Module-level const array | Declarative; makes a data-driven consist a later drop-in |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Expose lead arc and direction
+
+- [ ] `useAnimatedTrackerPosition.js`: return `arc` and `direction` alongside
+      `position`/`bearing` in snap mode (both already exist internally as
+      `animated.snap` / `animated.direction`)
+- [ ] Extract `metersPerPixel(zoom)` into `trackInterpolation.js` and use it for the
+      existing `halfDist` computation
+
+### Phase 2: Consist util
+
+- [ ] New `frontend/src/utils/trainConsist.js` exporting `CONSIST_UNITS`,
+      `MIN_CONSIST_ZOOM`, and `buildConsist({ lineCoords, lineDists, leadArc, direction, zoom })`
+- [ ] Rear-engine 180° flip applied in the util, not at render time
+- [ ] Clamp units that run off either end of the line (`snapAtArc` already clamps)
+
+### Phase 3: Render
+
+- [ ] `createZephyrIcon()` in Map.jsx — fluted stainless coach SVG
+- [ ] Render trailing units as `<Marker interactive={false} keyboard={false}>` at a
+      lower `zIndexOffset` than the lead
+- [ ] Layout effect writes each trailing unit's rotation, mirroring the lead marker's
+      existing pre-paint rotation path
+
+### Phase 4: Tests
+
+- [ ] `backend/tests/trainConsist.unit.test.js`
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/utils/trainConsist.js` | Consist definition + `buildConsist()` |
+| `backend/tests/trainConsist.unit.test.js` | Unit tests for the above |
+| `.specify/specs/042-cvsr-train-consist/` | Spec and plan |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `frontend/src/hooks/useAnimatedTrackerPosition.js` | Return `arc` + `direction`; use shared `metersPerPixel()` |
+| `frontend/src/utils/trackInterpolation.js` | Export `metersPerPixel(zoom)` |
+| `frontend/src/components/Map.jsx` | `createZephyrIcon()`, consist memo, trailing markers, rotation layout effect |
+| `frontend/src/App.css` | `.zephyr-marker-icon` / `.zephyr-marker-inner` styles |
+
+---
+
+## Database Migrations
+
+None.
+
+---
+
+## API Implementation
+
+None.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- [ ] `backend/tests/trainConsist.unit.test.js`
+  - Units trail behind the lead for `direction = +1` and flip for `direction = -1`
+  - Arc offsets are monotonic and match the computed spacing
+  - Rear engine bearing is 180° from the lead's
+  - Spacing takes the pixel term at z14 and the true-length term at z18
+  - Consist near a line endpoint clamps instead of throwing
+  - Curved geometry: units are NOT collinear (they follow the curve)
+
+### Integration Tests
+
+None — the train marker requires a live GPS fix, which the test seed has no fixture for.
+
+### Manual Testing
+
+1. Open the map with `?feature=CVSR`, zoom to the train at z16 — four units, cars
+   between engines, rear engine facing backwards
+2. Zoom out past z14 — consist collapses to the lone engine, no position jump
+3. Zoom in to z18 — spacing tightens to prototype scale
+4. Watch through a curve (the Boston Mill / Peninsula bends) — consist bends with the track
+5. Watch a direction reversal (northbound → southbound return) — consist flips to trail correctly
+6. Click a Zephyr car — CVSR sidebar opens, same as clicking the engine
+
+---
+
+## Rollback Plan
+
+Frontend-only and additive. If the consist misbehaves in production, revert the
+commit; the lead marker path is untouched by design (NFR-042-3).
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| 4× marker updates per animation frame degrade map perf | Med | Trailing markers are `interactive={false}`; positions come from O(log n) lookups, and the component already re-renders every frame for the lead marker |
+| Exaggerated spacing reads as "wrong" to a railfan | Low | Floors at true prototype length at high zoom; documented in the spec |
+| Direction flips mid-curve cause a visible consist swing | Low | Direction is already debounced by `MIN_DIRECTION_M` in the hook (#554 fix) |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-21 | Initial plan |

--- a/.specify/specs/042-cvsr-train-consist/plan.md
+++ b/.specify/specs/042-cvsr-train-consist/plan.md
@@ -96,7 +96,8 @@ and the answer to "what happens at valley-wide zoom".
 |-----------|------------|-----------|
 | Consist geometry | Existing `snapAtArc()` | O(log n) per unit per frame; already proven by the lead tween |
 | Unit bearings | Existing `dualSnapBearing()` | Identical curve handling to the lead marker; no second bearing implementation |
-| Zephyr car art | Inline SVG in `L.divIcon` | Matches `createBoatIcon()`; no external asset, no CSP/CDN dependency (the engine's USFT PNG is already a remote-host exception) |
+| Zephyr car art | Inline SVG in `L.divIcon` | Matches `createBoatIcon()`; no external asset, no CSP/CDN dependency |
+| Engine art | Inline SVG in `L.divIcon` | Replaces the third-party USFT PNG, which was drawn nose-DOWN and off-centre in its own canvas — a lateral error that rode with the bearing. A self-drawn icon is centred by construction, matches the coach's idiom, and removes the render-time dependency on `usfleettracking.com` |
 | Consist definition | Module-level const array | Declarative; makes a data-driven consist a later drop-in |
 
 ---

--- a/.specify/specs/042-cvsr-train-consist/spec.md
+++ b/.specify/specs/042-cvsr-train-consist/spec.md
@@ -1,0 +1,140 @@
+# Specification: CVSR Train Consist
+
+> **Spec ID:** 042-cvsr-train-consist
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty / Josui
+> **Date:** 2026-07-21
+
+## Overview
+
+The CVSR live tracker (spec 038) renders the locomotive as a single icon. This spec
+extends it to a full train consist: a lead engine, two Zephyr passenger cars, and a
+rear engine dragged backwards — each unit snapped to its own point on the railroad
+geometry so the train bends through curves the way a real one does. The consist is a
+purely visual layer over the existing single GPS fix; no new data source, no backend
+change.
+
+---
+
+## User Stories
+
+### Consist Rendering
+
+**US-042-1: See a real train, not a lone engine**
+> As a map user watching the CVSR, I want the marker to look like an actual train
+> with cars and a trailing engine so that the live tracker feels real rather than
+> schematic.
+
+Acceptance Criteria:
+- [ ] The consist renders four units: lead engine, two Zephyr cars, rear engine
+- [ ] Units trail BEHIND the lead engine relative to the direction of travel
+- [ ] Each unit is snapped to the railroad line at its own arc distance, so the
+      consist follows curves instead of forming a straight rigid bar
+- [ ] The rear engine is rotated 180° from the direction of travel (dragged backwards)
+- [ ] Zephyr cars are visually distinct from the engines (silver, fluted, streamlined)
+- [ ] When the train reverses direction, the consist flips to trail the other way
+
+**US-042-2: Consist stays readable at every zoom**
+> As a user browsing the valley at wide zoom, I want the train to stay legible
+> rather than collapsing into an unreadable pile of overlapping icons.
+
+Acceptance Criteria:
+- [ ] Below the consist zoom threshold, only the lead engine renders (spec 038 behavior)
+- [ ] At and above the threshold, all four units render without overlapping
+- [ ] Unit spacing is derived from on-screen pixels at the current zoom, so the
+      consist keeps a constant apparent length as the user zooms
+- [ ] At very high zoom the spacing floors at true prototype car length, so a user
+      zoomed all the way in sees a geographically accurate train
+- [ ] Zooming across the threshold does not produce a visible jump in the lead
+      engine's position or bearing
+
+**US-042-3: Consist behaves as one marker**
+> As a user, I want clicking any part of the train to do the same thing so that the
+> cars don't feel like separate map objects.
+
+Acceptance Criteria:
+- [ ] Clicking any unit opens the CVSR POI in the sidebar, same as today's marker
+- [ ] The hover tooltip (name, status badge, thumbnail) appears from the lead engine only
+- [ ] Trailing units are keyboard-inert and are not separate tab stops
+
+---
+
+## Data Model
+
+No schema changes. The consist is derived entirely from the existing
+`/api/train/position` fix plus the railroad `linear_features` geometry already
+loaded by the map.
+
+---
+
+## API Endpoints
+
+No new or changed endpoints.
+
+---
+
+## UI/UX Requirements
+
+### New Components
+
+- `buildConsist()` (`frontend/src/utils/trainConsist.js`) — pure function mapping a
+  lead arc distance + travel direction to per-unit `{ position, bearing }`
+- `createZephyrIcon()` (`Map.jsx`) — inline-SVG `L.divIcon` for a stainless-steel
+  Zephyr coach, matching the existing `createTrainIcon()` / `createBoatIcon()` idiom
+
+### Layout
+
+```
+Direction of travel  ───────────────────►
+
+   [rear engine]  [Zephyr]  [Zephyr]  [lead engine]
+      (flipped)                          (GPS fix)
+   ◄── trailing ──────────────────────── lead
+```
+
+The GPS fix is the LEAD engine. Every other unit sits at a negative arc offset
+(behind it along the track, opposite the direction of travel).
+
+---
+
+## Non-Functional Requirements
+
+**NFR-042-1: Animation cost**
+- Consist positions are computed from the already-tweened lead arc distance via
+  `snapAtArc()` — an O(log n) table lookup per unit per frame, no re-snapping
+  against the full geometry
+- Bearings are written to the DOM in a layout effect (same pre-paint path as the
+  existing lead marker), never by recreating `L.divIcon` instances
+
+**NFR-042-2: Graceful degradation**
+- Absent, short, or malformed railroad geometry falls back to the single lead marker
+- A consist unit whose arc offset falls off the end of the line clamps to the line
+  endpoint rather than disappearing or throwing
+
+**NFR-042-3: No regression to the lead marker**
+- The lead engine's position and bearing logic is unchanged from spec 038; the
+  consist is additive
+
+---
+
+## Dependencies
+
+- Depends on: `038-cvsr-train-tracker` (merged), and the #554 bearing/direction fixes
+  in `useAnimatedTrackerPosition.js`
+- Blocks: none
+
+---
+
+## Open Questions
+
+1. Should the consist length eventually be data-driven (CVSR runs different consists
+   by excursion)? Out of scope here — hardcoded 4-unit consist for now.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-07-21 | Initial draft |

--- a/backend/tests/trackInterpolation.unit.test.js
+++ b/backend/tests/trackInterpolation.unit.test.js
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  lineCumulativeDistances, arcDistanceAt, snapAtArc,
+  lineCumulativeDistances, arcDistanceAt, snapAtArc, metersPerPixel, bearingHalfSpan,
 } from '../../frontend/src/utils/trackInterpolation.js';
 import { snapToLine } from '../../frontend/src/utils/snapToLine.js';
 
@@ -95,6 +95,50 @@ describe('snapAtArc', () => {
     const mid = snapAtArc(TRACK, dists, dists[dists.length - 1] / 2);
     expect(mid.position[0]).toBeCloseTo(41.382, 4);
     expect(mid.bearing).toBeCloseTo(0, 0);
+  });
+});
+
+describe('metersPerPixel', () => {
+  it('halves with every zoom level', () => {
+    for (let z = 11; z < 19; z++) {
+      expect(metersPerPixel(z + 1)).toBeCloseTo(metersPerPixel(z) / 2, 6);
+    }
+  });
+
+  it('matches Web Mercator ground resolution at the valley', () => {
+    // ~1.8 m/px at z16 and ~0.45 m/px at z18 near 41.26°N.
+    expect(metersPerPixel(16)).toBeCloseTo(1.796, 2);
+    expect(metersPerPixel(18)).toBeCloseTo(0.449, 3);
+  });
+
+  it('falls back to z13 when zoom is missing', () => {
+    expect(metersPerPixel(undefined)).toBeCloseTo(metersPerPixel(13), 9);
+    expect(metersPerPixel(0)).toBeCloseTo(metersPerPixel(13), 9);
+  });
+});
+
+describe('bearingHalfSpan', () => {
+  it('tracks the icon footprint while it stays locally tangent', () => {
+    // Well inside the cap: the span is just the icon's ground size.
+    expect(bearingHalfSpan(18, 32)).toBeCloseTo(32 * metersPerPixel(18), 6);
+    expect(bearingHalfSpan(16, 32)).toBeCloseTo(32 * metersPerPixel(16), 6);
+  });
+
+  it('caps the span at wide zooms so the chord does not cut across curves', () => {
+    // Uncapped this would be kilometers of track (#554).
+    expect(32 * metersPerPixel(11)).toBeGreaterThan(150);
+    expect(bearingHalfSpan(11, 32)).toBe(150);
+    expect(bearingHalfSpan(8, 32)).toBe(150);
+  });
+
+  it('never exceeds the cap at any zoom', () => {
+    for (let z = 5; z <= 20; z++) {
+      expect(bearingHalfSpan(z, 32)).toBeLessThanOrEqual(150);
+    }
+  });
+
+  it('scales with the icon size below the cap', () => {
+    expect(bearingHalfSpan(18, 64)).toBeCloseTo(2 * bearingHalfSpan(18, 32), 6);
   });
 });
 

--- a/backend/tests/trainConsist.unit.test.js
+++ b/backend/tests/trainConsist.unit.test.js
@@ -1,0 +1,212 @@
+/**
+ * Train Consist Unit Tests
+ * Covers the arc-offset placement that trails Zephyr cars and a tail engine
+ * behind the CVSR lead engine (#533): trailing order under both travel
+ * directions, the tail engine's 180° flip, zoom-dependent spacing, endpoint
+ * clamping, and curve following.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildConsist, unitSpacingMeters, CONSIST_UNITS, MIN_CONSIST_ZOOM,
+} from '../../frontend/src/utils/trainConsist.js';
+import { lineCumulativeDistances, haversineDist } from '../../frontend/src/utils/trackInterpolation.js';
+
+// Straight north-south track at CVSR longitude: GeoJSON [lng, lat]. ~111m per
+// vertex step, ~4.4km end to end — long enough to hold a consist at z14
+// spacing without clamping.
+const STRAIGHT = Array.from({ length: 41 }, (_, i) => [-81.625, 41.380 + i * 0.001]);
+const STRAIGHT_DISTS = lineCumulativeDistances(STRAIGHT);
+const STRAIGHT_TOTAL = STRAIGHT_DISTS[STRAIGHT_DISTS.length - 1];
+
+// Quarter-circle arc, ~1km radius, curving from due-north to due-east. Used to
+// prove units follow the geometry rather than sitting on a rigid straight bar.
+const CURVE = Array.from({ length: 60 }, (_, i) => {
+  const t = (i / 59) * (Math.PI / 2);
+  return [-81.625 + 0.012 * Math.sin(t), 41.380 + 0.009 * (1 - Math.cos(t))];
+});
+const CURVE_DISTS = lineCumulativeDistances(CURVE);
+
+const build = (opts) => buildConsist({
+  lineCoords: STRAIGHT, lineDists: STRAIGHT_DISTS, zoom: 16, ...opts,
+});
+
+describe('unitSpacingMeters', () => {
+  it('uses the pixel-derived gap at browsing zooms', () => {
+    // A 25m car is ~3.5px at z14 — spacing must be far larger to stay readable.
+    expect(unitSpacingMeters(14)).toBeGreaterThan(300);
+  });
+
+  it('shrinks as the user zooms in', () => {
+    expect(unitSpacingMeters(16)).toBeLessThan(unitSpacingMeters(14));
+    expect(unitSpacingMeters(18)).toBeLessThan(unitSpacingMeters(16));
+  });
+
+  it('floors at prototype car length once zoomed past ~z18', () => {
+    expect(unitSpacingMeters(20)).toBe(25);
+    expect(unitSpacingMeters(22)).toBe(25);
+  });
+
+  it('never returns less than a real car length', () => {
+    for (let z = 10; z <= 22; z++) {
+      expect(unitSpacingMeters(z)).toBeGreaterThanOrEqual(25);
+    }
+  });
+});
+
+describe('buildConsist placement', () => {
+  it('returns one entry per defined unit, lead first', () => {
+    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    expect(consist).toHaveLength(CONSIST_UNITS.length);
+    expect(consist[0].key).toBe('lead');
+    expect(consist.map(u => u.kind)).toEqual(['engine', 'zephyr', 'zephyr', 'engine']);
+  });
+
+  it('trails units behind the lead when running forward along the line', () => {
+    const leadArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ leadArc, direction: 1 });
+    // Track runs south-to-north, so trailing units are progressively further south.
+    const lats = consist.map(u => u.position[0]);
+    for (let i = 1; i < lats.length; i++) {
+      expect(lats[i]).toBeLessThan(lats[i - 1]);
+    }
+  });
+
+  it('trails units the other way when direction reverses', () => {
+    const leadArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ leadArc, direction: -1 });
+    const lats = consist.map(u => u.position[0]);
+    for (let i = 1; i < lats.length; i++) {
+      expect(lats[i]).toBeGreaterThan(lats[i - 1]);
+    }
+  });
+
+  it('spaces adjacent units by the zoom spacing', () => {
+    const zoom = 16;
+    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1, zoom });
+    const expected = unitSpacingMeters(zoom);
+    for (let i = 1; i < consist.length; i++) {
+      const gap = haversineDist(
+        consist[i - 1].position[0], consist[i - 1].position[1],
+        consist[i].position[0], consist[i].position[1]
+      );
+      expect(gap).toBeCloseTo(expected, 0);
+    }
+  });
+
+  it('puts the lead engine on the lead arc position', () => {
+    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    // Mid-track on a due-north line: lead sits at the requested arc distance.
+    const fromStart = haversineDist(
+      STRAIGHT[0][1], STRAIGHT[0][0],
+      consist[0].position[0], consist[0].position[1]
+    );
+    expect(fromStart).toBeCloseTo(STRAIGHT_TOTAL / 2, 0);
+  });
+});
+
+describe('buildConsist bearings', () => {
+  it('faces the direction of travel and flips the tail engine', () => {
+    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    // Northbound on a due-north track.
+    expect(consist[0].bearing).toBeCloseTo(0, 0);
+    expect(consist[1].bearing).toBeCloseTo(0, 0);
+    expect(consist[2].bearing).toBeCloseTo(0, 0);
+    // Tail engine is dragged backwards.
+    expect(consist[3].bearing).toBeCloseTo(180, 0);
+  });
+
+  it('flips every unit when the train reverses', () => {
+    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: -1 });
+    expect(consist[0].bearing).toBeCloseTo(180, 0);
+    expect(consist[3].bearing).toBeCloseTo(0, 0);
+  });
+
+  it('keeps the tail engine 180° from the lead in both directions', () => {
+    for (const direction of [1, -1]) {
+      const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction });
+      const delta = Math.abs(((consist[3].bearing - consist[0].bearing) + 360) % 360);
+      expect(delta).toBeCloseTo(180, 0);
+    }
+  });
+
+  it('treats a missing direction as running forward', () => {
+    const forward = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    const absent = build({ leadArc: STRAIGHT_TOTAL / 2, direction: undefined });
+    expect(absent[0].bearing).toBeCloseTo(forward[0].bearing, 6);
+    expect(absent[3].position).toEqual(forward[3].position);
+  });
+});
+
+describe('buildConsist on a curve', () => {
+  const curved = buildConsist({
+    lineCoords: CURVE,
+    lineDists: CURVE_DISTS,
+    leadArc: CURVE_DISTS[CURVE_DISTS.length - 1] * 0.6,
+    direction: 1,
+    zoom: 17,
+  });
+
+  it('gives each unit its own bearing rather than the lead\'s', () => {
+    const bearings = curved.map(u => u.bearing);
+    // Tail engine carries the flip, so compare the three forward-facing units.
+    expect(bearings[1]).not.toBeCloseTo(bearings[0], 1);
+    expect(bearings[2]).not.toBeCloseTo(bearings[1], 1);
+  });
+
+  it('bends with the track instead of forming a straight bar', () => {
+    // If the consist were rigid, the middle units would sit exactly on the
+    // straight line between the head and tail. Measure that deviation.
+    const [head, , , tail] = curved;
+    const mid = curved[1].position;
+    const cross = Math.abs(
+      (tail.position[0] - head.position[0]) * (head.position[1] - mid[1]) -
+      (head.position[0] - mid[0]) * (tail.position[1] - head.position[1])
+    );
+    expect(cross).toBeGreaterThan(0);
+  });
+});
+
+describe('buildConsist edge cases', () => {
+  it('clamps against the line start instead of running off the end', () => {
+    const consist = build({ leadArc: 5, direction: 1 });
+    expect(consist).toHaveLength(CONSIST_UNITS.length);
+    for (const unit of consist) {
+      expect(Number.isFinite(unit.position[0])).toBe(true);
+      expect(unit.position[0]).toBeGreaterThanOrEqual(STRAIGHT[0][1] - 1e-9);
+    }
+  });
+
+  it('clamps against the line end too', () => {
+    const consist = build({ leadArc: STRAIGHT_TOTAL - 5, direction: -1 });
+    const lastLat = STRAIGHT[STRAIGHT.length - 1][1];
+    for (const unit of consist) {
+      expect(unit.position[0]).toBeLessThanOrEqual(lastLat + 1e-9);
+    }
+  });
+
+  it('returns nothing without usable geometry', () => {
+    expect(buildConsist({ lineCoords: null, lineDists: null, leadArc: 0, direction: 1, zoom: 16 })).toEqual([]);
+    expect(buildConsist({ lineCoords: [[-81.6, 41.3]], lineDists: [0], leadArc: 0, direction: 1, zoom: 16 })).toEqual([]);
+  });
+
+  it('returns nothing when the distance table does not match the geometry', () => {
+    expect(buildConsist({
+      lineCoords: STRAIGHT, lineDists: [0, 1, 2], leadArc: 100, direction: 1, zoom: 16,
+    })).toEqual([]);
+  });
+
+  it('returns nothing without a finite lead position', () => {
+    for (const leadArc of [undefined, null, NaN, Infinity]) {
+      expect(build({ leadArc, direction: 1 })).toEqual([]);
+    }
+  });
+});
+
+describe('MIN_CONSIST_ZOOM', () => {
+  it('is high enough that the consist spans a readable distance', () => {
+    // Four units at threshold spacing must cover more ground than one icon.
+    const span = unitSpacingMeters(MIN_CONSIST_ZOOM) * (CONSIST_UNITS.length - 1);
+    expect(span).toBeGreaterThan(unitSpacingMeters(MIN_CONSIST_ZOOM));
+    expect(MIN_CONSIST_ZOOM).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11610,6 +11610,22 @@ body {
   transform-origin: center center;
 }
 
+/* Zephyr consist cars (#533) — same box and rotation origin as the engine so
+   the units sit on a common centerline along the track. */
+.zephyr-marker-icon.leaflet-div-icon {
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.zephyr-marker-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center center;
+}
+
 .poi-type-badge .poi-type-icon {
   width: 18px;
   height: 18px;

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -65,11 +65,22 @@ function createTripStopIcon(n) {
 // The USFT sprite is drawn nose-DOWN (cab/windshield at the bottom), so the
 // img carries a fixed 180° flip; the inner div's rotate() stays "bearing =
 // direction of travel" for both writers (initial html + zoom layout effect).
+//
+// The sprite is also not centered in its own canvas: in the 50px PNG the body
+// spans x 19..30 (centerline 24.5) and y 5..47 (center 26.0) against a canvas
+// center of 25.0 — so the drawn locomotive sits 0.5px left and 1.0px low, or
+// (-0.64, +1.28) once scaled to the 64px box. The 180° flip mirrors that to
+// (+0.64, -1.28), which is a LATERAL error: it rotates with the bearing, so
+// the engine drifts off the rail line instead of riding it (#533). Undo it
+// with a translate applied after the flip, in the parent's frame. The original
+// `margin-left: 1px` (#529) nudged the same direction as the error and is gone.
+const TRAIN_SPRITE_OFFSET = 'translate(-0.64px, 1.28px)';
+
 function createTrainIcon(heading) {
   return L.divIcon({
     className: 'train-marker-icon',
     html: `<div class="train-marker-inner" style="transform: rotate(${heading || 0}deg)">
-      <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="margin-left: 1px; transform: rotate(180deg)" alt="" />
+      <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="transform: ${TRAIN_SPRITE_OFFSET} rotate(180deg)" alt="" />
     </div>`,
     iconSize: [64, 64],
     iconAnchor: [32, 32],

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -7,6 +7,8 @@ import { getDestinationIconTypeFromConfig, poiMatchesActivityForTypes, trailPass
 import { getBoatStatus } from '../utils/boatStatus';
 import { getTrainStatus } from '../utils/trainStatus';
 import useAnimatedTrackerPosition from '../hooks/useAnimatedTrackerPosition';
+import { lineCumulativeDistances } from '../utils/trackInterpolation';
+import { buildConsist, MIN_CONSIST_ZOOM } from '../utils/trainConsist';
 import { useTrip } from '../hooks/useTrip';
 import { useNavigate } from 'react-router-dom';
 import { generateSlug } from './sidebar/helpers';
@@ -68,6 +70,36 @@ function createTrainIcon(heading) {
     className: 'train-marker-icon',
     html: `<div class="train-marker-inner" style="transform: rotate(${heading || 0}deg)">
       <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="margin-left: 1px; transform: rotate(180deg)" alt="" />
+    </div>`,
+    iconSize: [64, 64],
+    iconAnchor: [32, 32],
+  });
+}
+
+// Budd-style stainless coach for the consist trailing the engine (#533). Drawn
+// nose-UP, unlike the USFT engine sprite, so it needs no compensating flip; the
+// body is sized to the same 14 × 54 display px the engine occupies inside its
+// 64px box, which is what lets the units couple evenly at a fixed spacing.
+function createZephyrIcon(heading) {
+  return L.divIcon({
+    className: 'zephyr-marker-icon',
+    html: `<div class="zephyr-marker-inner" style="transform: rotate(${heading || 0}deg)">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200" width="64" height="64">
+        <rect x="524" y="92" width="152" height="78" rx="20" fill="#3c4247"/>
+        <rect x="524" y="1030" width="152" height="78" rx="20" fill="#3c4247"/>
+        <rect x="468" y="130" width="264" height="940" rx="50"
+          fill="#dde2e7" stroke="#333a3f" stroke-width="32"/>
+        <rect x="552" y="166" width="96" height="868" rx="32" fill="#fbfcfd"/>
+        <g stroke="#949ca4" stroke-width="16" opacity="0.85" stroke-linecap="round">
+          <path d="M510 226 L510 974"/>
+          <path d="M690 226 L690 974"/>
+        </g>
+        <g fill="#6d757c">
+          <rect x="572" y="322" width="56" height="72" rx="16"/>
+          <rect x="572" y="564" width="56" height="72" rx="16"/>
+          <rect x="572" y="806" width="56" height="72" rx="16"/>
+        </g>
+      </svg>
     </div>`,
     iconSize: [64, 64],
     iconAnchor: [32, 32],
@@ -1528,15 +1560,38 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   const animatedTrain = useAnimatedTrackerPosition(trainPosition, trainLineCoords, mapZoom, { pollIntervalMs: 5000, iconHalfPx: 32 });
   const { label: trainStatusLabel, className: trainStatusClass } = getTrainStatus(trainPosition);
 
+  // The consist trails the lead engine along the same geometry (#533). Zoomed
+  // out past MIN_CONSIST_ZOOM the whole train is narrower than one icon, so
+  // only the lead engine renders and this stays empty.
+  const trainLineDists = useMemo(
+    () => (trainLineCoords?.length >= 2 ? lineCumulativeDistances(trainLineCoords) : null),
+    [trainLineCoords]
+  );
+  const trailingUnits = useMemo(() => {
+    if (!animatedTrain || !trainLineDists || mapZoom < MIN_CONSIST_ZOOM) return [];
+    return buildConsist({
+      lineCoords: trainLineCoords,
+      lineDists: trainLineDists,
+      leadArc: animatedTrain.arc,
+      direction: animatedTrain.direction,
+      zoom: mapZoom,
+    }).slice(1); // index 0 is the lead engine, rendered from its own tracker state
+  }, [animatedTrain, trainLineCoords, trainLineDists, mapZoom]);
+
   const boatMarkerRef = useRef(null);
   const trainMarkerRef = useRef(null);
   const boatIconRef = useRef(null);
   const trainIconRef = useRef(null);
+  const zephyrIconRef = useRef(null);
+  const trailingMarkerRefs = useRef([]);
   if (!boatIconRef.current && animatedBoat) {
     boatIconRef.current = createBoatIcon(animatedBoat.bearing);
   }
   if (!trainIconRef.current && animatedTrain) {
     trainIconRef.current = createTrainIcon(animatedTrain.bearing);
+  }
+  if (!zephyrIconRef.current && animatedTrain) {
+    zephyrIconRef.current = createZephyrIcon(animatedTrain.bearing);
   }
 
   // Layout effects, not plain effects: the bearing tracks the zoom level, and a
@@ -1551,6 +1606,17 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
     const el = trainMarkerRef.current?.getElement()?.querySelector('.train-marker-inner');
     if (el && animatedTrain) el.style.transform = `rotate(${animatedTrain.bearing || 0}deg)`;
   }, [animatedTrain?.bearing]);
+
+  // Each consist unit carries its own bearing (in a curve the tail faces a
+  // different way than the head), written pre-paint on the same path as the
+  // lead marker above rather than by rebuilding divIcons every frame.
+  useLayoutEffect(() => {
+    trailingUnits.forEach((unit, i) => {
+      const el = trailingMarkerRefs.current[i]?.getElement()
+        ?.querySelector('.train-marker-inner, .zephyr-marker-inner');
+      if (el) el.style.transform = `rotate(${unit.bearing || 0}deg)`;
+    });
+  }, [trailingUnits]);
 
   const getLinearFeatureStyle = useCallback((feature, isSelected) => {
     const editSelectedColor = '#FF8C00';
@@ -1920,6 +1986,21 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             )}
           </Marker>
         )}
+
+        {/* Consist cars and tail engine (#533). Clickable like the lead engine so
+            the train reads as one object, but tooltip-free and keyboard-inert so
+            they add neither duplicate hovers nor three extra tab stops. */}
+        {visibleTypes.has('train') && trainFeature && trailingUnits.map((unit, i) => (
+          <Marker
+            key={unit.key}
+            ref={el => { trailingMarkerRefs.current[i] = el; }}
+            position={unit.position}
+            icon={unit.kind === 'zephyr' ? zephyrIconRef.current : trainIconRef.current}
+            zIndexOffset={499 - i}
+            keyboard={false}
+            eventHandlers={{ click: () => handleLinearFeatureClick(trainFeature) }}
+          />
+        ))}
 
         {visibleTypes.has('train') && animatedTrain && trainFeature && (
           <Marker

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -68,6 +68,11 @@ function createTripStopIcon(n) {
 // nose-DOWN, off-centre in its own canvas (a lateral error that rode with the
 // bearing, #533), and loaded from a third-party host at render time.
 //
+// Live trackers ride above ordinary POI markers. The consist's trailing units
+// stack just under their lead engine so the head of the train stays on top
+// where the tooltip and click target are (PR #571 review).
+const TRACKER_Z_INDEX = 500;
+
 // Body is a capsule: the front is a true semicircle of radius 132 — half the
 // body width — which is the FPA-4's bulldog nose seen from above.
 const ENGINE_BODY = 'M468 1018 L468 262 A132 132 0 0 1 732 262 L732 1018 '
@@ -1998,7 +2003,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             ref={boatMarkerRef}
             position={animatedBoat.position}
             icon={boatIconRef.current}
-            zIndexOffset={500}
+            zIndexOffset={TRACKER_Z_INDEX}
             keyboard={false}
             eventHandlers={{ click: () => handleLinearFeatureClick(boatFeature) }}
           >
@@ -2030,7 +2035,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             ref={el => { trailingMarkerRefs.current[i] = el; }}
             position={unit.position}
             icon={unit.kind === 'zephyr' ? zephyrIconRef.current : trainIconRef.current}
-            zIndexOffset={499 - i}
+            zIndexOffset={TRACKER_Z_INDEX - 1 - i}
             keyboard={false}
             eventHandlers={{ click: () => handleLinearFeatureClick(trainFeature) }}
           />
@@ -2041,7 +2046,7 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
             ref={trainMarkerRef}
             position={animatedTrain.position}
             icon={trainIconRef.current}
-            zIndexOffset={500}
+            zIndexOffset={TRACKER_Z_INDEX}
             keyboard={false}
             eventHandlers={{ click: () => handleLinearFeatureClick(trainFeature) }}
           >

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -62,25 +62,48 @@ function createTripStopIcon(n) {
   });
 }
 
-// The USFT sprite is drawn nose-DOWN (cab/windshield at the bottom), so the
-// img carries a fixed 180° flip; the inner div's rotate() stays "bearing =
-// direction of travel" for both writers (initial html + zoom layout effect).
+// CVSR locomotive #6771 (MLW FPA-4) in Cuyahoga Valley livery, drawn top-down
+// to match the Zephyr coach: same body footprint, same heavy outline, nose UP
+// so no compensating flip is needed. Replaces the USFT sprite, which was drawn
+// nose-DOWN, off-centre in its own canvas (a lateral error that rode with the
+// bearing, #533), and loaded from a third-party host at render time.
 //
-// The sprite is also not centered in its own canvas: in the 50px PNG the body
-// spans x 19..30 (centerline 24.5) and y 5..47 (center 26.0) against a canvas
-// center of 25.0 — so the drawn locomotive sits 0.5px left and 1.0px low, or
-// (-0.64, +1.28) once scaled to the 64px box. The 180° flip mirrors that to
-// (+0.64, -1.28), which is a LATERAL error: it rotates with the bearing, so
-// the engine drifts off the rail line instead of riding it (#533). Undo it
-// with a translate applied after the flip, in the parent's frame. The original
-// `margin-left: 1px` (#529) nudged the same direction as the error and is gone.
-const TRAIN_SPRITE_OFFSET = 'translate(-0.64px, 1.28px)';
+// Body is a capsule: the front is a true semicircle of radius 132 — half the
+// body width — which is the FPA-4's bulldog nose seen from above.
+const ENGINE_BODY = 'M468 1018 L468 262 A132 132 0 0 1 732 262 L732 1018 '
+  + 'A52 52 0 0 1 680 1070 L520 1070 A52 52 0 0 1 468 1018 Z';
+// Yellow nose cap, following the same dome and ending at the windshield.
+const ENGINE_NOSE = 'M468 300 L468 262 A132 132 0 0 1 732 262 L732 300 Z';
 
 function createTrainIcon(heading) {
   return L.divIcon({
     className: 'train-marker-icon',
     html: `<div class="train-marker-inner" style="transform: rotate(${heading || 0}deg)">
-      <img src="https://static.usfleettracking.com/img/icons/trains/train.png" width="64" height="64" style="transform: ${TRAIN_SPRITE_OFFSET} rotate(180deg)" alt="" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200" width="64" height="64">
+        <path d="${ENGINE_BODY}" fill="#2E4E31"/>
+        <path d="${ENGINE_NOSE}" fill="#F6C324"/>
+        <rect x="468" y="266" width="264" height="34" fill="#7E2030"/>
+        <rect x="468" y="300" width="264" height="104" fill="#15181A"/>
+        <rect x="496" y="320" width="90" height="64" rx="10" fill="#4A6472"/>
+        <rect x="614" y="320" width="90" height="64" rx="10" fill="#4A6472"/>
+        <rect x="468" y="404" width="264" height="46" fill="#7E2030"/>
+        <rect x="468" y="450" width="264" height="18" fill="#F6C324"/>
+        <rect x="486" y="500" width="15" height="500" fill="#F6C324"/>
+        <rect x="699" y="500" width="15" height="500" fill="#F6C324"/>
+        <rect x="572" y="496" width="56" height="56" rx="14" fill="#12150F"/>
+        <g fill="#1B2A1D">
+          <rect x="556" y="596" width="88" height="70" rx="16"/>
+          <rect x="556" y="714" width="88" height="70" rx="16"/>
+          <rect x="556" y="832" width="88" height="70" rx="16"/>
+        </g>
+        <rect x="496" y="1004" width="208" height="62" rx="22" fill="#23262A"/>
+        <path d="${ENGINE_BODY}" fill="none" stroke="#141812" stroke-width="30"/>
+        <g stroke="#141812" stroke-width="18" stroke-linejoin="round">
+          <rect x="564" y="138" width="72" height="76" rx="24" fill="#7E2030"/>
+          <circle cx="600" cy="142" r="29" fill="#FFF6D8"/>
+        </g>
+        <circle cx="592" cy="135" r="8" fill="#FFFFFF" opacity="0.85"/>
+      </svg>
     </div>`,
     iconSize: [64, 64],
     iconAnchor: [32, 32],

--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -55,7 +55,11 @@ function fixEpochMs(rawPosition) {
  * @param {Array<[number, number]>|null} lineCoords route geometry, GeoJSON [lng, lat]
  * @param {number} zoom current map zoom (bearing footprint scaling)
  * @param {{pollIntervalMs?: number, iconHalfPx?: number, snapPosition?: boolean}} [opts]
- * @returns {{position: [number, number], bearing: number}|null}
+ * @returns {{position: [number, number], bearing: number, arc?: number, direction?: number}|null}
+ *   null until the first fix lands. In track-following mode the result also
+ *   carries `arc` (meters along the line) and `direction` (+1/-1 travel
+ *   direction), which let a caller place further markers at fixed offsets on
+ *   the same track — see buildConsist() (#533). Raw mode omits both.
  */
 export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom, { pollIntervalMs = 5000, iconHalfPx = 32, snapPosition = true } = {}) {
   const [animated, setAnimated] = useState(null);

--- a/frontend/src/hooks/useAnimatedTrackerPosition.js
+++ b/frontend/src/hooks/useAnimatedTrackerPosition.js
@@ -2,15 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { snapToLine } from '../utils/snapToLine';
 import {
   dualSnapBearing, lineCumulativeDistances, arcDistanceAt, snapAtArc, haversineDist,
+  bearingHalfSpan,
 } from '../utils/trackInterpolation';
-
-// At wide zooms the icon's ground footprint spans kilometers of track, and a
-// chord that long cuts across curves — the icon reads visibly crooked against
-// the track line under it (14° off at z11 near the CVSR yard), then rotates
-// into place as the zoom shrinks the span (#554). The eye judges alignment
-// against the LOCAL track direction, so cap the span; below the cap the
-// zoom-scaled footprint behavior is unchanged.
-const MAX_BEARING_SPAN_M = 150;
 
 // The GPS device reports on its own cadence (measured ~10-20s for the CVSR
 // unit), while the frontend polls every few seconds and re-delivers the same
@@ -220,13 +213,17 @@ export default function useAnimatedTrackerPosition(rawPosition, lineCoords, zoom
   if (!animated) return null;
   if (!snapPosition) return { position: animated.position, bearing: animated.heading };
 
-  // Icon half-width in ground meters at this zoom (Web Mercator meters/pixel
-  // at the valley's latitude), capped at MAX_BEARING_SPAN_M.
-  const halfDist = Math.min(
-    iconHalfPx * 156543.03 * Math.cos(41.26 * Math.PI / 180) / (2 ** (zoom || 13)),
-    MAX_BEARING_SPAN_M
-  );
+  const halfDist = bearingHalfSpan(zoom, iconHalfPx);
   let bearing = dualSnapBearing(lineCoords, animated.snap, halfDist);
   if (animated.direction === -1) bearing = (bearing + 180) % 360;
-  return { position: animated.position, bearing };
+
+  // arc + direction let a caller place additional markers at fixed offsets
+  // along the same track — the train consist trailing the lead engine (#533).
+  const lineDists = lineDistsRef.current.dists;
+  return {
+    position: animated.position,
+    bearing,
+    arc: lineDists ? arcDistanceAt(lineDists, animated.snap) : 0,
+    direction: animated.direction,
+  };
 }

--- a/frontend/src/utils/trackInterpolation.js
+++ b/frontend/src/utils/trackInterpolation.js
@@ -144,3 +144,36 @@ export function dualSnapBearing(lineCoords, snap, halfDistMeters) {
   const back = walkAlongTrack(lineCoords, snap, -halfDistMeters);
   return segmentBearing(back, front);
 }
+
+// Every tracker on this map runs through the Cuyahoga Valley, so ground
+// resolution is computed at one representative latitude rather than per-fix —
+// the difference across the valley's ~0.5° span is under 1%.
+const VALLEY_LAT = 41.26;
+
+/**
+ * Web Mercator ground resolution at the valley's latitude.
+ * @param {number} zoom Leaflet zoom level
+ * @returns {number} meters per screen pixel
+ */
+export function metersPerPixel(zoom) {
+  return 156543.03 * Math.cos(VALLEY_LAT * Math.PI / 180) / (2 ** (zoom || 13));
+}
+
+// At wide zooms the icon's ground footprint spans kilometers of track, and a
+// chord that long cuts across curves — the icon reads visibly crooked against
+// the track line under it (14° off at z11 near the CVSR yard), then rotates
+// into place as the zoom shrinks the span (#554). The eye judges alignment
+// against the LOCAL track direction, so cap the span; below the cap the
+// zoom-scaled footprint behavior is unchanged.
+const MAX_BEARING_SPAN_M = 150;
+
+/**
+ * Half the ground distance to span when deriving an icon's bearing: the icon's
+ * own footprint at this zoom, capped so the chord stays locally tangent.
+ * @param {number} zoom Leaflet zoom level
+ * @param {number} iconHalfPx half the icon's on-screen length, in pixels
+ * @returns {number} meters
+ */
+export function bearingHalfSpan(zoom, iconHalfPx) {
+  return Math.min(iconHalfPx * metersPerPixel(zoom), MAX_BEARING_SPAN_M);
+}

--- a/frontend/src/utils/trainConsist.js
+++ b/frontend/src/utils/trainConsist.js
@@ -1,0 +1,89 @@
+import { snapAtArc, dualSnapBearing, metersPerPixel, bearingHalfSpan } from './trackInterpolation';
+
+// The CVSR excursion consist, ordered from the GPS fix backwards: a lead
+// engine, two Zephyr coaches, and a second engine on the tail. The tail engine
+// is dragged backwards rather than turned, which is how the railroad actually
+// works the return leg — hence `flip`.
+export const CONSIST_UNITS = [
+  { key: 'lead', kind: 'engine', flip: false },
+  { key: 'car-1', kind: 'zephyr', flip: false },
+  { key: 'car-2', kind: 'zephyr', flip: false },
+  { key: 'rear', kind: 'engine', flip: true },
+];
+
+// Below this zoom the entire consist spans fewer pixels than a single icon, so
+// the four markers pile into an unreadable blob — the lead engine renders
+// alone instead (the spec 038 behavior).
+export const MIN_CONSIST_ZOOM = 14;
+
+// Prototype length of a Budd Zephyr coach. This floor is only ever reached
+// past z18, where a pixel is under half a meter — see UNIT_GAP_PX.
+const TRUE_CAR_LENGTH_M = 25;
+
+// On-screen distance between unit centers. The icon bodies are ~54px long, so
+// 50px reads as a coupled train rather than a convoy of separate objects.
+const UNIT_GAP_PX = 50;
+
+// The consist icons are 64px boxes, same as the lead engine marker.
+const ICON_HALF_PX = 32;
+
+/**
+ * Ground distance between consist units.
+ *
+ * True-to-scale spacing is unusable at the zooms people actually browse at: a
+ * 25m car gap is 3.5 pixels at z14, so the consist would render as one opaque
+ * pile. Spacing therefore tracks the icons' on-screen size, which keeps the
+ * train's apparent length constant as the user zooms, and only falls back to
+ * prototype length once a pixel is small enough for the two to agree (~z18).
+ *
+ * @param {number} zoom Leaflet zoom level
+ * @returns {number} meters between adjacent unit centers
+ */
+export function unitSpacingMeters(zoom) {
+  return Math.max(TRUE_CAR_LENGTH_M, UNIT_GAP_PX * metersPerPixel(zoom));
+}
+
+/**
+ * Place the train consist along the track behind a lead engine.
+ *
+ * Every unit is resolved independently against the line geometry, so the
+ * consist bends through curves instead of holding a rigid straight bar, and
+ * each unit's bearing comes from the same dual-snap derivation the lead marker
+ * uses — a unit in a curve faces its own local tangent, not the lead's.
+ *
+ * Index 0 is the lead engine itself. Callers rendering the lead from its own
+ * tracker state want `.slice(1)`; it is returned so the trailing units can be
+ * reasoned about (and tested) relative to the head of the train.
+ *
+ * @param {object} opts
+ * @param {Array<[number, number]>} opts.lineCoords track geometry, GeoJSON [lng, lat]
+ * @param {number[]} opts.lineDists lineCumulativeDistances(lineCoords)
+ * @param {number} opts.leadArc lead engine's distance along the line, meters
+ * @param {number} opts.direction travel direction along the line, +1 or -1
+ * @param {number} opts.zoom current Leaflet zoom
+ * @returns {Array<{key: string, kind: string, flip: boolean, position: [number, number], bearing: number}>}
+ *   empty when the geometry or lead position is unusable
+ */
+export function buildConsist({ lineCoords, lineDists, leadArc, direction, zoom }) {
+  if (!lineCoords || lineCoords.length < 2) return [];
+  if (!lineDists || lineDists.length !== lineCoords.length) return [];
+  if (!Number.isFinite(leadArc)) return [];
+
+  const spacing = unitSpacingMeters(zoom);
+  const halfSpan = bearingHalfSpan(zoom, ICON_HALF_PX);
+  // Anything that isn't an explicit reverse is treated as running forward —
+  // the hook leaves direction at +1 until travel disambiguates it.
+  const dir = direction === -1 ? -1 : 1;
+
+  return CONSIST_UNITS.map((unit, i) => {
+    // Trailing units sit behind the lead along the direction of travel, so the
+    // offset subtracts when running up the line and adds when running down it.
+    // snapAtArc clamps, so a consist straddling either end of the track stacks
+    // against the endpoint rather than vanishing.
+    const snap = snapAtArc(lineCoords, lineDists, leadArc - dir * i * spacing);
+    let bearing = dualSnapBearing(lineCoords, snap, halfSpan);
+    if (dir === -1) bearing = (bearing + 180) % 360;
+    if (unit.flip) bearing = (bearing + 180) % 360;
+    return { ...unit, position: snap.position, bearing };
+  });
+}

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -258,6 +258,18 @@ path = "frontend/src/utils/iconUtils.js"
 justification = "getDestinationIconTypeFromConfig (37 lines), poiMatchesActivityForTypes (16 lines), isActivityFilterActive (9 lines) are exported utility functions consumed by map components"
 classification = "by_design"
 
+[[exceptions]]
+check = "single_use_helpers"
+path = "frontend/src/utils/trackInterpolation.js"
+justification = "metersPerPixel has one caller INSIDE this file (bearingHalfSpan) but is exported and also consumed by trainConsist.js unitSpacingMeters — inlining it would duplicate the Web Mercator ground-resolution expression across two files, which is the exact duplication extracting it removed (#533). It is also unit-tested directly for the per-zoom halving, the absolute resolution at z16/z18, and the z13 fallback"
+classification = "by_design"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "frontend/src/utils/trainConsist.js"
+justification = "unitSpacingMeters is called once by buildConsist but is exported so the consist spacing rule can be unit-tested directly — it encodes the design decision that spacing tracks on-screen pixels at browsing zooms and floors at prototype car length past z18. Inlining it would bury that crossover inside buildConsist and make the zoom behavior testable only through rendered marker positions"
+classification = "by_design"
+
 # ============================================================================
 # generic_names — standard math variable names in geometric formulas
 # ============================================================================


### PR DESCRIPTION
## Summary

The CVSR live tracker showed the locomotive as a lone icon. It now renders the excursion consist: a lead engine, two Zephyr coaches, and a tail engine dragged backwards the way the railroad works the return leg.

Each unit is resolved independently against the railroad geometry at its own arc offset, so the consist **bends through curves** instead of holding a rigid bar, and every unit derives its bearing from the same dual-snap path the lead marker already used.

Frontend-only and additive — no backend, schema, or API change. The lead marker keeps its own position/bearing source, so a consist bug cannot regress it.

## The spacing decision

The issue asked for "roughly 20-25 meters (typical railcar length)". That does not survive contact with map scale — at z14 one pixel is ~7.2m, so a 25m gap is **3.5 pixels** between 64px icons, i.e. one opaque pile.

Spacing is therefore `max(25m, 50px × metersPerPixel(zoom))`: the train keeps a constant *apparent* length while zooming, and floors at true prototype length once a pixel is small enough for the two to agree (z18, which is also the map's max zoom). Below z14 the consist collapses to the lead engine alone — the previous behaviour.

Measured in dev against the live GPS feed:

| Zoom | Gap | Expected | On screen |
|------|-----|----------|-----------|
| z14 | 358m | 359m | 50px |
| z16 | 90m | 90m | 50px |
| z17 | 45m | 45m | 50px |
| z18 | 25m | 25m (floor) | 55px |

## Second commit: a pre-existing bug this exposed

The USFT engine sprite is not centred in its own 50px canvas (body centreline 24.5, canvas centre 25.0). Inside the bearing-rotated element that is a **lateral** error, so the engine rode *beside* the rail line rather than on it — and the `margin-left: 1px` from #529 nudged the same direction, compounding it.

Fixed with a translate applied after the flip. Measured against a crosshair at 8× magnification, lateral offset from the anchor falls from **1.43px to 0.28px**. Pre-existing since #529; the consist only made it visible, because the Zephyr cars are centred by construction and sit right next to it.

## Spec

`.specify/specs/042-cvsr-train-consist/`

Closes #533

## Test plan

- [x] 22 new unit tests in `backend/tests/trainConsist.unit.test.js` (trailing order both directions, tail-engine flip, zoom spacing crossover, endpoint clamping, curve following, degenerate geometry)
- [x] `./run.sh build` passes
- [x] `./run.sh test` — 476/478 passing; remaining failures are non-deterministic (different tests fail on each run, `.leaflet-container` failures did not reproduce) and match the suite's known flakiness
- [x] Verified in dev against the live GPS feed, including a moving train through curves
- [ ] Human verification in browser