### PR TITLE
fix: stop backend crash loop from undefined jobType in news checkpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3094,6 +3094,13 @@ async function start() {
   });
 }
 
+// Background jobs run on timer-dispatched promises with no caller to catch them, so a
+// transient failure (usually a pg pool timeout) would otherwise exit the process and
+// take the site down with it. Stay up and log — a dropped job beats a dropped site.
+process.on('unhandledRejection', reason => {
+  console.error('[unhandledRejection] Backend stayed up; investigate:', reason);
+});
+
 process.on('SIGTERM', async () => {
   console.log('SIGTERM received, shutting down gracefully...');
   stopTracker();

--- a/backend/services/collection/BatchRunner.js
+++ b/backend/services/collection/BatchRunner.js
@@ -64,18 +64,29 @@ export async function runBatch({
       }
     }
 
+    // A checkpoint is bookkeeping — if it fails (e.g. a pg pool timeout) we log and
+    // keep going. Letting it reject would escape processNext, which is dispatched from
+    // a bare setTimeout, and take the whole process down.
+    const safeCheckpoint = async (collected, error) => {
+      try {
+        await checkpointFn(item, collected, error);
+      } catch (checkpointError) {
+        console.error(`[${label} Job ${jobId}] [${index + 1}/${items.length}] Checkpoint failed: ${checkpointError.message}`);
+      }
+    };
+
     try {
       console.log(`[${label} Job ${jobId}] [${index + 1}/${items.length}] Starting (Slot ${slotId}, ${inFlight} in flight)`);
 
       const collected = await collectFn(item, context);
       results.push({ item, result: collected, success: true });
 
-      await checkpointFn(item, collected, null);
+      await safeCheckpoint(collected, null);
     } catch (error) {
       console.error(`[${label} Job ${jobId}] [${index + 1}/${items.length}] Error: ${error.message}`);
       results.push({ item, result: null, success: false, error: error.message });
 
-      await checkpointFn(item, null, error);
+      await safeCheckpoint(null, error);
     }
 
     inFlight--;

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1548,6 +1548,7 @@ export async function createNewsCollectionJob(pool, poiIds, source = 'batch') {
 
 export async function processNewsCollectionJob(pool, sheets, pgBossJobId, jobData) {
   const { jobId } = jobData;
+  const jobType = 'news';
 
   const jobResult = await pool.query('SELECT * FROM news_job_status WHERE id = $1', [jobId]);
   if (jobResult.rows.length === 0) {


### PR DESCRIPTION
## Incident

The backend crashed **52 times** across 7/30–7/31 (27 and 25). Each exit took the site down for ~5s until systemd restarted it, which is why ROTV looked intermittently down while HTTP checks mostly passed.

## Root cause

`processNewsCollectionJob` referenced `jobType` in three places but never declared it. All three sit on the **error-handling** path, so they only execute when a POI collection fails.

Podman's `aardvark-dns` on lotor was wedged, so containers had no DNS. Every outbound fetch failed (Serper, Gemini, Apify, USFT). Every failed POI then hit:

```
ReferenceError: jobType is not defined
    at checkpointFn (file:///app/services/newsService.js:1695:27)
    at processNext (file:///app/services/collection/BatchRunner.js:78:13)
```

`BatchRunner` awaited that checkpoint from a bare `setTimeout` with no `.catch()`, so the rejection went unhandled and Node exited.

The DNS resolver has been restarted separately — that fix is already live and unblocked the train tracker and water taxi. This PR fixes the code that turned a network outage into a crash loop.

## Changes

- **`newsService.js`** — declare `jobType = 'news'`, matching the literal already used elsewhere in the same function and the default in every other function in the file.
- **`BatchRunner.js`** — route both `checkpointFn` calls through `safeCheckpoint`, which logs and swallows. A checkpoint is bookkeeping and must never kill the process. This also fixes a latent **double-checkpoint**: a checkpoint that threw on the success path fell into the `catch`, which called `checkpointFn` a second time and double-counted `processed++`.
- **`server.js`** — add an `unhandledRejection` handler as a backstop so a future unguarded background job degrades instead of taking the site down. Deliberately no `uncaughtException` handler, which would leave the process in an undefined state.

## Process gap

`npm run lint` flags this as three `no-undef` errors — verified by reverting the fix and re-running:

```
1674:28  error  'jobType' is not defined  no-undef
1678:28  error  'jobType' is not defined  no-undef
1696:27  error  'jobType' is not defined  no-undef
```

Lint is configured in `backend/eslint.config.js` with `no-undef: 'error'`, but **no CI workflow runs it**. Wiring it in would have caught this before it shipped. Filing separately.

## Testing

`./run.sh test` — **488 passed**, 2 failed.

The two failures are frontend UI tests (tablet Login button visibility, satellite tile toggle). These changes are backend-only, so they are unrelated — but I did not verify them against master, so I am not claiming they were already red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
