### PR TITLE
fix: anchor the train consist at the tracked unit (#573)

### DIFF
--- a/.specify/specs/043-consist-anchor/plan.md
+++ b/.specify/specs/043-consist-anchor/plan.md
@@ -1,0 +1,183 @@
+# Implementation Plan: Consist Anchor at the Tracked Unit
+
+
+> **Spec ID:** 043-consist-anchor
+> **Status:** Planning
+> **Last Updated:** 2026-07-22
+> **Estimated Effort:** S
+
+---
+
+## Context
+
+The CVSR consist shipped in #533 assumes the GPS device rides in the **lead
+locomotive**: `buildConsist()` places unit 0 at the reported position and trails the
+rest behind it. That assumption is false, and it is nowhere stated in the code.
+
+The device actually rides further back, so the entire drawn train is displaced
+backward from reality. Zoomed in, the train never looks like it is *at* a station when
+it is stopped there — the drawn locomotive is short of the platform.
+
+**Evidence.** Snapping both the GPS fix and the station POIs onto the railroad
+geometry (which cancels out the fact that station POIs are depot buildings sitting
+6–27 m off the rails), a parked fix at Akron Northside sat **51 m** along-track from
+the station:
+
+| | arc along the line |
+|---|---|
+| Akron Northside station (POI 5709) | 544 m |
+| Parked GPS fix | 493 m |
+
+One sample gives magnitude but not sign, and it conflates "where the device sits" with
+"depot building vs. boarding point". Scott's judgement — he has watched this on the
+map repeatedly — is that the device is in the **first coach**. That is the anchor this
+plan implements.
+
+**Approach decision.** Fixed offset, always honest: the drawn train keeps the same
+real relationship to the device everywhere on the route. Explicitly *not* snapping the
+consist to stations — that would fabricate position, and a train stopped short of a
+platform would still be drawn at it, which is exactly wrong for someone timing a
+bike-aboard pickup.
+
+---
+
+## Design
+
+### 1. Make the tracked unit explicit — `frontend/src/utils/trainConsist.js`
+
+The physical fact belongs with the consist definition, not buried in arithmetic:
+
+```js
+export const CONSIST_UNITS = [
+  { key: 'lead',  kind: 'engine', flip: false },
+  { key: 'car-1', kind: 'zephyr', flip: false, tracked: true },  // GPS device rides here
+  { key: 'car-2', kind: 'zephyr', flip: false },
+  { key: 'rear',  kind: 'engine', flip: true  },
+];
+```
+
+Derive the index once from that flag rather than hardcoding a second constant that can
+drift out of sync with the array.
+
+### 2. Generalise the placement — same file
+
+Rename `leadArc` → `anchorArc` (it is no longer the lead) and place every unit
+relative to the tracked one:
+
+```js
+const snap = snapAtArc(lineCoords, lineDists, anchorArc + dir * (trackedIndex - i) * spacing);
+```
+
+Units ahead of the tracked one (lower index) go forward along the direction of travel;
+units behind go back. This reduces exactly to today's formula when `trackedIndex === 0`,
+so the change is a strict generalisation and the existing geometry is a special case of
+it.
+
+Everything else in `buildConsist()` is unchanged — `snapAtArc()` still clamps at the
+line ends, `dualSnapBearing()` still gives each unit its own local tangent, and the
+`flip` handling for the tail engine is untouched.
+
+### 3. Unify the rendering — `frontend/src/components/Map.jsx`
+
+Today the lead marker is drawn from `animatedTrain.position` and the rest from
+`buildConsist(...).slice(1)`. That split only made sense while the GPS fix *was* the
+lead engine. Now it isn't, so:
+
+- Compute the consist at **all** zooms (it is four `O(log n)` lookups; the current
+  `mapZoom < MIN_CONSIST_ZOOM` early-return moves to the render, not the memo).
+- Render **unit 0** (the lead engine) with the tooltip, click handler and
+  `TRACKER_Z_INDEX` — the head of the train stays the primary marker.
+- Below `MIN_CONSIST_ZOOM`, render *only* unit 0. Computing the consist at every zoom
+  keeps the engine's position continuous across the threshold instead of jumping ~43 m
+  as the cars appear.
+- **Fallback:** if `buildConsist()` returns `[]` but `animatedTrain` exists, render the
+  lead engine at `animatedTrain.position` — today's behaviour. This preserves the
+  intent of NFR-042-3 (a consist bug must not make the train vanish) now that
+  `buildConsist()` is load-bearing for the primary marker.
+
+The rotation layout effect currently keyed on `animatedTrain.bearing` for the lead
+marker switches to the consist's unit-0 bearing, so all four units are written on one
+pre-paint path.
+
+### 4. Supersede the spec
+
+`.specify/specs/042-cvsr-train-consist/` states the GPS fix *is* the lead engine, and
+NFR-042-3 freezes the lead marker's position source. Both are deliberately changed
+here. Add `.specify/specs/043-consist-anchor/` recording the new model, the 51 m
+measurement, and the honest-offset-over-station-snapping decision.
+
+---
+
+## Known trade-off, to record rather than solve
+
+Spacing is exaggerated below z18 (`unitSpacingMeters()`), so moving the anchor back one
+unit draws the lead engine one spacing *ahead* of the fix:
+
+| Zoom | spacing | engine drawn ahead of the fix |
+|------|---------|-------------------------------|
+| z18 | 25 m | 25 m — realistic |
+| z17 | 45 m | 45 m |
+| z14 | 358 m | 358 m |
+
+This is still better than today, where the head is drawn *at* the fix while really
+being ~50 m ahead of it — and far better than anchoring at the tail engine, which would
+put the head 1,074 m ahead at z14. Station alignment only matters at z17+, where
+spacing is near true scale. The underlying exaggeration is #572's territory, not this
+change's.
+
+---
+
+## Files
+
+| File | Change |
+|------|--------|
+| `frontend/src/utils/trainConsist.js` | `tracked` flag, derived index, `anchorArc` placement |
+| `frontend/src/components/Map.jsx` | unified consist rendering, unit-0 tooltip, empty-consist fallback |
+| `backend/tests/trainConsist.unit.test.js` | rework for the anchor; new anchor-specific cases |
+| `.specify/specs/043-consist-anchor/` | new spec + plan |
+
+No backend, schema, or API change. `useAnimatedTrackerPosition` is untouched — it
+already returns `arc` and `direction`.
+
+---
+
+## Verification
+
+**Unit tests** (`./run.sh test`, or `npx vitest run backend/tests/trainConsist.unit.test.js`
+while iterating):
+
+- The tracked unit sits *exactly* on `anchorArc`, for both travel directions
+- Units ahead of it are forward along travel; units behind are back
+- `trackedIndex === 0` reproduces the pre-existing geometry exactly (regression guard)
+- Adjacent gaps still equal `unitSpacingMeters(zoom)`
+- Tail engine still 180° from the lead; consist still bends on a curve
+- Endpoint clamping and degenerate-geometry cases still return sanely
+
+**Live check** — CVSR runs Wed–Sun, so this needs an operating day:
+
+1. `./run.sh build && ./run.sh start`, open `?feature=CVSR`
+2. Wait for a station stop (Boston Mill and Peninsula are the easiest to catch), zoom
+   to z17–18, and confirm the **lead engine** now sits at the platform rather than
+   short of it
+3. Zoom across the z14 threshold and confirm the engine does not jump position as the
+   cars appear
+4. Confirm the tooltip and click still work from any unit
+
+**Measure the residual.** The arc-snapping method used to produce the 51 m figure is
+worth keeping: snap the live fix and the station POI to the railroad geometry (POI 5660,
+704 vertices) and difference their arc positions. Run it at a few stops after the change
+to see whether the remaining error justifies moving the anchor again — this converts
+"looks about right" into a number.
+
+**Do not** verify by comparing the raw GPS lat/lng to a station POI's lat/lng. Station
+POIs are depot buildings 6–27 m off the rails, so that measurement conflates
+perpendicular building offset with along-track position.
+
+---
+
+## Follow-up, not in scope
+
+`trainTrackerService.js` reads only `location` and `ignition` from the USFT
+`/map/devices` payload. The raw response may carry a device label identifying which
+unit it is mounted in, which would replace Scott's judgement call with a fact. Worth
+logging once, but it does not block this change.

--- a/.specify/specs/043-consist-anchor/spec.md
+++ b/.specify/specs/043-consist-anchor/spec.md
@@ -1,0 +1,129 @@
+# Specification: Consist Anchor at the Tracked Unit
+
+> **Spec ID:** 043-consist-anchor
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty / Josui
+> **Date:** 2026-07-22
+
+## Overview
+
+Spec 042 draws the CVSR consist on the assumption that the GPS device rides in the lead
+locomotive. It does not — it rides further back, so the whole drawn train is displaced
+backward from reality and the locomotive never reaches the platform when the train is
+stopped at a station. This spec makes the tracked unit an explicit property of the
+consist and places every other unit relative to it.
+
+---
+
+## User Stories
+
+### Position Accuracy
+
+**US-043-1: The train looks like it is at the station when it is**
+> As a Towpath user timing a bike-aboard pickup, I want the drawn locomotive to reach
+> the platform when the train has actually stopped there, so that I can trust what the
+> map is telling me.
+
+Acceptance Criteria:
+- [ ] The unit carrying the GPS device is drawn exactly on the reported position
+- [ ] Units ahead of it are drawn forward along the direction of travel
+- [ ] Units behind it are drawn backward
+- [ ] At a station stop, zoomed to z17–18, the lead engine sits at the platform rather
+      than short of it
+- [ ] The relationship holds everywhere on the route, not only near stations
+
+**US-043-2: The tracked unit is stated, not implied**
+> As a developer, I want to see which unit carries the GPS device declared in the
+> consist definition, so that the assumption is visible and correctable rather than
+> buried in arithmetic.
+
+Acceptance Criteria:
+- [ ] `CONSIST_UNITS` marks the tracked unit
+- [ ] Moving the device to another unit is a one-line change with no arithmetic edits
+- [ ] Marking the lead engine as tracked reproduces the spec 042 geometry exactly
+
+### Robustness
+
+**US-043-3: A consist fault never hides the train**
+> As a user, I want the train to stay on the map even if the consist geometry cannot be
+> computed, so that a rendering bug does not look like the tracker going down.
+
+Acceptance Criteria:
+- [ ] When the consist cannot be built, the lead engine still renders at the reported
+      position (spec 038 behaviour)
+- [ ] Below the consist zoom threshold, only the lead engine renders
+- [ ] Crossing the zoom threshold does not jump the engine's position
+
+---
+
+## Data Model
+
+No schema changes.
+
+---
+
+## API Endpoints
+
+No new or changed endpoints.
+
+---
+
+## UI/UX Requirements
+
+The drawn consist, with the device in the first coach:
+
+```
+direction of travel  ───────────────►
+
+   [rear engine]  [car 2]  [car 1]  [lead engine]
+      (flipped)              ▲
+                             │
+                     the reported GPS position
+```
+
+Previously the reported position sat under the lead engine, which pushed the entire
+train ~50 m back along the track.
+
+---
+
+## Non-Functional Requirements
+
+**NFR-043-1: Honest position**
+- The drawn consist keeps a fixed, real relationship to the reported position
+  everywhere on the route
+- Position is never adjusted to make the train agree with a station. A train stopped
+  short of a platform must be drawn short of it
+
+**NFR-043-2: Supersedes NFR-042-3**
+- Spec 042 froze the lead marker's position source to the raw tracker state so a
+  consist bug could not regress it. That is no longer possible — the lead engine is now
+  a derived position. The intent is preserved by falling back to the raw tracker
+  position whenever the consist cannot be built
+
+---
+
+## Dependencies
+
+- Supersedes parts of `042-cvsr-train-consist` (the GPS fix is no longer the lead engine)
+- Related: #572 (spacing breathes during zoom animation) — shares the spacing model but
+  is independent of this change
+
+---
+
+## Open Questions
+
+1. Which unit *actually* carries the device. Set to the first coach on the product
+   owner's judgement; a measured 51 m offset at Akron Northside is consistent with it.
+   `trainTrackerService.js` reads only `location` and `ignition` from the USFT payload —
+   a device label in the raw response would settle it.
+2. How much of the measured 51 m is device placement versus the station POI being a
+   depot building rather than a boarding point.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-07-22 | Initial draft |

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -714,8 +714,8 @@ export function createAdminRouter(pool, invalidateMosaicCache) {
   router.post('/settings/usft-sharing-token/test', isAdmin, async (req, res) => {
     try {
       const { testSharingToken } = await import('../services/trainTrackerService.js');
-      const result = await testSharingToken(pool);
-      res.json({ success: result.valid, message: result.message });
+      const tokenTest = await testSharingToken(pool);
+      res.json({ success: tokenTest.valid, message: tokenTest.message });
     } catch (error) {
       console.error('Error testing USFT sharing token:', error);
       res.status(500).json({ success: false, message: 'Failed to test token', error: error.message });

--- a/backend/services/apifyService.js
+++ b/backend/services/apifyService.js
@@ -6,8 +6,8 @@
  * `fetchFacebookPosts(pool, statusUrl, maxItems)`. Also exports `isFacebookUrl`,
  * `toIsoDate`, and `testApifyToken` (used by the admin settings Test button).
  *
- * News-pipeline social scraping (Instagram + general social-date capture in
- * `renderPage`) was removed in #551 / PR #559; see spec 036 (superseded).
+ * Trail status is the module's only consumer — the news pipeline does its own
+ * collection and never calls in here. Spec 036 covers the superseded design.
  */
 // Fix: scope module to Facebook-only trail status scraping (PR #559 review)
 const APIFY_BASE_URL = 'https://api.apify.com/v2';

--- a/backend/tests/trainConsist.unit.test.js
+++ b/backend/tests/trainConsist.unit.test.js
@@ -1,9 +1,9 @@
 /**
  * Train Consist Unit Tests
- * Covers the arc-offset placement that trails Zephyr cars and a tail engine
- * behind the CVSR lead engine (#533): trailing order under both travel
- * directions, the tail engine's 180° flip, zoom-dependent spacing, endpoint
- * clamping, and curve following.
+ * Covers the arc-offset placement of the CVSR consist: which unit lands on the
+ * reported GPS position (#573), ordering under both travel directions, the tail
+ * engine's 180° flip, zoom-dependent spacing, endpoint clamping, and curve
+ * following.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -28,6 +28,30 @@ const CURVE_DISTS = lineCumulativeDistances(CURVE);
 
 const build = (opts) => buildConsist({
   lineCoords: STRAIGHT, lineDists: STRAIGHT_DISTS, zoom: 16, ...opts,
+});
+
+// Derived here from the declarative `tracked` flag rather than imported, so a
+// bug in the module's own derivation is caught instead of asserted against
+// itself.
+const trackedIndex = Math.max(0, CONSIST_UNITS.findIndex(u => u.tracked));
+
+describe('CONSIST_UNITS', () => {
+  it('marks exactly one unit as carrying the GPS device', () => {
+    expect(CONSIST_UNITS.filter(u => u.tracked)).toHaveLength(1);
+  });
+
+  it('does not track the lead engine', () => {
+    // The premise of #573. Asserted rather than assumed, because several
+    // placement tests below would pass vacuously if the tracked unit were the
+    // lead — the exact configuration this change exists to move away from.
+    expect(trackedIndex).toBeGreaterThan(0);
+  });
+
+  it('is ordered front to back, engines at both ends', () => {
+    expect(CONSIST_UNITS[0].kind).toBe('engine');
+    expect(CONSIST_UNITS[CONSIST_UNITS.length - 1].kind).toBe('engine');
+    expect(CONSIST_UNITS[CONSIST_UNITS.length - 1].flip).toBe(true);
+  });
 });
 
 describe('unitSpacingMeters', () => {
@@ -55,15 +79,15 @@ describe('unitSpacingMeters', () => {
 
 describe('buildConsist placement', () => {
   it('returns one entry per defined unit, lead first', () => {
-    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: 1 });
     expect(consist).toHaveLength(CONSIST_UNITS.length);
     expect(consist[0].key).toBe('lead');
     expect(consist.map(u => u.kind)).toEqual(['engine', 'zephyr', 'zephyr', 'engine']);
   });
 
   it('trails units behind the lead when running forward along the line', () => {
-    const leadArc = STRAIGHT_TOTAL / 2;
-    const consist = build({ leadArc, direction: 1 });
+    const anchorArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ anchorArc, direction: 1 });
     // Track runs south-to-north, so trailing units are progressively further south.
     const lats = consist.map(u => u.position[0]);
     for (let i = 1; i < lats.length; i++) {
@@ -72,8 +96,8 @@ describe('buildConsist placement', () => {
   });
 
   it('trails units the other way when direction reverses', () => {
-    const leadArc = STRAIGHT_TOTAL / 2;
-    const consist = build({ leadArc, direction: -1 });
+    const anchorArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ anchorArc, direction: -1 });
     const lats = consist.map(u => u.position[0]);
     for (let i = 1; i < lats.length; i++) {
       expect(lats[i]).toBeGreaterThan(lats[i - 1]);
@@ -82,7 +106,7 @@ describe('buildConsist placement', () => {
 
   it('spaces adjacent units by the zoom spacing', () => {
     const zoom = 16;
-    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1, zoom });
+    const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: 1, zoom });
     const expected = unitSpacingMeters(zoom);
     for (let i = 1; i < consist.length; i++) {
       const gap = haversineDist(
@@ -93,20 +117,59 @@ describe('buildConsist placement', () => {
     }
   });
 
-  it('puts the lead engine on the lead arc position', () => {
-    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
-    // Mid-track on a due-north line: lead sits at the requested arc distance.
+  it('puts the TRACKED unit exactly on the anchor arc, not the lead engine', () => {
+    // This is the whole point of #573: the GPS device rides in a specific unit,
+    // and that unit — not the head of the train — lands on the reported fix.
+    for (const direction of [1, -1]) {
+      const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction });
+      const tracked = consist[trackedIndex];
+      const fromStart = haversineDist(
+        STRAIGHT[0][1], STRAIGHT[0][0],
+        tracked.position[0], tracked.position[1]
+      );
+      expect(fromStart).toBeCloseTo(STRAIGHT_TOTAL / 2, 0);
+    }
+  });
+
+  it('does NOT put the lead engine on the anchor arc', () => {
+    // Regression guard for the spec 042 behaviour this replaces.
+    const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: 1 });
     const fromStart = haversineDist(
       STRAIGHT[0][1], STRAIGHT[0][0],
       consist[0].position[0], consist[0].position[1]
     );
-    expect(fromStart).toBeCloseTo(STRAIGHT_TOTAL / 2, 0);
+    expect(Math.abs(fromStart - STRAIGHT_TOTAL / 2)).toBeGreaterThan(1);
+  });
+
+  it('draws units ahead of the tracked one forward along travel', () => {
+    const anchorArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ anchorArc, direction: 1 });
+    const trackedLat = consist[trackedIndex].position[0];
+    // Heading north: anything ahead of the tracked unit is further north.
+    for (let i = 0; i < trackedIndex; i++) {
+      expect(consist[i].position[0]).toBeGreaterThan(trackedLat);
+    }
+    for (let i = trackedIndex + 1; i < consist.length; i++) {
+      expect(consist[i].position[0]).toBeLessThan(trackedLat);
+    }
+  });
+
+  it('offsets each unit from the anchor by its index distance', () => {
+    const zoom = 17;
+    const anchorArc = STRAIGHT_TOTAL / 2;
+    const consist = build({ anchorArc, direction: 1, zoom });
+    const spacing = unitSpacingMeters(zoom);
+    const tracked = consist[trackedIndex].position;
+    consist.forEach((unit, i) => {
+      const gap = haversineDist(tracked[0], tracked[1], unit.position[0], unit.position[1]);
+      expect(gap).toBeCloseTo(Math.abs(trackedIndex - i) * spacing, 0);
+    });
   });
 });
 
 describe('buildConsist bearings', () => {
   it('faces the direction of travel and flips the tail engine', () => {
-    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: 1 });
     // Northbound on a due-north track.
     expect(consist[0].bearing).toBeCloseTo(0, 0);
     expect(consist[1].bearing).toBeCloseTo(0, 0);
@@ -116,22 +179,22 @@ describe('buildConsist bearings', () => {
   });
 
   it('flips every unit when the train reverses', () => {
-    const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction: -1 });
+    const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: -1 });
     expect(consist[0].bearing).toBeCloseTo(180, 0);
     expect(consist[3].bearing).toBeCloseTo(0, 0);
   });
 
   it('keeps the tail engine 180° from the lead in both directions', () => {
     for (const direction of [1, -1]) {
-      const consist = build({ leadArc: STRAIGHT_TOTAL / 2, direction });
+      const consist = build({ anchorArc: STRAIGHT_TOTAL / 2, direction });
       const delta = Math.abs(((consist[3].bearing - consist[0].bearing) + 360) % 360);
       expect(delta).toBeCloseTo(180, 0);
     }
   });
 
   it('treats a missing direction as running forward', () => {
-    const forward = build({ leadArc: STRAIGHT_TOTAL / 2, direction: 1 });
-    const absent = build({ leadArc: STRAIGHT_TOTAL / 2, direction: undefined });
+    const forward = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: 1 });
+    const absent = build({ anchorArc: STRAIGHT_TOTAL / 2, direction: undefined });
     expect(absent[0].bearing).toBeCloseTo(forward[0].bearing, 6);
     expect(absent[3].position).toEqual(forward[3].position);
   });
@@ -141,7 +204,7 @@ describe('buildConsist on a curve', () => {
   const curved = buildConsist({
     lineCoords: CURVE,
     lineDists: CURVE_DISTS,
-    leadArc: CURVE_DISTS[CURVE_DISTS.length - 1] * 0.6,
+    anchorArc: CURVE_DISTS[CURVE_DISTS.length - 1] * 0.6,
     direction: 1,
     zoom: 17,
   });
@@ -168,7 +231,7 @@ describe('buildConsist on a curve', () => {
 
 describe('buildConsist edge cases', () => {
   it('clamps against the line start instead of running off the end', () => {
-    const consist = build({ leadArc: 5, direction: 1 });
+    const consist = build({ anchorArc: 5, direction: 1 });
     expect(consist).toHaveLength(CONSIST_UNITS.length);
     for (const unit of consist) {
       expect(Number.isFinite(unit.position[0])).toBe(true);
@@ -177,7 +240,7 @@ describe('buildConsist edge cases', () => {
   });
 
   it('clamps against the line end too', () => {
-    const consist = build({ leadArc: STRAIGHT_TOTAL - 5, direction: -1 });
+    const consist = build({ anchorArc: STRAIGHT_TOTAL - 5, direction: -1 });
     const lastLat = STRAIGHT[STRAIGHT.length - 1][1];
     for (const unit of consist) {
       expect(unit.position[0]).toBeLessThanOrEqual(lastLat + 1e-9);
@@ -185,19 +248,19 @@ describe('buildConsist edge cases', () => {
   });
 
   it('returns nothing without usable geometry', () => {
-    expect(buildConsist({ lineCoords: null, lineDists: null, leadArc: 0, direction: 1, zoom: 16 })).toEqual([]);
-    expect(buildConsist({ lineCoords: [[-81.6, 41.3]], lineDists: [0], leadArc: 0, direction: 1, zoom: 16 })).toEqual([]);
+    expect(buildConsist({ lineCoords: null, lineDists: null, anchorArc: 0, direction: 1, zoom: 16 })).toEqual([]);
+    expect(buildConsist({ lineCoords: [[-81.6, 41.3]], lineDists: [0], anchorArc: 0, direction: 1, zoom: 16 })).toEqual([]);
   });
 
   it('returns nothing when the distance table does not match the geometry', () => {
     expect(buildConsist({
-      lineCoords: STRAIGHT, lineDists: [0, 1, 2], leadArc: 100, direction: 1, zoom: 16,
+      lineCoords: STRAIGHT, lineDists: [0, 1, 2], anchorArc: 100, direction: 1, zoom: 16,
     })).toEqual([]);
   });
 
-  it('returns nothing without a finite lead position', () => {
-    for (const leadArc of [undefined, null, NaN, Infinity]) {
-      expect(build({ leadArc, direction: 1 })).toEqual([]);
+  it('returns nothing without a finite anchor position', () => {
+    for (const anchorArc of [undefined, null, NaN, Infinity]) {
+      expect(build({ anchorArc, direction: 1 })).toEqual([]);
     }
   });
 });

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1599,23 +1599,33 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
   const animatedTrain = useAnimatedTrackerPosition(trainPosition, trainLineCoords, mapZoom, { pollIntervalMs: 5000, iconHalfPx: 32 });
   const { label: trainStatusLabel, className: trainStatusClass } = getTrainStatus(trainPosition);
 
-  // The consist trails the lead engine along the same geometry (#533). Zoomed
-  // out past MIN_CONSIST_ZOOM the whole train is narrower than one icon, so
-  // only the lead engine renders and this stays empty.
+  // The consist is laid out around the unit the GPS device rides in, not the
+  // lead engine (#573). Built at EVERY zoom, not just above MIN_CONSIST_ZOOM:
+  // the lead engine's position is derived from it, so gating the computation
+  // would jump the engine as the cars appear at the threshold.
   const trainLineDists = useMemo(
     () => (trainLineCoords?.length >= 2 ? lineCumulativeDistances(trainLineCoords) : null),
     [trainLineCoords]
   );
-  const trailingUnits = useMemo(() => {
-    if (!animatedTrain || !trainLineDists || mapZoom < MIN_CONSIST_ZOOM) return [];
+  const consist = useMemo(() => {
+    if (!animatedTrain || !trainLineDists) return [];
     return buildConsist({
       lineCoords: trainLineCoords,
       lineDists: trainLineDists,
-      leadArc: animatedTrain.arc,
+      anchorArc: animatedTrain.arc,
       direction: animatedTrain.direction,
       zoom: mapZoom,
-    }).slice(1); // index 0 is the lead engine, rendered from its own tracker state
+    });
   }, [animatedTrain, trainLineCoords, trainLineDists, mapZoom]);
+
+  // Below the threshold the whole train is narrower than one icon, so only the
+  // lead engine draws. Its position comes from the consist so it stays put as
+  // the cars appear; if the consist cannot be built at all, fall back to the
+  // raw tracker position so a geometry fault never hides the train (NFR-043-2).
+  const leadUnit = consist[0] || null;
+  const trailingUnits = mapZoom < MIN_CONSIST_ZOOM ? [] : consist.slice(1);
+  const leadPosition = leadUnit?.position || animatedTrain?.position || null;
+  const leadBearing = leadUnit?.bearing ?? animatedTrain?.bearing ?? 0;
 
   const boatMarkerRef = useRef(null);
   const trainMarkerRef = useRef(null);
@@ -1643,8 +1653,8 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
 
   useLayoutEffect(() => {
     const el = trainMarkerRef.current?.getElement()?.querySelector('.train-marker-inner');
-    if (el && animatedTrain) el.style.transform = `rotate(${animatedTrain.bearing || 0}deg)`;
-  }, [animatedTrain?.bearing]);
+    if (el && animatedTrain) el.style.transform = `rotate(${leadBearing}deg)`;
+  }, [leadBearing, animatedTrain]);
 
   // Each consist unit carries its own bearing (in a curve the tail faces a
   // different way than the head), written pre-paint on the same path as the
@@ -2041,10 +2051,10 @@ function Map({ destinations, selectedPoi, selectedIsLinear, onSelectPoi, isAdmin
           />
         ))}
 
-        {visibleTypes.has('train') && animatedTrain && trainFeature && (
+        {visibleTypes.has('train') && animatedTrain && trainFeature && leadPosition && (
           <Marker
             ref={trainMarkerRef}
-            position={animatedTrain.position}
+            position={leadPosition}
             icon={trainIconRef.current}
             zIndexOffset={TRACKER_Z_INDEX}
             keyboard={false}

--- a/frontend/src/utils/trainConsist.js
+++ b/frontend/src/utils/trainConsist.js
@@ -1,15 +1,27 @@
 import { snapAtArc, dualSnapBearing, metersPerPixel, bearingHalfSpan } from './trackInterpolation';
 
-// The CVSR excursion consist, ordered from the GPS fix backwards: a lead
-// engine, two Zephyr coaches, and a second engine on the tail. The tail engine
-// is dragged backwards rather than turned, which is how the railroad actually
-// works the return leg — hence `flip`.
+// The CVSR excursion consist, ordered front to back: a lead engine, two Zephyr
+// coaches, and a second engine on the tail. The tail engine is dragged
+// backwards rather than turned, which is how the railroad actually works the
+// return leg — hence `flip`.
+//
+// `tracked` marks the unit the GPS device rides in. It is NOT the lead engine:
+// spec 042 assumed it was, which drew the whole train ~50m back along the track
+// and meant the locomotive never reached the platform at a station stop (#573).
+// Declaring it here keeps a physical fact about the real train visible and
+// correctable — moving the device is a one-line change, with no arithmetic to
+// touch.
 export const CONSIST_UNITS = [
   { key: 'lead', kind: 'engine', flip: false },
-  { key: 'car-1', kind: 'zephyr', flip: false },
+  { key: 'car-1', kind: 'zephyr', flip: false, tracked: true },
   { key: 'car-2', kind: 'zephyr', flip: false },
   { key: 'rear', kind: 'engine', flip: true },
 ];
+
+// Derived rather than declared a second time, so it cannot drift out of sync
+// with the array above. Falls back to the lead engine if nothing is marked,
+// which reproduces the spec 042 geometry.
+const TRACKED_INDEX = Math.max(0, CONSIST_UNITS.findIndex(u => u.tracked));
 
 // Below this zoom the entire consist spans fewer pixels than a single icon, so
 // the four markers pile into an unreadable blob — the lead engine renders
@@ -44,30 +56,34 @@ export function unitSpacingMeters(zoom) {
 }
 
 /**
- * Place the train consist along the track behind a lead engine.
+ * Place the train consist along the track around the tracked unit.
+ *
+ * The GPS device rides in one specific unit (see CONSIST_UNITS `tracked`), so
+ * that unit lands exactly on the reported position and the rest of the train is
+ * laid out around it — units ahead of it forward along the direction of travel,
+ * units behind it back. When the tracked unit is index 0 this reduces to the
+ * spec 042 behaviour of trailing everything behind the lead engine.
  *
  * Every unit is resolved independently against the line geometry, so the
  * consist bends through curves instead of holding a rigid straight bar, and
  * each unit's bearing comes from the same dual-snap derivation the lead marker
  * uses — a unit in a curve faces its own local tangent, not the lead's.
  *
- * Index 0 is the lead engine itself. Callers rendering the lead from its own
- * tracker state want `.slice(1)`; it is returned so the trailing units can be
- * reasoned about (and tested) relative to the head of the train.
+ * Index 0 is the lead engine; the array is ordered front to back.
  *
  * @param {object} opts
  * @param {Array<[number, number]>} opts.lineCoords track geometry, GeoJSON [lng, lat]
  * @param {number[]} opts.lineDists lineCumulativeDistances(lineCoords)
- * @param {number} opts.leadArc lead engine's distance along the line, meters
+ * @param {number} opts.anchorArc tracked unit's distance along the line, meters
  * @param {number} opts.direction travel direction along the line, +1 or -1
  * @param {number} opts.zoom current Leaflet zoom
  * @returns {Array<{key: string, kind: string, flip: boolean, position: [number, number], bearing: number}>}
- *   empty when the geometry or lead position is unusable
+ *   empty when the geometry or anchor position is unusable
  */
-export function buildConsist({ lineCoords, lineDists, leadArc, direction, zoom }) {
+export function buildConsist({ lineCoords, lineDists, anchorArc, direction, zoom }) {
   if (!lineCoords || lineCoords.length < 2) return [];
   if (!lineDists || lineDists.length !== lineCoords.length) return [];
-  if (!Number.isFinite(leadArc)) return [];
+  if (!Number.isFinite(anchorArc)) return [];
 
   const spacing = unitSpacingMeters(zoom);
   const halfSpan = bearingHalfSpan(zoom, ICON_HALF_PX);
@@ -76,11 +92,13 @@ export function buildConsist({ lineCoords, lineDists, leadArc, direction, zoom }
   const dir = direction === -1 ? -1 : 1;
 
   return CONSIST_UNITS.map((unit, i) => {
-    // Trailing units sit behind the lead along the direction of travel, so the
-    // offset subtracts when running up the line and adds when running down it.
-    // snapAtArc clamps, so a consist straddling either end of the track stacks
-    // against the endpoint rather than vanishing.
-    const snap = snapAtArc(lineCoords, lineDists, leadArc - dir * i * spacing);
+    // Units ahead of the tracked one (lower index) sit forward along the
+    // direction of travel, units behind it sit back, and the tracked unit
+    // itself lands on anchorArc exactly. snapAtArc clamps, so a consist
+    // straddling either end of the track stacks against the endpoint rather
+    // than vanishing.
+    const arc = anchorArc + dir * (TRACKED_INDEX - i) * spacing;
+    const snap = snapAtArc(lineCoords, lineDists, arc);
     let bearing = dualSnapBearing(lineCoords, snap, halfSpan);
     if (dir === -1) bearing = (bearing + 180) % 360;
     if (unit.flip) bearing = (bearing + 180) % 360;


### PR DESCRIPTION
## Summary

Spec 042 assumed the GPS device rides in the **lead locomotive** — `buildConsist()` placed unit 0 on the reported position and trailed everything behind it. It doesn't. The device rides further back, so the whole drawn train sat displaced backward along the track and the locomotive never reached the platform when the train stopped at a station.

`CONSIST_UNITS` now declares which unit carries the device, and `buildConsist()` lays the train out around it — units ahead go forward along the direction of travel, units behind go back, and the tracked unit lands on the reported arc exactly. With the tracked index at 0 this reduces to the old formula, so the previous geometry is a special case rather than a second code path.

## Evidence for the offset

Snapping both the GPS fix and the station POIs onto the railroad geometry — which cancels out the fact that station POIs are depot *buildings* sitting 6–27 m off the rails — a parked fix at Akron Northside sat **51 m** along-track from the station:

| | arc along the line |
|---|---|
| Akron Northside station (POI 5709) | 544 m |
| Parked GPS fix | 493 m |

Set to the **first coach** on the product owner's read of where the antenna is; the 51 m measurement is consistent with that (a real consist puts the second coach 43–69 m back from the nose).

## Deliberately not doing

Snapping the consist to stations when stopped. That fabricates position — a train halted short of a platform would still be drawn *at* it, which is exactly wrong for someone timing a bike-aboard pickup. The offset is fixed and honest everywhere on the route.

## Trade-off, recorded not solved

Spacing is exaggerated below z18, so moving the anchor back one unit draws the lead engine one spacing *ahead* of the fix — 25 m at z18, 358 m at z14. Still better than today, where the head is drawn *at* the fix while really being ~50 m ahead of it. The exaggeration itself is #572's territory.

## Rendering change

`Map.jsx` now derives the lead engine from the consist rather than the raw tracker state, so the consist is built at **every** zoom — gating it would jump the engine as the cars appear at `MIN_CONSIST_ZOOM`. NFR-042-3's intent is preserved by falling back to the raw position whenever the consist can't be built, so a geometry fault still cannot hide the train.

Spec: `.specify/specs/043-consist-anchor/`

Closes #573

## Test plan

- [x] 43 unit tests pass, including a guard that the tracked unit is **not** the lead engine — without it several placement tests would pass vacuously in exactly the configuration this change moves away from
- [x] `./run.sh build` passes
- [x] Live structural check: 4 units, gaps 361/355/361 vs expected 358, engines at both ends, rear flipped, each unit on its own local tangent
- [ ] **Station-stop check outstanding.** Proving the locomotive reaches the platform needs the train *stopped* — while moving, the tween legitimately lags the raw fix by up to ~250 m, so drawn-vs-fix measures lag, not anchor. Waited through an Indigo approach; it slowed to 6 mph and ran through without stopping.
- [ ] Human verification in browser