### PR TITLE
feat: link Google and Facebook logins on a shared email

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -1,6 +1,7 @@
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Strategy as FacebookStrategy } from 'passport-facebook';
+import { findOrCreateUser as resolveUserAccount } from './userAccount.js';
 
 export function configurePassport(pool) {
   const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'scott.mccarty@gmail.com';
@@ -23,55 +24,8 @@ export function configurePassport(pool) {
     }
   });
 
-  async function findOrCreateUser(provider, profile, credentials) {
-    const email = profile.emails?.[0]?.value;
-    const name = profile.displayName;
-    const pictureUrl = profile.photos?.[0]?.value;
-    const providerId = profile.id;
-    const isAdmin = email && email.toLowerCase() === ADMIN_EMAIL.toLowerCase();
-
-    let userLookup = await pool.query(
-      'SELECT * FROM users WHERE oauth_provider = $1 AND oauth_provider_id = $2',
-      [provider, providerId]
-    );
-
-    if (userLookup.rows.length > 0) {
-      const updateFields = ['last_login_at = CURRENT_TIMESTAMP', 'picture_url = $1', 'name = $2'];
-      const updateValues = [pictureUrl, name];
-
-      if (isAdmin && !userLookup.rows[0].is_admin) {
-        updateFields.push(`is_admin = $${updateValues.length + 1}`);
-        updateValues.push(true);
-        updateFields.push(`role = $${updateValues.length + 1}`);
-        updateValues.push('admin');
-      }
-
-      if (isAdmin && credentials) {
-        updateFields.push(`oauth_credentials = $${updateValues.length + 1}`);
-        updateValues.push(JSON.stringify(credentials));
-      }
-
-      updateValues.push(userLookup.rows[0].id);
-
-      await pool.query(
-        `UPDATE users SET ${updateFields.join(', ')} WHERE id = $${updateValues.length}`,
-        updateValues
-      );
-
-      userLookup = await pool.query('SELECT * FROM users WHERE id = $1', [userLookup.rows[0].id]);
-      return userLookup.rows[0];
-    }
-
-    const role = isAdmin ? 'admin' : 'viewer';
-    const insertResult = await pool.query(
-      `INSERT INTO users (email, name, picture_url, oauth_provider, oauth_provider_id, is_admin, role, oauth_credentials, last_login_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP)
-       RETURNING *`,
-      [email, name, pictureUrl, provider, providerId, isAdmin, role, isAdmin && credentials ? JSON.stringify(credentials) : null]
-    );
-
-    return insertResult.rows[0];
-  }
+  const findOrCreateUser = (provider, profile, credentials) =>
+    resolveUserAccount(pool, ADMIN_EMAIL, provider, profile, credentials);
 
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     passport.use('google', new GoogleStrategy({

--- a/backend/config/userAccount.js
+++ b/backend/config/userAccount.js
@@ -1,0 +1,107 @@
+/**
+ * Resolves an OAuth login to a ROTV user account.
+ *
+ * Logins live in `user_identities`, so one account can carry both a Google and a
+ * Facebook identity. When an unrecognised identity arrives with an email that
+ * already belongs to an account, it is linked to that account instead of
+ * creating a second one — `users.email` is UNIQUE, so the previous
+ * create-always path threw a constraint violation the first time an existing
+ * user signed in through a second provider.
+ *
+ * Linking trusts the email the provider asserts. Google and Facebook both
+ * verify addresses before releasing them, so this matches the account-linking
+ * behaviour users expect from "sign in with X" buttons.
+ *
+ * `users.oauth_provider` / `oauth_provider_id` are left pointing at whichever
+ * provider created the account. They are no longer the lookup key, but the
+ * admin user list still reports them as the account's origin.
+ */
+export async function findOrCreateUser(pool, adminEmail, provider, profile, credentials) {
+  const email = profile.emails?.[0]?.value || null;
+  const name = profile.displayName || null;
+  const pictureUrl = profile.photos?.[0]?.value || null;
+  const providerId = profile.id;
+  const isAdmin = Boolean(email && email.toLowerCase() === adminEmail.toLowerCase());
+
+  const identity = await pool.query(
+    'SELECT user_id FROM user_identities WHERE provider = $1 AND provider_id = $2',
+    [provider, providerId]
+  );
+  let userId = identity.rows[0]?.user_id ?? null;
+
+  if (!userId && email) {
+    const byEmail = await pool.query(
+      'SELECT id FROM users WHERE LOWER(email) = LOWER($1)',
+      [email]
+    );
+    userId = byEmail.rows[0]?.id ?? null;
+
+    if (userId) {
+      await pool.query(
+        `INSERT INTO user_identities (user_id, provider, provider_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (provider, provider_id) DO NOTHING`,
+        [userId, provider, providerId]
+      );
+    }
+  }
+
+  if (!userId) {
+    const role = isAdmin ? 'admin' : 'viewer';
+    const created = await pool.query(
+      `INSERT INTO users (email, name, picture_url, oauth_provider, oauth_provider_id, is_admin, role, oauth_credentials, last_login_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP)
+       RETURNING *`,
+      [email, name, pictureUrl, provider, providerId, isAdmin, role, isAdmin && credentials ? JSON.stringify(credentials) : null]
+    );
+
+    await pool.query(
+      `INSERT INTO user_identities (user_id, provider, provider_id)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (provider, provider_id) DO NOTHING`,
+      [created.rows[0].id, provider, providerId]
+    );
+
+    return created.rows[0];
+  }
+
+  const existing = await pool.query('SELECT * FROM users WHERE id = $1', [userId]);
+  const current = existing.rows[0];
+
+  const updateFields = ['last_login_at = CURRENT_TIMESTAMP'];
+  const updateValues = [];
+
+  // Only overwrite when this provider actually supplied a value, so signing in
+  // through a sparser profile cannot blank out a good name or avatar.
+  if (pictureUrl) {
+    updateValues.push(pictureUrl);
+    updateFields.push(`picture_url = $${updateValues.length}`);
+  }
+  if (name) {
+    updateValues.push(name);
+    updateFields.push(`name = $${updateValues.length}`);
+  }
+
+  if (isAdmin && !current.is_admin) {
+    updateValues.push(true);
+    updateFields.push(`is_admin = $${updateValues.length}`);
+    updateValues.push('admin');
+    updateFields.push(`role = $${updateValues.length}`);
+  }
+
+  // Facebook logins carry no credentials, so a Facebook sign-in must never wipe
+  // the Google tokens the admin Drive integration depends on.
+  if (isAdmin && credentials) {
+    updateValues.push(JSON.stringify(credentials));
+    updateFields.push(`oauth_credentials = $${updateValues.length}`);
+  }
+
+  updateValues.push(userId);
+  await pool.query(
+    `UPDATE users SET ${updateFields.join(', ')} WHERE id = $${updateValues.length}`,
+    updateValues
+  );
+
+  const refreshed = await pool.query('SELECT * FROM users WHERE id = $1', [userId]);
+  return refreshed.rows[0];
+}

--- a/backend/migrations/088_user_identities.sql
+++ b/backend/migrations/088_user_identities.sql
@@ -1,0 +1,28 @@
+-- Migration: 088_user_identities
+-- Description: Let one account carry several OAuth logins so a user can sign in with
+-- either Google or Facebook on the same email. `users.email` is UNIQUE, so the old
+-- "look up by (oauth_provider, oauth_provider_id), otherwise INSERT" path raised a
+-- constraint violation the first time an existing user arrived via a second provider —
+-- which is what blocked Facebook login entirely.
+--
+-- `users.oauth_provider` / `oauth_provider_id` are deliberately left in place. They no
+-- longer act as the lookup key, but the admin user list still reports them as the
+-- provider the account was created with.
+--
+-- initDatabase() in server.js performs the same work on every boot, so production
+-- self-heals on deploy; this file keeps the documented migration path complete.
+
+CREATE TABLE IF NOT EXISTS user_identities (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider VARCHAR(50) NOT NULL,
+  provider_id VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(provider, provider_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_identities_user_id ON user_identities(user_id);
+
+INSERT INTO user_identities (user_id, provider, provider_id, created_at)
+SELECT id, oauth_provider, oauth_provider_id, created_at FROM users
+ON CONFLICT (provider, provider_id) DO NOTHING;

--- a/backend/server.js
+++ b/backend/server.js
@@ -482,6 +482,30 @@ async function initDatabase() {
       END $$;
     `);
 
+    // One account, many logins: lets the same person sign in with Google or
+    // Facebook without colliding on the UNIQUE users.email. Backfilled from the
+    // legacy per-user provider columns, which now only record account origin.
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS user_identities (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        provider VARCHAR(50) NOT NULL,
+        provider_id VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(provider, provider_id)
+      )
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_identities_user_id ON user_identities(user_id)
+    `);
+
+    await client.query(`
+      INSERT INTO user_identities (user_id, provider, provider_id, created_at)
+      SELECT id, oauth_provider, oauth_provider_id, created_at FROM users
+      ON CONFLICT (provider, provider_id) DO NOTHING
+    `);
+
     await client.query(`
       CREATE TABLE IF NOT EXISTS admin_settings (
         key VARCHAR(255) PRIMARY KEY,

--- a/backend/tests/oauthAccountLinking.unit.test.js
+++ b/backend/tests/oauthAccountLinking.unit.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import { findOrCreateUser } from '../config/userAccount.js';
+
+const ADMIN_EMAIL = 'scott.mccarty@gmail.com';
+
+/**
+ * In-memory stand-in for the pg pool, matching only the queries userAccount.js
+ * issues. Keeps the linking logic testable without a live PostgreSQL.
+ */
+function makeFakePool({ users = [], identities = [] } = {}) {
+  const state = {
+    users: users.map((u) => ({ is_admin: false, role: 'viewer', oauth_credentials: null, ...u })),
+    identities: [...identities]
+  };
+  let nextUserId = Math.max(0, ...state.users.map((u) => u.id)) + 1;
+
+  state.query = async (sql, params = []) => {
+    const s = sql.replace(/\s+/g, ' ').trim();
+
+    if (s.startsWith('SELECT user_id FROM user_identities')) {
+      const [provider, providerId] = params;
+      const hit = state.identities.find((i) => i.provider === provider && i.provider_id === providerId);
+      return { rows: hit ? [{ user_id: hit.user_id }] : [] };
+    }
+
+    if (s.startsWith('SELECT id FROM users WHERE LOWER(email)')) {
+      const [email] = params;
+      const hit = state.users.find((u) => u.email && u.email.toLowerCase() === String(email).toLowerCase());
+      return { rows: hit ? [{ id: hit.id }] : [] };
+    }
+
+    if (s.startsWith('SELECT * FROM users WHERE id')) {
+      const [id] = params;
+      const hit = state.users.find((u) => u.id === id);
+      return { rows: hit ? [{ ...hit }] : [] };
+    }
+
+    if (s.startsWith('INSERT INTO user_identities')) {
+      const [userId, provider, providerId] = params;
+      const clash = state.identities.some((i) => i.provider === provider && i.provider_id === providerId);
+      if (!clash) state.identities.push({ user_id: userId, provider, provider_id: providerId });
+      return { rows: [] };
+    }
+
+    if (s.startsWith('INSERT INTO users')) {
+      const [email, name, pictureUrl, provider, providerId, isAdmin, role, credentials] = params;
+      if (email && state.users.some((u) => u.email === email)) {
+        throw new Error('duplicate key value violates unique constraint "users_email_key"');
+      }
+      const row = {
+        id: nextUserId++,
+        email,
+        name,
+        picture_url: pictureUrl,
+        oauth_provider: provider,
+        oauth_provider_id: providerId,
+        is_admin: isAdmin,
+        role,
+        oauth_credentials: credentials
+      };
+      state.users.push(row);
+      return { rows: [{ ...row }] };
+    }
+
+    if (s.startsWith('UPDATE users SET')) {
+      const id = params[params.length - 1];
+      const row = state.users.find((u) => u.id === id);
+      const columns = [...s.matchAll(/(\w+) = \$(\d+)/g)];
+      for (const [, column, index] of columns) {
+        row[column] = params[Number(index) - 1];
+      }
+      return { rows: [] };
+    }
+
+    throw new Error(`unexpected query: ${s}`);
+  };
+
+  return state;
+}
+
+const googleProfile = {
+  id: 'google-123',
+  displayName: 'Scott McCarty',
+  emails: [{ value: ADMIN_EMAIL }],
+  photos: [{ value: 'https://google.example/avatar.jpg' }]
+};
+
+const facebookProfile = {
+  id: 'facebook-987',
+  displayName: 'Scott McCarty',
+  emails: [{ value: ADMIN_EMAIL }],
+  photos: [{ value: 'https://facebook.example/avatar.jpg' }]
+};
+
+describe('findOrCreateUser', () => {
+  it('creates an account and its identity for a first-time login', async () => {
+    const pool = makeFakePool();
+
+    const user = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    expect(user.email).toBe(ADMIN_EMAIL);
+    expect(pool.users).toHaveLength(1);
+    expect(pool.identities).toEqual([
+      { user_id: user.id, provider: 'google', provider_id: 'google-123' }
+    ]);
+  });
+
+  it('returns the same account on a repeat login without creating a second row', async () => {
+    const pool = makeFakePool();
+
+    const first = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+    const second = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    expect(second.id).toBe(first.id);
+    expect(pool.users).toHaveLength(1);
+    expect(pool.identities).toHaveLength(1);
+  });
+
+  // The bug that blocked Facebook login: users.email is UNIQUE, so a second
+  // provider used to hit a constraint violation instead of linking.
+  it('links a Facebook login to the existing account with the same email', async () => {
+    const pool = makeFakePool();
+    const google = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    const facebook = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', facebookProfile, null);
+
+    expect(facebook.id).toBe(google.id);
+    expect(pool.users).toHaveLength(1);
+    expect(pool.identities).toHaveLength(2);
+  });
+
+  it('matches emails case-insensitively when linking', async () => {
+    const pool = makeFakePool();
+    const google = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    const shouty = { ...facebookProfile, emails: [{ value: ADMIN_EMAIL.toUpperCase() }] };
+    const facebook = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', shouty, null);
+
+    expect(facebook.id).toBe(google.id);
+    expect(pool.users).toHaveLength(1);
+  });
+
+  it('keeps the account reachable from either provider once linked', async () => {
+    const pool = makeFakePool();
+    const google = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+    await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', facebookProfile, null);
+
+    const backViaGoogle = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+    const backViaFacebook = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', facebookProfile, null);
+
+    expect(backViaGoogle.id).toBe(google.id);
+    expect(backViaFacebook.id).toBe(google.id);
+    expect(pool.users).toHaveLength(1);
+  });
+
+  it('preserves admin Google credentials across a Facebook sign-in', async () => {
+    const pool = makeFakePool();
+    await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, { access_token: 'drive-token' });
+
+    const linked = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', facebookProfile, null);
+
+    expect(JSON.parse(linked.oauth_credentials)).toEqual({ access_token: 'drive-token' });
+    expect(linked.is_admin).toBe(true);
+  });
+
+  it('creates a separate account when Facebook withholds an email', async () => {
+    const pool = makeFakePool();
+    await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    const anonymous = { ...facebookProfile, emails: undefined };
+    const created = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', anonymous, null);
+
+    expect(created.email).toBeNull();
+    expect(created.is_admin).toBe(false);
+    expect(pool.users).toHaveLength(2);
+  });
+
+  it('does not blank an existing avatar when a provider supplies none', async () => {
+    const pool = makeFakePool();
+    const google = await findOrCreateUser(pool, ADMIN_EMAIL, 'google', googleProfile, null);
+
+    const noPhoto = { ...facebookProfile, photos: [] };
+    const linked = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', noPhoto, null);
+
+    expect(linked.id).toBe(google.id);
+    expect(linked.picture_url).toBe('https://google.example/avatar.jpg');
+  });
+
+  it('promotes a linked account to admin when the email matches ADMIN_EMAIL', async () => {
+    const pool = makeFakePool({
+      users: [{ id: 1, email: ADMIN_EMAIL, name: 'Scott', oauth_provider: 'google', oauth_provider_id: 'google-123' }],
+      identities: [{ user_id: 1, provider: 'google', provider_id: 'google-123' }]
+    });
+
+    const linked = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', facebookProfile, null);
+
+    expect(linked.id).toBe(1);
+    expect(linked.is_admin).toBe(true);
+    expect(linked.role).toBe('admin');
+  });
+
+  it('leaves a non-admin login as a viewer', async () => {
+    const pool = makeFakePool();
+    const visitor = {
+      id: 'facebook-555',
+      displayName: 'Trail Visitor',
+      emails: [{ value: 'visitor@example.com' }],
+      photos: []
+    };
+
+    const created = await findOrCreateUser(pool, ADMIN_EMAIL, 'facebook', visitor, null);
+
+    expect(created.is_admin).toBe(false);
+    expect(created.role).toBe('viewer');
+  });
+});


### PR DESCRIPTION
## Summary

`users.email` is `UNIQUE`, and the old login path looked accounts up by `(oauth_provider, oauth_provider_id)` and otherwise `INSERT`ed. So the first time an existing Google user signed in through Facebook, the insert hit `users_email_key` and the login 500'd — indistinguishable from broken OAuth. Production has real accounts in exactly that state (`scott.mccarty@gmail.com`, `fatherlinux@gmail.com`, both Google).

This adds a `user_identities` join table so one account can carry several logins. An unrecognised identity arriving with an email that already belongs to an account is linked to that account instead of creating a second one. Linking trusts the provider-asserted email — Google and Facebook both verify addresses before releasing them.

`users.oauth_provider` / `oauth_provider_id` stay put. They are no longer the lookup key, but the admin user list still reports them as the account's origin, and `oauth_credentials` carries the Google Drive tokens the admin integration depends on — a Facebook sign-in must never clobber those.

The schema work lives in `initDatabase()`, which runs on every boot, so production self-heals on deploy. `088_user_identities.sql` mirrors it to keep the documented migration path complete.

### Notes

- `findOrCreateUser` moved out of the passport closure into `backend/config/userAccount.js` so it can be unit-tested without a live pool.
- If a provider withholds the email there is nothing to link on, so that login gets its own account. Deliberate: the guarantee is "same verified email", not "same person".
- This does not by itself enable Facebook login — production still has no `FACEBOOK_APP_ID` / `FACEBOOK_APP_SECRET`, so `/auth/facebook` returns 501. This clears the failure waiting behind that one.

## Test plan

- `./run.sh build` — passes
- `./run.sh test` — 497 passed / 3 failed / 1 skipped; the 3 failures are pre-existing accessibility `color-contrast` checks, unrelated to this backend-only change
- 10 new unit tests in `backend/tests/oauthAccountLinking.unit.test.js` covering: first-time create, repeat login, Facebook linking to an existing Google account on the same email, case-insensitive matching, reachability from either provider once linked, admin Google credentials surviving a Facebook sign-in, separate account when email is withheld, avatar not blanked by a sparser profile, admin promotion, non-admin staying viewer
- End-to-end against a real Facebook profile is still untested — blocked on the credentials above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pkEQBZoudBaBRseq3CrDU